### PR TITLE
3479: Quake game config updates from Bal.

### DIFF
--- a/app/resources/games/Quake/GameConfig.cfg
+++ b/app/resources/games/Quake/GameConfig.cfg
@@ -35,6 +35,12 @@
                 "match": "classname",
                 "pattern": "trigger*",
                 "texture": "trigger" // set this texture when tag is enabled
+            },
+            {
+                "name": "Func",
+                "attribs": [],
+                "match": "classname",
+                "pattern": "func*"
             }
         ],
         "brushface": [
@@ -46,7 +52,6 @@
             },
             {
                 "name": "Skip",
-                "attribs": [ "transparent" ],
                 "match": "texture",
                 "pattern": "skip"
             },
@@ -58,6 +63,7 @@
             },
             {
                 "name": "Liquid",
+                "attribs": [ "transparent" ],
                 "match": "texture",
                 "pattern": "\**"
             }


### PR DESCRIPTION
Fixes #3479

- Added "func" to the brush tags (so I can alt-f to get func creation
  drop-down on the fly)
- Made skip opaque, because transparent skip is pretty hellish really.
  I know a few people have switched this as well. Skip is solid and
  structural, no real reason to have it transparent.
- On the other hand, made Liquid transparent, cause that makes a lot
  more sense, even when using opaque liquid in game it's good to see through it in editor!

(I left off the transparent `*glass*` brushface tag)