### PR TITLE
Entity::removeLinkTarget, Entity::removeKillTarget: prevent hang

### DIFF
--- a/Source/Model/Entity.cpp
+++ b/Source/Model/Entity.cpp
@@ -110,6 +110,8 @@ namespace TrenchBroom {
                     it = m_linkTargets.erase(it);
                     continue;
                 }
+		    
+                ++it;
             }
         }
         
@@ -140,6 +142,8 @@ namespace TrenchBroom {
                     it = m_killTargets.erase(it);
                     continue;
                 }
+		    
+                ++it;
             }
         }
         


### PR DESCRIPTION
Prevent an infinite loop that will occurr if neither if() block inside the while() loop executes, by adding ++it at the end of the while() loop. Previously, it was possible for the iterator to not be incremented, so the while() loop would spin endlessly.

Fixes hang when deleting the "target1" key from the trigger_once in this map:

```
{
"spawnflags" "0"
"classname" "worldspawn"
}
{
"spawnflags" "0"
"classname" "item_armor1"
"origin" "48 -0 -0"
"angle" "-0"
"targetname" "a"
}
{
"spawnflags" "0"
"classname" "item_armor1"
"origin" "16 -0 -0"
"angle" "-0"
"targetname" "a"
}
{
"spawnflags" "0"
"classname" "item_armor1"
"origin" "-16 -0 -0"
"angle" "-0"
"targetname" "b"
}
{
"spawnflags" "0"
"classname" "trigger_once"
"target" "a"
"target1" "b"
{
( 32 48 -0 ) ( 32 48 16 ) ( 80 48 -0 ) __TB_empty -16 -0 -0 1 1
( 32 48 -0 ) ( 32 64 -0 ) ( 32 48 16 ) __TB_empty -0 -0 -0 1 1
( 32 48 -0 ) ( 80 48 -0 ) ( 32 64 -0 ) __TB_empty -16 -0 -0 1 1
( 80 80 16 ) ( 32 80 16 ) ( 80 80 -0 ) __TB_empty -16 -0 -0 1 1
( 80 64 16 ) ( 80 64 -0 ) ( 80 48 16 ) __TB_empty -0 -0 -0 1 1
( 80 64 16 ) ( 80 48 16 ) ( 32 64 16 ) __TB_empty -16 -0 -0 1 1
}
}
```
