### PR TITLE
Fix compilation with clang, Xcode 5.1.1 on OS X 10.9.4

### DIFF
--- a/common/src/Assets/AssetTypes.h
+++ b/common/src/Assets/AssetTypes.h
@@ -45,12 +45,12 @@ namespace TrenchBroom {
         typedef std::map<String, EntityDefinitionList> EntityDefinitionGroups;
         
         class PropertyDefinition;
-        typedef std::tr1::shared_ptr<PropertyDefinition> PropertyDefinitionPtr;
+        typedef TrenchBroom::shared_ptr<PropertyDefinition> PropertyDefinitionPtr;
         typedef std::vector<PropertyDefinitionPtr> PropertyDefinitionList;
         typedef std::map<String, PropertyDefinitionPtr> PropertyDefinitionMap;
         
         class ModelDefinition;
-        typedef std::tr1::shared_ptr<ModelDefinition> ModelDefinitionPtr;
+        typedef TrenchBroom::shared_ptr<ModelDefinition> ModelDefinitionPtr;
         typedef std::vector<ModelDefinitionPtr> ModelDefinitionList;
         static const ModelDefinitionList EmptyModelDefinitionList;
         

--- a/common/src/ByteBuffer.h
+++ b/common/src/ByteBuffer.h
@@ -29,7 +29,7 @@ template <typename T>
 class Buffer {
 private:
     typedef std::vector<T> InternalBuffer;
-    typedef std::tr1::shared_ptr<InternalBuffer> InternalBufferPtr;
+    typedef TrenchBroom::shared_ptr<InternalBuffer> InternalBufferPtr;
     InternalBufferPtr m_buffer;
 public:
     typedef std::vector<Buffer<T> > List;

--- a/common/src/CollectionUtils.h
+++ b/common/src/CollectionUtils.h
@@ -135,10 +135,10 @@ namespace VectorUtils {
     }
     
     template <typename T, class P>
-    const std::tr1::shared_ptr<T> findIf(const std::vector<std::tr1::shared_ptr<T> >& vec, const P& predicate) {
-        typename std::vector<std::tr1::shared_ptr<T> >::const_iterator it = std::find_if(vec.begin(), vec.end(), predicate);
+    const TrenchBroom::shared_ptr<T> findIf(const std::vector<TrenchBroom::shared_ptr<T> >& vec, const P& predicate) {
+        typename std::vector<TrenchBroom::shared_ptr<T> >::const_iterator it = std::find_if(vec.begin(), vec.end(), predicate);
         if (it == vec.end())
-            return std::tr1::shared_ptr<T>();
+            return TrenchBroom::shared_ptr<T>();
         return *it;
     }
     

--- a/common/src/ConfigTypes.h
+++ b/common/src/ConfigTypes.h
@@ -40,7 +40,7 @@ namespace TrenchBroom {
             Type_Table  = 1 << 2
         } Type;
         
-        typedef std::tr1::shared_ptr<ConfigEntry> Ptr;
+        typedef TrenchBroom::shared_ptr<ConfigEntry> Ptr;
     private:
         Type m_type;
     public:
@@ -57,7 +57,7 @@ namespace TrenchBroom {
     
     class ConfigValue : public ConfigEntry {
     public:
-        typedef std::tr1::shared_ptr<ConfigValue> Ptr;
+        typedef TrenchBroom::shared_ptr<ConfigValue> Ptr;
     private:
         String m_value;
     public:
@@ -68,7 +68,7 @@ namespace TrenchBroom {
     
     class ConfigList : public ConfigEntry {
     public:
-        typedef std::tr1::shared_ptr<ConfigList> Ptr;
+        typedef TrenchBroom::shared_ptr<ConfigList> Ptr;
     private:
         typedef std::vector<ConfigEntry::Ptr> EntryList;
         EntryList m_entries;
@@ -83,7 +83,7 @@ namespace TrenchBroom {
     
     class ConfigTable : public ConfigEntry {
     public:
-        typedef std::tr1::shared_ptr<ConfigTable> Ptr;
+        typedef TrenchBroom::shared_ptr<ConfigTable> Ptr;
     private:
         typedef std::map<String, ConfigEntry::Ptr> EntryMap;
         StringSet m_keys;

--- a/common/src/Controller/AddRemoveObjectsCommand.h
+++ b/common/src/Controller/AddRemoveObjectsCommand.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         class AddRemoveObjectsCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<AddRemoveObjectsCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<AddRemoveObjectsCommand> Ptr;
         private:
             typedef enum {
                 Action_Add,

--- a/common/src/Controller/BrushVertexHandleCommand.h
+++ b/common/src/Controller/BrushVertexHandleCommand.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
     namespace Controller {
         class BrushVertexHandleCommand : public Command {
         public:
-            typedef std::tr1::shared_ptr<BrushVertexHandleCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<BrushVertexHandleCommand> Ptr;
         public:
             BrushVertexHandleCommand(CommandType type, const String& name, bool undoable, bool modifiesDocument);
             ~BrushVertexHandleCommand();

--- a/common/src/Controller/Command.h
+++ b/common/src/Controller/Command.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
     namespace Controller {
         class Command {
         public:
-            typedef std::tr1::shared_ptr<Command> Ptr;
+            typedef TrenchBroom::shared_ptr<Command> Ptr;
             typedef std::vector<Ptr> List;
             typedef size_t CommandType;
             
@@ -64,8 +64,8 @@ namespace TrenchBroom {
             bool collateWith(Ptr command);
             
             template <class T>
-            static std::tr1::shared_ptr<T> cast(Ptr& command) {
-                return std::tr1::static_pointer_cast<T>(command);
+            static TrenchBroom::shared_ptr<T> cast(Ptr& command) {
+                return TrenchBroom::static_pointer_cast<T>(command);
             }
         private:
             virtual bool doPerformDo() = 0;

--- a/common/src/Controller/EntityPropertyCommand.h
+++ b/common/src/Controller/EntityPropertyCommand.h
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         class EntityPropertyCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<EntityPropertyCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<EntityPropertyCommand> Ptr;
         private:
             typedef enum {
                 Action_Rename,

--- a/common/src/Controller/FaceAttributeCommand.h
+++ b/common/src/Controller/FaceAttributeCommand.h
@@ -37,7 +37,7 @@ namespace TrenchBroom {
         class FaceAttributeCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<FaceAttributeCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<FaceAttributeCommand> Ptr;
         private:
             typedef enum {
                 ValueOp_None,

--- a/common/src/Controller/FixPlanePointsCommand.h
+++ b/common/src/Controller/FixPlanePointsCommand.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         class FixPlanePointsCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<FixPlanePointsCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<FixPlanePointsCommand> Ptr;
         private:
             typedef enum {
                 Action_SnapPoints,

--- a/common/src/Controller/MoveBrushEdgesCommand.h
+++ b/common/src/Controller/MoveBrushEdgesCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class MoveBrushEdgesCommand : public BrushVertexHandleCommand {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<MoveBrushEdgesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<MoveBrushEdgesCommand> Ptr;
         private:
             typedef std::map<Model::Brush*, Edge3::List> BrushEdgesMap;
             

--- a/common/src/Controller/MoveBrushFacesCommand.h
+++ b/common/src/Controller/MoveBrushFacesCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class MoveBrushFacesCommand : public BrushVertexHandleCommand {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<MoveBrushFacesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<MoveBrushFacesCommand> Ptr;
         private:
             typedef std::map<Model::Brush*, Polygon3::List> BrushFacesMap;
             

--- a/common/src/Controller/MoveBrushVerticesCommand.h
+++ b/common/src/Controller/MoveBrushVerticesCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class MoveBrushVerticesCommand : public BrushVertexHandleCommand {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<MoveBrushVerticesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<MoveBrushVerticesCommand> Ptr;
         private:
             typedef std::map<Model::Brush*, Vec3::List> BrushVerticesMap;
 

--- a/common/src/Controller/MoveTexturesCommand.h
+++ b/common/src/Controller/MoveTexturesCommand.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         class MoveTexturesCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<MoveTexturesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<MoveTexturesCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             Model::BrushFaceList m_faces;

--- a/common/src/Controller/NewDocumentCommand.h
+++ b/common/src/Controller/NewDocumentCommand.h
@@ -37,7 +37,7 @@ namespace TrenchBroom {
         class NewDocumentCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<NewDocumentCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<NewDocumentCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             BBox3 m_worldBounds;

--- a/common/src/Controller/OpenDocumentCommand.h
+++ b/common/src/Controller/OpenDocumentCommand.h
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         class OpenDocumentCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<OpenDocumentCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<OpenDocumentCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             BBox3 m_worldBounds;

--- a/common/src/Controller/ReparentBrushesCommand.h
+++ b/common/src/Controller/ReparentBrushesCommand.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         class ReparentBrushesCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<ReparentBrushesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<ReparentBrushesCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             Model::BrushList m_brushes;

--- a/common/src/Controller/ResizeBrushesCommand.h
+++ b/common/src/Controller/ResizeBrushesCommand.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         class ResizeBrushesCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<ResizeBrushesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<ResizeBrushesCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             Model::BrushFaceList m_faces;

--- a/common/src/Controller/RotateTexturesCommand.h
+++ b/common/src/Controller/RotateTexturesCommand.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         class RotateTexturesCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<RotateTexturesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<RotateTexturesCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             Model::BrushFaceList m_faces;

--- a/common/src/Controller/SelectionCommand.h
+++ b/common/src/Controller/SelectionCommand.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         class SelectionCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<SelectionCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<SelectionCommand> Ptr;
 
             typedef enum {
                 Action_SelectObjects,

--- a/common/src/Controller/SetEntityDefinitionFileCommand.h
+++ b/common/src/Controller/SetEntityDefinitionFileCommand.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         class SetEntityDefinitionFileCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<SetEntityDefinitionFileCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<SetEntityDefinitionFileCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             Model::EntityDefinitionFileSpec m_newSpec;

--- a/common/src/Controller/SetModsCommand.h
+++ b/common/src/Controller/SetModsCommand.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         class SetModsCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<SetModsCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<SetModsCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             StringList m_newMods;

--- a/common/src/Controller/SnapBrushVerticesCommand.h
+++ b/common/src/Controller/SnapBrushVerticesCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class SnapBrushVerticesCommand : public BrushVertexHandleCommand {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<SnapBrushVerticesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<SnapBrushVerticesCommand> Ptr;
         private:
             typedef std::map<Model::Brush*, Vec3::List> BrushVerticesMap;
             

--- a/common/src/Controller/SplitBrushEdgesCommand.h
+++ b/common/src/Controller/SplitBrushEdgesCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class SplitBrushEdgesCommand : public BrushVertexHandleCommand {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<SplitBrushEdgesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<SplitBrushEdgesCommand> Ptr;
         private:
             typedef std::map<Model::Brush*, Edge3::List> BrushEdgesMap;
             

--- a/common/src/Controller/SplitBrushFacesCommand.h
+++ b/common/src/Controller/SplitBrushFacesCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class SplitBrushFacesCommand : public BrushVertexHandleCommand {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<SplitBrushFacesCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<SplitBrushFacesCommand> Ptr;
         private:
             typedef std::map<Model::Brush*, Polygon3::List> BrushFacesMap;
             

--- a/common/src/Controller/TextureCollectionCommand.h
+++ b/common/src/Controller/TextureCollectionCommand.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class TextureCollectionCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<TextureCollectionCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<TextureCollectionCommand> Ptr;
         private:
             typedef enum {
                 Action_Add,

--- a/common/src/Controller/TransformObjectsCommand.h
+++ b/common/src/Controller/TransformObjectsCommand.h
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         class TransformObjectsCommand : public Command {
         public:
             static const CommandType Type;
-            typedef std::tr1::shared_ptr<TransformObjectsCommand> Ptr;
+            typedef TrenchBroom::shared_ptr<TransformObjectsCommand> Ptr;
         private:
             View::MapDocumentWPtr m_document;
             Mat4x4 m_transformation;

--- a/common/src/HitFilter.h
+++ b/common/src/HitFilter.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
     
     class HitFilterChain : public HitFilter {
     private:
-        typedef std::tr1::shared_ptr<HitFilter> FilterPtr;
+        typedef TrenchBroom::shared_ptr<HitFilter> FilterPtr;
         FilterPtr m_filter;
         FilterPtr m_next;
     public:

--- a/common/src/Holder.h
+++ b/common/src/Holder.h
@@ -26,7 +26,7 @@ template <typename T> class Holder;
 
 class BaseHolder {
 public:
-    typedef std::tr1::shared_ptr<BaseHolder> Ptr;
+    typedef TrenchBroom::shared_ptr<BaseHolder> Ptr;
     virtual ~BaseHolder() {}
     
     template <typename T>

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
             using Model::GameConfig;
 
             const ConfigEntry::Ptr root = m_parser.parse();
-            if (root == NULL)
+            if (root.get() == NULL)
                 throw ParserException("Empty game config");
             
             expectEntry(ConfigEntry::Type_Table, *root);

--- a/common/src/IO/GameFileSystem.cpp
+++ b/common/src/IO/GameFileSystem.cpp
@@ -95,7 +95,7 @@ namespace TrenchBroom {
                 const FSPtr fileSystem = *it;
                 if (fileSystem->fileExists(path)) {
                     const MappedFile::Ptr file = fileSystem->openFile(path);
-                    if (file != NULL)
+                    if (file.get() != NULL)
                         return file;
                 }
             }

--- a/common/src/IO/GameFileSystem.h
+++ b/common/src/IO/GameFileSystem.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         
         class GameFileSystem : public FileSystem {
         private:
-            typedef std::tr1::shared_ptr<FileSystem> FSPtr;
+            typedef TrenchBroom::shared_ptr<FileSystem> FSPtr;
             typedef std::vector<FSPtr> FileSystemList;
             FileSystemList m_fileSystems;
         public:

--- a/common/src/IO/MappedFile.h
+++ b/common/src/IO/MappedFile.h
@@ -37,7 +37,7 @@ namespace TrenchBroom {
         
         class MappedFile {
         public:
-            typedef std::tr1::shared_ptr<MappedFile> Ptr;
+            typedef TrenchBroom::shared_ptr<MappedFile> Ptr;
             typedef std::vector<Ptr> List;
         private:
             const char* m_begin;

--- a/common/src/IO/Wad.cpp
+++ b/common/src/IO/Wad.cpp
@@ -83,7 +83,7 @@ namespace TrenchBroom {
 
         Wad::Wad(const Path& path) {
             m_file = Disk::openFile(path);
-            if (m_file == NULL)
+            if (m_file.get() == NULL)
                 throw AssetException("Cannot open wad file " + path.asString());
             loadEntries();
         }

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -44,7 +44,7 @@ namespace TrenchBroom {
         class BrushSnapshot {
         private:
             struct FacesHolder {
-                typedef std::tr1::shared_ptr<FacesHolder> Ptr;
+                typedef TrenchBroom::shared_ptr<FacesHolder> Ptr;
                 BrushFaceList faces;
                 ~FacesHolder();
             };

--- a/common/src/Model/FaceAdjacencyGraph.h
+++ b/common/src/Model/FaceAdjacencyGraph.h
@@ -38,7 +38,7 @@ namespace TrenchBroom {
             
             class Edge {
             public:
-                typedef std::tr1::shared_ptr<Edge> Ptr;
+                typedef TrenchBroom::shared_ptr<Edge> Ptr;
                 typedef std::vector<Ptr> List;
             private:
                 Node* m_node1;

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -93,7 +93,7 @@ namespace TrenchBroom {
                 return GamePtr();
             
             const IO::MappedFile::Ptr file = IO::Disk::openFile(IO::Disk::fixPath(path));
-            if (file == NULL)
+            if (file.get() == NULL)
                 return GamePtr();
             
             // we will try to detect a comment in the beginning of the file formatted like so:

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -34,7 +34,7 @@ namespace TrenchBroom {
     namespace Model {
         class GameImpl : public Game {
         private:
-            typedef std::tr1::shared_ptr<IO::MapWriter> MapWriterPtr;
+            typedef TrenchBroom::shared_ptr<IO::MapWriter> MapWriterPtr;
             
             GameConfig m_config;
             IO::Path m_gamePath;

--- a/common/src/Model/ModelTypes.h
+++ b/common/src/Model/ModelTypes.h
@@ -93,7 +93,7 @@ namespace TrenchBroom {
         typedef std::vector<Pickable*> PickableList;
         
         class Game;
-        typedef std::tr1::shared_ptr<Game> GamePtr;
+        typedef TrenchBroom::shared_ptr<Game> GamePtr;
 
         typedef std::map<Vec3, BrushList, Vec3::LexicographicOrder> VertexToBrushesMap;
         typedef std::map<Vec3, BrushEdgeList, Vec3::LexicographicOrder> VertexToEdgesMap;

--- a/common/src/Model/Octree.h
+++ b/common/src/Model/Octree.h
@@ -165,7 +165,7 @@ namespace TrenchBroom {
         public:
             typedef std::vector<T> List;
         private:
-            typedef std::tr1::shared_ptr<OctreeNode<F,T> > NodePtr;
+            typedef TrenchBroom::shared_ptr<OctreeNode<F,T> > NodePtr;
             BBox<F,3> m_bounds;
             NodePtr m_root;
         public:

--- a/common/src/Renderer/TextRenderer.h
+++ b/common/src/Renderer/TextRenderer.h
@@ -50,7 +50,7 @@ namespace TrenchBroom {
         
         class TextAnchor {
         public:
-            typedef std::tr1::shared_ptr<TextAnchor> Ptr;
+            typedef TrenchBroom::shared_ptr<TextAnchor> Ptr;
         public:
             virtual ~TextAnchor() {}
             Vec3f offset(const Camera& camera, const Vec2f& size) const;

--- a/common/src/Renderer/Vbo.h
+++ b/common/src/Renderer/Vbo.h
@@ -60,7 +60,7 @@ namespace TrenchBroom {
         
         class Vbo {
         public:
-            typedef std::tr1::shared_ptr<Vbo> Ptr;
+            typedef TrenchBroom::shared_ptr<Vbo> Ptr;
         private:
             typedef std::vector<VboBlock*> VboBlockList;
             static const float GrowthFactor;

--- a/common/src/Renderer/VertexArray.cpp
+++ b/common/src/Renderer/VertexArray.cpp
@@ -48,11 +48,11 @@ namespace TrenchBroom {
         }
 
         size_t VertexArray::size() const {
-            return m_holder == NULL ? 0 : m_holder->size();
+            return m_holder.get() == NULL ? 0 : m_holder->size();
         }
 
         size_t VertexArray::vertexCount() const {
-            return m_holder == NULL ? 0 : m_holder->vertexCount();
+            return m_holder.get() == NULL ? 0 : m_holder->vertexCount();
         }
 
         bool VertexArray::prepared() const {
@@ -60,7 +60,7 @@ namespace TrenchBroom {
         }
 
         void VertexArray::prepare(Vbo& vbo) {
-            if (!m_prepared && m_holder != NULL && m_holder->vertexCount() > 0)
+            if (!m_prepared && m_holder.get() != NULL && m_holder->vertexCount() > 0)
                 m_holder->prepare(vbo);
             m_prepared = true;
         }
@@ -68,7 +68,7 @@ namespace TrenchBroom {
         void VertexArray::render() {
             assert(m_prepared);
             
-            if (m_holder == NULL || m_holder->vertexCount() == 0)
+            if (m_holder.get() == NULL || m_holder->vertexCount() == 0)
                 return;
 
             m_holder->setup();

--- a/common/src/Renderer/VertexArray.h
+++ b/common/src/Renderer/VertexArray.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
     namespace Renderer {
         class BaseHolder {
         public:
-            typedef std::tr1::shared_ptr<BaseHolder> Ptr;
+            typedef TrenchBroom::shared_ptr<BaseHolder> Ptr;
             virtual ~BaseHolder() {}
             
             virtual size_t vertexCount() const = 0;

--- a/common/src/SharedPointer.h
+++ b/common/src/SharedPointer.h
@@ -22,30 +22,42 @@
 
 #include <cassert>
 
-#if defined _MSC_VER
+#if defined(_MSC_VER) || defined(__clang__)
 #include <memory>
+namespace TrenchBroom {
+    using std::shared_ptr;
+    using std::weak_ptr;
+    using std::static_pointer_cast;
+    using std::enable_shared_from_this;
+}
 #else
 #include <tr1/memory>
+namespace TrenchBroom {
+    using std::tr1::shared_ptr;
+    using std::tr1::weak_ptr;
+    using std::tr1::static_pointer_cast;
+    using std::tr1::enable_shared_from_this;
+}
 #endif
 
 template <typename T>
-std::tr1::shared_ptr<T> lock(std::tr1::shared_ptr<T> ptr) {
+TrenchBroom::shared_ptr<T> lock(TrenchBroom::shared_ptr<T> ptr) {
     return ptr;
 }
 
 template <typename T>
-bool expired(std::tr1::shared_ptr<T> ptr) {
+bool expired(TrenchBroom::shared_ptr<T> ptr) {
     return true;
 }
 
 template <typename T>
-std::tr1::shared_ptr<T> lock(std::tr1::weak_ptr<T> ptr) {
+TrenchBroom::shared_ptr<T> lock(TrenchBroom::weak_ptr<T> ptr) {
     assert(!ptr.expired());
     return ptr.lock();
 }
 
 template <typename T>
-bool expired(std::tr1::weak_ptr<T> ptr) {
+bool expired(TrenchBroom::weak_ptr<T> ptr) {
     return ptr.expired();
 }
 

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -108,7 +108,7 @@ namespace TrenchBroom {
                 const IO::Path path(pathStr);
                 const Model::GameFactory& gameFactory = Model::GameFactory::instance();
                 Model::GamePtr game = gameFactory.detectGame(path);
-                if (game == NULL) {
+                if (game.get() == NULL) {
                     String gameName;
                     if (!OpenDocumentGameDialog::showDialog(NULL, gameName))
                         return false;

--- a/common/src/View/Animation.h
+++ b/common/src/View/Animation.h
@@ -38,7 +38,7 @@ namespace TrenchBroom {
             typedef int Type;
             static const Type NoType = -1;
             
-            typedef std::tr1::shared_ptr<Animation> Ptr;
+            typedef TrenchBroom::shared_ptr<Animation> Ptr;
             typedef std::vector<Ptr> List;
             
             typedef enum {

--- a/common/src/View/ExecutableEvent.h
+++ b/common/src/View/ExecutableEvent.h
@@ -29,7 +29,7 @@ namespace TrenchBroom {
         public:
             class Executable {
             public:
-                typedef std::tr1::shared_ptr<Executable> Ptr;
+                typedef TrenchBroom::shared_ptr<Executable> Ptr;
             public:
                 virtual ~Executable();
                 void operator()();

--- a/common/src/View/GLContextHolder.h
+++ b/common/src/View/GLContextHolder.h
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         class GLContextHolder {
         public:
             typedef std::vector<int> GLAttribs;
-            typedef std::tr1::shared_ptr<GLContextHolder> Ptr;
+            typedef TrenchBroom::shared_ptr<GLContextHolder> Ptr;
         private:
             wxGLContext* m_context;
         public:

--- a/common/src/View/KeyboardPreferencePane.h
+++ b/common/src/View/KeyboardPreferencePane.h
@@ -65,7 +65,7 @@ namespace TrenchBroom {
 
         class ActionEntry {
         public:
-            typedef std::tr1::shared_ptr<ActionEntry> Ptr;
+            typedef TrenchBroom::shared_ptr<ActionEntry> Ptr;
         private:
             Action& m_action;
             bool m_conflicts;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -295,7 +295,7 @@ namespace TrenchBroom {
         }
         
         bool MapDocument::isGamePathPreference(const IO::Path& path) const {
-            return m_game != NULL && m_game->isGamePathPreference(path);
+            return m_game.get() != NULL && m_game->isGamePathPreference(path);
         }
 
         bool MapDocument::modified() const {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         public:
             static const BBox3 DefaultWorldBounds;
         private:
-            typedef std::tr1::weak_ptr<MapDocument> WkPtr;
+            typedef TrenchBroom::weak_ptr<MapDocument> WkPtr;
             
             BBox3 m_worldBounds;
             IO::Path m_path;

--- a/common/src/View/Menu.h
+++ b/common/src/View/Menu.h
@@ -45,7 +45,7 @@ namespace TrenchBroom {
                 Type_Menu
             } Type;
             
-            typedef std::tr1::shared_ptr<MenuItem> Ptr;
+            typedef TrenchBroom::shared_ptr<MenuItem> Ptr;
             typedef std::vector<Ptr> List;
         private:
             Type m_type;

--- a/common/src/View/SmartColorEditor.cpp
+++ b/common/src/View/SmartColorEditor.cpp
@@ -44,7 +44,7 @@ namespace TrenchBroom {
         SmartColorEditor::ColorPtr SmartColorEditor::Color::parseColor(const String& str) {
             const StringList components = StringUtils::splitAndTrim(str, " ");
             if (components.size() != 3)
-                return ColorPtr(new ByteColor(0, 0, 0));
+                return NonConstColorPtr(new ByteColor(0, 0, 0));
             
             const ColorRange range = detectRange(components);
             assert(range != ColorRange_Mixed);
@@ -53,17 +53,17 @@ namespace TrenchBroom {
                 const int r = std::atoi(components[0].c_str());
                 const int g = std::atoi(components[1].c_str());
                 const int b = std::atoi(components[2].c_str());
-                return ColorPtr(new ByteColor(r, g, b));
+                return NonConstColorPtr(new ByteColor(r, g, b));
             }
             
             const float r = static_cast<float>(std::atof(components[0].c_str()));
             const float g = static_cast<float>(std::atof(components[1].c_str()));
             const float b = static_cast<float>(std::atof(components[2].c_str()));
-            return ColorPtr(new FloatColor(r, g, b));
+            return NonConstColorPtr(new FloatColor(r, g, b));
         }
         
         SmartColorEditor::ColorPtr SmartColorEditor::Color::fromWxColor(const wxColor& wxColor, const ColorRange range) {
-            ColorPtr byteColor(new ByteColor(wxColor.Red(), wxColor.Green(), wxColor.Blue()));
+            NonConstColorPtr byteColor(new ByteColor(wxColor.Red(), wxColor.Green(), wxColor.Blue()));
             return byteColor->toColor(range);
         }
 
@@ -105,7 +105,7 @@ namespace TrenchBroom {
         }
         
         SmartColorEditor::ColorPtr SmartColorEditor::FloatColor::toByteColor() const {
-            return ColorPtr(new ByteColor(static_cast<int>(Math::round(r() * 255.0f)),
+            return NonConstColorPtr(new ByteColor(static_cast<int>(Math::round(r() * 255.0f)),
                                           static_cast<int>(Math::round(g() * 255.0f)),
                                           static_cast<int>(Math::round(b() * 255.0f))));
         }
@@ -148,7 +148,7 @@ namespace TrenchBroom {
         }
         
         SmartColorEditor::ColorPtr SmartColorEditor::ByteColor::toFloatColor() const {
-            return ColorPtr(new FloatColor(static_cast<float>(r()) / 255.0f,
+            return NonConstColorPtr(new FloatColor(static_cast<float>(r()) / 255.0f,
                                            static_cast<float>(g()) / 255.0f,
                                            static_cast<float>(b()) / 255.0f));
         }

--- a/common/src/View/SmartColorEditor.h
+++ b/common/src/View/SmartColorEditor.h
@@ -49,9 +49,9 @@ namespace TrenchBroom {
             } ColorRange;
 
             class Color;
-            typedef std::tr1::shared_ptr<const Color> ColorPtr;
+            typedef TrenchBroom::shared_ptr<const Color> ColorPtr;
             
-            class Color : public std::tr1::enable_shared_from_this<Color> {
+            class Color : public TrenchBroom::enable_shared_from_this<Color> {
             public:
                 virtual ~Color();
                 
@@ -109,7 +109,8 @@ namespace TrenchBroom {
         private:
             static const size_t ColorHistoryCellSize = 15;
             typedef std::vector<wxColour> wxColorList;
-            
+            typedef TrenchBroom::shared_ptr<Color> NonConstColorPtr;
+
             wxPanel* m_panel;
             wxRadioButton* m_floatRadio;
             wxRadioButton* m_byteRadio;

--- a/common/src/View/SmartPropertyEditorManager.cpp
+++ b/common/src/View/SmartPropertyEditorManager.cpp
@@ -124,7 +124,7 @@ namespace TrenchBroom {
         }
         
         void SmartPropertyEditorManager::deactivateEditor() {
-            if (m_activeEditor != NULL) {
+            if (m_activeEditor.get() != NULL) {
                 m_activeEditor->deactivate();
                 m_activeEditor = EditorPtr();
                 m_key = "";
@@ -132,7 +132,7 @@ namespace TrenchBroom {
         }
 
         void SmartPropertyEditorManager::updateEditor() {
-            if (m_activeEditor != NULL) {
+            if (m_activeEditor.get() != NULL) {
                 MapDocumentSPtr document = lock(m_document);
                 m_activeEditor->update(document->allSelectedEntities());
             }

--- a/common/src/View/SmartPropertyEditorManager.h
+++ b/common/src/View/SmartPropertyEditorManager.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         
         class SmartPropertyEditorManager : public wxPanel {
         private:
-            typedef std::tr1::shared_ptr<SmartPropertyEditor> EditorPtr;
-            typedef std::tr1::shared_ptr<SmartPropertyEditorMatcher> MatcherPtr;
+            typedef TrenchBroom::shared_ptr<SmartPropertyEditor> EditorPtr;
+            typedef TrenchBroom::shared_ptr<SmartPropertyEditorMatcher> MatcherPtr;
             typedef std::pair<MatcherPtr, EditorPtr> MatcherEditorPair;
             typedef std::vector<MatcherEditorPair> EditorList;
             

--- a/common/src/View/ViewTypes.h
+++ b/common/src/View/ViewTypes.h
@@ -25,12 +25,12 @@
 namespace TrenchBroom {
     namespace View {
         class ControllerFacade;
-        typedef std::tr1::shared_ptr<ControllerFacade> ControllerSPtr;
-        typedef std::tr1::weak_ptr<ControllerFacade> ControllerWPtr;
+        typedef TrenchBroom::shared_ptr<ControllerFacade> ControllerSPtr;
+        typedef TrenchBroom::weak_ptr<ControllerFacade> ControllerWPtr;
         
         class MapDocument;
-        typedef std::tr1::shared_ptr<MapDocument> MapDocumentSPtr;
-        typedef std::tr1::weak_ptr<MapDocument> MapDocumentWPtr;
+        typedef TrenchBroom::shared_ptr<MapDocument> MapDocumentSPtr;
+        typedef TrenchBroom::weak_ptr<MapDocument> MapDocumentWPtr;
         
         typedef enum {
             RotationAxis_Roll,

--- a/common/src/tags
+++ b/common/src/tags
@@ -407,11 +407,11 @@ Color	Color.cpp	/^Color::Color(const int r, const int g, const int b, const int 
 Color	Color.cpp	/^Color::Color(const std::string& str) :$/;"	f	language:C++	class:Color
 Color	Color.cpp	/^Color::Color(const unsigned char r, const unsigned char g, const unsigned char b, const unsigned char a) :$/;"	f	language:C++	class:Color
 Color	Color.h	/^class Color : public Vec<float, 4> {$/;"	c	language:C++
-Color	View/SmartColorEditor.h	/^            class Color : public std::tr1::enable_shared_from_this<Color> {$/;"	c	language:C++	class:TrenchBroom::View::SmartColorEditor
+Color	View/SmartColorEditor.h	/^            class Color : public TrenchBroom::enable_shared_from_this<Color> {$/;"	c	language:C++	class:TrenchBroom::View::SmartColorEditor
 ColorCmp	View/SmartColorEditor.cpp	/^        struct ColorCmp {$/;"	s	language:C++	namespace:TrenchBroom::View	file:
 ColorHistoryCellSize	View/SmartColorEditor.h	/^            static const size_t ColorHistoryCellSize = 15;$/;"	m	language:C++	class:TrenchBroom::View::SmartColorEditor
 ColorList	View/ColorTable.h	/^            typedef std::vector<wxColour> ColorList;$/;"	t	language:C++	class:TrenchBroom::View::ColorTable
-ColorPtr	View/SmartColorEditor.h	/^            typedef std::tr1::shared_ptr<const Color> ColorPtr;$/;"	t	language:C++	class:TrenchBroom::View::SmartColorEditor
+ColorPtr	View/SmartColorEditor.h	/^            typedef TrenchBroom::shared_ptr<const Color> ColorPtr;$/;"	t	language:C++	class:TrenchBroom::View::SmartColorEditor
 ColorRange	View/SmartColorEditor.h	/^            } ColorRange;$/;"	t	language:C++	class:TrenchBroom::View::SmartColorEditor	typeref:enum:TrenchBroom::View::SmartColorEditor::__anon36
 ColorRange_Byte	View/SmartColorEditor.h	/^                ColorRange_Byte,$/;"	e	language:C++	enum:TrenchBroom::View::SmartColorEditor::__anon36
 ColorRange_Float	View/SmartColorEditor.h	/^                ColorRange_Float,$/;"	e	language:C++	enum:TrenchBroom::View::SmartColorEditor::__anon36
@@ -554,8 +554,8 @@ Controller	Controller/TransformObjectsCommand.h	/^    namespace Controller {$/;"
 Controller	View/ControllerFacade.h	/^    namespace Controller {$/;"	n	language:C++	namespace:TrenchBroom
 ControllerFacade	View/ControllerFacade.cpp	/^        ControllerFacade::ControllerFacade(MapDocumentWPtr document) :$/;"	f	language:C++	class:TrenchBroom::View::ControllerFacade
 ControllerFacade	View/ControllerFacade.h	/^        class ControllerFacade {$/;"	c	language:C++	namespace:TrenchBroom::View
-ControllerSPtr	View/ViewTypes.h	/^        typedef std::tr1::shared_ptr<ControllerFacade> ControllerSPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
-ControllerWPtr	View/ViewTypes.h	/^        typedef std::tr1::weak_ptr<ControllerFacade> ControllerWPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
+ControllerSPtr	View/ViewTypes.h	/^        typedef TrenchBroom::shared_ptr<ControllerFacade> ControllerSPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
+ControllerWPtr	View/ViewTypes.h	/^        typedef TrenchBroom::weak_ptr<ControllerFacade> ControllerWPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
 ConvertColorRange	View/SmartColorEditor.cpp	/^            ConvertColorRange(View::ControllerSPtr controller, const Model::PropertyKey& key, const SmartColorEditor::ColorRange toRange) :$/;"	f	language:C++	struct:TrenchBroom::View::ConvertColorRange
 ConvertColorRange	View/SmartColorEditor.cpp	/^        struct ConvertColorRange {$/;"	s	language:C++	namespace:TrenchBroom::View	file:
 Converter	Preference.h	/^    class Converter {$/;"	c	language:C++	namespace:TrenchBroom
@@ -806,7 +806,7 @@ EditVertexActions	View/CommandIds.h	/^                const int EditVertexAction
 EditYawObjectsCCW	View/CommandIds.h	/^                const int EditYawObjectsCCW                  = Lowest +  35;$/;"	m	language:C++	namespace:TrenchBroom::View::CommandIds::Menu
 EditYawObjectsCW	View/CommandIds.h	/^                const int EditYawObjectsCW                   = Lowest +  34;$/;"	m	language:C++	namespace:TrenchBroom::View::CommandIds::Menu
 EditorList	View/SmartPropertyEditorManager.h	/^            typedef std::vector<MatcherEditorPair> EditorList;$/;"	t	language:C++	class:TrenchBroom::View::SmartPropertyEditorManager
-EditorPtr	View/SmartPropertyEditorManager.h	/^            typedef std::tr1::shared_ptr<SmartPropertyEditor> EditorPtr;$/;"	t	language:C++	class:TrenchBroom::View::SmartPropertyEditorManager
+EditorPtr	View/SmartPropertyEditorManager.h	/^            typedef TrenchBroom::shared_ptr<SmartPropertyEditor> EditorPtr;$/;"	t	language:C++	class:TrenchBroom::View::SmartPropertyEditorManager
 ElementType	Renderer/AttributeSpec.h	/^            typedef Vec<DataType, S> ElementType;$/;"	t	language:C++	class:TrenchBroom::Renderer::AttributeSpec
 Empty	View/KeyboardShortcut.h	/^            static const KeyboardShortcut Empty;$/;"	m	language:C++	class:TrenchBroom::View::KeyboardShortcut
 EmptyBrushEntityIssue	Model/EmptyBrushEntityIssueGenerator.cpp	/^            EmptyBrushEntityIssue(Entity* entity) :$/;"	f	language:C++	class:TrenchBroom::Model::EmptyBrushEntityIssue
@@ -956,7 +956,7 @@ F	Notifier.h	/^            typedef void (R::*F)(A1 a1);$/;"	t	language:C++	class
 F	Notifier.h	/^            typedef void (R::*F)(A1 a1, A2 a2);$/;"	t	language:C++	class:TrenchBroom::Notifier2::CObserver
 F	Notifier.h	/^            typedef void (R::*F)(A1 a1, A2 a2, A3 a3);$/;"	t	language:C++	class:TrenchBroom::Notifier3::CObserver
 F	SetBool.h	/^        typedef void (R::*F)(bool b);$/;"	t	language:C++	class:TrenchBroom::SetBoolFun
-FSPtr	IO/GameFileSystem.h	/^            typedef std::tr1::shared_ptr<FileSystem> FSPtr;$/;"	t	language:C++	class:TrenchBroom::IO::GameFileSystem
+FSPtr	IO/GameFileSystem.h	/^            typedef TrenchBroom::shared_ptr<FileSystem> FSPtr;$/;"	t	language:C++	class:TrenchBroom::IO::GameFileSystem
 Face	Assets/Bsp29Model.cpp	/^        Bsp29Model::Face::Face(Assets::Texture* texture) :$/;"	f	language:C++	class:TrenchBroom::Assets::Bsp29Model::Face
 Face	Assets/Bsp29Model.h	/^            class Face {$/;"	c	language:C++	class:TrenchBroom::Assets::Bsp29Model
 FaceAdjacencyGraph	Model/FaceAdjacencyGraph.h	/^        class FaceAdjacencyGraph {$/;"	c	language:C++	namespace:TrenchBroom::Model
@@ -1025,7 +1025,7 @@ Filter	Renderer/EntityLinkRenderer.h	/^            class Filter {$/;"	c	language
 FilterEvent	TrenchBroomApp.cpp	/^        int TrenchBroomApp::FilterEvent(wxEvent& event) {$/;"	f	language:C++	class:TrenchBroom::View::TrenchBroomApp
 FilterIterator	FilterIterator.h	/^        FilterIterator(const Iterator& cur, const Iterator& end, const Filter& filter) :$/;"	f	language:C++	class:TrenchBroom::FilterIterator
 FilterIterator	FilterIterator.h	/^    class FilterIterator {$/;"	c	language:C++	namespace:TrenchBroom
-FilterPtr	HitFilter.h	/^        typedef std::tr1::shared_ptr<HitFilter> FilterPtr;$/;"	t	language:C++	class:TrenchBroom::HitFilterChain
+FilterPtr	HitFilter.h	/^        typedef TrenchBroom::shared_ptr<HitFilter> FilterPtr;$/;"	t	language:C++	class:TrenchBroom::HitFilterChain
 FindClosestFaceHit	View/ResizeBrushesTool.cpp	/^            FindClosestFaceHit(const Ray3& pickRay) :$/;"	f	language:C++	struct:TrenchBroom::View::FindClosestFaceHit
 FindClosestFaceHit	View/ResizeBrushesTool.cpp	/^        struct FindClosestFaceHit {$/;"	s	language:C++	namespace:TrenchBroom::View	file:
 FindFlagByValue	Assets/PropertyDefinition.cpp	/^            FindFlagByValue(const int i_value) : value(i_value) {}$/;"	f	language:C++	struct:TrenchBroom::Assets::FindFlagByValue
@@ -1122,7 +1122,7 @@ GameImpl	Model/GameImpl.h	/^        class GameImpl : public Game {$/;"	c	languag
 GameListBox	View/GameListBox.cpp	/^        GameListBox::GameListBox(wxWindow* parent, const long style) :$/;"	f	language:C++	class:TrenchBroom::View::GameListBox
 GameListBox	View/GameListBox.h	/^        class GameListBox : public ImageListBox {$/;"	c	language:C++	namespace:TrenchBroom::View
 GamePathMap	Model/GameFactory.h	/^            typedef std::map<String, Preference<IO::Path> > GamePathMap;$/;"	t	language:C++	class:TrenchBroom::Model::GameFactory
-GamePtr	Model/ModelTypes.h	/^        typedef std::tr1::shared_ptr<Game> GamePtr;$/;"	t	language:C++	namespace:TrenchBroom::Model
+GamePtr	Model/ModelTypes.h	/^        typedef TrenchBroom::shared_ptr<Game> GamePtr;$/;"	t	language:C++	namespace:TrenchBroom::Model
 GameSelectionCommand	View/GameSelectionCommand.cpp	/^        GameSelectionCommand::GameSelectionCommand() :$/;"	f	language:C++	class:TrenchBroom::View::GameSelectionCommand
 GameSelectionCommand	View/GameSelectionCommand.cpp	/^        GameSelectionCommand::GameSelectionCommand(wxEventType type, const String& gameName) :$/;"	f	language:C++	class:TrenchBroom::View::GameSelectionCommand
 GameSelectionCommand	View/GameSelectionCommand.h	/^        class GameSelectionCommand : public wxCommandEvent {$/;"	c	language:C++	namespace:TrenchBroom::View
@@ -1359,7 +1359,7 @@ IntegerPropertyDefinition	Assets/PropertyDefinition.cpp	/^        IntegerPropert
 IntegerPropertyDefinition	Assets/PropertyDefinition.cpp	/^        IntegerPropertyDefinition::IntegerPropertyDefinition(const String& name, const String& description, const int defaultValue) :$/;"	f	language:C++	class:TrenchBroom::Assets::IntegerPropertyDefinition
 IntegerPropertyDefinition	Assets/PropertyDefinition.h	/^        class IntegerPropertyDefinition : public PropertyDefinitionWithDefaultValue<int> {$/;"	c	language:C++	namespace:TrenchBroom::Assets
 InternalBuffer	ByteBuffer.h	/^    typedef std::vector<T> InternalBuffer;$/;"	t	language:C++	class:Buffer
-InternalBufferPtr	ByteBuffer.h	/^    typedef std::tr1::shared_ptr<InternalBuffer> InternalBufferPtr;$/;"	t	language:C++	class:Buffer
+InternalBufferPtr	ByteBuffer.h	/^    typedef TrenchBroom::shared_ptr<InternalBuffer> InternalBufferPtr;$/;"	t	language:C++	class:Buffer
 IntersectBrushGeometryWithFace	Model/IntersectBrushGeometryWithFace.cpp	/^        IntersectBrushGeometryWithFace::IntersectBrushGeometryWithFace(BrushGeometry& geometry, BrushFace* face) :$/;"	f	language:C++	class:TrenchBroom::Model::IntersectBrushGeometryWithFace
 IntersectBrushGeometryWithFace	Model/IntersectBrushGeometryWithFace.h	/^        class IntersectBrushGeometryWithFace : public BrushAlgorithm<AddFaceResult::Code> {$/;"	c	language:C++	namespace:TrenchBroom::Model
 InverseDotOrder	Vec.h	/^        InverseDotOrder(const Vec<T,S>& dir) :$/;"	f	language:C++	class:Vec::InverseDotOrder
@@ -1496,8 +1496,8 @@ Map	Vec.h	/^    typedef std::map<Vec<T,S>, Vec<T,S>, LexicographicOrder> Map;$/;
 MapBrushesIterator	Model/MapBrushesIterator.h	/^        struct MapBrushesIterator {$/;"	s	language:C++	namespace:TrenchBroom::Model
 MapDocument	View/MapDocument.cpp	/^        MapDocument::MapDocument() :$/;"	f	language:C++	class:TrenchBroom::View::MapDocument
 MapDocument	View/MapDocument.h	/^        class MapDocument : public CachingLogger {$/;"	c	language:C++	namespace:TrenchBroom::View
-MapDocumentSPtr	View/ViewTypes.h	/^        typedef std::tr1::shared_ptr<MapDocument> MapDocumentSPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
-MapDocumentWPtr	View/ViewTypes.h	/^        typedef std::tr1::weak_ptr<MapDocument> MapDocumentWPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
+MapDocumentSPtr	View/ViewTypes.h	/^        typedef TrenchBroom::shared_ptr<MapDocument> MapDocumentSPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
+MapDocumentWPtr	View/ViewTypes.h	/^        typedef TrenchBroom::weak_ptr<MapDocument> MapDocumentWPtr;$/;"	t	language:C++	namespace:TrenchBroom::View
 MapEntitiesIterator	Model/MapEntitiesIterator.h	/^        namespace MapEntitiesIterator {$/;"	n	language:C++	namespace:TrenchBroom::Model
 MapFacesIterator	Model/MapFacesIterator.h	/^        struct MapFacesIterator {$/;"	s	language:C++	namespace:TrenchBroom::Model
 MapFormat	Model/ModelTypes.h	/^        namespace MapFormat {$/;"	n	language:C++	namespace:TrenchBroom::Model
@@ -1518,7 +1518,7 @@ MapUtils	CollectionUtils.h	/^namespace MapUtils {$/;"	n	language:C++
 MapView	View/MapView.cpp	/^        MapView::MapView(wxWindow* parent, Logger* logger, View::MapDocumentWPtr document, ControllerWPtr controller, Renderer::Camera& camera) :$/;"	f	language:C++	class:TrenchBroom::View::MapView
 MapView	View/MapView.h	/^        class MapView : public RenderView, public ToolBoxHelper {$/;"	c	language:C++	namespace:TrenchBroom::View
 MapWriter	IO/MapWriter.h	/^        class MapWriter {$/;"	c	language:C++	namespace:TrenchBroom::IO
-MapWriterPtr	Model/GameImpl.h	/^            typedef std::tr1::shared_ptr<IO::MapWriter> MapWriterPtr;$/;"	t	language:C++	class:TrenchBroom::Model::GameImpl
+MapWriterPtr	Model/GameImpl.h	/^            typedef TrenchBroom::shared_ptr<IO::MapWriter> MapWriterPtr;$/;"	t	language:C++	class:TrenchBroom::Model::GameImpl
 Mapped	Renderer/Vbo.h	/^            static const Type Mapped    = 2;$/;"	m	language:C++	namespace:TrenchBroom::Renderer::VboState
 MappedFile	IO/MappedFile.cpp	/^        MappedFile::MappedFile() :$/;"	f	language:C++	class:TrenchBroom::IO::MappedFile
 MappedFile	IO/MappedFile.h	/^        class MappedFile {$/;"	c	language:C++	namespace:TrenchBroom::IO
@@ -1558,7 +1558,7 @@ MatchPartiallySelected	Model/Selection.cpp	/^        struct MatchPartiallySelect
 MatchSelected	Model/Selection.cpp	/^        struct MatchSelected  {$/;"	s	language:C++	namespace:TrenchBroom::Model	file:
 MatchUnselected	Model/Selection.cpp	/^        struct MatchUnselected {$/;"	s	language:C++	namespace:TrenchBroom::Model	file:
 MatcherEditorPair	View/SmartPropertyEditorManager.h	/^            typedef std::pair<MatcherPtr, EditorPtr> MatcherEditorPair;$/;"	t	language:C++	class:TrenchBroom::View::SmartPropertyEditorManager
-MatcherPtr	View/SmartPropertyEditorManager.h	/^            typedef std::tr1::shared_ptr<SmartPropertyEditorMatcher> MatcherPtr;$/;"	t	language:C++	class:TrenchBroom::View::SmartPropertyEditorManager
+MatcherPtr	View/SmartPropertyEditorManager.h	/^            typedef TrenchBroom::shared_ptr<SmartPropertyEditorMatcher> MatcherPtr;$/;"	t	language:C++	class:TrenchBroom::View::SmartPropertyEditorManager
 Math	MathUtils.h	/^namespace Math {$/;"	n	language:C++
 Math	TrenchBroom.h	/^namespace Math {$/;"	n	language:C++
 MatrixDeterminant	Mat.h	/^struct MatrixDeterminant {$/;"	s	language:C++
@@ -1833,7 +1833,7 @@ ModelCache	Assets/EntityModelManager.h	/^            typedef std::map<IO::Path, 
 ModelDefinition	Assets/ModelDefinition.cpp	/^        ModelDefinition::ModelDefinition() {}$/;"	f	language:C++	class:TrenchBroom::Assets::ModelDefinition
 ModelDefinition	Assets/ModelDefinition.h	/^        class ModelDefinition {$/;"	c	language:C++	namespace:TrenchBroom::Assets
 ModelDefinitionList	Assets/AssetTypes.h	/^        typedef std::vector<ModelDefinitionPtr> ModelDefinitionList;$/;"	t	language:C++	namespace:TrenchBroom::Assets
-ModelDefinitionPtr	Assets/AssetTypes.h	/^        typedef std::tr1::shared_ptr<ModelDefinition> ModelDefinitionPtr;$/;"	t	language:C++	namespace:TrenchBroom::Assets
+ModelDefinitionPtr	Assets/AssetTypes.h	/^        typedef TrenchBroom::shared_ptr<ModelDefinition> ModelDefinitionPtr;$/;"	t	language:C++	namespace:TrenchBroom::Assets
 ModelFaceIndex	IO/Bsp29Parser.cpp	/^            static const size_t ModelFaceIndex        = 0x38;$/;"	m	language:C++	namespace:TrenchBroom::IO::BspLayout	file:
 ModelFactory	Model/ModelFactory.cpp	/^        ModelFactory::ModelFactory(const MapFormat::Type format) :$/;"	f	language:C++	class:TrenchBroom::Model::ModelFactory
 ModelFactory	Model/ModelFactory.h	/^        class ModelFactory {$/;"	c	language:C++	namespace:TrenchBroom::Model
@@ -1953,7 +1953,7 @@ Node	Model/FaceAdjacencyGraph.h	/^            class Node {$/;"	c	language:C++	cl
 Node	StringIndex.h	/^            Node(const String& key) :$/;"	f	language:C++	class:TrenchBroom::StringIndex::Node
 Node	StringIndex.h	/^        class Node {$/;"	c	language:C++	class:TrenchBroom::StringIndex
 NodeMap	Model/FaceAdjacencyGraph.h	/^            typedef std::map<Vec3, Node::List, Vec3::LexicographicOrder> NodeMap;$/;"	t	language:C++	class:TrenchBroom::Model::FaceAdjacencyGraph
-NodePtr	Model/Octree.h	/^            typedef std::tr1::shared_ptr<OctreeNode<F,T> > NodePtr;$/;"	t	language:C++	class:TrenchBroom::Model::Octree
+NodePtr	Model/Octree.h	/^            typedef TrenchBroom::shared_ptr<OctreeNode<F,T> > NodePtr;$/;"	t	language:C++	class:TrenchBroom::Model::Octree
 NodeSet	StringIndex.h	/^            typedef std::set<Node> NodeSet;$/;"	t	language:C++	class:TrenchBroom::StringIndex::Node
 NonParallel	Ray.h	/^        static const LineDistance NonParallel(const T rayDistance, const T distance, const Vec<T,S>& point) {$/;"	f	language:C++	struct:Ray::LineDistance
 NopFunc	Renderer/MeshRenderer.cpp	/^        struct NopFunc {$/;"	s	language:C++	namespace:TrenchBroom::Renderer	file:
@@ -2415,7 +2415,7 @@ PropertyDefinition	Assets/PropertyDefinition.cpp	/^        PropertyDefinition::P
 PropertyDefinition	Assets/PropertyDefinition.h	/^        class PropertyDefinition {$/;"	c	language:C++	namespace:TrenchBroom::Assets
 PropertyDefinitionList	Assets/AssetTypes.h	/^        typedef std::vector<PropertyDefinitionPtr> PropertyDefinitionList;$/;"	t	language:C++	namespace:TrenchBroom::Assets
 PropertyDefinitionMap	Assets/AssetTypes.h	/^        typedef std::map<String, PropertyDefinitionPtr> PropertyDefinitionMap;$/;"	t	language:C++	namespace:TrenchBroom::Assets
-PropertyDefinitionPtr	Assets/AssetTypes.h	/^        typedef std::tr1::shared_ptr<PropertyDefinition> PropertyDefinitionPtr;$/;"	t	language:C++	namespace:TrenchBroom::Assets
+PropertyDefinitionPtr	Assets/AssetTypes.h	/^        typedef TrenchBroom::shared_ptr<PropertyDefinition> PropertyDefinitionPtr;$/;"	t	language:C++	namespace:TrenchBroom::Assets
 PropertyDefinitionWithDefaultValue	Assets/PropertyDefinition.h	/^            PropertyDefinitionWithDefaultValue(const String& name, const Type type, const String& description) :$/;"	f	language:C++	class:TrenchBroom::Assets::PropertyDefinitionWithDefaultValue
 PropertyDefinitionWithDefaultValue	Assets/PropertyDefinition.h	/^            PropertyDefinitionWithDefaultValue(const String& name, const Type type, const String& description, const T& defaultValue) :$/;"	f	language:C++	class:TrenchBroom::Assets::PropertyDefinitionWithDefaultValue
 PropertyDefinitionWithDefaultValue	Assets/PropertyDefinition.h	/^        class PropertyDefinitionWithDefaultValue : public PropertyDefinition {$/;"	c	language:C++	namespace:TrenchBroom::Assets
@@ -2432,47 +2432,47 @@ PropertyValue	Model/ModelTypes.h	/^        typedef String PropertyValue;$/;"	t	l
 PropertyValueList	Model/ModelTypes.h	/^        typedef std::vector<PropertyValue> PropertyValueList;$/;"	t	language:C++	namespace:TrenchBroom::Model
 PropertyValues	Model/EntityProperties.cpp	/^        namespace PropertyValues {$/;"	n	language:C++	namespace:TrenchBroom::Model	file:
 PropertyValues	Model/EntityProperties.h	/^        namespace PropertyValues {$/;"	n	language:C++	namespace:TrenchBroom::Model
-Ptr	ConfigTypes.h	/^        typedef std::tr1::shared_ptr<ConfigEntry> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigEntry
-Ptr	ConfigTypes.h	/^        typedef std::tr1::shared_ptr<ConfigList> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigList
-Ptr	ConfigTypes.h	/^        typedef std::tr1::shared_ptr<ConfigTable> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigTable
-Ptr	ConfigTypes.h	/^        typedef std::tr1::shared_ptr<ConfigValue> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigValue
-Ptr	Controller/AddRemoveObjectsCommand.h	/^            typedef std::tr1::shared_ptr<AddRemoveObjectsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::AddRemoveObjectsCommand
-Ptr	Controller/BrushVertexHandleCommand.h	/^            typedef std::tr1::shared_ptr<BrushVertexHandleCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::BrushVertexHandleCommand
-Ptr	Controller/Command.h	/^            typedef std::tr1::shared_ptr<Command> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::Command
-Ptr	Controller/EntityPropertyCommand.h	/^            typedef std::tr1::shared_ptr<EntityPropertyCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::EntityPropertyCommand
-Ptr	Controller/FaceAttributeCommand.h	/^            typedef std::tr1::shared_ptr<FaceAttributeCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::FaceAttributeCommand
-Ptr	Controller/FixPlanePointsCommand.h	/^            typedef std::tr1::shared_ptr<FixPlanePointsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::FixPlanePointsCommand
-Ptr	Controller/MoveBrushEdgesCommand.h	/^            typedef std::tr1::shared_ptr<MoveBrushEdgesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveBrushEdgesCommand
-Ptr	Controller/MoveBrushFacesCommand.h	/^            typedef std::tr1::shared_ptr<MoveBrushFacesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveBrushFacesCommand
-Ptr	Controller/MoveBrushVerticesCommand.h	/^            typedef std::tr1::shared_ptr<MoveBrushVerticesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveBrushVerticesCommand
-Ptr	Controller/MoveTexturesCommand.h	/^            typedef std::tr1::shared_ptr<MoveTexturesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveTexturesCommand
-Ptr	Controller/NewDocumentCommand.h	/^            typedef std::tr1::shared_ptr<NewDocumentCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::NewDocumentCommand
-Ptr	Controller/OpenDocumentCommand.h	/^            typedef std::tr1::shared_ptr<OpenDocumentCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::OpenDocumentCommand
-Ptr	Controller/RebuildBrushGeometryCommand.h	/^            typedef std::tr1::shared_ptr<RebuildBrushGeometryCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::RebuildBrushGeometryCommand
-Ptr	Controller/ReparentBrushesCommand.h	/^            typedef std::tr1::shared_ptr<ReparentBrushesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::ReparentBrushesCommand
-Ptr	Controller/ResizeBrushesCommand.h	/^            typedef std::tr1::shared_ptr<ResizeBrushesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::ResizeBrushesCommand
-Ptr	Controller/RotateTexturesCommand.h	/^            typedef std::tr1::shared_ptr<RotateTexturesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::RotateTexturesCommand
-Ptr	Controller/SelectionCommand.h	/^            typedef std::tr1::shared_ptr<SelectionCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SelectionCommand
-Ptr	Controller/SetEntityDefinitionFileCommand.h	/^            typedef std::tr1::shared_ptr<SetEntityDefinitionFileCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SetEntityDefinitionFileCommand
-Ptr	Controller/SetModsCommand.h	/^            typedef std::tr1::shared_ptr<SetModsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SetModsCommand
-Ptr	Controller/SnapBrushVerticesCommand.h	/^            typedef std::tr1::shared_ptr<SnapBrushVerticesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SnapBrushVerticesCommand
-Ptr	Controller/SplitBrushEdgesCommand.h	/^            typedef std::tr1::shared_ptr<SplitBrushEdgesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SplitBrushEdgesCommand
-Ptr	Controller/SplitBrushFacesCommand.h	/^            typedef std::tr1::shared_ptr<SplitBrushFacesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SplitBrushFacesCommand
-Ptr	Controller/TextureCollectionCommand.h	/^            typedef std::tr1::shared_ptr<TextureCollectionCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::TextureCollectionCommand
-Ptr	Controller/TransformObjectsCommand.h	/^            typedef std::tr1::shared_ptr<TransformObjectsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::TransformObjectsCommand
-Ptr	Holder.h	/^    typedef std::tr1::shared_ptr<BaseHolder> Ptr;$/;"	t	language:C++	class:BaseHolder
-Ptr	IO/MappedFile.h	/^            typedef std::tr1::shared_ptr<MappedFile> Ptr;$/;"	t	language:C++	class:TrenchBroom::IO::MappedFile
-Ptr	Model/Brush.h	/^                typedef std::tr1::shared_ptr<FacesHolder> Ptr;$/;"	t	language:C++	struct:TrenchBroom::Model::BrushSnapshot::FacesHolder
-Ptr	Model/FaceAdjacencyGraph.h	/^                typedef std::tr1::shared_ptr<Edge> Ptr;$/;"	t	language:C++	class:TrenchBroom::Model::FaceAdjacencyGraph::Edge
+Ptr	ConfigTypes.h	/^        typedef TrenchBroom::shared_ptr<ConfigEntry> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigEntry
+Ptr	ConfigTypes.h	/^        typedef TrenchBroom::shared_ptr<ConfigList> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigList
+Ptr	ConfigTypes.h	/^        typedef TrenchBroom::shared_ptr<ConfigTable> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigTable
+Ptr	ConfigTypes.h	/^        typedef TrenchBroom::shared_ptr<ConfigValue> Ptr;$/;"	t	language:C++	class:TrenchBroom::ConfigValue
+Ptr	Controller/AddRemoveObjectsCommand.h	/^            typedef TrenchBroom::shared_ptr<AddRemoveObjectsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::AddRemoveObjectsCommand
+Ptr	Controller/BrushVertexHandleCommand.h	/^            typedef TrenchBroom::shared_ptr<BrushVertexHandleCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::BrushVertexHandleCommand
+Ptr	Controller/Command.h	/^            typedef TrenchBroom::shared_ptr<Command> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::Command
+Ptr	Controller/EntityPropertyCommand.h	/^            typedef TrenchBroom::shared_ptr<EntityPropertyCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::EntityPropertyCommand
+Ptr	Controller/FaceAttributeCommand.h	/^            typedef TrenchBroom::shared_ptr<FaceAttributeCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::FaceAttributeCommand
+Ptr	Controller/FixPlanePointsCommand.h	/^            typedef TrenchBroom::shared_ptr<FixPlanePointsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::FixPlanePointsCommand
+Ptr	Controller/MoveBrushEdgesCommand.h	/^            typedef TrenchBroom::shared_ptr<MoveBrushEdgesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveBrushEdgesCommand
+Ptr	Controller/MoveBrushFacesCommand.h	/^            typedef TrenchBroom::shared_ptr<MoveBrushFacesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveBrushFacesCommand
+Ptr	Controller/MoveBrushVerticesCommand.h	/^            typedef TrenchBroom::shared_ptr<MoveBrushVerticesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveBrushVerticesCommand
+Ptr	Controller/MoveTexturesCommand.h	/^            typedef TrenchBroom::shared_ptr<MoveTexturesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::MoveTexturesCommand
+Ptr	Controller/NewDocumentCommand.h	/^            typedef TrenchBroom::shared_ptr<NewDocumentCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::NewDocumentCommand
+Ptr	Controller/OpenDocumentCommand.h	/^            typedef TrenchBroom::shared_ptr<OpenDocumentCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::OpenDocumentCommand
+Ptr	Controller/RebuildBrushGeometryCommand.h	/^            typedef TrenchBroom::shared_ptr<RebuildBrushGeometryCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::RebuildBrushGeometryCommand
+Ptr	Controller/ReparentBrushesCommand.h	/^            typedef TrenchBroom::shared_ptr<ReparentBrushesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::ReparentBrushesCommand
+Ptr	Controller/ResizeBrushesCommand.h	/^            typedef TrenchBroom::shared_ptr<ResizeBrushesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::ResizeBrushesCommand
+Ptr	Controller/RotateTexturesCommand.h	/^            typedef TrenchBroom::shared_ptr<RotateTexturesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::RotateTexturesCommand
+Ptr	Controller/SelectionCommand.h	/^            typedef TrenchBroom::shared_ptr<SelectionCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SelectionCommand
+Ptr	Controller/SetEntityDefinitionFileCommand.h	/^            typedef TrenchBroom::shared_ptr<SetEntityDefinitionFileCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SetEntityDefinitionFileCommand
+Ptr	Controller/SetModsCommand.h	/^            typedef TrenchBroom::shared_ptr<SetModsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SetModsCommand
+Ptr	Controller/SnapBrushVerticesCommand.h	/^            typedef TrenchBroom::shared_ptr<SnapBrushVerticesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SnapBrushVerticesCommand
+Ptr	Controller/SplitBrushEdgesCommand.h	/^            typedef TrenchBroom::shared_ptr<SplitBrushEdgesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SplitBrushEdgesCommand
+Ptr	Controller/SplitBrushFacesCommand.h	/^            typedef TrenchBroom::shared_ptr<SplitBrushFacesCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::SplitBrushFacesCommand
+Ptr	Controller/TextureCollectionCommand.h	/^            typedef TrenchBroom::shared_ptr<TextureCollectionCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::TextureCollectionCommand
+Ptr	Controller/TransformObjectsCommand.h	/^            typedef TrenchBroom::shared_ptr<TransformObjectsCommand> Ptr;$/;"	t	language:C++	class:TrenchBroom::Controller::TransformObjectsCommand
+Ptr	Holder.h	/^    typedef TrenchBroom::shared_ptr<BaseHolder> Ptr;$/;"	t	language:C++	class:BaseHolder
+Ptr	IO/MappedFile.h	/^            typedef TrenchBroom::shared_ptr<MappedFile> Ptr;$/;"	t	language:C++	class:TrenchBroom::IO::MappedFile
+Ptr	Model/Brush.h	/^                typedef TrenchBroom::shared_ptr<FacesHolder> Ptr;$/;"	t	language:C++	struct:TrenchBroom::Model::BrushSnapshot::FacesHolder
+Ptr	Model/FaceAdjacencyGraph.h	/^                typedef TrenchBroom::shared_ptr<Edge> Ptr;$/;"	t	language:C++	class:TrenchBroom::Model::FaceAdjacencyGraph::Edge
 Ptr	Renderer/FontTexture.h	/^            typedef std::auto_ptr<FontTexture> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::FontTexture
-Ptr	Renderer/TextRenderer.h	/^            typedef std::tr1::shared_ptr<TextAnchor> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::TextAnchor
-Ptr	Renderer/Vbo.h	/^            typedef std::tr1::shared_ptr<Vbo> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::Vbo
-Ptr	Renderer/VertexArray.h	/^            typedef std::tr1::shared_ptr<BaseHolder> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::BaseHolder
-Ptr	View/Animation.h	/^            typedef std::tr1::shared_ptr<Animation> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::Animation
-Ptr	View/ExecutableEvent.h	/^                typedef std::tr1::shared_ptr<Executable> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::ExecutableEvent::Executable
-Ptr	View/GLContextHolder.h	/^            typedef std::tr1::shared_ptr<GLContextHolder> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::GLContextHolder
-Ptr	View/KeyboardPreferencePane.h	/^            typedef std::tr1::shared_ptr<KeyboardShortcutEntry> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::KeyboardShortcutEntry
-Ptr	View/Menu.h	/^            typedef std::tr1::shared_ptr<MenuItem> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::MenuItem
+Ptr	Renderer/TextRenderer.h	/^            typedef TrenchBroom::shared_ptr<TextAnchor> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::TextAnchor
+Ptr	Renderer/Vbo.h	/^            typedef TrenchBroom::shared_ptr<Vbo> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::Vbo
+Ptr	Renderer/VertexArray.h	/^            typedef TrenchBroom::shared_ptr<BaseHolder> Ptr;$/;"	t	language:C++	class:TrenchBroom::Renderer::BaseHolder
+Ptr	View/Animation.h	/^            typedef TrenchBroom::shared_ptr<Animation> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::Animation
+Ptr	View/ExecutableEvent.h	/^                typedef TrenchBroom::shared_ptr<Executable> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::ExecutableEvent::Executable
+Ptr	View/GLContextHolder.h	/^            typedef TrenchBroom::shared_ptr<GLContextHolder> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::GLContextHolder
+Ptr	View/KeyboardPreferencePane.h	/^            typedef TrenchBroom::shared_ptr<KeyboardShortcutEntry> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::KeyboardShortcutEntry
+Ptr	View/Menu.h	/^            typedef TrenchBroom::shared_ptr<MenuItem> Ptr;$/;"	t	language:C++	class:TrenchBroom::View::MenuItem
 PtrCmp	CollectionUtils.h	/^    struct PtrCmp {$/;"	s	language:C++	namespace:Utils
 Quake	Model/ModelTypes.h	/^            static const Type Quake   = 1 << 1;$/;"	m	language:C++	namespace:TrenchBroom::Model::MapFormat
 Quake2	Model/ModelTypes.h	/^            static const Type Quake2  = 1 << 2;$/;"	m	language:C++	namespace:TrenchBroom::Model::MapFormat
@@ -4347,7 +4347,7 @@ Whitespace	IO/Tokenizer.h	/^        const String Tokenizer<TokenType>::Whitespac
 WinMappedFile	IO/MappedFile.cpp	/^        WinMappedFile::WinMappedFile(const Path& path, std::ios_base::openmode mode) :$/;"	f	language:C++	class:TrenchBroom::IO::WinMappedFile
 WinMappedFile	IO/MappedFile.h	/^        class WinMappedFile : public MappedFile {$/;"	c	language:C++	namespace:TrenchBroom::IO
 WinModifierOrder	View/KeyboardShortcut.h	/^            class WinModifierOrder {$/;"	c	language:C++	class:TrenchBroom::View::KeyboardShortcut
-WkPtr	View/MapDocument.h	/^            typedef std::tr1::weak_ptr<MapDocument> WkPtr;$/;"	t	language:C++	class:TrenchBroom::View::MapDocument
+WkPtr	View/MapDocument.h	/^            typedef TrenchBroom::weak_ptr<MapDocument> WkPtr;$/;"	t	language:C++	class:TrenchBroom::View::MapDocument
 Word	IO/DefParser.h	/^            static const Type Word            = 1 <<  7; \/\/ word$/;"	m	language:C++	namespace:TrenchBroom::IO::DefToken
 Word	IO/FgdParser.h	/^            static const Type Word              = 1 <<  2; \/\/ letter or digits, no whitespace$/;"	m	language:C++	namespace:TrenchBroom::IO::FgdToken
 WordDelims	IO/DefParser.cpp	/^        const String DefTokenizer::WordDelims = " \\t\\n\\r()[]{}?;,=";$/;"	m	language:C++	class:TrenchBroom::IO::DefTokenizer	file:
@@ -5103,7 +5103,7 @@ caption	View/KeyboardPreferencePane.cpp	/^        const String SimpleKeyboardSho
 caseInsensitiveEqual	StringUtils.cpp	/^    bool caseInsensitiveEqual(const String& str1, const String& str2) {$/;"	f	language:C++	namespace:StringUtils
 caseSensitiveEqual	StringUtils.cpp	/^    bool caseSensitiveEqual(const String& str1, const String& str2) {$/;"	f	language:C++	namespace:StringUtils
 cast	CollectionUtils.h	/^    std::vector<O> cast(const std::vector<I>& input) {$/;"	f	language:C++	namespace:VectorUtils
-cast	Controller/Command.h	/^            static std::tr1::shared_ptr<T> cast(Ptr& command) {$/;"	f	language:C++	class:TrenchBroom::Controller::Command
+cast	Controller/Command.h	/^            static TrenchBroom::shared_ptr<T> cast(Ptr& command) {$/;"	f	language:C++	class:TrenchBroom::Controller::Command
 castIterator	CastIterator.h	/^        static CastIterator<Iterator, OutType> castIterator(const Iterator& iterator) {$/;"	f	language:C++	struct:TrenchBroom::MakeCastIterator
 ceil	MathUtils.h	/^    T ceil(const T v) {$/;"	f	language:C++	namespace:Math
 cellAt	View/CellLayout.h	/^            bool cellAt(const float x, const float y, const Cell** result) const {$/;"	f	language:C++	class:TrenchBroom::View::LayoutRow
@@ -6241,8 +6241,8 @@ expect	Preference.h	/^        void expect(const wxString& token, const String& e
 expect	Preference.h	/^        wxString expect(wxStringTokenizer& tokenizer, const String& expected1, const String& expected2 = "", const String& expected3 = "") const {$/;"	f	language:C++	class:TrenchBroom::Converter
 expectEntry	IO/GameConfigParser.cpp	/^        void GameConfigParser::expectEntry(const int typeMask, const ConfigEntry& entry) const {$/;"	f	language:C++	class:TrenchBroom::IO::GameConfigParser
 expectTableEntry	IO/GameConfigParser.cpp	/^        void GameConfigParser::expectTableEntry(const String& key, const int typeMask, const ConfigTable& parent) const {$/;"	f	language:C++	class:TrenchBroom::IO::GameConfigParser
-expired	SharedPointer.h	/^bool expired(std::tr1::shared_ptr<T> ptr) {$/;"	f	language:C++
-expired	SharedPointer.h	/^bool expired(std::tr1::weak_ptr<T> ptr) {$/;"	f	language:C++
+expired	SharedPointer.h	/^bool expired(TrenchBroom::shared_ptr<T> ptr) {$/;"	f	language:C++
+expired	SharedPointer.h	/^bool expired(TrenchBroom::weak_ptr<T> ptr) {$/;"	f	language:C++
 extension	IO/Path.cpp	/^        const String Path::extension() const {$/;"	f	language:C++	class:TrenchBroom::IO::Path
 external	Model/EntityDefinitionFileSpec.cpp	/^        EntityDefinitionFileSpec EntityDefinitionFileSpec::external(const IO::Path& fullPath) {$/;"	f	language:C++	class:TrenchBroom::Model::EntityDefinitionFileSpec
 externalCollectionNames	Assets/TextureManager.cpp	/^        const StringList TextureManager::externalCollectionNames() const {$/;"	f	language:C++	class:TrenchBroom::Assets::TextureManager
@@ -6349,7 +6349,7 @@ findFrame	View/wxUtils.cpp	/^        wxFrame* findFrame(wxWindow* window) {$/;"	
 findFreeBlock	Renderer/Vbo.cpp	/^        Vbo::VboBlockList::iterator Vbo::findFreeBlock(const size_t minCapacity) {$/;"	f	language:C++	class:TrenchBroom::Renderer::Vbo
 findIf	CollectionUtils.h	/^    T* findIf(const std::vector<T*>& vec, const P& predicate) {$/;"	f	language:C++	namespace:VectorUtils
 findIf	CollectionUtils.h	/^    const T* findIf(const std::vector<T>& vec, const P& predicate) {$/;"	f	language:C++	namespace:VectorUtils
-findIf	CollectionUtils.h	/^    const std::tr1::shared_ptr<T> findIf(const std::vector<std::tr1::shared_ptr<T> >& vec, const P& predicate) {$/;"	f	language:C++	namespace:VectorUtils
+findIf	CollectionUtils.h	/^    const TrenchBroom::shared_ptr<T> findIf(const std::vector<TrenchBroom::shared_ptr<T> >& vec, const P& predicate) {$/;"	f	language:C++	namespace:VectorUtils
 findInsertPos	Renderer/OutlineTracer.cpp	/^        OutlineTracer::Position::List::iterator OutlineTracer::findInsertPos(const Position& position, Position::List& positions) const {$/;"	f	language:C++	class:TrenchBroom::Renderer::OutlineTracer
 findIntegerPlanePoints	Model/Brush.cpp	/^        void Brush::findIntegerPlanePoints(const BBox3& worldBounds) {$/;"	f	language:C++	class:TrenchBroom::Model::Brush
 findIntegerPlanePoints	Model/BrushFace.cpp	/^        void BrushFace::findIntegerPlanePoints() {$/;"	f	language:C++	class:TrenchBroom::Model::BrushFace
@@ -6897,8 +6897,8 @@ loadTextures	View/MapDocument.cpp	/^        void MapDocument::loadTextures() {$/
 loadWadTextureCollection	Model/GameImpl.cpp	/^        Assets::TextureCollection* GameImpl::loadWadTextureCollection(const Assets::TextureCollectionSpec& spec) const {$/;"	f	language:C++	class:TrenchBroom::Model::GameImpl
 loadWalTextureCollection	Model/GameImpl.cpp	/^        Assets::TextureCollection* GameImpl::loadWalTextureCollection(const Assets::TextureCollectionSpec& spec) const {$/;"	f	language:C++	class:TrenchBroom::Model::GameImpl
 loaded	Assets/TextureCollection.cpp	/^        bool TextureCollection::loaded() const {$/;"	f	language:C++	class:TrenchBroom::Assets::TextureCollection
-lock	SharedPointer.h	/^std::tr1::shared_ptr<T> lock(std::tr1::shared_ptr<T> ptr) {$/;"	f	language:C++
-lock	SharedPointer.h	/^std::tr1::shared_ptr<T> lock(std::tr1::weak_ptr<T> ptr) {$/;"	f	language:C++
+lock	SharedPointer.h	/^TrenchBroom::shared_ptr<T> lock(TrenchBroom::shared_ptr<T> ptr) {$/;"	f	language:C++
+lock	SharedPointer.h	/^TrenchBroom::shared_ptr<T> lock(TrenchBroom::weak_ptr<T> ptr) {$/;"	f	language:C++
 log	Logger.cpp	/^    void Logger::log(const LogLevel level, const String& message) {$/;"	f	language:C++	class:TrenchBroom::Logger
 log	Logger.cpp	/^    void Logger::log(const LogLevel level, const wxString& message) {$/;"	f	language:C++	class:TrenchBroom::Logger
 log	View/StatusBar.cpp	/^        void StatusBar::log(Logger::LogLevel level, const wxString& message) {$/;"	f	language:C++	class:TrenchBroom::View::StatusBar

--- a/test/src/Model/MockGame.h
+++ b/test/src/Model/MockGame.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
         class Map;
         
         class MockGame;
-        typedef std::tr1::shared_ptr<MockGame> MockGamePtr;
+        typedef TrenchBroom::shared_ptr<MockGame> MockGamePtr;
         
         class MockGame : public Game {
         public:


### PR DESCRIPTION
(`Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)`)

Instead of accessing shared_ptr and related types through std::tr1::, I put them in the TrenchBroom namespace instead (inspired by http://stackoverflow.com/a/6323298 ), though maybe there should be a different namespace for these.

Most of this is just a find/replace of std::tr1:: to TrenchBroom::, except:
- SmartColorEditor: was getting `error: no viable overloaded '='` for the lines like `return ColorPtr(new ByteColor(0, 0, 0));`.  I don't really understand this, but this is a reduced test case that fails to compile with clang:
  
  ```
  #include <memory>
  class Thing: public std::enable_shared_from_this<Thing> {};
  int main() {
    std::shared_ptr<const Thing> foo(new Thing);
    return 0;
  }
  ```
  
  Something about inheriting from enable_shared_from_this conflicts with creating an instance of a class like `std::shared_ptr<const Thing> foo(new Thing);`.  To fix it I removed the `const` in the shared_ptr type.
- clang rejects comparisons between a shared_ptr and NULL like `if (someSharedPtr == NULL)`. I changed these to look like: `someSharedPtr.get() == NULL`, though from what I read you could also do `if (someSharedPtr)` because shared_ptr implements conversion to bool.

Also, the libfreeimage.a included with trenchbroom wouldn't link for me, so I installed it via homebrew and commented out the `IF(APPLE)` part in cmake/FreeImage.cmake, so my homebrew copy was picked up. This isn't included in this commit though.

Finally, there were more tr1 related errors in gtest that I didn't investigate, but I did get a TrenchBroom.app that starts up.
