### PR TITLE
1448: paste across standard/valve maps

### DIFF
--- a/common/src/IO/BrushFaceReader.h
+++ b/common/src/IO/BrushFaceReader.h
@@ -39,6 +39,9 @@ namespace TrenchBroom {
     namespace IO {
         class ParserStatus;
 
+        /**
+         * Used for pasting brush faces (i.e. their texture alignment only)
+         */
         class BrushFaceReader : public MapReader {
         private:
             Model::ModelFactory& m_factory;

--- a/common/src/IO/MapParser.cpp
+++ b/common/src/IO/MapParser.cpp
@@ -72,8 +72,8 @@ namespace TrenchBroom {
             onEndBrush(startLine, lineCount, extraAttributes, status);
         }
 
-        void MapParser::brushFace(const size_t line, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) {
-            onBrushFace(line, point1, point2, point3, attribs, texAxisX, texAxisY, status);
+        void MapParser::brushFace(const size_t line, const Model::MapFormat format,  const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) {
+            onBrushFace(line, format, point1, point2, point3, attribs, texAxisX, texAxisY, status);
         }
     }
 }

--- a/common/src/IO/MapParser.cpp
+++ b/common/src/IO/MapParser.cpp
@@ -72,8 +72,12 @@ namespace TrenchBroom {
             onEndBrush(startLine, lineCount, extraAttributes, status);
         }
 
-        void MapParser::brushFace(const size_t line, const Model::MapFormat format,  const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) {
-            onBrushFace(line, format, point1, point2, point3, attribs, texAxisX, texAxisY, status);
+        void MapParser::standardBrushFace(const size_t line, const Model::MapFormat format,  const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, ParserStatus& status) {
+            onStandardBrushFace(line, format, point1, point2, point3, attribs, status);
+        }
+
+        void MapParser::valveBrushFace(const size_t line, const Model::MapFormat format,  const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) {
+            onValveBrushFace(line, format, point1, point2, point3, attribs, texAxisX, texAxisY, status);
         }
     }
 }

--- a/common/src/IO/MapParser.h
+++ b/common/src/IO/MapParser.h
@@ -77,15 +77,17 @@ namespace TrenchBroom {
             void beginEntity(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status);
             void endEntity(size_t startLine, size_t lineCount, ParserStatus& status);
             void beginBrush(size_t line, ParserStatus& status);
-            void endBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status);
-            void brushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status);
+            void endBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status);\
+            void standardBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, ParserStatus& status);
+            void valveBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status);
         private: // subclassing interface for users of the parser
             virtual void onFormatSet(Model::MapFormat format) = 0;
             virtual void onBeginEntity(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) = 0;
             virtual void onEndEntity(size_t startLine, size_t lineCount, ParserStatus& status) = 0;
             virtual void onBeginBrush(size_t line, ParserStatus& status) = 0;
             virtual void onEndBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status) = 0;
-            virtual void onBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) = 0;
+            virtual void onStandardBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, ParserStatus& status) = 0;
+            virtual void onValveBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) = 0;
         };
     }
 }

--- a/common/src/IO/MapParser.h
+++ b/common/src/IO/MapParser.h
@@ -78,14 +78,14 @@ namespace TrenchBroom {
             void endEntity(size_t startLine, size_t lineCount, ParserStatus& status);
             void beginBrush(size_t line, ParserStatus& status);
             void endBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status);
-            void brushFace(size_t line, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status);
+            void brushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status);
         private: // subclassing interface for users of the parser
             virtual void onFormatSet(Model::MapFormat format) = 0;
             virtual void onBeginEntity(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) = 0;
             virtual void onEndEntity(size_t startLine, size_t lineCount, ParserStatus& status) = 0;
             virtual void onBeginBrush(size_t line, ParserStatus& status) = 0;
             virtual void onEndBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status) = 0;
