### PR TITLE
3492: hide groups when everything inside is hidden

### DIFF
--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -172,7 +172,9 @@ namespace TrenchBroom {
             if (group->selected()) {
                 return true;
             }
-
+            if (!anyChildVisible(group)) {
+                return false;
+            }
             return group->visible();
         }
 


### PR DESCRIPTION
Related: #3492 (leaving open as this only fixes the easy part of that overall issue)

This is probably safe enough to go into 2020.2 (same logic is used below for brush entities). At the same time it's not a critical regression fix so could also wait.