### PR TITLE
Adding Quake2 (Valve) map support.

### DIFF
--- a/app/resources/games/DDayNormandy/GameConfig.cfg
+++ b/app/resources/games/DDayNormandy/GameConfig.cfg
@@ -2,7 +2,10 @@
     "version": 4,
     "name": "D-Day Normandy",
     "icon": "Icon.png",
-    "fileformats": [ { "format": "Quake2" } ],
+    "fileformats": [
+        { "format": "Quake2" },
+        { "format": "Quake2 (Valve)"}
+    ],
     "filesystem": {
         "searchpath": "dday",
         "packageformat": { "extension": "pak", "format": "idpak" }

--- a/app/resources/games/DigitalPaintball2/GameConfig.cfg
+++ b/app/resources/games/DigitalPaintball2/GameConfig.cfg
@@ -2,7 +2,10 @@
     "version": 4,
     "name": "Digital Paintball2",
     "icon": "Icon.png",
-    "fileformats": [ { "format": "Quake2" } ],
+    "fileformats": [
+        { "format": "Quake2" },
+        { "format": "Quake2 (Valve)"}
+    ],
     "filesystem": {
         "searchpath": "pball",
         "packageformat": { "extension": "pak", "format": "idpak" }


### PR DESCRIPTION
Alrighty, here we go! After a crash course in GitHub from Eric, I would like to present Quake 2 Valve map support for Quake 2 engine based games D-Day Normandy and Digital Paintball2.