### PR TITLE
3342: Allow users to add a task to export an Obj file when compiling.

### DIFF
--- a/common/src/IO/CompilationConfigParser.cpp
+++ b/common/src/IO/CompilationConfigParser.cpp
@@ -103,6 +103,12 @@ namespace TrenchBroom {
             return std::make_unique<Model::CompilationExportMap>(target);
         }
 
+        std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseExportObjTask(const EL::Value& value) const {
+            expectStructure(value, "[ {'type': 'String', 'target': 'String'}, {} ]");
+            const std::string target = value["target"].stringValue();
+            return std::make_unique<Model::CompilationExportObj>(target);
+        }
+
         std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseCopyTask(const EL::Value& value) const {
             expectStructure(value, "[ {'type': 'String', 'source': 'String', 'target': 'String'}, {} ]");
 

--- a/common/src/IO/CompilationConfigParser.h
+++ b/common/src/IO/CompilationConfigParser.h
@@ -51,6 +51,7 @@ namespace TrenchBroom {
             std::vector<std::unique_ptr<Model::CompilationTask>> parseTasks(const EL::Value& value) const;
             std::unique_ptr<Model::CompilationTask> parseTask(const EL::Value& value) const;
             std::unique_ptr<Model::CompilationTask> parseExportTask(const EL::Value& value) const;
+            std::unique_ptr<Model::CompilationTask> parseExportObjTask(const EL::Value& value) const;
             std::unique_ptr<Model::CompilationTask> parseCopyTask(const EL::Value& value) const;
             std::unique_ptr<Model::CompilationTask> parseToolTask(const EL::Value& value) const;
 

--- a/common/src/IO/CompilationConfigWriter.cpp
+++ b/common/src/IO/CompilationConfigWriter.cpp
@@ -74,6 +74,13 @@ namespace TrenchBroom {
                 m_array.push_back(EL::Value(map));
             }
 
+            void visit(const Model::CompilationExportObj& task) override {
+                EL::MapType map;
+                map["type"] = EL::Value("export");
+                map["target"] = EL::Value(task.targetSpec());
+                m_array.push_back(EL::Value(map));
+            }
+
             void visit(const Model::CompilationCopyFiles& task) override {
                 EL::MapType map;
                 map["type"] = EL::Value("copy");

--- a/common/src/Model/CompilationTask.cpp
+++ b/common/src/Model/CompilationTask.cpp
@@ -59,6 +59,38 @@ namespace TrenchBroom {
             return new CompilationExportMap(m_targetSpec);
         }
 
+        CompilationExportObj::CompilationExportObj(const std::string& targetSpec) :
+        m_targetSpec(targetSpec) {}
+
+        void CompilationExportObj::accept(CompilationTaskVisitor& visitor) {
+            visitor.visit(*this);
+        }
+
+        void CompilationExportObj::accept(ConstCompilationTaskVisitor& visitor) const {
+            visitor.visit(*this);
+        }
+
+        void CompilationExportObj::accept(const CompilationTaskConstVisitor& visitor) {
+            visitor.visit(*this);
+        }
+
+        void CompilationExportObj::accept(const ConstCompilationTaskConstVisitor& visitor) const {
+            visitor.visit(*this);
+        }
+
+        const std::string& CompilationExportObj::targetSpec() const {
+            return m_targetSpec;
+        }
+
+        void CompilationExportObj::setTargetSpec(const std::string& targetSpec) {
+            m_targetSpec = targetSpec;
+            taskDidChange();
+        }
+
+        CompilationExportObj* CompilationExportObj::clone() const {
+            return new CompilationExportObj(m_targetSpec);
+        }
+
         CompilationCopyFiles::CompilationCopyFiles(const std::string& sourceSpec, const std::string& targetSpec) :
         CompilationTask(),
         m_sourceSpec(sourceSpec),

--- a/common/src/Model/CompilationTask.h
+++ b/common/src/Model/CompilationTask.h
@@ -71,6 +71,26 @@ namespace TrenchBroom {
             deleteCopyAndMove(CompilationExportMap)
         };
 
+        class CompilationExportObj : public CompilationTask {
+        private:
+            std::string m_targetSpec;
+        public:
+            explicit CompilationExportObj(const std::string& targetSpec);
+
+            void accept(CompilationTaskVisitor& visitor) override;
+            void accept(ConstCompilationTaskVisitor& visitor) const override;
+            void accept(const CompilationTaskConstVisitor& visitor) override;
+            void accept(const ConstCompilationTaskConstVisitor& visitor) const override;
+
+            const std::string& targetSpec() const;
+
+            void setTargetSpec(const std::string& targetSpec);
+
+            CompilationExportObj* clone() const override;
+
+            deleteCopyAndMove(CompilationExportObj)
+        };
+
         class CompilationCopyFiles : public CompilationTask {
         private:
             std::string m_sourceSpec;
@@ -122,6 +142,7 @@ namespace TrenchBroom {
             virtual ~CompilationTaskVisitor();
 
             virtual void visit(CompilationExportMap& task) = 0;
+            virtual void visit(CompilationExportObj& task) = 0;
             virtual void visit(CompilationCopyFiles& task) = 0;
             virtual void visit(CompilationRunTool& task) = 0;
         };
@@ -131,6 +152,7 @@ namespace TrenchBroom {
             virtual ~ConstCompilationTaskVisitor();
 
             virtual void visit(const CompilationExportMap& task) = 0;
+            virtual void visit(const CompilationExportObj& task) = 0;
             virtual void visit(const CompilationCopyFiles& task) = 0;
             virtual void visit(const CompilationRunTool& task) = 0;
         };
@@ -140,6 +162,7 @@ namespace TrenchBroom {
             virtual ~CompilationTaskConstVisitor();
 
             virtual void visit(CompilationExportMap& task) const = 0;
+            virtual void visit(CompilationExportObj& task) const = 0;
             virtual void visit(CompilationCopyFiles& task) const = 0;
             virtual void visit(CompilationRunTool& task) const = 0;
         };
@@ -149,6 +172,7 @@ namespace TrenchBroom {
             virtual ~ConstCompilationTaskConstVisitor();
 
             virtual void visit(const CompilationExportMap& task) const = 0;
+            virtual void visit(const CompilationExportObj& task) const = 0;
             virtual void visit(const CompilationCopyFiles& task) const = 0;
             virtual void visit(const CompilationRunTool& task) const = 0;
         };

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -147,6 +147,7 @@ namespace TrenchBroom {
         void CompilationProfileEditor::addTask() {
             QMenu menu;
             auto* exportMapAction = menu.addAction("Export Map");
+            auto* exportObjAction = menu.addAction("Export Obj");
             auto* copyFilesAction = menu.addAction("Copy Files");
             auto* runToolAction   = menu.addAction("Run Tool");
 
@@ -154,6 +155,8 @@ namespace TrenchBroom {
             auto* chosenAction = menu.exec(QCursor::pos());
             if (chosenAction == exportMapAction) {
                 task = std::make_unique<Model::CompilationExportMap>("${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.map");
+            } else if (chosenAction == exportObjAction) {
+                task = std::make_unique<Model::CompilationExportObj>("${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.obj");
             } else if (chosenAction == copyFilesAction) {
                 task = std::make_unique<Model::CompilationCopyFiles>("", "");
             } else if (chosenAction == runToolAction) {

--- a/common/src/View/CompilationRunner.h
+++ b/common/src/View/CompilationRunner.h
@@ -33,6 +33,7 @@ namespace TrenchBroom {
     namespace Model {
         class CompilationCopyFiles;
         class CompilationExportMap;
+        class CompilationExportObj;
         class CompilationProfile;
         class CompilationRunTool;
     }
@@ -76,6 +77,20 @@ namespace TrenchBroom {
             void doTerminate() override;
 
             deleteCopyAndMove(CompilationExportMapTaskRunner)
+        };
+
+        class CompilationExportObjTaskRunner : public CompilationTaskRunner {
+            Q_OBJECT
+        private:
+            std::unique_ptr<const Model::CompilationExportObj> m_task;
+        public:
+            CompilationExportObjTaskRunner(CompilationContext& context, const Model::CompilationExportObj& task);
+            ~CompilationExportObjTaskRunner() override;
+        private:
+            void doExecute() override;
+            void doTerminate() override;
+
+            deleteCopyAndMove(CompilationExportObjTaskRunner)
         };
 
         class CompilationCopyFilesTaskRunner : public CompilationTaskRunner {

--- a/common/src/View/CompilationTaskListBox.h
+++ b/common/src/View/CompilationTaskListBox.h
@@ -33,6 +33,7 @@ namespace TrenchBroom {
     namespace Model {
         class CompilationCopyFiles;
         class CompilationExportMap;
+        class CompilationExportObj;
         class CompilationProfile;
         class CompilationRunTool;
         class CompilationTask;
@@ -84,6 +85,19 @@ namespace TrenchBroom {
         private:
             void updateItem() override;
             Model::CompilationExportMap& task();
+        private slots:
+            void targetSpecChanged(const QString& text);
+        };
+
+        class CompilationExportObjTaskEditor : public CompilationTaskEditorBase {
+            Q_OBJECT
+        private:
+            MultiCompletionLineEdit* m_targetEditor;
+        public:
+            CompilationExportObjTaskEditor(std::weak_ptr<MapDocument> document, Model::CompilationProfile& profile, Model::CompilationExportObj& task, QWidget* parent = nullptr);
+        private:
+            void updateItem() override;
+            Model::CompilationExportObj& task();
         private slots:
             void targetSpecChanged(const QString& text);
         };

--- a/common/test/src/IO/CompilationConfigParserTest.cpp
+++ b/common/test/src/IO/CompilationConfigParserTest.cpp
@@ -218,6 +218,10 @@ namespace TrenchBroom {
                 ASSERT_TRUE(false);
             }
 
+            void visit(const Model::CompilationExportObj& /* task */) const override {
+                ASSERT_TRUE(false);
+            }
+
             void visit(const Model::CompilationCopyFiles& task) const override {
                 ASSERT_EQ(m_sourceSpec, task.sourceSpec());
                 ASSERT_EQ(m_targetSpec, task.targetSpec());
@@ -238,6 +242,10 @@ namespace TrenchBroom {
             m_parameterSpec(parameterSpec) {}
 
             void visit(const Model::CompilationExportMap& /* task */) const override {
+                ASSERT_TRUE(false);
+            }
+
+            void visit(const Model::CompilationExportObj& /* task */) const override {
                 ASSERT_TRUE(false);
             }
 


### PR DESCRIPTION
The code changes are pretty simple. I mostly followed the behavior of the export map task and reproduced it to export an obj file instead. I did see some places in the code that likely still need to be changed to avoid confusion for example:
`parseExportTask` should likely change to `parseExportMapTask` to avoid confusion with: `parseExportObjTask`?

Let me know if there are any other code changes that are required.

fixes: #3342 