### PR TITLE
3487: fix entity links not rendering in 2D views

### DIFF
--- a/app/resources/shader/EntityLink.fragsh
+++ b/app/resources/shader/EntityLink.fragsh
@@ -21,11 +21,15 @@
 
 uniform float MaxDistance;
 uniform float Alpha;
+uniform bool IsOrtho;
 
 varying float distanceFromCamera;
 varying vec4 color;
 
 void main() {
-    float scale = (1.0 - clamp(distanceFromCamera / MaxDistance * 0.2 + 0.25, 0.0, 1.0));// * 0.35 + 0.65);
+    float scale = 1.0;
+    if (!IsOrtho) {
+        scale = (1.0 - clamp(distanceFromCamera / MaxDistance * 0.2 + 0.25, 0.0, 1.0));// * 0.35 + 0.65);
+    }
     gl_FragColor = vec4(color.rgb, color.a * scale * Alpha);
 }

--- a/app/resources/shader/EntityLinkArrow.fragsh
+++ b/app/resources/shader/EntityLinkArrow.fragsh
@@ -21,11 +21,15 @@
 
 uniform float MaxDistance;
 uniform float Alpha;
+uniform bool IsOrtho;
 
 varying float distanceFromCamera;
 varying vec4 color;
 
 void main() {
-    float scale = (1.0 - clamp(distanceFromCamera / MaxDistance * 0.2 + 0.25, 0.0, 1.0));// * 0.35 + 0.65);
+    float scale = 1.0;
+    if (!IsOrtho) {
+        scale = (1.0 - clamp(distanceFromCamera / MaxDistance * 0.2 + 0.25, 0.0, 1.0));// * 0.35 + 0.65);
+    }
     gl_FragColor = vec4(color.rgb, color.a * scale * Alpha);
 }

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -20,6 +20,8 @@
  */
 
 uniform vec3 CameraPosition;
+uniform bool IsOrtho;
+uniform float Zoom;
 
 attribute vec3 arrowPosition;
 attribute vec3 lineDir;
@@ -140,7 +142,12 @@ void main(void) {
     distanceFromCamera = length(CameraPosition - arrowPosition);
 
     // scale up as you get further away, to a maximum of 4x at 2048 units away
-    float scaleFactor = mix(1.0, 4.0, smoothstep(0.0, 2048.0, distanceFromCamera));
+    float scaleFactor = 1.0;
+    if (IsOrtho) {
+        scaleFactor = clamp(1.0 / Zoom, 1.0, 4.0);
+    } else {
+        scaleFactor = mix(1.0, 4.0, smoothstep(0.0, 2048.0, distanceFromCamera));
+    }
 
     // now apply the scale, rotations, and translation to gl_Vertex
     vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz * scaleFactor);

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -92,6 +92,7 @@ namespace TrenchBroom {
         void EntityLinkRenderer::renderLines(RenderContext& renderContext) {
             ActiveShader shader(renderContext.shaderManager(), Shaders::EntityLinkShader);
             shader.set("CameraPosition", renderContext.camera().position());
+            shader.set("IsOrtho", renderContext.camera().orthographicProjection());
             shader.set("MaxDistance", 6000.0f);
 
             glAssert(glDisable(GL_DEPTH_TEST));
@@ -106,7 +107,9 @@ namespace TrenchBroom {
         void EntityLinkRenderer::renderArrows(RenderContext& renderContext) {
             ActiveShader shader(renderContext.shaderManager(), Shaders::EntityLinkArrowShader);
             shader.set("CameraPosition", renderContext.camera().position());
+            shader.set("IsOrtho", renderContext.camera().orthographicProjection());
             shader.set("MaxDistance", 6000.0f);
+            shader.set("Zoom", renderContext.camera().zoom());
 
             glAssert(glDisable(GL_DEPTH_TEST));
             shader.set("Alpha", 0.4f);


### PR DESCRIPTION
Fixes #3487

Note, this was an existing bug that surfaced when we increased the
map bounds to +/-32K in 4b8a4451fb027eddce57dbbe24cfc3a028426ecd