-            virtual void onBrushFace(size_t line, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) = 0;
+            virtual void onBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) = 0;
         };
     }
 }

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -105,7 +105,7 @@ namespace TrenchBroom {
             void onEndEntity(size_t startLine, size_t lineCount, ParserStatus& status) override;
             void onBeginBrush(size_t line, ParserStatus& status) override;
             void onEndBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
-            void onBrushFace(size_t line, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) override;
+            void onBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) override;
         private: // helper methods
             void createLayer(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status);
             void createGroup(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status);

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -46,6 +46,13 @@ namespace TrenchBroom {
     namespace IO {
         class ParserStatus;
 
+        /**
+         * Abstract superclass containing common code for:
+         *
+         *  - WorldReader (loading a whole .map)
+         *  - NodeReader (reading part of a map, for pasting into an existing map)
+         *  - BrushFaceReader (reading faces when copy/pasting texture alignment)
+         */
         class MapReader : public StandardMapParser {
         protected:
             class ParentInfo {

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -112,7 +112,8 @@ namespace TrenchBroom {
             void onEndEntity(size_t startLine, size_t lineCount, ParserStatus& status) override;
             void onBeginBrush(size_t line, ParserStatus& status) override;
             void onEndBrush(size_t startLine, size_t lineCount, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
-            void onBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) override;
+            void onStandardBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, ParserStatus& status) override;
+            void onValveBrushFace(size_t line, Model::MapFormat format, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) override;
         private: // helper methods
             void createLayer(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status);
             void createGroup(size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status);

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -49,7 +49,8 @@ namespace TrenchBroom {
             const Model::MapFormat preferredFormat = m_factory.format();
 
             try {
-                return readAsFormat(worldBounds, preferredFormat, status);
+                readAsFormat(worldBounds, preferredFormat, status);
+                return m_nodes;
             } catch (const ParserException&) {
             }
 
@@ -59,7 +60,8 @@ namespace TrenchBroom {
                 }
 
                 try {
-                    return readAsFormat(worldBounds, format, status);
+                    readAsFormat(worldBounds, format, status);
+                    return m_nodes;
                 } catch (const ParserException&) {
                 }
             }
@@ -68,11 +70,10 @@ namespace TrenchBroom {
             return m_nodes;
         }
 
-        const std::vector<Model::Node*>& NodeReader::readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status) {
+        void NodeReader::readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status) {
             try {
                 reset();
                 readEntities(format, worldBounds, status);
-                return m_nodes;
             } catch (const ParserException&) {
                 kdl::vec_clear_and_delete(m_nodes);
             }
@@ -80,7 +81,6 @@ namespace TrenchBroom {
             try {
                 reset();
                 readBrushes(format, worldBounds, status);
-                return m_nodes;
             } catch (const ParserException&) {
                 kdl::vec_clear_and_delete(m_nodes);
                 throw;

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -47,18 +47,7 @@ namespace TrenchBroom {
         const std::vector<Model::Node*>& NodeReader::read(const vm::bbox3& worldBounds, ParserStatus& status) {
             // try preferred format first
             const Model::MapFormat preferredFormat = m_factory.format();
-
-            try {
-                readAsFormat(worldBounds, preferredFormat, status);
-                return m_nodes;
-            } catch (const ParserException&) {
-            }
-
             for (const auto format : Model::compatibleFormats(preferredFormat)) {
-                if (format == preferredFormat) {
-                    continue;
-                }
-
                 try {
                     readAsFormat(worldBounds, format, status);
                     return m_nodes;

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -63,6 +63,7 @@ namespace TrenchBroom {
             try {
                 reset();
                 readEntities(format, worldBounds, status);
+                return;
             } catch (const ParserException&) {
                 kdl::vec_clear_and_delete(m_nodes);
             }
@@ -70,6 +71,7 @@ namespace TrenchBroom {
             try {
                 reset();
                 readBrushes(format, worldBounds, status);
+                return;
             } catch (const ParserException&) {
                 kdl::vec_clear_and_delete(m_nodes);
                 throw;

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -45,24 +45,50 @@ namespace TrenchBroom {
         }
 
         const std::vector<Model::Node*>& NodeReader::read(const vm::bbox3& worldBounds, ParserStatus& status) {
+            // try preferred format first
+            const Model::MapFormat preferredFormat = m_factory.format();
+
             try {
-                readEntities(m_factory.format(), worldBounds, status);
+                return readAsFormat(worldBounds, preferredFormat, status);
             } catch (const ParserException&) {
-                kdl::vec_clear_and_delete(m_nodes);
+            }
+
+            for (const auto format : Model::compatibleFormats(preferredFormat)) {
+                if (format == preferredFormat) {
+                    continue;
+                }
 
                 try {
-                    reset();
-                    readBrushes(m_factory.format(), worldBounds, status);
+                    return readAsFormat(worldBounds, format, status);
                 } catch (const ParserException&) {
-                    kdl::vec_clear_and_delete(m_nodes);
-                    throw;
                 }
             }
+
+            assert(m_nodes.empty());
             return m_nodes;
         }
 
-        Model::ModelFactory& NodeReader::initialize([[maybe_unused]] const Model::MapFormat format) {
-            assert(format == m_factory.format());
+        const std::vector<Model::Node*>& NodeReader::readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status) {
+            try {
+                reset();
+                readEntities(format, worldBounds, status);
+                return m_nodes;
+            } catch (const ParserException&) {
+                kdl::vec_clear_and_delete(m_nodes);
+            }
+
+            try {
+                reset();
+                readBrushes(format, worldBounds, status);
+                return m_nodes;
+            } catch (const ParserException&) {
+                kdl::vec_clear_and_delete(m_nodes);
+                throw;
+            }
+        }
+
+        Model::ModelFactory& NodeReader::initialize(const Model::MapFormat) {
+            // NOTE: m_factory.format() may be different than the passed in format
             return m_factory;
         }
 

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             static std::vector<Model::Node*> read(const std::string& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
             const std::vector<Model::Node*>& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private:
-            const std::vector<Model::Node*>& readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
+            void readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
         private: // implement MapReader interface
             Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -41,6 +41,8 @@ namespace TrenchBroom {
 
             static std::vector<Model::Node*> read(const std::string& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
             const std::vector<Model::Node*>& read(const vm::bbox3& worldBounds, ParserStatus& status);
+        private:
+            const std::vector<Model::Node*>& readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
         private: // implement MapReader interface
             Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -455,7 +455,7 @@ namespace TrenchBroom {
             attribs.setXScale(parseFloat());
             attribs.setYScale(parseFloat());
 
-            brushFace(line, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
         }
 
         void StandardMapParser::parseQuake2Face(ParserStatus& status) {
@@ -478,7 +478,7 @@ namespace TrenchBroom {
                 attribs.setSurfaceValue(parseFloat());
             }
 
-            brushFace(line, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
         }
 
         void StandardMapParser::parseQuake2ValveFace(ParserStatus& status) {
@@ -503,7 +503,7 @@ namespace TrenchBroom {
                 attribs.setSurfaceValue(parseFloat());
             }
 
-            brushFace(line, p1, p2, p3, attribs, texX, texY, status);
+            brushFace(line, m_format, p1, p2, p3, attribs, texX, texY, status);
         }
 
         void StandardMapParser::parseHexen2Face(ParserStatus& status) {
@@ -524,7 +524,7 @@ namespace TrenchBroom {
                 m_tokenizer.nextToken(); // noone seems to know what the extra value does in Hexen 2
             }
 
-            brushFace(line, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
         }
 
         void StandardMapParser::parseDaikatanaFace(ParserStatus& status) {
@@ -553,7 +553,7 @@ namespace TrenchBroom {
                 }
             }
 
-            brushFace(line, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
         }
 
         void StandardMapParser::parseValveFace(ParserStatus& status) {
@@ -571,7 +571,7 @@ namespace TrenchBroom {
             attribs.setXScale(parseFloat());
             attribs.setYScale(parseFloat());
 
-            brushFace(line, p1, p2, p3, attribs, texX, texY, status);
+            brushFace(line, m_format, p1, p2, p3, attribs, texX, texY, status);
         }
 
         void StandardMapParser::parsePrimitiveFace(ParserStatus& status) {

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -455,7 +455,7 @@ namespace TrenchBroom {
             attribs.setXScale(parseFloat());
             attribs.setYScale(parseFloat());
 
-            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            standardBrushFace(line, m_format, p1, p2, p3, attribs, status);
         }
 
         void StandardMapParser::parseQuake2Face(ParserStatus& status) {
@@ -478,7 +478,7 @@ namespace TrenchBroom {
                 attribs.setSurfaceValue(parseFloat());
             }
 
-            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            standardBrushFace(line, m_format, p1, p2, p3, attribs, status);
         }
 
         void StandardMapParser::parseQuake2ValveFace(ParserStatus& status) {
@@ -503,7 +503,7 @@ namespace TrenchBroom {
                 attribs.setSurfaceValue(parseFloat());
             }
 
-            brushFace(line, m_format, p1, p2, p3, attribs, texX, texY, status);
+            valveBrushFace(line, m_format, p1, p2, p3, attribs, texX, texY, status);
         }
 
         void StandardMapParser::parseHexen2Face(ParserStatus& status) {
@@ -524,7 +524,7 @@ namespace TrenchBroom {
                 m_tokenizer.nextToken(); // noone seems to know what the extra value does in Hexen 2
             }
 
-            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            standardBrushFace(line, m_format, p1, p2, p3, attribs, status);
         }
 
         void StandardMapParser::parseDaikatanaFace(ParserStatus& status) {
@@ -553,7 +553,7 @@ namespace TrenchBroom {
                 }
             }
 
-            brushFace(line, m_format, p1, p2, p3, attribs, vm::vec3::zero(), vm::vec3::zero(), status);
+            standardBrushFace(line, m_format, p1, p2, p3, attribs, status);
         }
 
         void StandardMapParser::parseValveFace(ParserStatus& status) {
@@ -571,7 +571,7 @@ namespace TrenchBroom {
             attribs.setXScale(parseFloat());
             attribs.setYScale(parseFloat());
 
-            brushFace(line, m_format, p1, p2, p3, attribs, texX, texY, status);
+            valveBrushFace(line, m_format, p1, p2, p3, attribs, texX, texY, status);
         }
 
         void StandardMapParser::parsePrimitiveFace(ParserStatus& status) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -959,6 +959,18 @@ namespace TrenchBroom {
                 );
         }
 
+        void Brush::convertToParaxial() {
+            for (auto& face : m_faces) {
+                face.convertToParaxial();
+            }
+        }
+
+        void Brush::convertToParallel() {
+            for (auto& face : m_faces) {
+                face.convertToParallel();
+            }
+        }
+
         bool Brush::checkFaceLinks() const {
             if (faceCount() != m_geometry->faceCount()) {
                 return false;

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -959,16 +959,20 @@ namespace TrenchBroom {
                 );
         }
 
-        void Brush::convertToParaxial() {
-            for (auto& face : m_faces) {
+        Brush Brush::convertToParaxial() const {
+            Brush result(*this);
+            for (auto& face : result.m_faces) {
                 face.convertToParaxial();
             }
+            return result;
         }
 
-        void Brush::convertToParallel() {
-            for (auto& face : m_faces) {
+        Brush Brush::convertToParallel() const {
+            Brush result(*this);
+            for (auto& face : result.m_faces) {
                 face.convertToParallel();
             }
+            return result;
         }
 
         bool Brush::checkFaceLinks() const {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -257,8 +257,8 @@ namespace TrenchBroom {
              */
             kdl::result<Brush, BrushError> createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const BrushGeometry& geometry, const std::vector<const Brush*>& subtrahends) const;
         public: // texture format conversion
-            void convertToParaxial();
-            void convertToParallel();
+            Brush convertToParaxial() const;
+            Brush convertToParallel() const;
         private:
             bool checkFaceLinks() const;
         };

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -256,6 +256,9 @@ namespace TrenchBroom {
              * @return the newly created brush
              */
             kdl::result<Brush, BrushError> createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const BrushGeometry& geometry, const std::vector<const Brush*>& subtrahends) const;
+        public: // texture format conversion
+            void convertToParaxial();
+            void convertToParallel();
         private:
             bool checkFaceLinks() const;
         };

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -339,14 +339,14 @@ namespace TrenchBroom {
         void BrushFace::convertToParaxial() {
             auto [newTexCoordSystem, newAttributes] = m_texCoordSystem->toParaxial(m_points[0], m_points[1], m_points[2], m_attributes);
 
-            m_attributes = *newAttributes;
+            m_attributes = newAttributes;
             m_texCoordSystem = std::move(newTexCoordSystem);
         }
 
         void BrushFace::convertToParallel() {
             auto [newTexCoordSystem, newAttributes] = m_texCoordSystem->toParallel(m_points[0], m_points[1], m_points[2], m_attributes);
 
-            m_attributes = *newAttributes;
+            m_attributes = newAttributes;
             m_texCoordSystem = std::move(newTexCoordSystem);
         }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -25,6 +25,8 @@
 #include "Polyhedron.h"
 #include "Assets/Texture.h"
 #include "Model/BrushError.h"
+#include "Model/ParallelTexCoordSystem.h"
+#include "Model/ParaxialTexCoordSystem.h"
 #include "Model/TagMatcher.h"
 #include "Model/TagVisitor.h"
 #include "Model/TexCoordSystem.h"
@@ -292,6 +294,10 @@ namespace TrenchBroom {
             }
         }
 
+        const TexCoordSystem& BrushFace::texCoordSystem() const {
+            return *m_texCoordSystem;
+        }
+
         Assets::Texture* BrushFace::texture() const {
             return m_textureReference.texture();
         }
@@ -329,6 +335,21 @@ namespace TrenchBroom {
         void BrushFace::resetTextureAxes() {
             m_texCoordSystem->resetTextureAxes(m_boundary.normal);
         }
+
+        void BrushFace::convertToParaxial() {
+            auto [newTexCoordSystem, newAttributes] = m_texCoordSystem->toParaxial(m_points[0], m_points[1], m_points[2], m_attributes);
+
+            m_attributes = *newAttributes;
+            m_texCoordSystem = std::move(newTexCoordSystem);
+        }
+
+        void BrushFace::convertToParallel() {
+            auto [newTexCoordSystem, newAttributes] = m_texCoordSystem->toParallel(m_points[0], m_points[1], m_points[2], m_attributes);
+
+            m_attributes = *newAttributes;
+            m_texCoordSystem = std::move(newTexCoordSystem);
+        }
+
 
         void BrushFace::moveTexture(const vm::vec3& up, const vm::vec3& right, const vm::vec2f& offset) {
             m_texCoordSystem->moveTexture(m_boundary.normal, up, right, offset, m_attributes);

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -131,6 +131,7 @@ namespace TrenchBroom {
             bool setAttributes(const BrushFace& other);
 
             void resetTexCoordSystemCache();
+            const TexCoordSystem& texCoordSystem() const;
 
             Assets::Texture* texture() const;
             vm::vec2f textureSize() const;
@@ -141,6 +142,9 @@ namespace TrenchBroom {
             vm::vec3 textureXAxis() const;
             vm::vec3 textureYAxis() const;
             void resetTextureAxes();
+
+            void convertToParaxial();
+            void convertToParallel();
 
             void moveTexture(const vm::vec3& up, const vm::vec3& right, const vm::vec2f& offset);
             void rotateTexture(float angle);

--- a/common/src/Model/MapFormat.cpp
+++ b/common/src/Model/MapFormat.cpp
@@ -78,19 +78,23 @@ namespace TrenchBroom {
         std::vector<MapFormat> compatibleFormats(const MapFormat format) {
             switch (format) {
                 case MapFormat::Standard:
+                    return { MapFormat::Standard, MapFormat::Valve };
                 case MapFormat::Valve:
-                    return { MapFormat::Standard, MapFormat::Valve};
+                    return { MapFormat::Valve, MapFormat::Standard };
                 case MapFormat::Quake2:
+                    return { MapFormat::Quake2, MapFormat::Quake2_Valve };
                 case MapFormat::Quake2_Valve:
-                    return { MapFormat::Quake2, MapFormat::Quake2_Valve};
+                    return { MapFormat::Quake2_Valve,  MapFormat::Quake2 };
                 case MapFormat::Hexen2:
                     return { MapFormat::Hexen2 };
                 case MapFormat::Daikatana:
                     return { MapFormat::Daikatana };
                 case MapFormat::Quake3_Legacy:
-                case MapFormat::Quake3_Valve:
-                case MapFormat::Quake3:
                     return { MapFormat::Quake3_Legacy, MapFormat::Quake3_Valve, MapFormat::Quake3 };
+                case MapFormat::Quake3_Valve:
+                    return { MapFormat::Quake3_Valve, MapFormat::Quake3, MapFormat::Quake3_Legacy };
+                case MapFormat::Quake3:
+                    return { MapFormat::Quake3, MapFormat::Quake3_Valve, MapFormat::Quake3_Legacy };
                 case MapFormat::Unknown:
                     return { MapFormat::Unknown };
                 switchDefault()

--- a/common/src/Model/MapFormat.cpp
+++ b/common/src/Model/MapFormat.cpp
@@ -111,6 +111,7 @@ namespace TrenchBroom {
                 case MapFormat::Quake3:
                 case MapFormat::Unknown:
                     return false;
+                switchDefault()
             }
         }
     }

--- a/common/src/Model/MapFormat.cpp
+++ b/common/src/Model/MapFormat.cpp
@@ -74,5 +74,44 @@ namespace TrenchBroom {
                 switchDefault()
             }
         }
+
+        std::vector<MapFormat> compatibleFormats(const MapFormat format) {
+            switch (format) {
+                case MapFormat::Standard:
+                case MapFormat::Valve:
+                    return { MapFormat::Standard, MapFormat::Valve};
+                case MapFormat::Quake2:
+                case MapFormat::Quake2_Valve:
+                    return { MapFormat::Quake2, MapFormat::Quake2_Valve};
+                case MapFormat::Hexen2:
+                    return { MapFormat::Hexen2 };
+                case MapFormat::Daikatana:
+                    return { MapFormat::Daikatana };
+                case MapFormat::Quake3_Legacy:
+                case MapFormat::Quake3_Valve:
+                case MapFormat::Quake3:
+                    return { MapFormat::Quake3_Legacy, MapFormat::Quake3_Valve, MapFormat::Quake3 };
+                case MapFormat::Unknown:
+                    return { MapFormat::Unknown };
+                switchDefault()
+            }
+        }
+
+        bool isParallelTexCoordSystem(MapFormat format) {
+            switch (format) {
+                case MapFormat::Valve:
+                case MapFormat::Quake2_Valve:
+                case MapFormat::Quake3_Valve:
+                    return true;
+                case MapFormat::Standard:
+                case MapFormat::Quake2:
+                case MapFormat::Hexen2:
+                case MapFormat::Daikatana:
+                case MapFormat::Quake3_Legacy:
+                case MapFormat::Quake3:
+                case MapFormat::Unknown:
+                    return false;
+            }
+        }
     }
 }

--- a/common/src/Model/MapFormat.cpp
+++ b/common/src/Model/MapFormat.cpp
@@ -97,7 +97,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool isParallelTexCoordSystem(MapFormat format) {
+        bool isParallelTexCoordSystem(const MapFormat format) {
             switch (format) {
                 case MapFormat::Valve:
                 case MapFormat::Quake2_Valve:

--- a/common/src/Model/MapFormat.h
+++ b/common/src/Model/MapFormat.h
@@ -21,6 +21,7 @@
 #define TrenchBroom_MapFormat
 
 #include <string>
+#include <vector>
 
 namespace TrenchBroom {
     namespace Model {
@@ -83,6 +84,10 @@ namespace TrenchBroom {
          * @return the name
          */
         std::string formatName(MapFormat format);
+
+        std::vector<MapFormat> compatibleFormats(MapFormat format);
+
+        bool isParallelTexCoordSystem(MapFormat format);
     }
 }
 

--- a/common/src/Model/MapFormat.h
+++ b/common/src/Model/MapFormat.h
@@ -84,9 +84,7 @@ namespace TrenchBroom {
          * @return the name
          */
         std::string formatName(MapFormat format);
-
         std::vector<MapFormat> compatibleFormats(MapFormat format);
-
         bool isParallelTexCoordSystem(MapFormat format);
     }
 }

--- a/common/src/Model/MapFormat.h
+++ b/common/src/Model/MapFormat.h
@@ -84,6 +84,12 @@ namespace TrenchBroom {
          * @return the name
          */
         std::string formatName(MapFormat format);
+        /**
+         * Returns a vector starting with the given format, then the other formats which are compatible with it.
+         *
+         * @param format the preferred format
+         * @return the preferred format, then the other compatible formats
+         */
         std::vector<MapFormat> compatibleFormats(MapFormat format);
         bool isParallelTexCoordSystem(MapFormat format);
     }

--- a/common/src/Model/ModelFactory.cpp
+++ b/common/src/Model/ModelFactory.cpp
@@ -57,8 +57,12 @@ namespace TrenchBroom {
             return doCreateFace(point1, point2, point3, attribs);
         }
 
-        kdl::result<BrushFace, BrushError> ModelFactory::createFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
-            return doCreateFace(point1, point2, point3, attribs, texAxisX, texAxisY);
+        kdl::result<BrushFace, BrushError> ModelFactory::createFaceFromStandard(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
+            return doCreateFaceFromStandard(point1, point2, point3, attribs);
+        }
+
+        kdl::result<BrushFace, BrushError> ModelFactory::createFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
+            return doCreateFaceFromValve(point1, point2, point3, attribs, texAxisX, texAxisY);
         }
         
         BrushNode* ModelFactory::doCreateBrush(Brush brush) const {

--- a/common/src/Model/ModelFactory.h
+++ b/common/src/Model/ModelFactory.h
@@ -54,8 +54,33 @@ namespace TrenchBroom {
             EntityNode* createEntity() const;
             BrushNode* createBrush(Brush brush) const;
 
+            /**
+             * Creates a face using TB's default texture projection for the current map format
+             * returned by format() and the given plane.
+             *
+             * Used when creating new faces when we don't have a particular texture alignment to request.
+             * On Valve format maps, this differs from createFaceFromStandard() by creating a face-aligned texture projection,
+             * whereas createFaceFromStandard() creates an axis-aligned texture projection.
+             *
+             * The returned face has a TexCoordSystem matching format().
+             */
             kdl::result<BrushFace, BrushError> createFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const;
-            kdl::result<BrushFace, BrushError> createFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const;
+            /**
+             * Creates a face from a Standard texture projection, converting it to Valve if necessary.
+             *
+             * Used when loading/pasting a Standard format map.
+             *
+             * The returned face has a TexCoordSystem matching format().
+             */
+            kdl::result<BrushFace, BrushError> createFaceFromStandard(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const;
+            /**
+             * Creates a face from a Valve texture projection, converting it to Standard if necessary.
+             *
+             * Used when loading/pasting a Valve format map.
+             *
+             * The returned face has a TexCoordSystem matching format().
+             */
+            kdl::result<BrushFace, BrushError> createFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const;
         private:
             virtual MapFormat doGetFormat() const = 0;
             virtual WorldNode* doCreateWorld() const = 0;
@@ -64,7 +89,8 @@ namespace TrenchBroom {
             virtual EntityNode* doCreateEntity() const = 0;
             virtual BrushNode* doCreateBrush(Brush brush) const;
             virtual kdl::result<BrushFace, BrushError> doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const = 0;
-            virtual kdl::result<BrushFace, BrushError> doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const = 0;
+            virtual kdl::result<BrushFace, BrushError> doCreateFaceFromStandard(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const = 0;
+            virtual kdl::result<BrushFace, BrushError> doCreateFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const = 0;
         };
     }
 }

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -34,8 +34,6 @@
 #include <kdl/result.h>
 #include <kdl/string_utils.h>
 
-#include <QDebug>
-
 #include <cassert>
 
 namespace TrenchBroom {
@@ -74,7 +72,7 @@ namespace TrenchBroom {
 
         kdl::result<BrushFace, BrushError> ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
             assert(m_format != MapFormat::Unknown);
-            return m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve
+            return Model::isParallelTexCoordSystem(m_format)
                    ? BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs))
                    : BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
         }
@@ -86,9 +84,6 @@ namespace TrenchBroom {
             std::unique_ptr<BrushFaceAttributes> attribs;
 
             if (Model::isParallelTexCoordSystem(m_format)) {
-                // NOTE: tests are failing because this code path is hit, expecting the old behavioru which
-                // was creting a face-aligned tex coord system, not a conversion from paraxial -> parallel
-
                 // Convert paraxial to parallel
                 std::tie(texCoordSystem, attribs) = ParallelTexCoordSystem::fromParaxial(point1, point2, point3, inputAttribs);
             } else {

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -81,7 +81,7 @@ namespace TrenchBroom {
             assert(m_format != MapFormat::Unknown);
 
             std::unique_ptr<TexCoordSystem> texCoordSystem;
-            std::unique_ptr<BrushFaceAttributes> attribs;
+            BrushFaceAttributes attribs("");
 
             if (Model::isParallelTexCoordSystem(m_format)) {
                 // Convert paraxial to parallel
@@ -89,28 +89,28 @@ namespace TrenchBroom {
             } else {
                 // Pass through paraxial
                 texCoordSystem = std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, inputAttribs);
-                attribs = std::make_unique<BrushFaceAttributes>(inputAttribs);
+                attribs = inputAttribs;
             }
 
-            return BrushFace::create(point1, point2, point3, *attribs, std::move(texCoordSystem));
+            return BrushFace::create(point1, point2, point3, attribs, std::move(texCoordSystem));
         }
 
         kdl::result<BrushFace, BrushError> ModelFactoryImpl::doCreateFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& inputAttribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
             assert(m_format != MapFormat::Unknown);
 
             std::unique_ptr<TexCoordSystem> texCoordSystem;
-            std::unique_ptr<BrushFaceAttributes> attribs;
+            BrushFaceAttributes attribs("");
 
             if (Model::isParallelTexCoordSystem(m_format)) {
                 // Pass through parallel
                 texCoordSystem = std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY);
-                attribs = std::make_unique<BrushFaceAttributes>(inputAttribs);
+                attribs = inputAttribs;
             } else {
                 // Convert parallel to paraxial
                 std::tie(texCoordSystem, attribs) = ParaxialTexCoordSystem::fromParallel(point1, point2, point3, inputAttribs, texAxisX, texAxisY);
             }
 
-            return BrushFace::create(point1, point2, point3, *attribs, std::move(texCoordSystem));
+            return BrushFace::create(point1, point2, point3, attribs, std::move(texCoordSystem));
         }
     }
 }

--- a/common/src/Model/ModelFactoryImpl.h
+++ b/common/src/Model/ModelFactoryImpl.h
@@ -48,7 +48,8 @@ namespace TrenchBroom {
             EntityNode* doCreateEntity() const override;
 
             kdl::result<BrushFace, BrushError> doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const override;
-            kdl::result<BrushFace, BrushError> doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const override;
+            kdl::result<BrushFace, BrushError> doCreateFaceFromStandard(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const override;
+            kdl::result<BrushFace, BrushError> doCreateFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const override;
         };
     }
 }

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -55,6 +55,14 @@ namespace TrenchBroom {
             ensure(false, "wrong coord system type");
         }
 
+        /**
+         * Constructs a parallel tex coord system where the texture is projected form the face plane
+         *
+         * @param point0 a point defining the face plane
+         * @param point1 a point defining the face plane
+         * @param point2 a point defining the face plane
+         * @param attribs face attributes
+         */
         ParallelTexCoordSystem::ParallelTexCoordSystem(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) {
             const vm::vec3 normal = vm::normalize(vm::cross(point2 - point0, point1 - point0));
             computeInitialAxes(normal, m_xAxis, m_yAxis);
@@ -64,6 +72,11 @@ namespace TrenchBroom {
         ParallelTexCoordSystem::ParallelTexCoordSystem(const vm::vec3& xAxis, const vm::vec3& yAxis) :
         m_xAxis(xAxis),
         m_yAxis(yAxis) {}
+
+        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParallelTexCoordSystem::fromParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) {
+            const auto tempParaxial = ParaxialTexCoordSystem(point0, point1, point2, attribs);
+            return { ParallelTexCoordSystem(tempParaxial.xAxis(), tempParaxial.yAxis()).clone(), std::make_unique<BrushFaceAttributes>(attribs) };
+        }
 
         std::unique_ptr<TexCoordSystem> ParallelTexCoordSystem::doClone() const {
             return std::make_unique<ParallelTexCoordSystem>(m_xAxis, m_yAxis);
@@ -308,6 +321,9 @@ namespace TrenchBroom {
             return currentAngle + vm::to_degrees(angleInRadians);
         }
 
+        /**
+         * Generates two vectors which are perpendicular to `normal` and perpendicular to each other.
+         */
         void ParallelTexCoordSystem::computeInitialAxes(const vm::vec3& normal, vm::vec3& xAxis, vm::vec3& yAxis) const {
             switch (vm::find_abs_max_component(normal)) {
                 case vm::axis::x:
@@ -320,6 +336,14 @@ namespace TrenchBroom {
             }
 
             yAxis = vm::normalize(vm::cross(m_xAxis, normal));
+        }
+
+        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParallelTexCoordSystem::doToParallel(const vm::vec3&, const vm::vec3&, const vm::vec3&, const BrushFaceAttributes& attribs) const {
+            return { clone(), std::make_unique<BrushFaceAttributes>(attribs) };
+        }
+
+        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParallelTexCoordSystem::doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+            return ParaxialTexCoordSystem::fromParallel(point0, point1, point2, attribs, m_xAxis, m_yAxis);
         }
     }
 }

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -73,9 +73,9 @@ namespace TrenchBroom {
         m_xAxis(xAxis),
         m_yAxis(yAxis) {}
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParallelTexCoordSystem::fromParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> ParallelTexCoordSystem::fromParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) {
             const auto tempParaxial = ParaxialTexCoordSystem(point0, point1, point2, attribs);
-            return { ParallelTexCoordSystem(tempParaxial.xAxis(), tempParaxial.yAxis()).clone(), std::make_unique<BrushFaceAttributes>(attribs) };
+            return { ParallelTexCoordSystem(tempParaxial.xAxis(), tempParaxial.yAxis()).clone(), attribs };
         }
 
         std::unique_ptr<TexCoordSystem> ParallelTexCoordSystem::doClone() const {
@@ -338,11 +338,11 @@ namespace TrenchBroom {
             yAxis = vm::normalize(vm::cross(m_xAxis, normal));
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParallelTexCoordSystem::doToParallel(const vm::vec3&, const vm::vec3&, const vm::vec3&, const BrushFaceAttributes& attribs) const {
-            return { clone(), std::make_unique<BrushFaceAttributes>(attribs) };
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> ParallelTexCoordSystem::doToParallel(const vm::vec3&, const vm::vec3&, const vm::vec3&, const BrushFaceAttributes& attribs) const {
+            return { clone(), attribs };
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParallelTexCoordSystem::doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> ParallelTexCoordSystem::doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
             return ParaxialTexCoordSystem::fromParallel(point0, point1, point2, attribs, m_xAxis, m_yAxis);
         }
     }

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -28,6 +28,7 @@
 #include <vecmath/vec.h>
 
 #include <memory>
+#include <tuple>
 
 namespace TrenchBroom {
     namespace Model {
@@ -53,6 +54,8 @@ namespace TrenchBroom {
         public:
             ParallelTexCoordSystem(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
             ParallelTexCoordSystem(const vm::vec3& xAxis, const vm::vec3& yAxis);
+
+            static std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> fromParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
         private:
             std::unique_ptr<TexCoordSystem> doClone() const override;
             std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() const override;
@@ -83,6 +86,9 @@ namespace TrenchBroom {
 
             float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const override;
             void computeInitialAxes(const vm::vec3& normal, vm::vec3& xAxis, vm::vec3& yAxis) const;
+
+            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
+            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
 
             deleteCopyAndMove(ParallelTexCoordSystem)
         };

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             ParallelTexCoordSystem(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
             ParallelTexCoordSystem(const vm::vec3& xAxis, const vm::vec3& yAxis);
 
-            static std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> fromParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
+            static std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> fromParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
         private:
             std::unique_ptr<TexCoordSystem> doClone() const override;
             std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() const override;
@@ -87,8 +87,8 @@ namespace TrenchBroom {
             float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const override;
             void computeInitialAxes(const vm::vec3& normal, vm::vec3& xAxis, vm::vec3& yAxis) const;
 
-            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
-            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
+            std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
+            std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
 
             deleteCopyAndMove(ParallelTexCoordSystem)
         };

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -567,10 +567,12 @@ namespace TrenchBroom {
                     return std::nullopt;
                 }
 
-                // figure out texture offset by testing point (0, 0, 0)
-                const vm::vec3f testPoint = vm::vec3f::zero();
-                const vm::vec2f testActualUV = getTexCoordsAtPoint(appendOffset(*result, vm::vec2f(0, 0)), faceplane,
-                                                                   vm::vec3(testPoint));
+                // figure out texture offset by testing one point.
+                // NOTE: the choice of point shouldn't matter in the case when the conversion is lossless (no shearing).
+                // However, if there is shearing (which we can't capture in the paraxial format), this test point should
+                // be somewhere on the face, because the texture may only be aligned properly around this point.
+                const vm::vec3f testPoint = facePoints[0];
+                const vm::vec2f testActualUV = getTexCoordsAtPoint(appendOffset(*result, vm::vec2f(0, 0)), faceplane, vm::vec3(testPoint));
                 const vm::vec2f testDesiredUV = vm::vec2f(worldToTexSpace * vm::vec4f(testPoint, 1.0f));
                 return appendOffset(*result, testDesiredUV - testActualUV);
             }

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -263,13 +263,13 @@ namespace TrenchBroom {
             return vm::to_degrees(angleInRadians);
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParaxialTexCoordSystem::doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> ParaxialTexCoordSystem::doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
             return ParallelTexCoordSystem::fromParaxial(point0, point1, point2, attribs);
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParaxialTexCoordSystem::doToParaxial(const vm::vec3&, const vm::vec3&, const vm::vec3&, const BrushFaceAttributes& attribs) const {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> ParaxialTexCoordSystem::doToParaxial(const vm::vec3&, const vm::vec3&, const vm::vec3&, const BrushFaceAttributes& attribs) const {
             // Already in the requested format
-            return { clone(), std::make_unique<BrushFaceAttributes>(attribs)};
+            return { clone(), attribs };
         }
 
         void ParaxialTexCoordSystem::rotateAxes(vm::vec3& xAxis, vm::vec3& yAxis, const FloatType angleInRadians, const size_t planeNormIndex) const {
@@ -610,7 +610,7 @@ namespace TrenchBroom {
             }
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> ParaxialTexCoordSystem::fromParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, const vm::vec3& xAxis, const vm::vec3& yAxis) {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> ParaxialTexCoordSystem::fromParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, const vm::vec3& xAxis, const vm::vec3& yAxis) {
             const vm::plane3 facePlane = planeFromPoints(point0, point1, point2);
             const vm::mat4x4f worldToTexSpace = FromParallel::valveTo4x4Matrix(facePlane, attribs, xAxis, yAxis);
             const auto facePoints = std::array<vm::vec3f, 3>{vm::vec3f(point0), vm::vec3f(point1), vm::vec3f(point2)};
@@ -629,7 +629,7 @@ namespace TrenchBroom {
             }
 
             return { std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, newAttribs),
-                     std::make_unique<BrushFaceAttributes>(newAttribs) };
+                     newAttribs };
         }
     }
 }

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -410,7 +410,7 @@ namespace TrenchBroom {
 
                         // recheck, they should be perpendicular now
                         const float newCosAngle = vm::dot(vm::normalize(Xvec), vm::normalize(Yvec));
-                        assert(fabs(newCosAngle) <= 0.001);
+                        assert(fabs(newCosAngle) <= 0.001); unused(newCosAngle);
 
                         // update M
                         M[0][0] = Xvec[0];

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -374,14 +374,6 @@ namespace TrenchBroom {
                 return unsignedDegrees;
             }
 
-            /**
-             *
-             *
-             * @param M
-             * @param facePlane the face plane in world space
-             * @param preserveX whether to preserve the X or Y coordinate of the texture if there is shearing in M
-             * @return std::nullopt if the conversion failed for some reason
-             */
             static std::optional<ParaxialAttribsNoOffset> extractParaxialAttribs(vm::mat2x2f M, const vm::plane3& facePlane, const bool preserveX) {
                 // Check for shear, because we might tweak M to remove it
                 {
@@ -500,7 +492,7 @@ namespace TrenchBroom {
                 return std::nullopt;
             }
 
-            static std::optional<ParaxialAttribs> TexDef_BSPToQuakeEd(const vm::plane3& faceplane, const vm::mat4x4f& worldToTexSpace, const std::array<vm::vec3f, 3>& facePoints) {
+            static std::optional<ParaxialAttribs> texCoordMatrixToParaxial(const vm::plane3& faceplane, const vm::mat4x4f& worldToTexSpace, const std::array<vm::vec3f, 3>& facePoints) {
                 // First get the un-rotated, un-scaled unit texture vecs (based on the face plane).
                 vm::vec3f snappedNormal;
                 vm::vec3f unrotatedVecs[2];
@@ -621,7 +613,7 @@ namespace TrenchBroom {
             const vm::mat4x4f worldToTexSpace = FromParallel::valveTo4x4Matrix(facePlane, attribs, xAxis, yAxis);
             const auto facePoints = std::array<vm::vec3f, 3>{vm::vec3f(point0), vm::vec3f(point1), vm::vec3f(point2)};
 
-            const auto conversionResult = FromParallel::TexDef_BSPToQuakeEd(facePlane, worldToTexSpace, facePoints);
+            const auto conversionResult = FromParallel::texCoordMatrixToParaxial(facePlane, worldToTexSpace, facePoints);
 
             BrushFaceAttributes newAttribs = attribs;
             if (conversionResult.has_value()) {

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -506,7 +506,7 @@ namespace TrenchBroom {
 
                 // Project the 3 reference points onto the axis plane. They are now 2d points.
                 vm::vec2f facepointsProjected[3];
-                for (int i=0; i<3; i++) {
+                for (size_t i = 0; i < 3; ++i) {
                     facepointsProjected[i] = projectToAxisPlane(snappedNormal, facePoints[i]);
                 }
 

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -73,12 +73,12 @@ namespace TrenchBroom {
 
             float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const override;
 
-            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
-            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
+            std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
+            std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
         private:
             void rotateAxes(vm::vec3& xAxis, vm::vec3& yAxis, FloatType angleInRadians, size_t planeNormIndex) const;
         public:
-            static std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> fromParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, const vm::vec3& xAxis, const vm::vec3& yAxis);
+            static std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> fromParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, const vm::vec3& xAxis, const vm::vec3& yAxis);
         private:
             deleteCopyAndMove(ParaxialTexCoordSystem)
         };

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -45,6 +45,7 @@ namespace TrenchBroom {
             static size_t planeNormalIndex(const vm::vec3& normal);
             static void axes(size_t index, vm::vec3& xAxis, vm::vec3& yAxis);
             static void axes(size_t index, vm::vec3& xAxis, vm::vec3& yAxis, vm::vec3& projectionAxis);
+            static vm::plane3 planeFromPoints(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2);
         private:
             std::unique_ptr<TexCoordSystem> doClone() const override;
             std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() const override;
@@ -71,9 +72,14 @@ namespace TrenchBroom {
             void doShearTexture(const vm::vec3& normal, const vm::vec2f& factors) override;
 
             float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const override;
+
+            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
+            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const override;
         private:
             void rotateAxes(vm::vec3& xAxis, vm::vec3& yAxis, FloatType angleInRadians, size_t planeNormIndex) const;
-
+        public:
+            static std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> fromParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, const vm::vec3& xAxis, const vm::vec3& yAxis);
+        private:
             deleteCopyAndMove(ParaxialTexCoordSystem)
         };
     }

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -20,6 +20,8 @@
 #include "TexCoordSystem.h"
 
 #include "Model/BrushFace.h"
+#include "Model/ParallelTexCoordSystem.h"
+#include "Model/ParaxialTexCoordSystem.h"
 
 #include <vecmath/mat.h>
 #include <vecmath/mat_ext.h>
@@ -217,5 +219,12 @@ namespace TrenchBroom {
                          dot(point, safeScaleAxis(getYAxis(), scale.y())));
         }
 
+        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> TexCoordSystem::toParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+            return doToParallel(point0, point1, point2, attribs);
+        }
+
+        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> TexCoordSystem::toParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+            return doToParaxial(point0, point1, point2, attribs);
+        }
     }
 }

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -219,11 +219,11 @@ namespace TrenchBroom {
                          dot(point, safeScaleAxis(getYAxis(), scale.y())));
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> TexCoordSystem::toParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> TexCoordSystem::toParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
             return doToParallel(point0, point1, point2, attribs);
         }
 
-        std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> TexCoordSystem::toParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
+        std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> TexCoordSystem::toParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const {
             return doToParaxial(point0, point1, point2, attribs);
         }
     }

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -23,6 +23,8 @@
 #include "FloatType.h"
 #include "Macros.h"
 
+#include "Model/BrushFaceAttributes.h"
+
 #include <vecmath/vec.h>
 
 #include <memory>
@@ -30,7 +32,6 @@
 
 namespace TrenchBroom {
     namespace Model {
-        class BrushFaceAttributes;
         class ParallelTexCoordSystem;
         class ParaxialTexCoordSystem;
         class TexCoordSystem;
@@ -87,8 +88,8 @@ namespace TrenchBroom {
             vm::mat4x4 fromMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;
             float measureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const;
 
-            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> toParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const;
-            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> toParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const;
+            std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> toParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const;
+            std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> toParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const;
         private:
             virtual std::unique_ptr<TexCoordSystem> doClone() const = 0;
             virtual std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() const = 0;
@@ -116,8 +117,8 @@ namespace TrenchBroom {
 
             virtual float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const = 0;
 
-            virtual std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const = 0;
-            virtual std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const = 0;
+            virtual std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const = 0;
+            virtual std::tuple<std::unique_ptr<TexCoordSystem>, BrushFaceAttributes> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const = 0;
         protected:
             vm::vec2f computeTexCoords(const vm::vec3& point, const vm::vec2f& scale) const;
 

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -26,7 +26,7 @@
 #include <vecmath/vec.h>
 
 #include <memory>
-#include <utility> // for std::pair
+#include <tuple>
 
 namespace TrenchBroom {
     namespace Model {

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -26,6 +26,7 @@
 #include <vecmath/vec.h>
 
 #include <memory>
+#include <utility> // for std::pair
 
 namespace TrenchBroom {
     namespace Model {
@@ -85,6 +86,9 @@ namespace TrenchBroom {
             vm::mat4x4 toMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;
             vm::mat4x4 fromMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;
             float measureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const;
+
+            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> toParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const;
+            std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> toParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const;
         private:
             virtual std::unique_ptr<TexCoordSystem> doClone() const = 0;
             virtual std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() const = 0;
@@ -111,6 +115,9 @@ namespace TrenchBroom {
             virtual void doShearTexture(const vm::vec3& normal, const vm::vec2f& factors) = 0;
 
             virtual float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const = 0;
+
+            virtual std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const = 0;
+            virtual std::tuple<std::unique_ptr<TexCoordSystem>, std::unique_ptr<BrushFaceAttributes>> doToParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) const = 0;
         protected:
             vm::vec2f computeTexCoords(const vm::vec3& point, const vm::vec2f& scale) const;
 

--- a/common/src/Model/WorldNode.cpp
+++ b/common/src/Model/WorldNode.cpp
@@ -415,8 +415,12 @@ namespace TrenchBroom {
             return m_factory->createFace(point1, point2, point3, attribs);
         }
 
-        kdl::result<BrushFace, BrushError> WorldNode::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
-            return m_factory->createFace(point1, point2, point3, attribs, texAxisX, texAxisY);
+        kdl::result<BrushFace, BrushError> WorldNode::doCreateFaceFromStandard(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
+            return m_factory->createFaceFromStandard(point1, point2, point3, attribs);
+        }
+
+        kdl::result<BrushFace, BrushError> WorldNode::doCreateFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
+            return m_factory->createFaceFromValve(point1, point2, point3, attribs, texAxisX, texAxisY);
         }
 
         void WorldNode::doAcceptTagVisitor(TagVisitor& visitor) {

--- a/common/src/Model/WorldNode.h
+++ b/common/src/Model/WorldNode.h
@@ -134,7 +134,8 @@ namespace TrenchBroom {
             GroupNode* doCreateGroup(const std::string& name) const override;
             EntityNode* doCreateEntity() const override;
             kdl::result<BrushFace, BrushError> doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const override;
-            kdl::result<BrushFace, BrushError> doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const override;
+            kdl::result<BrushFace, BrushError> doCreateFaceFromStandard(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const override;
+            kdl::result<BrushFace, BrushError> doCreateFaceFromValve(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const override;
         private: // implement Taggable interface
             void doAcceptTagVisitor(TagVisitor& visitor) override;
             void doAcceptTagVisitor(ConstTagVisitor& visitor) const override;

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -153,7 +153,7 @@ namespace TrenchBroom {
             // Otherwise, the UV comparisons below could spuriously pass.
             ASSERT_NE(nullptr, face.texture());
 
-            ASSERT_TRUE(UVListsEqual(uvs, transformedVertUVs));
+            CHECK(UVListsEqual(uvs, transformedVertUVs));
         }
 
         /**
@@ -196,6 +196,30 @@ namespace TrenchBroom {
             }
 
             checkUVListsEqual(face_UVs, resetFace_UVs, face);
+        }
+
+        static void checkFaceUVsEqual(const BrushFace& face, const BrushFace& other) {
+            std::vector<vm::vec3> verts;
+            std::vector<vm::vec2f> faceUVs;
+            std::vector<vm::vec2f> otherFaceUVs;
+
+            for (const auto* vertex : face.vertices()) {
+                verts.push_back(vertex->position());
+
+                const vm::vec3 position(vertex->position());
+                faceUVs.push_back(face.textureCoords(position));
+                otherFaceUVs.push_back(other.textureCoords(position));
+            }
+
+            checkUVListsEqual(faceUVs, otherFaceUVs, face);
+        }
+
+        static void checkBrushUVsEqual(const Brush& brush, const Brush& other) {
+            assert(brush.faceCount() == other.faceCount());
+
+            for (size_t i = 0; i < brush.faceCount(); ++i) {
+                checkFaceUVsEqual(brush.face(i), other.face(i));
+            }
         }
 
         /**
@@ -246,7 +270,8 @@ namespace TrenchBroom {
          * generates many different transformations and checks that the UVs are
          * stable after these transformations.
          */
-        static void checkTextureLockWithTranslationAnd90DegreeRotations(const BrushFace& origFace) {
+        template <class L>
+        static void doWithTranslationAnd90DegreeRotations(L&& lambda) {
             for (int i=0; i<(1 << 7); i++) {
                 vm::mat4x4 xform;
 
@@ -276,16 +301,16 @@ namespace TrenchBroom {
                 if (pitchPlus90) xform = vm::rotation_matrix(0.0, vm::to_radians(90.0), 0.0) * xform;
                 if (yawPlus90) xform = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0)) * xform;
 
-                checkTextureLockOnWithTransform(xform, origFace);
+                lambda(xform);
             }
         }
 
         /**
-         * Tests texture lock by rotating by the given amount, in each axis alone,
+         * Generates transforms for testing texture lock, etc., by rotating by the given amount, in each axis alone,
          * as well as in all combinations of axes.
          */
-        static void checkTextureLockWithMultiAxisRotations(const BrushFace& origFace,
-                                                           double degrees) {
+        template <class L>
+        static void doMultiAxisRotations(const double degrees, L&& lambda) {
             const double rotateRadians = vm::to_radians(degrees);
 
             for (int i=0; i<(1 << 3); i++) {
@@ -305,15 +330,16 @@ namespace TrenchBroom {
                     xform = vm::rotation_matrix(0.0, 0.0, rotateRadians) * xform;
                 }
 
-                checkTextureLockOnWithTransform(xform, origFace);
+                lambda(xform);
             }
         }
 
         /**
-         * Tests texture lock by rotating +/- the given amount, in one axis at a time.
+         * Runs the given lambda of type `const vm::mat4x4& -> void` with
+         * rotations of the given angle in degrees in +/- pitch, yaw, and roll.
          */
-        static void checkTextureLockWithSingleAxisRotations(const BrushFace& origFace,
-                                                            double degrees) {
+        template <class L>
+        static void doWithSingleAxisRotations(const double degrees, L&& lambda) {
             const double rotateRadians = vm::to_radians(degrees);
 
             for (int i=0; i<6; i++) {
@@ -328,7 +354,7 @@ namespace TrenchBroom {
                     case 5: xform = vm::rotation_matrix(0.0, 0.0, -rotateRadians) * xform; break;
                 }
 
-                checkTextureLockOnWithTransform(xform, origFace);
+                lambda(xform);
             }
         }
 
@@ -337,33 +363,43 @@ namespace TrenchBroom {
             checkTextureLockOffWithTransform(xform, origFace);
         }
 
-        static void checkTextureLockWithScale(const BrushFace& origFace, const vm::vec3& scaleFactors) {
+        template <class L>
+        static void doWithScale(const vm::vec3& scaleFactors, L&& lambda) {
             vm::mat4x4 xform = vm::scaling_matrix(scaleFactors);
-            checkTextureLockOnWithTransform(xform, origFace);
+            lambda(xform);
         }
 
-        static void checkTextureLockWithShear(const BrushFace& origFace) {
+        template <class L>
+        static void doWithShear(L&& lambda) {
             // shear the x axis towards the y axis
             vm::mat4x4 xform = vm::shear_matrix(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-            checkTextureLockOnWithTransform(xform, origFace);
+            lambda(xform);
         }
 
-        static void checkTextureLockForFace(const BrushFace& origFace, bool doParallelTests) {
-            checkTextureLockWithTranslationAnd90DegreeRotations(origFace);
-            checkTextureLockWithSingleAxisRotations(origFace, 30);
-            checkTextureLockWithSingleAxisRotations(origFace, 45);
+        template <class L>
+        static void doWithTextureLockTestTransforms(const bool doParallelTests, L&& lambda) {
+            doWithTranslationAnd90DegreeRotations(lambda);
+            doWithSingleAxisRotations(30, lambda);
+            doWithSingleAxisRotations(45, lambda);
 
             // rotation on multiple axes simultaneously is only expected to work on ParallelTexCoordSystem
             if (doParallelTests) {
-                checkTextureLockWithMultiAxisRotations(origFace, 30);
-                checkTextureLockWithMultiAxisRotations(origFace, 45);
+                doMultiAxisRotations(30.0, lambda);
+                doMultiAxisRotations(45.0, lambda);
 
-                checkTextureLockWithShear(origFace);
+                doWithShear(lambda);
             }
 
-            checkTextureLockOffWithTranslation(origFace);
+            doWithScale(vm::vec3(2, 2, 1), lambda);
+            doWithScale(vm::vec3(2, 2, -1), lambda);
+        }
 
-            checkTextureLockWithScale(origFace, vm::vec3(2, 2, 1));
+        static void checkTextureLockForFace(const BrushFace& origFace, const bool doParallelTests) {
+            doWithTextureLockTestTransforms(doParallelTests, [&](const vm::mat4x4& xform){
+                checkTextureLockOnWithTransform(xform, origFace);
+            });
+
+            checkTextureLockOffWithTranslation(origFace);
         }
 
         /**
@@ -639,6 +675,76 @@ namespace TrenchBroom {
             CHECK(brush.moveBoundary(worldBounds, *angledFaceIndex, vm::vec3(-7.9999999999999973, 7.9999999999999973, 0), true).is_success());
 
             kdl::vec_clear_and_delete(nodes);
+        }
+
+        TEST_CASE("BrushFaceTest.formatConversion", "[BrushFaceTest]") {
+            const vm::bbox3 worldBounds(4096.0);
+
+            WorldNode standardWorld(MapFormat::Standard);
+            WorldNode valveWorld(MapFormat::Valve);
+
+            BrushBuilder standardBuilder(&standardWorld, worldBounds);
+            BrushBuilder valveBuilder(&valveWorld, worldBounds);
+
+            Assets::Texture texture("testTexture", 64, 64);
+
+            const Brush startingCube = standardBuilder.createCube(128.0, "")
+                    .and_then([&](Brush&& brush){
+                        for (size_t i = 0; i < brush.faceCount(); ++i) {
+                            BrushFace& face = brush.face(i);
+                            face.setTexture(&texture);
+                        }
+                        return kdl::result<Brush>::success(brush);
+                    }).value();
+
+            auto testTransform = [&](const vm::mat4x4& transform){
+                const Brush standardCube = startingCube.transform(worldBounds, transform, true).value();
+
+                Brush valveCube = standardCube;
+                valveCube.convertToParallel();
+                checkBrushUVsEqual(standardCube, valveCube);
+
+                Brush standardCubeRoundTrip = valveCube;
+                standardCubeRoundTrip.convertToParaxial();
+                checkBrushUVsEqual(standardCube, standardCubeRoundTrip);
+            };
+
+            // NOTE: intentionally include the shear/multi-axis rotations which won't work properly on Standard.
+            // We're not testing texture lock, just generating interesting brushes to test
+            // Standard -> Valve -> Standard round trip, so it doesn't matter if texture lock works.
+            doWithTextureLockTestTransforms(true, testTransform);
+        }
+
+        TEST_CASE("BrushFaceTest.nodeReaderConversion", "[BrushFaceTest]") {
+            const std::string data(R"(
+// entity 0
+{
+"classname" "worldspawn"
+"mapversion" "220"
+// brush 0
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) __TB_empty [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) __TB_empty [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+}
+}
+)");
+
+            const vm::bbox3 worldBounds(4096.0);
+            WorldNode world(MapFormat::Standard);
+
+            IO::TestParserStatus status;
+            IO::NodeReader reader(data, world);
+
+            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            auto* brushNode = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
+            REQUIRE(brushNode != nullptr);
+
+            Brush brush = brushNode->brush();
+            CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
     }
 }

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -699,13 +699,14 @@ namespace TrenchBroom {
 
             auto testTransform = [&](const vm::mat4x4& transform){
                 const Brush standardCube = startingCube.transform(worldBounds, transform, true).value();
+                CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&standardCube.face(0).texCoordSystem()));
 
-                Brush valveCube = standardCube;
-                valveCube.convertToParallel();
+                const Brush valveCube = standardCube.convertToParallel();
+                CHECK(dynamic_cast<const ParallelTexCoordSystem*>(&valveCube.face(0).texCoordSystem()));
                 checkBrushUVsEqual(standardCube, valveCube);
 
-                Brush standardCubeRoundTrip = valveCube;
-                standardCubeRoundTrip.convertToParaxial();
+                const Brush standardCubeRoundTrip = valveCube.convertToParaxial();
+                CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&standardCubeRoundTrip.face(0).texCoordSystem()));
                 checkBrushUVsEqual(standardCube, standardCubeRoundTrip);
             };
 


### PR DESCRIPTION
Fixes #1448

- conversion only happens in `NodeReader::read`, i.e. when pasting, not when opening maps.
- conversion only happens between Standard and Valve variants of a game, not between games. 

Here's a screenshot of a valve -> standard conversion:
![v](https://user-images.githubusercontent.com/239161/89725442-e06cbd80-d9cc-11ea-84de-2622f05cb1af.PNG)
![s_tb](https://user-images.githubusercontent.com/239161/89725447-e793cb80-d9cc-11ea-8229-edaf24c6ffc9.PNG)
