### PR TITLE
3450: rewrite Grid::moveDeltaForBounds to avoid off-grid pastes on slopes

### DIFF
--- a/common/src/View/CreateEntityTool.cpp
+++ b/common/src/View/CreateEntityTool.cpp
@@ -117,8 +117,7 @@ namespace TrenchBroom {
             const auto& hit = pickResult.query().pickable().type(Model::BrushNode::BrushHitType).occluded().first();
             if (const auto faceHandle = Model::hitToFaceHandle(hit)) {
                 const auto& face = faceHandle->face();
-                const auto dragPlane = vm::aligned_orthogonal_plane(hit.hitPoint(), face.boundary().normal);
-                delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay);
+                delta = grid.moveDeltaForBounds(face.boundary(), m_entity->definitionBounds(), document->worldBounds(), pickRay);
             } else {
                 const auto newPosition = vm::point_at_distance(pickRay, static_cast<FloatType>(Renderer::Camera::DefaultPointDistance));
                 const auto boundsCenter = m_entity->definitionBounds().center();

--- a/common/src/View/Grid.cpp
+++ b/common/src/View/Grid.cpp
@@ -138,6 +138,7 @@ namespace TrenchBroom {
          * Intended to be used for placing objects (e.g. when pasting, or dragging from the entity browser)
          *
          * - One of the box corners is placed at the ray/targetPlane intersection, grid snapped
+         *   (snapping towards the ray origin)
          * - Exception to the previous point: if the targetPlane is axial plane,
          *   we'll treat the plane's normal axis as "on grid" even if it's not. This allows, e.g. pasting on
          *   top of 1 unit thick floor detail on grid 8.
@@ -160,7 +161,7 @@ namespace TrenchBroom {
             const size_t localX = vm::find_abs_max_component(targetPlane.normal, 1);
             const size_t localY = vm::find_abs_max_component(targetPlane.normal, 2);
 
-            vm::vec3 firstCorner = snap(hitPoint);
+            vm::vec3 firstCorner = snapTowards(hitPoint, -ray.direction);
             if (vm::is_equal(targetPlane.normal,
                              vm::get_abs_max_component_axis(targetPlane.normal),
                              vm::C::almost_zero())) {

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -334,11 +334,7 @@ namespace TrenchBroom {
              * Otherwise, returns the original point for that axis.
              */
             vm::vec3 moveDeltaForPoint(const vm::vec3& point, const vm::vec3& delta) const;
-            /**
-             * Returns a delta to `bounds.mins` which moves the box to point where `ray` impacts `dragPlane`, grid snapped.
-             * The box is positioned so it is in front of `dragPlane`.
-             */
-            vm::vec3 moveDeltaForBounds(const vm::plane3& dragPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::ray3& ray) const;
+            vm::vec3 moveDeltaForBounds(const vm::plane3& targetPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::ray3& ray) const;
             vm::vec3 moveDelta(const vm::bbox3& bounds, const vm::vec3& delta) const;
             vm::vec3 moveDelta(const vm::vec3& point, const vm::vec3& delta) const;
             vm::vec3 moveDelta(const vm::vec3& delta) const;

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -60,6 +60,9 @@ namespace TrenchBroom {
             void incSize();
             void decSize();
             FloatType actualSize() const;
+            /**
+             * Snap increment in radians for angle snapping
+             */
             FloatType angle() const;
 
             bool visible() const;
@@ -73,6 +76,9 @@ namespace TrenchBroom {
                 return snapAngle(a, angle());
             }
 
+            /**
+             * Snaps the given angle `a` to the nearest multiple of `snapAngle`, if grid snapping is enabled.
+             */
             template <typename T>
             T snapAngle(const T a, const T snapAngle) const {
                 if (!snap()) {
@@ -107,11 +113,32 @@ namespace TrenchBroom {
             }
         private:
             typedef enum {
+                /**
+                 * Snap to nearest grid increment (rounding away from 0 if the input is half way between two
+                 * multiples of the grid size).
+                 */
                 SnapDir_None,
+                /**
+                 * If off-grid, snap to the next larger grid increment.
+                 */
                 SnapDir_Up,
+                /**
+                 * If off-grid, snap to the next smaller grid increment.
+                 */
                 SnapDir_Down
             } SnapDir;
 
+            /**
+             * Snaps a scalar to the grid.
+             *
+             * @tparam T scalar type
+             * @param f scalar to snap
+             * @param snapDir snap direction, see SnapDir
+             * @param skip If true, SnapDir_Up/SnapDir_Down snap to the next larger/smaller grid increment even if
+             *             the input is already on-grid (within almost_zero()).
+             *             If false, on-grid inputs stay at the same grid increment.
+             * @return snapped scalar
+             */
             template <typename T>
             T snap(const T f, const SnapDir snapDir, const bool skip = false) const {
                 if (!snap()) {
@@ -134,6 +161,9 @@ namespace TrenchBroom {
                 }
             }
         public: // Snap vectors.
+            /**
+             * Snap each component to the nearest grid increment.
+             */
             template <typename T, size_t S>
             vm::vec<T,S> snap(const vm::vec<T,S>& p) const {
                 return snap(p, SnapDir_None);
@@ -187,7 +217,7 @@ namespace TrenchBroom {
                 }
                 return result;
             }
-        public: // Snapping on a plane! Surprise, motherfucker!
+        public: // Snapping on a plane.
             template <typename T>
             vm::vec<T,3> snap(const vm::vec<T,3>& p, const vm::plane<T,3>& onPlane) const {
                 return snap(p, onPlane, SnapDir_None, false);
@@ -224,6 +254,11 @@ namespace TrenchBroom {
                 return snap(p, onPlane, snapDirs, skip);
             }
 
+            /**
+             * Snaps p to grid on the two axes that aren't onPlane's major axis, then projects
+             * these two coordinates onto the plane to get the third axis. The resulting point will be on the plane
+             * and have two axes snapped to grid.
+             */
             template <typename T, size_t S>
             vm::vec<T,S> snap(const vm::vec<T,S>& p, const vm::plane<T,3>& onPlane, const SnapDir snapDirs[], const bool skip = false) const {
 

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -218,12 +218,11 @@ namespace TrenchBroom {
                 const auto& hit = pickResult.query().pickable().type(Model::BrushNode::BrushHitType).occluded().first();
                 if (const auto faceHandle = Model::hitToFaceHandle(hit)) {
                     const auto& face = faceHandle->face();
-                    const auto dragPlane = vm::aligned_orthogonal_plane(hit.hitPoint(), face.boundary().normal);
-                    return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay);
+                    return grid.moveDeltaForBounds(face.boundary(), bounds, document->worldBounds(), pickRay);
                 } else {
                     const auto point = vm::vec3(grid.snap(m_camera->defaultPoint(pickRay)));
-                    const auto dragPlane = vm::aligned_orthogonal_plane(point, -vm::vec3(vm::get_abs_max_component_axis(m_camera->direction())));
-                    return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay);
+                    const auto targetPlane = vm::plane3(point, -vm::vec3(m_camera->direction()));
+                    return grid.moveDeltaForBounds(targetPlane, bounds, document->worldBounds(), pickRay);
                 }
             } else {
                 const auto oldMin = bounds.min;

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -31,6 +31,7 @@
 #include <vecmath/forward.h>
 #include <vecmath/mat.h>
 #include <vecmath/vec.h>
+#include <vecmath/vec_io.h> // enable Catch2 to print vm::vec on test failures
 
 #include <string>
 

--- a/common/test/src/View/GridTest.cpp
+++ b/common/test/src/View/GridTest.cpp
@@ -282,6 +282,17 @@ namespace TrenchBroom {
                 // We allow a sub-grid result here because it's a flat plane
                 CHECK(grid16.moveDeltaForBounds(subGridPlatform, box, worldBounds, pickRay) == vm::vec3(16, 16, 4));
             }
+
+            SECTION("drop onto a slope") {
+                const auto [ok, slope] = vm::from_points(vm::vec3::zero(), vm::vec3(0, 100, 5), vm::vec3(100, 0, 0));
+                REQUIRE(ok);
+                CHECK(slope.normal.z() > 0.0);
+
+                const auto pickRay = make_ray_from_to(vm::vec3(0, 0, 200), vm::vec3(17, 17, 0));
+
+                // Float above the sloped plane
+                CHECK(grid16.moveDeltaForBounds(slope, box, worldBounds, pickRay) == vm::vec3(16, 16, 16));
+            }
         }
     }
 }


### PR DESCRIPTION
Document the heuritics used.

Fixes #3450