### PR TITLE
3480: make "Reveal in Texture Browser" use face under mouse, not selection

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1609,9 +1609,13 @@ namespace TrenchBroom {
 
         void MapFrame::revealTexture() {
             if (const auto texture = textureToReveal(m_document)) {
-                m_inspector->switchToPage(InspectorPage::Face);
-                m_inspector->faceInspector()->revealTexture(texture);
+                revealTexture(texture);
             }
+        }
+
+        void MapFrame::revealTexture(const Assets::Texture* texture) {
+            m_inspector->switchToPage(InspectorPage::Face);
+            m_inspector->faceInspector()->revealTexture(texture);
         }
 
         void MapFrame::debugPrintVertices() {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -45,6 +45,10 @@ class QToolBar;
 namespace TrenchBroom {
     class Logger;
 
+    namespace Assets {
+        class Texture;
+    }
+
     namespace IO {
         class Path;
     }
@@ -345,6 +349,8 @@ namespace TrenchBroom {
 
             bool canRevealTexture() const;
             void revealTexture();
+
+            void revealTexture(const Assets::Texture* texture);
 
             void debugPrintVertices();
             void debugCreateBrush();

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1115,8 +1115,13 @@ namespace TrenchBroom {
 
             menu.addSeparator();
 
-            if (mapFrame->canRevealTexture()) {
-                menu.addAction(tr("Reveal in Texture Browser"), mapFrame, &MapFrame::revealTexture);
+            const Model::Hit& hit = pickResult().query().pickable().type(Model::BrushNode::BrushHitType).occluded().first();
+            const auto faceHandle = Model::hitToFaceHandle(hit);
+            if (faceHandle) {
+                const Assets::Texture* texture = faceHandle->face().texture();
+                menu.addAction(tr("Reveal %1 in Texture Browser").arg(QString::fromStdString(faceHandle->face().attributes().textureName())), mapFrame, [=](){
+                    mapFrame->revealTexture(texture);
+                });
 
                 menu.addSeparator();
             }


### PR DESCRIPTION
Fixes #3480

Note, if you set a key binding to "Reveal in Texture Browser", it uses the old behaviour of revealing the texture of the selected face/brush. We can tweak that later, if needed (e.g. it could use the new behaviour of looking at the face under the mouse.)