### PR TITLE
3447: catch exceptions in compile dialog with malformed EL input

### DIFF
--- a/common/src/View/CompilationRun.cpp
+++ b/common/src/View/CompilationRun.cpp
@@ -85,7 +85,12 @@ namespace TrenchBroom {
         }
 
         std::string CompilationRun::buildWorkDir(const Model::CompilationProfile* profile, std::shared_ptr<MapDocument> document) {
-            return EL::interpolate(profile->workDirSpec(), EL::EvaluationContext(CompilationWorkDirVariables(document)));
+            try {
+                return EL::interpolate(profile->workDirSpec(),
+                                       EL::EvaluationContext(CompilationWorkDirVariables(document)));
+            } catch (const Exception&) {
+                return "";
+            }
         }
 
         void CompilationRun::cleanup() {

--- a/common/src/View/CompilationTaskListBox.cpp
+++ b/common/src/View/CompilationTaskListBox.cpp
@@ -79,8 +79,13 @@ namespace TrenchBroom {
         }
 
         void CompilationTaskEditorBase::updateCompleter(QCompleter* completer) {
-            const auto workDir = EL::interpolate(m_profile->workDirSpec(), EL::EvaluationContext(CompilationWorkDirVariables(
-                kdl::mem_lock(m_document))));
+            std::string workDir;
+            try {
+                workDir = EL::interpolate(m_profile->workDirSpec(),
+                                          EL::EvaluationContext(CompilationWorkDirVariables(kdl::mem_lock(m_document))));
+            } catch (const Exception&) {
+            }
+
             const auto variables = CompilationVariables(kdl::mem_lock(m_document), workDir);
             completer->setModel(new VariableStoreModel(variables));
         }

--- a/common/test/src/EL/InterpolatorTest.cpp
+++ b/common/test/src/EL/InterpolatorTest.cpp
@@ -67,5 +67,16 @@ namespace TrenchBroom {
             context.declareVariable("TEST", Value("interesting"));
             ASSERT_EL(" an \\interesting expression", " an \\${TEST} expression", context);
         }
+
+        TEST_CASE("ELInterpolatorTest.interpolateStringWithUnknownVariable", "[ELInterpolatorTest]") {
+            EvaluationContext context;
+            CHECK_THROWS(interpolate(" an ${TEST} expression", context));
+        }
+
+        TEST_CASE("ELInterpolatorTest.interpolateStringWithUnterminatedEL", "[ELInterpolatorTest]") {
+            EvaluationContext context;
+            CHECK_THROWS(interpolate(" an ${TEST", context));
+            CHECK_THROWS(interpolate(" an ${TEST expression", context));
+        }
     }
 }


### PR DESCRIPTION
Fixes #3447

I tested putting invalid EL into all of the text boxes of the compile dialog, and it no longer crashes with these fixes.