### PR TITLE
Windows build updates:

### DIFF
--- a/Windows/Build.txt
+++ b/Windows/Build.txt
@@ -1,9 +1,9 @@
 Build environment
-1. You need Microsoft Visual C++ 2010. The Express edition won't work. Sorry.
+1. You need Microsoft Visual C++ 2010. The Express edition will work.
 
 2. wxWidgets
 - Get the binary build of wxWidgets 2.9.5 for your platform from
-  http://sourceforge.net/projects/wxwindows/files/2.9.4/binaries/
+  http://sourceforge.net/projects/wxwindows/files/2.9.5/binaries/
 
   - For 32bit builds, you need the following files:
     - wxWidgets-2.9.5_Headers.7z
@@ -12,9 +12,8 @@ Build environment
     - wxMSW-2.9.5_vc100_ReleasePDB.7z
 
 - Unpack all files into the same directory so that "include" and "lib" directories are at the same level after unpacking.
-- Rename the directory lib/vc100_dll to lib/vc_dll
 - Set up an environment variable named "WXWIN" pointing to the directory that contains the aforementioned directories.
-- Add C:\wxWidgets-2.9.5\lib\vc_dll to the "PATH" environment variable.
+- Add C:\wxWidgets-2.9.5\lib\vc100_dll to the "PATH" environment variable.
 
 3. Build
 Open the Visual Studio solution at Windows/TrenchBroom.sln and compile / run it!

--- a/Windows/TrenchBroom/TrenchBroom.vcxproj
+++ b/Windows/TrenchBroom/TrenchBroom.vcxproj
@@ -108,14 +108,14 @@ XCopy "$(ProjectDir)..\..\Resources\Help\Documentation\*" "$(TargetDir)Resources
 Copy "$(ProjectDir)..\Lib\freetype6.dll" "$(TargetDir)"
 Copy "$(ProjectDir)..\Lib\zlib1.dll" "$(TargetDir)"
 
-Copy "$(WXWIN)\lib\vc_dll\wxbase295ud_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxbase295ud_vc100.pdb" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295ud_core_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295ud_core_vc100.pdb" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295ud_adv_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295ud_adv_vc100.pdb" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295ud_gl_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295ud_gl_vc100.pdb" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxbase295ud_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxbase295ud_vc100.pdb" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295ud_core_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295ud_core_vc100.pdb" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295ud_adv_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295ud_adv_vc100.pdb" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295ud_gl_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295ud_gl_vc100.pdb" "$(TargetDir)"
 </Command>
     </PostBuildEvent>
     <PreBuildEvent>
@@ -188,10 +188,10 @@ XCopy "$(ProjectDir)..\..\Resources\Help\Documentation\*" "$(TargetDir)Resources
 Copy "$(ProjectDir)..\Lib\freetype6.dll" "$(TargetDir)"
 Copy "$(ProjectDir)..\Lib\zlib1.dll" "$(TargetDir)"
 
-Copy "$(WXWIN)\lib\vc_dll\wxbase295u_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295u_core_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295u_adv_vc100.dll" "$(TargetDir)"
-Copy "$(WXWIN)\lib\vc_dll\wxmsw295u_gl_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxbase295u_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295u_core_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295u_adv_vc100.dll" "$(TargetDir)"
+Copy "$(WXWIN)\lib\vc100_dll\wxmsw295u_gl_vc100.dll" "$(TargetDir)"
 </Command>
     </PostBuildEvent>
     <PreBuildEvent>


### PR DESCRIPTION
-replace vc_dll with vc100_dll in TrenchBroom/TrenchBroom.vcxproj
-update build instructions to say VS2010 Express works, remove
step that renames vc100_dll directory to vc_dll
