### PR TITLE
3421: entity attribute grid fixes

### DIFF
--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -47,6 +47,8 @@
 #include <QSortFilterProxyModel>
 #include <QTimer>
 
+#define GRID_LOG(x)
+
 namespace TrenchBroom {
     namespace View {
         EntityAttributeGrid::EntityAttributeGrid(std::weak_ptr<MapDocument> document, QWidget* parent) :
@@ -63,23 +65,24 @@ namespace TrenchBroom {
         void EntityAttributeGrid::backupSelection() {
             m_selectionBackup.clear();
 
-            qDebug() << "Backup selection";
+            GRID_LOG(qDebug() << "Backup selection");
             for (const QModelIndex& index : m_table->selectionModel()->selectedIndexes()) {
                 const QModelIndex sourceIndex = m_proxyModel->mapToSource(index);
                 const std::string attributeName = m_model->attributeName(sourceIndex.row());
                 m_selectionBackup.push_back({ attributeName, sourceIndex.column() });
 
-                qDebug() << "Backup selection: " << QString::fromStdString(attributeName) << "," << sourceIndex.column();
+                GRID_LOG(qDebug() << "Backup selection: " << QString::fromStdString(attributeName) << "," << sourceIndex.column());
             }
         }
 
         void EntityAttributeGrid::restoreSelection() {
             m_table->selectionModel()->clearSelection();
 
+            GRID_LOG(qDebug() << "Restore selection");
             for (const auto& selection : m_selectionBackup) {
                 const int row = m_model->rowForAttributeName(selection.attributeName);
                 if (row == -1) {
-                    qDebug() << "Restore selection: couldn't find " << QString::fromStdString(selection.attributeName);
+                    GRID_LOG(qDebug() << "Restore selection: couldn't find " << QString::fromStdString(selection.attributeName));
                     continue;
                 }
                 const QModelIndex sourceIndex = m_model->index(row, selection.column);
@@ -87,8 +90,9 @@ namespace TrenchBroom {
                 m_table->selectionModel()->select(proxyIndex, QItemSelectionModel::Select);
                 m_table->selectionModel()->setCurrentIndex(proxyIndex, QItemSelectionModel::Current);
 
-                qDebug() << "Restore selection: " << QString::fromStdString(selection.attributeName) << "," << selection.column;
+                GRID_LOG(qDebug() << "Restore selection: " << QString::fromStdString(selection.attributeName) << "," << selection.column);
             }
+            GRID_LOG(qDebug() << "Restore selection: current is " << QString::fromStdString(selectedRowName()));
         }
 
         void EntityAttributeGrid::addAttribute() {
@@ -241,7 +245,7 @@ namespace TrenchBroom {
                 // So selectedRowsAndCursorRow() will return a mix of the new current row and old selection.
                 // Because of this, it's important to also call updateControlsEnabled() in response to QItemSelectionModel::selectionChanged
                 // as we do below. (#3165)
-                qDebug() << "current changed form " << previous << " to " << current;
+                GRID_LOG(qDebug() << "current changed form " << previous << " to " << current);
                 updateControlsEnabled();
                 ensureSelectionVisible();
                 emit currentRowChanged();

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -19,6 +19,7 @@
 
 #include "EntityAttributeGrid.h"
 
+#include "Macros.h"
 #include "Model/EntityAttributes.h"
 #include "View/BorderLine.h"
 #include "View/EntityAttributeItemDelegate.h"
@@ -44,6 +45,7 @@
 #include <QDebug>
 #include <QKeyEvent>
 #include <QSortFilterProxyModel>
+#include <QTimer>
 
 namespace TrenchBroom {
     namespace View {
@@ -56,6 +58,37 @@ namespace TrenchBroom {
 
         EntityAttributeGrid::~EntityAttributeGrid() {
             unbindObservers();
+        }
+
+        void EntityAttributeGrid::backupSelection() {
+            m_selectionBackup.clear();
+
+            qDebug() << "Backup selection";
+            for (const QModelIndex& index : m_table->selectionModel()->selectedIndexes()) {
+                const QModelIndex sourceIndex = m_proxyModel->mapToSource(index);
+                const std::string attributeName = m_model->attributeName(sourceIndex.row());
+                m_selectionBackup.push_back({ attributeName, sourceIndex.column() });
+
+                qDebug() << "Backup selection: " << QString::fromStdString(attributeName) << "," << sourceIndex.column();
+            }
+        }
+
+        void EntityAttributeGrid::restoreSelection() {
+            m_table->selectionModel()->clearSelection();
+
+            for (const auto& selection : m_selectionBackup) {
+                const int row = m_model->rowForAttributeName(selection.attributeName);
+                if (row == -1) {
+                    qDebug() << "Restore selection: couldn't find " << QString::fromStdString(selection.attributeName);
+                    continue;
+                }
+                const QModelIndex sourceIndex = m_model->index(row, selection.column);
+                const QModelIndex proxyIndex = m_proxyModel->mapFromSource(sourceIndex);
+                m_table->selectionModel()->select(proxyIndex, QItemSelectionModel::Select);
+                m_table->selectionModel()->setCurrentIndex(proxyIndex, QItemSelectionModel::Current);
+
+                qDebug() << "Restore selection: " << QString::fromStdString(selection.attributeName) << "," << selection.column;
+            }
         }
 
         void EntityAttributeGrid::addAttribute() {
@@ -202,6 +235,8 @@ namespace TrenchBroom {
             });
 
             connect(m_table->selectionModel(), &QItemSelectionModel::currentChanged, this, [=](const QModelIndex& current, const QModelIndex& previous){
+                unused(current);
+                unused(previous);
                 // NOTE: when we get this signal, the selection hasn't been updated yet.
                 // So selectedRowsAndCursorRow() will return a mix of the new current row and old selection.
                 // Because of this, it's important to also call updateControlsEnabled() in response to QItemSelectionModel::selectionChanged
@@ -213,6 +248,9 @@ namespace TrenchBroom {
             });
 
             connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged, this, [=](){
+                if (!m_table->selectionModel()->selectedIndexes().empty()) {
+                    backupSelection();
+                }
                 updateControlsEnabled();
                 emit currentRowChanged();
             });
@@ -292,9 +330,15 @@ namespace TrenchBroom {
             // is selected. If we call this directly, it'll cause the table to be rebuilt based on that intermediate
             // state. Everything is fine except you lose the selected row in the table, unless it's a key
             // name that exists in worldspawn. To avoid that problem, make a delayed call to update the table.
-            QMetaObject::invokeMethod(m_model, "updateFromMapDocument", Qt::QueuedConnection);
+            QTimer::singleShot(0, this, [&](){
+                m_model->updateFromMapDocument();
+
+                if (m_table->selectionModel()->selectedIndexes().empty()) {
+                    restoreSelection();
+                }
+                ensureSelectionVisible();
+            });
             updateControlsEnabled();
-            ensureSelectionVisible();
         }
 
         void EntityAttributeGrid::ensureSelectionVisible() {

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -43,6 +43,11 @@ namespace TrenchBroom {
         class MapDocument;
         class Selection;
 
+        struct AttributeGridSelection {
+            std::string attributeName;
+            int column;
+        };
+
         /**
          * Panel with the entity attribute table, and the toolbar below it (add/remove icons,
          * "show default properties" checkbox, etc.)
@@ -58,10 +63,14 @@ namespace TrenchBroom {
             QAbstractButton* m_addAttributeButton;
             QAbstractButton* m_removePropertiesButton;
             QCheckBox* m_showDefaultPropertiesCheckBox;
+            std::vector<AttributeGridSelection> m_selectionBackup;
         public:
             explicit EntityAttributeGrid(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
             ~EntityAttributeGrid() override;
         private:
+            void backupSelection();
+            void restoreSelection();
+
             void addAttribute();
             void removeSelectedAttributes();
 

--- a/common/src/View/EntityAttributeModel.cpp
+++ b/common/src/View/EntityAttributeModel.cpp
@@ -52,6 +52,8 @@
 #include <QString>
 #include <QTimer>
 
+#define MODEL_LOG(x)
+
 namespace TrenchBroom {
     namespace View {
         // AttributeRow
@@ -313,7 +315,7 @@ namespace TrenchBroom {
             const auto oldRowMap = makeNameToAttributeRowMap(m_rows);
 
             if (newRowMap == oldRowMap) {
-                qDebug() << "EntityAttributeModel::setRows: no change";
+                MODEL_LOG(qDebug() << "EntityAttributeModel::setRows: no change");
                 return;
             }
 
@@ -330,7 +332,7 @@ namespace TrenchBroom {
                 const AttributeRow& oldDeletion = oldRowMap.at(diff.removed[0]);
                 const AttributeRow& newAddition = newRowMap.at(diff.added[0]);
 
-                qDebug() << "EntityAttributeModel::setRows: one row changed: " << mapStringToUnicode(document->encoding(), oldDeletion.name()) << " -> " << mapStringToUnicode(document->encoding(), newAddition.name());
+                MODEL_LOG(qDebug() << "EntityAttributeModel::setRows: one row changed: " << mapStringToUnicode(document->encoding(), oldDeletion.name()) << " -> " << mapStringToUnicode(document->encoding(), newAddition.name()));
 
                 const auto oldIndex = kdl::vec_index_of(m_rows, oldDeletion);
                 ensure(oldIndex, "deleted row must be found");
@@ -346,13 +348,13 @@ namespace TrenchBroom {
 
             // Handle edited rows
 
-            qDebug() << "EntityAttributeModel::setRows: " << diff.updated.size() << " common keys";
+            MODEL_LOG(qDebug() << "EntityAttributeModel::setRows: " << diff.updated.size() << " common keys");
             for (const auto& key : diff.updated) {
                 const AttributeRow& oldRow = oldRowMap.at(key);
                 const AttributeRow& newRow = newRowMap.at(key);
                 const auto oldIndex = kdl::vec_index_of(m_rows, oldRow);
 
-                qDebug() << "   updating row " << *oldIndex << "(" << QString::fromStdString(key) << ")";
+                MODEL_LOG(qDebug() << "   updating row " << *oldIndex << "(" << QString::fromStdString(key) << ")");
 
                 m_rows.at(*oldIndex) = newRow;
 
@@ -364,7 +366,7 @@ namespace TrenchBroom {
 
             // Insertions
             if (!diff.added.empty()) {
-                qDebug() << "EntityAttributeModel::setRows: inserting " << diff.added.size() << " rows";
+                MODEL_LOG(qDebug() << "EntityAttributeModel::setRows: inserting " << diff.added.size() << " rows");
 
                 const int firstNewRow = static_cast<int>(m_rows.size());
                 const int lastNewRow = firstNewRow + static_cast<int>(diff.added.size()) - 1;
@@ -380,7 +382,7 @@ namespace TrenchBroom {
 
             // Deletions
             if (!diff.removed.empty()) {
-                qDebug() << "EntityAttributeModel::setRows: deleting " << diff.removed.size() << " rows";
+                MODEL_LOG(qDebug() << "EntityAttributeModel::setRows: deleting " << diff.removed.size() << " rows");
 
                 for (const std::string& key : diff.removed) {
                     const AttributeRow& row = oldRowMap.at(key);
@@ -504,7 +506,7 @@ namespace TrenchBroom {
         }
 
         void EntityAttributeModel::updateFromMapDocument() {
-            qDebug() << "updateFromMapDocument";
+            MODEL_LOG(qDebug() << "updateFromMapDocument");
 
             auto document = kdl::mem_lock(m_document);
 
@@ -640,15 +642,15 @@ namespace TrenchBroom {
 
             if (index.column() == 0) {
                 // rename key
-                qDebug() << "tried to rename " << mapStringToUnicode(document->encoding(), attributeRow.name()) << " to " << value.toString();
+                MODEL_LOG(qDebug() << "tried to rename " << mapStringToUnicode(document->encoding(), attributeRow.name()) << " to " << value.toString());
 
                 const std::string newName = mapStringFromUnicode(document->encoding(), value.toString());
                 if (renameAttribute(rowIndex, newName, attributables)) {
                     return true;
                 }
             } else if (index.column() == 1) {
-                qDebug() << "tried to set " << mapStringToUnicode(document->encoding(), attributeRow.name()) << " to "
-                         << value.toString();
+                MODEL_LOG(qDebug() << "tried to set " << mapStringToUnicode(document->encoding(), attributeRow.name()) << " to "
+                                   << value.toString());
 
                 if (updateAttribute(rowIndex, mapStringFromUnicode(document->encoding(), value.toString()), attributables)) {
                     return true;

--- a/common/src/View/EntityAttributeModel.h
+++ b/common/src/View/EntityAttributeModel.h
@@ -107,6 +107,9 @@ namespace TrenchBroom {
          *
          * All edits to the table flow this way; the EntityAttributeGridTable is never modified in response to
          * a UI action.
+         *
+         * The order of m_rows is not significant; it's expected that there is a sort proxy model
+         * used on top of this model.
          */
         class EntityAttributeModel : public QAbstractTableModel {
             Q_OBJECT

--- a/common/src/View/SmartAttributeEditorManager.cpp
+++ b/common/src/View/SmartAttributeEditorManager.cpp
@@ -72,7 +72,7 @@ namespace TrenchBroom {
                                                   new SmartFlagsEditor(m_document)));
             m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartAttributeEditorKeyMatcher({ "*_color", "*_color2", "*_colour" })),
                                                   new SmartColorEditor(m_document)));
-            m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartTypeEditorMatcher(Assets::AttributeDefinitionType::ChoiceAttribute)),
+            m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartTypeWithSameDefinitionEditorMatcher(Assets::AttributeDefinitionType::ChoiceAttribute)),
                                                   new SmartChoiceEditor(m_document)));
             m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartAttributeEditorDefaultMatcher()),
                                                   new SmartDefaultAttributeEditor(m_document)));

--- a/common/src/View/SmartTypeEditorMatcher.cpp
+++ b/common/src/View/SmartTypeEditorMatcher.cpp
@@ -24,10 +24,33 @@
 
 namespace TrenchBroom {
     namespace View {
+        // SmartTypeEditorMatcher
+
         SmartTypeEditorMatcher::SmartTypeEditorMatcher(const Assets::AttributeDefinitionType type) :
         m_type(type) {}
 
         bool SmartTypeEditorMatcher::doMatches(const std::string& name, const std::vector<Model::AttributableNode*>& attributables) const {
+            if (attributables.empty()) {
+                return false;
+            }
+            for (const auto* node : attributables) {
+                const auto* attrDef = node->attributeDefinition(name);
+                if (attrDef == nullptr) {
+                    return false;
+                }
+                if (attrDef->type() != m_type) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // SmartTypeWithSameDefinitionEditorMatcher
+
+        SmartTypeWithSameDefinitionEditorMatcher::SmartTypeWithSameDefinitionEditorMatcher(const Assets::AttributeDefinitionType type) :
+        m_type(type) {}
+
+        bool SmartTypeWithSameDefinitionEditorMatcher::doMatches(const std::string& name, const std::vector<Model::AttributableNode*>& attributables) const {
             const Assets::AttributeDefinition* attrDef = Model::AttributableNode::selectAttributeDefinition(name, attributables);
             return attrDef != nullptr && attrDef->type() == m_type;
         }

--- a/common/src/View/SmartTypeEditorMatcher.h
+++ b/common/src/View/SmartTypeEditorMatcher.h
@@ -35,11 +35,28 @@ namespace TrenchBroom {
     }
 
     namespace View {
+        /**
+         * Matches if all of the nodes have an attribute definition for the give attribute name that is of the
+         * type passed to the constructor.
+         */
         class SmartTypeEditorMatcher : public SmartAttributeEditorMatcher {
         private:
             Assets::AttributeDefinitionType m_type;
         public:
             SmartTypeEditorMatcher(Assets::AttributeDefinitionType type);
+        private:
+            bool doMatches(const std::string& name, const std::vector<Model::AttributableNode*>& attributables) const override;
+        };
+
+        /**
+         * Matches if all of the nodes have an attribute definition for the give attribute name that is of the
+         * type passed to the constructor, and these attribute definitions are all equal.
+         */
+        class SmartTypeWithSameDefinitionEditorMatcher : public SmartAttributeEditorMatcher {
+        private:
+            Assets::AttributeDefinitionType m_type;
+        public:
+            SmartTypeWithSameDefinitionEditorMatcher(Assets::AttributeDefinitionType type);
         private:
             bool doMatches(const std::string& name, const std::vector<Model::AttributableNode*>& attributables) const override;
         };


### PR DESCRIPTION
Fixes #3421

There are 3 changes here:

1. 671515cea03019d3e32acbf436b7aea41065b4fa stopped showing the spawnflags smart editor for multiple entities, if they had different spawnflags definitons. I've changed the meaning of `SmartTypeEditorMatcher` to allow this again, and added a new `SmartTypeWithSameDefinitionEditorMatcher` that does what `SmartTypeEditorMatcher` used to.

2. generate more precise diffs in EntityAttributeModel - the previous code only handled a few cases and it would give up and reset the model if rows were both added and removed. This change fixes the bug where a selected cell (e.g. "target") would get deselected if you clicked on a different entity with a different classname that still had a "target" cell.

3. Back up and restore selections in the attribute grid. This covers the case when you select a cell  (e.g. "target"), then select an entity that doesn't have that attribute (e.g. worldspawn), then select another entity that does have a "target". In 2019.6 we'd re-select "target", whereas in 2020.1 you would end up with nothing selected in the attribute grid. This change restores 2019.6 behaviour.