### PR TITLE
3422: fix crash when a compile task fails

### DIFF
--- a/common/src/View/CompilationRun.cpp
+++ b/common/src/View/CompilationRun.cpp
@@ -78,9 +78,9 @@ namespace TrenchBroom {
             CompilationVariables variables(document, buildWorkDir(profile, document));
 
             auto compilationContext = std::make_unique<CompilationContext>(document, variables, TextOutputAdapter(currentOutput), test);
-            m_currentRun = std::make_unique<CompilationRunner>(std::move(compilationContext), profile);
-            connect(m_currentRun.get(), &CompilationRunner::compilationStarted, this, &CompilationRun::compilationStarted);
-            connect(m_currentRun.get(), &CompilationRunner::compilationEnded, this, [&]() { cleanup(); emit compilationEnded(); });
+            m_currentRun = new CompilationRunner(std::move(compilationContext), profile, this);
+            connect(m_currentRun, &CompilationRunner::compilationStarted, this, &CompilationRun::compilationStarted);
+            connect(m_currentRun, &CompilationRunner::compilationEnded, this, [&]() { cleanup(); emit compilationEnded(); });
             m_currentRun->execute();
         }
 
@@ -89,7 +89,11 @@ namespace TrenchBroom {
         }
 
         void CompilationRun::cleanup() {
-            m_currentRun.reset();
+            if (m_currentRun != nullptr) {
+                // It's not safe to delete a CompilationRunner during execution of one of its signals, so use deleteLater()
+                m_currentRun->deleteLater();
+                m_currentRun = nullptr;
+            }
         }
     }
 }

--- a/common/src/View/CompilationRun.h
+++ b/common/src/View/CompilationRun.h
@@ -41,7 +41,7 @@ namespace TrenchBroom {
         class CompilationRun : public QObject {
             Q_OBJECT
         private:
-            std::unique_ptr<CompilationRunner> m_currentRun;
+            CompilationRunner* m_currentRun;
         public:
             CompilationRun();
             ~CompilationRun() override;

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -215,10 +215,11 @@ namespace TrenchBroom {
             }
         }
 
-        CompilationRunner::CompilationRunner(std::unique_ptr<CompilationContext> context, const Model::CompilationProfile* profile) :
+        CompilationRunner::CompilationRunner(std::unique_ptr<CompilationContext> context, const Model::CompilationProfile* profile, QObject* parent) :
         m_context(std::move(context)),
         m_taskRunners(createTaskRunners(*m_context, profile)),
-        m_currentTask(std::end(m_taskRunners)) {}
+        m_currentTask(std::end(m_taskRunners)),
+        QObject(parent) {}
 
         CompilationRunner::~CompilationRunner() = default;
 

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -216,10 +216,10 @@ namespace TrenchBroom {
         }
 
         CompilationRunner::CompilationRunner(std::unique_ptr<CompilationContext> context, const Model::CompilationProfile* profile, QObject* parent) :
+        QObject(parent),
         m_context(std::move(context)),
         m_taskRunners(createTaskRunners(*m_context, profile)),
-        m_currentTask(std::end(m_taskRunners)),
-        QObject(parent) {}
+        m_currentTask(std::end(m_taskRunners)) {}
 
         CompilationRunner::~CompilationRunner() = default;
 

--- a/common/src/View/CompilationRunner.h
+++ b/common/src/View/CompilationRunner.h
@@ -125,7 +125,7 @@ namespace TrenchBroom {
             TaskRunnerList m_taskRunners;
             TaskRunnerList::iterator m_currentTask;
         public:
-            CompilationRunner(std::unique_ptr<CompilationContext> context, const Model::CompilationProfile* profile);
+            CompilationRunner(std::unique_ptr<CompilationContext> context, const Model::CompilationProfile* profile, QObject* parent = nullptr);
             ~CompilationRunner() override;
         private:
             class CreateTaskRunnerVisitor;


### PR DESCRIPTION
Caused by deleting the CompilationRun (deleting the QProcess) during execution of a QProcess signal.

Fixes #3422