### PR TITLE
TB1: Fix an uninitialized read of m_forceIntegerFacePoints reported by valgrind

### DIFF
--- a/Source/Model/Face.cpp
+++ b/Source/Model/Face.cpp
@@ -353,6 +353,7 @@ namespace TrenchBroom {
         Face::Face(const BBoxf& worldBounds, bool forceIntegerFacePoints, const Vec3f& point1, const Vec3f& point2, const Vec3f& point3, const String& textureName) : m_worldBounds(worldBounds), m_textureName(textureName) {
             init();
             m_worldBounds = worldBounds;
+            m_forceIntegerFacePoints = forceIntegerFacePoints;
             m_points[0] = point1;
             m_points[1] = point2;
             m_points[2] = point3;


### PR DESCRIPTION
As I was saying on func, I had a test map that seemed to randomly load differently, sometimes the vertices would be in the correct place, and sometimes they would appear to drift.

I think this unitialized read reported by valgrind is the culprit, as it seems to be snapping a face (or not) depending on uninitialized memory. If I change the patch to be `m_forceIntegerFacePoints = true;`, the test map reliably loads with the vertices "drifted" away from where they should be.

Here was the valgrind log:

```
==32250== Conditional jump or move depends on uninitialised value(s)
==32250==    at 0x54B631: TrenchBroom::Model::FindFacePoints::instance(bool) (Face.cpp:34)
==32250==    by 0x54E1A3: TrenchBroom::Model::Face::updatePointsFromBoundary() (Face.cpp:488)
==32250==    by 0x54D31C: TrenchBroom::Model::Face::Face(TrenchBroom::VecMath::BBox<float> const&, bool, TrenchBroom::VecMath::Vec<float, 3ul> const&, TrenchBroom::VecMath::Vec<float, 3ul> const&, TrenchBroom::VecMath::Vec<float, 3ul> const&, std::string const&) (Face.cpp:361)
==32250==    by 0x4E2E6F: TrenchBroom::IO::MapParser::parseFace(TrenchBroom::VecMath::BBox<float> const&, bool) (MapParser.cpp:339)
==32250==    by 0x4E1C5F: TrenchBroom::IO::MapParser::parseBrush(TrenchBroom::VecMath::BBox<float> const&, bool, TrenchBroom::Utility::ProgressIndicator*) (MapParser.cpp:244)
==32250==    by 0x4E1606: TrenchBroom::IO::MapParser::parseEntity(TrenchBroom::VecMath::BBox<float> const&, TrenchBroom::IO::MapParser::FacePointFormat&, TrenchBroom::Utility::ProgressIndicator*) (MapParser.cpp:165)
==32250==    by 0x4E1A55: TrenchBroom::IO::MapParser::parseMap(TrenchBroom::Model::Map&, TrenchBroom::Utility::ProgressIndicator*) (MapParser.cpp:213)
==32250==    by 0x55731D: TrenchBroom::Model::MapDocument::loadMap(char*, char*, TrenchBroom::Utility::ProgressIndicator&) (MapDocument.cpp:136)
==32250==    by 0x556AE9: TrenchBroom::Model::MapDocument::DoOpenDocument(wxString const&) (MapDocument.cpp:79)
==32250==    by 0x727FBF: wxDocument::OnOpenDocument(wxString const&) (docview.cpp:417)
==32250==    by 0x55A325: TrenchBroom::Model::MapDocument::OnOpenDocument(wxString const&) (MapDocument.cpp:668)
==32250==    by 0x72C861: wxDocManager::CreateDocument(wxString const&, long) (docview.cpp:1522)
```

Here is a test map:

```
{
"classname" "worldspawn"
}
{
"spawnflags" "0"
"classname" "func_group"
{
( -1120 848 3840 ) ( -1135.99658203125 848 3840 ) ( -1120 848 3968 ) church1_2 0 16 180 1 -1
( -1120 848 3840 ) ( -1120 848 3968 ) ( -1120 976 3840 ) church1_2 -16 16 0 1 1
( -1120 976 3840 ) ( -1135.994140625 976 3840 ) ( -1120 848 3840 ) church1_2 0 16 -180 1 -1
( -1120 976 3968 ) ( -1167.994140625 976 3968 ) ( -1120 976 3840 ) church1_2 0 16 180 1 -1
( -1200 943.994140625 3968 ) ( -1200 880.00341796875 3968 ) ( -1168 943.994140625 3840 ) church1_2 -16 16 0 1 1
( -1120 848 3968 ) ( -1167.99658203125 848 3968 ) ( -1120 976 3968 ) church1_2 0 16 -180 1 -1
( -1168 880.00341796875 3840 ) ( -1200 880.00341796875 3968 ) ( -1135.99658203125 848 3840 ) church1_2 0.0101318 -3.34912 0 1 1.0952
( -1168 943.994140625 3840 ) ( -1135.994140625 976 3840 ) ( -1200 943.994140625 3968 ) church1_2 -15.9927 -21.0376 0 1 1.16365
}
{
( -1120 848 3568 ) ( -1136 848 3568 ) ( -1120 848 3584 ) church1_2 0 0 180 1 -1
( -1120 864 3568 ) ( -1120 864 3584 ) ( -1120 976 3568 ) church1_2 -16 0 0 1 1
( -1120 864 3568 ) ( -1120 976 3568 ) ( -1136 864 3568 ) church1_2 0 16 -180 1 -1
( -1136 976 3584 ) ( -1136 976 3568 ) ( -1120 976 3584 ) church1_2 0 0 180 1 -1
( -1168 976 3584 ) ( -1168 864 3584 ) ( -1168 976 3568 ) church1_2 -16 0 0 1 1
( -1136 976 3840 ) ( -1120 976 3840 ) ( -1136 864 3840 ) church1_2 0 16 -180 1 -1
( -1168 880 3568 ) ( -1168 880 3600 ) ( -1136 848 3568 ) church1_2 -15.9857 0 0 1 1
( -1136 976 3568 ) ( -1136 976 3696 ) ( -1168 944 3568 ) church1_2 -16 0 180 1 -1
}
{
( -1120 848 3968 ) ( -1167.9970703125 848 3968 ) ( -1120 848 4064 ) church1_2 0 16 180 1 -1
( -1120 848 3968 ) ( -1120 848 4064 ) ( -1120 976 3968 ) church1_2 -16 16 0 1 1
( -1120 976 3968 ) ( -1167.99365234375 976 3968 ) ( -1120 848 3968 ) church1_2 0 16 -180 1 -1
( -1120 976 4064 ) ( -1223.99365234375 976 4064 ) ( -1120 976 3968 ) church1_2 0 16 180 1 -1
( -1256 943.9951171875 4064 ) ( -1256 880.00341796875 4064 ) ( -1200 943.9951171875 3968 ) church1_2 -16 16 0 1 1
( -1120 848 4064 ) ( -1223.9970703125 848 4064 ) ( -1120 976 4064 ) church1_2 0 16 -180 1 -1
( -1256 880.00341796875 4064 ) ( -1223.9970703125 848 4064 ) ( -1200 880.00341796875 3968 ) church1_2 -7.98328 27.6355 0 1 1.79636
( -1200 943.9951171875 3968 ) ( -1167.99365234375 976 3968 ) ( -1256 943.9951171875 4064 ) church1_2 0 16 180 1 -1
}
}
```
