### PR TITLE
3436: clear tag actions in MapDocument::clearDocument()

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -324,6 +324,10 @@ namespace TrenchBroom {
             m_tagActions = actionManager.createTagActions(m_tagManager->smartTags());
         }
 
+        void MapDocument::clearTagActions() {
+            m_tagActions.clear();
+        }
+
         void MapDocument::createEntityDefinitionActions() {
             const auto& actionManager = ActionManager::instance();
             m_entityDefinitionActions = actionManager.createEntityDefinitionActions(m_entityDefinitionManager->definitions());
@@ -391,6 +395,7 @@ namespace TrenchBroom {
                 m_editorContext->reset();
                 clearSelection();
                 unloadAssets();
+                clearTagActions();
                 clearWorld();
                 clearModificationCount();
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -242,6 +242,7 @@ namespace TrenchBroom {
             }
 
             void createTagActions();
+            void clearTagActions();
             void createEntityDefinitionActions();
         public: // new, load, save document
             void newDocument(Model::MapFormat mapFormat, const vm::bbox3& worldBounds, std::shared_ptr<Model::Game> game);


### PR DESCRIPTION
Fixes #3436