### PR TITLE
MapParser.cpp: Hack to permit texture names to start with a { character,...

### DIFF
--- a/Source/IO/MapParser.cpp
+++ b/Source/IO/MapParser.cpp
@@ -287,9 +287,16 @@ namespace TrenchBroom {
             expect(TokenType::OParenthesis, token = m_tokenizer.nextToken());
             p3 = parseVector().corrected();
             expect(TokenType::CParenthesis, token = m_tokenizer.nextToken());
-            
-            expect(TokenType::String, token = m_tokenizer.nextToken());
-            String textureName = token.data();
+		
+            String textureName;
+            token = m_tokenizer.nextToken();
+            if (token.type() == TokenType::OBrace) { // Alpha-mask textures start with a { character, which will be its own token
+                expect(TokenType::String, token = m_tokenizer.nextToken());
+                textureName = "{" + token.data();
+            } else {
+                expect(TokenType::String, token);
+                textureName = token.data();
+            }
             
             token = m_tokenizer.nextToken();
             if (m_format == Undefined) {


### PR DESCRIPTION
... fixes https://github.com/kduske/TrenchBroom/issues/576
