### PR TITLE
3485: Replace command repetition

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -410,6 +410,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/RemoveBrushVerticesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/RenderView.cpp
         ${COMMON_SOURCE_DIR}/View/ReparentNodesCommand.cpp
+        ${COMMON_SOURCE_DIR}/View/RepeatStack.cpp
         ${COMMON_SOURCE_DIR}/View/ReplaceTextureDialog.cpp
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesTool.cpp
@@ -960,6 +961,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/RemoveBrushVerticesCommand.h
         ${COMMON_SOURCE_DIR}/View/RenderView.h
         ${COMMON_SOURCE_DIR}/View/ReparentNodesCommand.h
+        ${COMMON_SOURCE_DIR}/View/RepeatStack.h
         ${COMMON_SOURCE_DIR}/View/ReplaceTextureDialog.h
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesCommand.h
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesTool.h

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -109,10 +109,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool AddRemoveNodesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool AddRemoveNodesCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -58,8 +58,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(AddRemoveNodesCommand)

--- a/common/src/View/ChangeBrushFaceAttributesCommand.cpp
+++ b/common/src/View/ChangeBrushFaceAttributesCommand.cpp
@@ -62,10 +62,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ChangeBrushFaceAttributesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool ChangeBrushFaceAttributesCommand::doCollateWith(UndoableCommand* command) {
             ChangeBrushFaceAttributesCommand* other = static_cast<ChangeBrushFaceAttributesCommand*>(command);
             return m_request.collateWith(other->m_request);

--- a/common/src/View/ChangeBrushFaceAttributesCommand.cpp
+++ b/common/src/View/ChangeBrushFaceAttributesCommand.cpp
@@ -62,12 +62,8 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ChangeBrushFaceAttributesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedBrushFaces();
-        }
-
-        std::unique_ptr<UndoableCommand> ChangeBrushFaceAttributesCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<ChangeBrushFaceAttributesCommand>(m_request);
+        bool ChangeBrushFaceAttributesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
+            return false;
         }
 
         bool ChangeBrushFaceAttributesCommand::doCollateWith(UndoableCommand* command) {

--- a/common/src/View/ChangeBrushFaceAttributesCommand.h
+++ b/common/src/View/ChangeBrushFaceAttributesCommand.h
@@ -47,8 +47,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
         private:
             ChangeBrushFaceAttributesCommand(const ChangeBrushFaceAttributesCommand& other);

--- a/common/src/View/ChangeBrushFaceAttributesCommand.h
+++ b/common/src/View/ChangeBrushFaceAttributesCommand.h
@@ -48,7 +48,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
 
             bool doCollateWith(UndoableCommand* command) override;
         private:

--- a/common/src/View/ChangeEntityAttributesCommand.cpp
+++ b/common/src/View/ChangeEntityAttributesCommand.cpp
@@ -137,10 +137,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ChangeEntityAttributesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool ChangeEntityAttributesCommand::doCollateWith(UndoableCommand* command) {
             ChangeEntityAttributesCommand* other = static_cast<ChangeEntityAttributesCommand*>(command);
             if (other->m_action != m_action) {

--- a/common/src/View/ChangeEntityAttributesCommand.h
+++ b/common/src/View/ChangeEntityAttributesCommand.h
@@ -79,8 +79,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(ChangeEntityAttributesCommand)

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -68,8 +68,6 @@ namespace TrenchBroom {
             Notifier<Command*>& m_commandDoneNotifier;
             Notifier<UndoableCommand*>& m_commandUndoNotifier;
             Notifier<UndoableCommand*>& m_commandUndoneNotifier;
-
-            bool m_isRepeatDelimiter;
         public:
             TransactionCommand(
                 const std::string& name, std::vector<std::unique_ptr<UndoableCommand>>&& commands,
@@ -82,15 +80,7 @@ namespace TrenchBroom {
                 m_commandDoNotifier(i_commandDoNotifier),
                 m_commandDoneNotifier(i_commandDoneNotifier),
                 m_commandUndoNotifier(i_commandUndoNotifier),
-                m_commandUndoneNotifier(i_commandUndoneNotifier),
-                m_isRepeatDelimiter(false) {
-                for (const auto& command : m_commands) {
-                    if (command->isRepeatDelimiter()) {
-                        m_isRepeatDelimiter = true;
-                        break;
-                    }
-                }
-            }
+                m_commandUndoneNotifier(i_commandUndoneNotifier) {}
         private:
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override {
                 for (auto& command : m_commands) {
@@ -113,30 +103,6 @@ namespace TrenchBroom {
                     notifyCommandIfNotType(m_commandUndoneNotifier, TransactionCommand::Type, command.get());
                 }
                 return std::make_unique<CommandResult>(true);
-            }
-
-            bool doIsRepeatDelimiter() const override {
-                return m_isRepeatDelimiter;
-            }
-
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override {
-                for (auto it = std::begin(m_commands), end = std::end(m_commands); it != end; ++it) {
-                    auto& command = *it;
-                    if (!command->isRepeatable(document)) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override {
-                std::vector<std::unique_ptr<UndoableCommand>> clones;
-                for (auto it = std::begin(m_commands), end = std::end(m_commands); it != end; ++it) {
-                    auto& command = *it;
-                    assert(command->isRepeatable(document));
-                    clones.push_back(command->repeat(document));
-                }
-                return std::make_unique<TransactionCommand>(name(), std::move(clones), m_commandDoNotifier, m_commandDoneNotifier, m_commandUndoNotifier, m_commandUndoneNotifier);
             }
 
             bool doCollateWith(UndoableCommand*) override {
@@ -211,7 +177,7 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<CommandResult> CommandProcessor::executeAndStore(std::unique_ptr<UndoableCommand> command) {
-            return executeAndStoreCommand(std::move(command), true, true).commandResult;
+            return executeAndStoreCommand(std::move(command), true).commandResult;
         }
 
         std::unique_ptr<CommandResult> CommandProcessor::undo() {
@@ -240,62 +206,27 @@ namespace TrenchBroom {
                 auto command = popFromRedoStack();
                 auto result = executeCommand(command.get());
                 if (result->success()) {
-                    assertResult(pushToUndoStack(std::move(command), false, true))
+                    assertResult(pushToUndoStack(std::move(command), false))
                 }
                 return result;
             }
         }
 
-        bool CommandProcessor::canRepeat() const {
-            for (const auto* command : m_repeatStack) {
-                if (command->isRepeatable(m_document)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        std::unique_ptr<CommandResult> CommandProcessor::repeat() {
-            std::vector<std::unique_ptr<UndoableCommand>> commands;
-
-            for (auto* command : m_repeatStack) {
-                if (command->isRepeatable(m_document)) {
-                    commands.push_back(command->repeat(m_document));
-                }
-            }
-
-            if (commands.empty()) {
-                return std::make_unique<CommandResult>(false);
-            } else if (commands.size() == 1u) {
-                auto command = std::move(commands.front()); commands.clear();
-                return executeAndStoreCommand(std::move(command), false, false).commandResult;
-            } else {
-                const auto name = kdl::str_to_string("Repeat ", commands.size(), " Commands");
-                auto repeatableCommand = createTransaction(name, std::move(commands));
-                return executeAndStoreCommand(std::move(repeatableCommand), false, false).commandResult;
-            }
-        }
-
-        void CommandProcessor::clearRepeatStack() {
-            m_repeatStack.clear();
-        }
-
         void CommandProcessor::clear() {
             assert(m_transactionStack.empty());
 
-            clearRepeatStack();
             m_undoStack.clear();
             m_redoStack.clear();
             m_lastCommandTimestamp = std::chrono::time_point<std::chrono::system_clock>();
         }
 
-        CommandProcessor::SubmitAndStoreResult CommandProcessor::executeAndStoreCommand(std::unique_ptr<UndoableCommand> command, const bool collate, const bool repeatable) {
+        CommandProcessor::SubmitAndStoreResult CommandProcessor::executeAndStoreCommand(std::unique_ptr<UndoableCommand> command, const bool collate) {
             auto commandResult = executeCommand(command.get());
             if (!commandResult->success()) {
                 return SubmitAndStoreResult(std::move(commandResult), false);
             }
 
-            const auto commandStored = storeCommand(std::move(command), collate, repeatable);
+            const auto commandStored = storeCommand(std::move(command), collate);
             m_redoStack.clear();
             return SubmitAndStoreResult(std::move(commandResult), commandStored);
         }
@@ -325,9 +256,9 @@ namespace TrenchBroom {
             return result;
         }
 
-        bool CommandProcessor::storeCommand(std::unique_ptr<UndoableCommand> command, const bool collate, const bool repeatable) {
+        bool CommandProcessor::storeCommand(std::unique_ptr<UndoableCommand> command, const bool collate) {
             if (m_transactionStack.empty()) {
-                return pushToUndoStack(std::move(command), collate, repeatable);
+                return pushToUndoStack(std::move(command), collate);
             } else {
                 return pushTransactionCommand(std::move(command), collate);
             }
@@ -358,7 +289,7 @@ namespace TrenchBroom {
                 auto command = createTransaction(transaction.name, std::move(transaction.commands));
 
                 if (m_transactionStack.empty()) {
-                    pushToUndoStack(std::move(command), false, true);
+                    pushToUndoStack(std::move(command), false);
                 } else {
                     pushTransactionCommand(std::move(command), false);
                 }
@@ -375,7 +306,7 @@ namespace TrenchBroom {
                 commandUndoneNotifier);
         }
 
-        bool CommandProcessor::pushToUndoStack(std::unique_ptr<UndoableCommand> command, const bool collate, const bool repeatable) {
+        bool CommandProcessor::pushToUndoStack(std::unique_ptr<UndoableCommand> command, const bool collate) {
             assert(m_transactionStack.empty());
 
             const auto timestamp = std::chrono::system_clock::now();
@@ -388,10 +319,6 @@ namespace TrenchBroom {
                 }
             }
 
-            if (repeatable) {
-                pushToRepeatStack(command.get());
-            }
-
             m_undoStack.push_back(std::move(command));
             return true;
         }
@@ -400,9 +327,7 @@ namespace TrenchBroom {
             assert(m_transactionStack.empty());
             assert(!m_undoStack.empty());
 
-            auto lastCommand = kdl::vec_pop_back(m_undoStack);
-            popFromRepeatStack(lastCommand.get());
-            return lastCommand;
+            return kdl::vec_pop_back(m_undoStack);
         }
 
         bool CommandProcessor::collatable(const bool collate, const std::chrono::system_clock::time_point timestamp) const {
@@ -419,24 +344,6 @@ namespace TrenchBroom {
             assert(!m_redoStack.empty());
 
             return kdl::vec_pop_back(m_redoStack);
-        }
-
-        void CommandProcessor::pushToRepeatStack(UndoableCommand* command) {
-            if (command->isRepeatDelimiter()) {
-                return;
-            }
-
-            if (!m_undoStack.empty() && m_undoStack.back()->isRepeatDelimiter()) {
-                clearRepeatStack();
-            }
-
-            m_repeatStack.push_back(command);
-        }
-
-        void CommandProcessor::popFromRepeatStack(UndoableCommand* command) {
-            if (!m_repeatStack.empty() && m_repeatStack.back() == command) {
-                m_repeatStack.pop_back();
-            }
         }
     }
 }

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -247,7 +247,12 @@ namespace TrenchBroom {
         }
 
         bool CommandProcessor::canRepeat() const {
-            return !m_repeatStack.empty();
+            for (const auto* command : m_repeatStack) {
+                if (command->isRepeatable(m_document)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         std::unique_ptr<CommandResult> CommandProcessor::repeat() {

--- a/common/src/View/ConvertEntityColorCommand.cpp
+++ b/common/src/View/ConvertEntityColorCommand.cpp
@@ -47,10 +47,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ConvertEntityColorCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool ConvertEntityColorCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/ConvertEntityColorCommand.h
+++ b/common/src/View/ConvertEntityColorCommand.h
@@ -52,8 +52,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(ConvertEntityColorCommand)

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -69,10 +69,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool CopyTexCoordSystemFromFaceCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -69,12 +69,8 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool CopyTexCoordSystemFromFaceCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedBrushFaces();
-        }
-
-        std::unique_ptr<UndoableCommand> CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<CopyTexCoordSystemFromFaceCommand>(*m_coordSystemSnapshot, m_attribs, m_sourceFacePlane, m_wrapStyle);
+        bool CopyTexCoordSystemFromFaceCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
+            return false;
         }
 
         bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand*) {

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.h
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.h
@@ -57,7 +57,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
 
             bool doCollateWith(UndoableCommand* command) override;
 

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.h
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.h
@@ -56,8 +56,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(CopyTexCoordSystemFromFaceCommand)

--- a/common/src/View/CurrentGroupCommand.cpp
+++ b/common/src/View/CurrentGroupCommand.cpp
@@ -62,9 +62,5 @@ namespace TrenchBroom {
         bool CurrentGroupCommand::doCollateWith(UndoableCommand*) {
             return false;
         }
-
-        bool CurrentGroupCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
     }
 }

--- a/common/src/View/CurrentGroupCommand.h
+++ b/common/src/View/CurrentGroupCommand.h
@@ -46,7 +46,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             bool doCollateWith(UndoableCommand* command) override;
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
 
             deleteCopyAndMove(CurrentGroupCommand)
         };

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -119,14 +119,6 @@ namespace TrenchBroom {
             return query.result();
         }
 
-        bool DuplicateNodesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedNodes();
-        }
-
-        std::unique_ptr<UndoableCommand> DuplicateNodesCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<DuplicateNodesCommand>();
-        }
-
         bool DuplicateNodesCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/DuplicateNodesCommand.h
+++ b/common/src/View/DuplicateNodesCommand.h
@@ -53,9 +53,6 @@ namespace TrenchBroom {
             class CloneParentQuery;
             bool shouldCloneParentWhenCloningNode(const Model::Node* node) const;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(DuplicateNodesCommand)

--- a/common/src/View/EntityDefinitionFileCommand.cpp
+++ b/common/src/View/EntityDefinitionFileCommand.cpp
@@ -45,10 +45,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool EntityDefinitionFileCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool EntityDefinitionFileCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/EntityDefinitionFileCommand.h
+++ b/common/src/View/EntityDefinitionFileCommand.h
@@ -42,7 +42,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(EntityDefinitionFileCommand)

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1906,10 +1906,6 @@ namespace TrenchBroom {
                 return std::make_unique<CommandResult>(true);
             }
 
-            bool doIsRepeatable(MapDocumentCommandFacade*) const override {
-                return false;
-            }
-
             bool doCollateWith(UndoableCommand*) override {
                 return false;
             }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -112,6 +112,7 @@
 #include "View/ReparentNodesCommand.h"
 #include "View/ResizeBrushesCommand.h"
 #include "View/CopyTexCoordSystemFromFaceCommand.h"
+#include "View/RepeatStack.h"
 #include "View/RotateTexturesCommand.h"
 #include "View/SelectionCommand.h"
 #include "View/SetLockStateCommand.h"
@@ -173,7 +174,8 @@ namespace TrenchBroom {
         m_currentTextureName(Model::BrushFaceAttributes::NoTextureName),
         m_lastSelectionBounds(0.0, 32.0),
         m_selectionBoundsValid(true),
-        m_viewEffectsService(nullptr) {
+        m_viewEffectsService(nullptr),
+        m_repeatStack(std::make_unique<RepeatStack>()) {
                 bindObservers();
         }
 
@@ -330,6 +332,7 @@ namespace TrenchBroom {
         void MapDocument::newDocument(const Model::MapFormat mapFormat, const vm::bbox3& worldBounds, std::shared_ptr<Model::Game> game) {
             info("Creating new document");
 
+            clearRepeatableCommands();
             clearDocument();
             createWorld(mapFormat, worldBounds, game);
 
@@ -346,6 +349,7 @@ namespace TrenchBroom {
         void MapDocument::loadDocument(const Model::MapFormat mapFormat, const vm::bbox3& worldBounds, std::shared_ptr<Model::Game> game, const IO::Path& path) {
             info("Loading document from " + path.asString());
 
+            clearRepeatableCommands();
             clearDocument();
             loadWorld(mapFormat, worldBounds, game, path);
 
@@ -611,6 +615,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::selectAllNodes() {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::selectAllNodes());
         }
 
@@ -696,23 +701,28 @@ namespace TrenchBroom {
         }
 
         void MapDocument::select(const std::vector<Model::Node*>& nodes) {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::select(nodes));
         }
 
         void MapDocument::select(Model::Node* node) {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::select(std::vector<Model::Node*>(1, node)));
         }
 
         void MapDocument::select(const std::vector<Model::BrushFaceHandle>& handles) {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::select(handles));
         }
 
         void MapDocument::select(const Model::BrushFaceHandle& handle) {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::select({ handle }));
             setCurrentTextureName(handle.face().attributes().textureName());
         }
 
         void MapDocument::convertToFaceSelection() {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::convertToFaces());
         }
 
@@ -732,8 +742,10 @@ namespace TrenchBroom {
         }
 
         void MapDocument::deselectAll() {
-            if (hasSelection())
+            if (hasSelection()) {
+                m_repeatStack->clearOnNextPush();
                 executeAndStore(SelectionCommand::deselectAll());
+            }
         }
 
         void MapDocument::deselect(Model::Node* node) {
@@ -741,10 +753,12 @@ namespace TrenchBroom {
         }
 
         void MapDocument::deselect(const std::vector<Model::Node*>& nodes) {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::deselect(nodes));
         }
 
         void MapDocument::deselect(const Model::BrushFaceHandle& handle) {
+            m_repeatStack->clearOnNextPush();
             executeAndStore(SelectionCommand::deselect({ handle }));
         }
 
@@ -947,6 +961,7 @@ namespace TrenchBroom {
                 if (m_viewEffectsService) {
                     m_viewEffectsService->flashSelection();
                 }
+                m_repeatStack->push([=]() { this->duplicateObjects(); });
                 return true;
             }
             return false;
@@ -1443,32 +1458,56 @@ namespace TrenchBroom {
 
         bool MapDocument::translateObjects(const vm::vec3& delta) {
             const auto result = executeAndStore(TransformObjectsCommand::translate(delta, pref(Preferences::TextureLock)));
-            return result->success();
+            if (result->success()) {
+                m_repeatStack->push([=]() { this->translateObjects(delta); });
+                return true;
+            }
+            return false;
         }
 
         bool MapDocument::rotateObjects(const vm::vec3& center, const vm::vec3& axis, const FloatType angle) {
             const auto result = executeAndStore(TransformObjectsCommand::rotate(center, axis, angle, pref(Preferences::TextureLock)));
-            return result->success();
+            if (result->success()) {
+                m_repeatStack->push([=]() { this->rotateObjects(center, axis, angle); });
+                return true;
+            }
+            return false;
         }
 
         bool MapDocument::scaleObjects(const vm::bbox3& oldBBox, const vm::bbox3& newBBox) {
             const auto result = executeAndStore(TransformObjectsCommand::scale(oldBBox, newBBox, pref(Preferences::TextureLock)));
-            return result->success();
+            if (result->success()) {
+                m_repeatStack->push([=]() { this->scaleObjects(oldBBox, newBBox); });
+                return true;
+            }
+            return false;
         }
 
         bool MapDocument::scaleObjects(const vm::vec3& center, const vm::vec3& scaleFactors) {
             const auto result = executeAndStore(TransformObjectsCommand::scale(center, scaleFactors, pref(Preferences::TextureLock)));
-            return result->success();
+            if (result->success()) {
+                m_repeatStack->push([=]() { this->scaleObjects(center, scaleFactors); });
+                return true;
+            }
+            return false;
         }
 
         bool MapDocument::shearObjects(const vm::bbox3& box, const vm::vec3& sideToShear, const vm::vec3& delta) {
             const auto result = executeAndStore(TransformObjectsCommand::shearBBox(box, sideToShear, delta,  pref(Preferences::TextureLock)));
-            return result->success();
+            if (result->success()) {
+                m_repeatStack->push([=]() { this->shearObjects(box, sideToShear, delta); });
+                return true;
+            }
+            return false;
         }
 
         bool MapDocument::flipObjects(const vm::vec3& center, const vm::axis::type axis) {
             const auto result = executeAndStore(TransformObjectsCommand::flip(center, axis, pref(Preferences::TextureLock)));
-            return result->success();
+            if (result->success()) {
+                m_repeatStack->push([=]() { this->flipObjects(center, axis); });
+                return true;
+            }
+            return false;
         }
 
         bool MapDocument::createBrush(const std::vector<vm::vec3>& points) {
@@ -1908,15 +1947,15 @@ namespace TrenchBroom {
         }
 
         bool MapDocument::canRepeatCommands() const {
-            return doCanRepeatCommands();
+            return m_repeatStack->size() > 0u;
         }
 
-        std::unique_ptr<CommandResult> MapDocument::repeatCommands() {
-            return doRepeatCommands();
+        void MapDocument::repeatCommands() {
+            m_repeatStack->repeat();
         }
 
         void MapDocument::clearRepeatableCommands() {
-            doClearRepeatableCommands();
+            m_repeatStack->clear();
         }
 
         void MapDocument::startTransaction(const std::string& name) {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -76,6 +76,7 @@ namespace TrenchBroom {
         class CommandResult;
         class Grid;
         enum class PasteType;
+        class RepeatStack;
         class Selection;
         class UndoableCommand;
         class ViewEffectsService;
@@ -121,6 +122,15 @@ namespace TrenchBroom {
             mutable bool m_selectionBoundsValid;
 
             ViewEffectsService* m_viewEffectsService;
+
+            /*
+             * All actions pushed to this stack can be repeated later. The stack must be
+             * primed to be cleared whenever the selection changes. The effect is that
+             * changing the selection automatically begins a new "macro", but at the same
+             * time the current repeat stack can still be repeated after the selection
+             * was changed.
+             */
+            std::unique_ptr<RepeatStack> m_repeatStack;
         public: // notification
             Notifier<Command*> commandDoNotifier;
             Notifier<Command*> commandDoneNotifier;
@@ -435,7 +445,7 @@ namespace TrenchBroom {
             void undoCommand();
             void redoCommand();
             bool canRepeatCommands() const;
-            std::unique_ptr<CommandResult> repeatCommands();
+            void repeatCommands();
             void clearRepeatableCommands();
         public: // transactions
             void startTransaction(const std::string& name = "");
@@ -452,9 +462,6 @@ namespace TrenchBroom {
             virtual const std::string& doGetRedoCommandName() const = 0;
             virtual void doUndoCommand() = 0;
             virtual void doRedoCommand() = 0;
-            virtual bool doCanRepeatCommands() const = 0;
-            virtual std::unique_ptr<CommandResult> doRepeatCommands() = 0;
-            virtual void doClearRepeatableCommands() = 0;
 
             virtual void doStartTransaction(const std::string& name) = 0;
             virtual void doCommitTransaction() = 0;

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -1054,18 +1054,6 @@ namespace TrenchBroom {
             m_commandProcessor->redo();
         }
 
-        bool MapDocumentCommandFacade::doCanRepeatCommands() const {
-            return m_commandProcessor->canRepeat();
-        }
-
-        std::unique_ptr<CommandResult> MapDocumentCommandFacade::doRepeatCommands() {
-            return m_commandProcessor->repeat();
-        }
-
-        void MapDocumentCommandFacade::doClearRepeatableCommands() {
-            m_commandProcessor->clearRepeatStack();
-        }
-
         void MapDocumentCommandFacade::doStartTransaction(const std::string& name) {
             m_commandProcessor->startTransaction(name);
         }

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -158,9 +158,6 @@ namespace TrenchBroom {
             const std::string& doGetRedoCommandName() const override;
             void doUndoCommand() override;
             void doRedoCommand() override;
-            bool doCanRepeatCommands() const override;
-            std::unique_ptr<CommandResult> doRepeatCommands() override;
-            void doClearRepeatableCommands() override;
 
             void doStartTransaction(const std::string& name) override;
             void doCommitTransaction() override;

--- a/common/src/View/MoveTexturesCommand.cpp
+++ b/common/src/View/MoveTexturesCommand.cpp
@@ -52,10 +52,6 @@ namespace TrenchBroom {
             document->performMoveTextures(m_cameraUp, m_cameraRight, delta);
         }
 
-        bool MoveTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool MoveTexturesCommand::doCollateWith(UndoableCommand* command) {
             const MoveTexturesCommand* other = static_cast<MoveTexturesCommand*>(command);
 

--- a/common/src/View/MoveTexturesCommand.cpp
+++ b/common/src/View/MoveTexturesCommand.cpp
@@ -52,12 +52,8 @@ namespace TrenchBroom {
             document->performMoveTextures(m_cameraUp, m_cameraRight, delta);
         }
 
-        bool MoveTexturesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedBrushFaces();
-        }
-
-        std::unique_ptr<UndoableCommand> MoveTexturesCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<MoveTexturesCommand>(m_cameraUp, m_cameraRight, m_delta);
+        bool MoveTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
+            return false;
         }
 
         bool MoveTexturesCommand::doCollateWith(UndoableCommand* command) {

--- a/common/src/View/MoveTexturesCommand.h
+++ b/common/src/View/MoveTexturesCommand.h
@@ -47,8 +47,6 @@ namespace TrenchBroom {
 
             void moveTextures(MapDocumentCommandFacade* document, const vm::vec2f& delta) const;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(MoveTexturesCommand)

--- a/common/src/View/MoveTexturesCommand.h
+++ b/common/src/View/MoveTexturesCommand.h
@@ -48,7 +48,6 @@ namespace TrenchBroom {
             void moveTextures(MapDocumentCommandFacade* document, const vm::vec2f& delta) const;
 
             bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
 
             bool doCollateWith(UndoableCommand* command) override;
 

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -47,10 +47,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ReparentNodesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool ReparentNodesCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -47,8 +47,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(ReparentNodesCommand)

--- a/common/src/View/RepeatStack.cpp
+++ b/common/src/View/RepeatStack.cpp
@@ -1,0 +1,62 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "RepeatStack.h"
+
+#include <kdl/set_temp.h>
+
+#include <cassert>
+
+namespace TrenchBroom {
+    namespace View {
+        RepeatStack::RepeatStack() :
+        m_clearOnNextPush(false),
+        m_repeating(false) {}
+
+        size_t RepeatStack::size() const {
+            return m_stack.size();
+        }
+
+        void RepeatStack::push(RepeatableAction repeatableAction) {
+            if (!m_repeating) {
+                if (m_clearOnNextPush) {
+                    m_clearOnNextPush = false;
+                    clear();
+                }
+                m_stack.push_back(std::move(repeatableAction));
+            }
+        }
+
+        void RepeatStack::repeat() const {
+            const kdl::set_temp repeating(m_repeating);
+            for (const auto& repeatable : m_stack) {
+                repeatable();
+            }
+        }
+
+        void RepeatStack::clear() {
+            assert(!m_repeating);
+            m_stack.clear();
+        }
+
+        void RepeatStack::clearOnNextPush() {
+            m_clearOnNextPush = true;
+        }
+    }
+}

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -1,0 +1,94 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TrenchBroom_RepeatStack
+#define TrenchBroom_RepeatStack
+
+#include <functional>
+#include <vector>
+
+namespace TrenchBroom {
+    namespace View {
+        /**
+         * A stack of actions (C++ callables) that can be repeatedly executed as a whole.
+         *
+         * Actions are repeated in the order in which they have been added to the stack. If the
+         * stack is currently repeating, requests for adding an action are ignored so that repeating
+         * actions doesn't put the repeated actions on the stack again.
+         *
+         * The stack can be cleared immediately or it can be primed to be cleared automatically when
+         * the next action is pushed to the stack.
+         */ 
+        class RepeatStack {
+        public:
+            using RepeatableAction = std::function<void()>;
+        private:
+            std::vector<RepeatableAction> m_stack;
+            bool m_clearOnNextPush;
+            mutable bool m_repeating;
+        public:
+            /**
+             * Creates a new instance.
+             */
+            RepeatStack();
+
+            /**
+             * Returns the number of repeatable actions on this repeat stack.
+             */
+            size_t size() const;
+
+            /**
+             * Adds the given repeatable action to this repeat stack.
+             * 
+             * If this stack is currently repeating actions, the given action is not added.
+             * If clearOnNextPush() was called, the repeat stack will be cleared before the given action
+             * is added.
+             * 
+             * @param repeatableAction the action to add
+             */
+            void push(RepeatableAction repeatableAction);
+
+            /**
+             * Repeats the actions on this stack in the order in which they were added.
+             *
+             * No new actions will be added to the stack while it is repeating, so the list of
+             * actions on the stack will be the same when this function finishes.
+             */
+            void repeat() const;
+
+            /**
+             * Clears all repeatable actions on this stack.
+             * 
+             * The stack must not be repeating actions when this function is called.
+             */ 
+            void clear();
+
+            /**
+             * Prime the stack so that it is cleared when the next action is pushed.
+             * 
+             * The effect is that the action currently on the stack can still be repeated
+             * (even multiple times). But when the next action is pushed onto the stack, it
+             * is cleared.
+             */
+            void clearOnNextPush();
+        };
+    }
+}
+
+#endif /* defined(TrenchBroom_RepeatStack) */

--- a/common/src/View/ResizeBrushesCommand.cpp
+++ b/common/src/View/ResizeBrushesCommand.cpp
@@ -43,11 +43,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(!m_newFaces.empty());
         }
 
-
-        bool ResizeBrushesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool ResizeBrushesCommand::doCollateWith(UndoableCommand* command) {
             ResizeBrushesCommand* other = static_cast<ResizeBrushesCommand*>(command);
             if (other->m_faces == m_newFaces) {

--- a/common/src/View/ResizeBrushesCommand.h
+++ b/common/src/View/ResizeBrushesCommand.h
@@ -46,8 +46,6 @@ namespace TrenchBroom {
         private:
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(ResizeBrushesCommand)

--- a/common/src/View/RotateTexturesCommand.cpp
+++ b/common/src/View/RotateTexturesCommand.cpp
@@ -47,12 +47,8 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool RotateTexturesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedBrushFaces();
-        }
-
-        std::unique_ptr<UndoableCommand> RotateTexturesCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<RotateTexturesCommand>(m_angle);
+        bool RotateTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
+            return false;
         }
 
         bool RotateTexturesCommand::doCollateWith(UndoableCommand* command) {

--- a/common/src/View/RotateTexturesCommand.cpp
+++ b/common/src/View/RotateTexturesCommand.cpp
@@ -47,10 +47,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool RotateTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool RotateTexturesCommand::doCollateWith(UndoableCommand* command) {
             const RotateTexturesCommand* other = static_cast<RotateTexturesCommand*>(command);
 

--- a/common/src/View/RotateTexturesCommand.h
+++ b/common/src/View/RotateTexturesCommand.h
@@ -43,7 +43,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> rotateTextures(MapDocumentCommandFacade* document, float angle) const;
 
             bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
 
             bool doCollateWith(UndoableCommand* command) override;
 

--- a/common/src/View/RotateTexturesCommand.h
+++ b/common/src/View/RotateTexturesCommand.h
@@ -42,8 +42,6 @@ namespace TrenchBroom {
 
             std::unique_ptr<CommandResult> rotateTextures(MapDocumentCommandFacade* document, float angle) const;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(RotateTexturesCommand)

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -154,14 +154,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool SelectionCommand::doIsRepeatDelimiter() const {
-            return true;
-        }
-
-        bool SelectionCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool SelectionCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -81,9 +81,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatDelimiter() const override;
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(SelectionCommand)

--- a/common/src/View/SetCurrentLayerCommand.cpp
+++ b/common/src/View/SetCurrentLayerCommand.cpp
@@ -48,9 +48,5 @@ namespace TrenchBroom {
             m_currentLayer = other->m_currentLayer;
             return true;
         }
-
-        bool SetCurrentLayerCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
     }
 }

--- a/common/src/View/SetCurrentLayerCommand.h
+++ b/common/src/View/SetCurrentLayerCommand.h
@@ -46,7 +46,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             bool doCollateWith(UndoableCommand* command) override;
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
 
             deleteCopyAndMove(SetCurrentLayerCommand)
         };

--- a/common/src/View/SetLockStateCommand.cpp
+++ b/common/src/View/SetLockStateCommand.cpp
@@ -70,9 +70,5 @@ namespace TrenchBroom {
         bool SetLockStateCommand::doCollateWith(UndoableCommand*) {
             return false;
         }
-
-        bool SetLockStateCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
     }
 }

--- a/common/src/View/SetLockStateCommand.h
+++ b/common/src/View/SetLockStateCommand.h
@@ -55,7 +55,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             bool doCollateWith(UndoableCommand* command) override;
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
 
             deleteCopyAndMove(SetLockStateCommand)
         };

--- a/common/src/View/SetModsCommand.cpp
+++ b/common/src/View/SetModsCommand.cpp
@@ -47,10 +47,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool SetModsCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool SetModsCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/SetModsCommand.h
+++ b/common/src/View/SetModsCommand.h
@@ -43,7 +43,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(SetModsCommand)

--- a/common/src/View/SetTextureCollectionsCommand.cpp
+++ b/common/src/View/SetTextureCollectionsCommand.cpp
@@ -44,10 +44,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool SetTextureCollectionsCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool SetTextureCollectionsCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/SetTextureCollectionsCommand.h
+++ b/common/src/View/SetTextureCollectionsCommand.h
@@ -46,7 +46,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(SetTextureCollectionsCommand)

--- a/common/src/View/SetVisibilityCommand.cpp
+++ b/common/src/View/SetVisibilityCommand.cpp
@@ -90,9 +90,5 @@ namespace TrenchBroom {
         bool SetVisibilityCommand::doCollateWith(UndoableCommand*) {
             return false;
         }
-
-        bool SetVisibilityCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
     }
 }

--- a/common/src/View/SetVisibilityCommand.h
+++ b/common/src/View/SetVisibilityCommand.h
@@ -63,7 +63,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             bool doCollateWith(UndoableCommand* command) override;
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
 
             deleteCopyAndMove(SetVisibilityCommand)
         };

--- a/common/src/View/ShearTexturesCommand.cpp
+++ b/common/src/View/ShearTexturesCommand.cpp
@@ -51,12 +51,8 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ShearTexturesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedBrushFaces();
-        }
-
-        std::unique_ptr<UndoableCommand> ShearTexturesCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<ShearTexturesCommand>(m_factors);
+        bool ShearTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
+            return false;
         }
 
         bool ShearTexturesCommand::doCollateWith(UndoableCommand* command) {

--- a/common/src/View/ShearTexturesCommand.cpp
+++ b/common/src/View/ShearTexturesCommand.cpp
@@ -51,10 +51,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool ShearTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool ShearTexturesCommand::doCollateWith(UndoableCommand* command) {
             ShearTexturesCommand* other = static_cast<ShearTexturesCommand*>(command);
             m_factors = m_factors + other->m_factors;

--- a/common/src/View/ShearTexturesCommand.h
+++ b/common/src/View/ShearTexturesCommand.h
@@ -43,8 +43,6 @@ namespace TrenchBroom {
 
             std::unique_ptr<CommandResult> shearTextures(MapDocumentCommandFacade* document, const vm::vec2f& factors);
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(ShearTexturesCommand)

--- a/common/src/View/ShearTexturesCommand.h
+++ b/common/src/View/ShearTexturesCommand.h
@@ -44,7 +44,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> shearTextures(MapDocumentCommandFacade* document, const vm::vec2f& factors);
 
             bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
 
             bool doCollateWith(UndoableCommand* command) override;
 

--- a/common/src/View/SnapBrushVerticesCommand.cpp
+++ b/common/src/View/SnapBrushVerticesCommand.cpp
@@ -39,10 +39,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(success);
         }
 
-        bool SnapBrushVerticesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool SnapBrushVerticesCommand::doCollateWith(UndoableCommand* command) {
             SnapBrushVerticesCommand* other = static_cast<SnapBrushVerticesCommand*>(command);
             return other->m_snapTo == m_snapTo;

--- a/common/src/View/SnapBrushVerticesCommand.h
+++ b/common/src/View/SnapBrushVerticesCommand.h
@@ -37,7 +37,6 @@ namespace TrenchBroom {
             explicit SnapBrushVerticesCommand(FloatType snapTo);
         private:
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
 
             bool doCollateWith(UndoableCommand* command) override;
 

--- a/common/src/View/TransformObjectsCommand.cpp
+++ b/common/src/View/TransformObjectsCommand.cpp
@@ -74,14 +74,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(success);
         }
 
-        bool TransformObjectsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
-            return document->hasSelectedNodes();
-        }
-
-        std::unique_ptr<UndoableCommand> TransformObjectsCommand::doRepeat(MapDocumentCommandFacade*) const {
-            return std::make_unique<TransformObjectsCommand>(m_action, m_name, m_transform, m_lockTextures);
-        }
-
         bool TransformObjectsCommand::doCollateWith(UndoableCommand* command) {
             auto* other = static_cast<TransformObjectsCommand*>(command);
             if (other->m_lockTextures != m_lockTextures) {

--- a/common/src/View/TransformObjectsCommand.h
+++ b/common/src/View/TransformObjectsCommand.h
@@ -57,9 +57,6 @@ namespace TrenchBroom {
             TransformObjectsCommand(Action action, const std::string& name, const vm::mat4x4& transform, bool lockTextures);
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(TransformObjectsCommand)

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -41,31 +41,11 @@ namespace TrenchBroom {
             return result;
         }
 
-        bool UndoableCommand::isRepeatDelimiter() const {
-            return doIsRepeatDelimiter();
-        }
-
-        bool UndoableCommand::isRepeatable(MapDocumentCommandFacade* document) const {
-            return doIsRepeatable(document);
-        }
-
-        std::unique_ptr<UndoableCommand> UndoableCommand::repeat(MapDocumentCommandFacade* document) const {
-            return doRepeat(document);
-        }
-
         bool UndoableCommand::collateWith(UndoableCommand* command) {
             assert(command != this);
             if (command->type() != m_type)
                 return false;
             return doCollateWith(command);
-        }
-
-        bool UndoableCommand::doIsRepeatDelimiter() const {
-            return false;
-        }
-
-        std::unique_ptr<UndoableCommand> UndoableCommand::doRepeat(MapDocumentCommandFacade*) const {
-            throw CommandProcessorException("Command is not repeatable");
         }
 
         size_t UndoableCommand::documentModificationCount() const {

--- a/common/src/View/UndoableCommand.h
+++ b/common/src/View/UndoableCommand.h
@@ -38,17 +38,9 @@ namespace TrenchBroom {
 
             virtual std::unique_ptr<CommandResult> performUndo(MapDocumentCommandFacade* document);
 
-            bool isRepeatDelimiter() const;
-            bool isRepeatable(MapDocumentCommandFacade* document) const;
-            std::unique_ptr<UndoableCommand> repeat(MapDocumentCommandFacade* document) const;
-
             virtual bool collateWith(UndoableCommand* command);
         private:
             virtual std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) = 0;
-
-            virtual bool doIsRepeatDelimiter() const;
-            virtual bool doIsRepeatable(MapDocumentCommandFacade* document) const = 0;
-            virtual std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const;
 
             virtual bool doCollateWith(UndoableCommand* command) = 0;
         public: // this method is just a service for DocumentCommand and should never be called from anywhere else

--- a/common/src/View/UpdateEntitySpawnflagCommand.cpp
+++ b/common/src/View/UpdateEntitySpawnflagCommand.cpp
@@ -52,10 +52,6 @@ namespace TrenchBroom {
             return std::make_unique<CommandResult>(true);
         }
 
-        bool UpdateEntitySpawnflagCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         bool UpdateEntitySpawnflagCommand::doCollateWith(UndoableCommand*) {
             return false;
         }

--- a/common/src/View/UpdateEntitySpawnflagCommand.h
+++ b/common/src/View/UpdateEntitySpawnflagCommand.h
@@ -45,8 +45,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
-
             bool doCollateWith(UndoableCommand* command) override;
 
             deleteCopyAndMove(UpdateEntitySpawnflagCommand)

--- a/common/src/View/VertexCommand.cpp
+++ b/common/src/View/VertexCommand.cpp
@@ -111,10 +111,6 @@ namespace TrenchBroom {
             document->restoreSnapshot(snapshot.get());
         }
 
-        bool VertexCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
-            return false;
-        }
-
         void VertexCommand::takeSnapshot() {
             assert(m_snapshot == nullptr);
             m_snapshot = std::make_unique<Model::Snapshot>(std::begin(m_brushes), std::end(m_brushes));

--- a/common/src/View/VertexCommand.h
+++ b/common/src/View/VertexCommand.h
@@ -88,7 +88,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
             void restoreAndTakeNewSnapshot(MapDocumentCommandFacade* document);
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
         private:
             void takeSnapshot();
             void deleteSnapshot();

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -77,6 +77,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/RemoveNodesTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/ResizeBrushesToolTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/ReparentNodesTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/RepeatableActionsTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/ScaleObjectsToolTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SelectionCommandTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SelectionTest.cpp"

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -100,26 +100,22 @@ namespace TrenchBroom {
 
         struct DoPerformDo   { bool returnSuccess; };
         struct DoPerformUndo { bool returnSuccess; };
-        struct DoRepeat      { std::unique_ptr<UndoableCommand> repeatCommandToReturn; };
         struct DoCollateWith { bool returnCanCollate; UndoableCommand* expectedOtherCommand; };
 
-        using TestCommandCall = std::variant<DoPerformDo, DoPerformUndo, DoRepeat, DoCollateWith>;
+        using TestCommandCall = std::variant<DoPerformDo, DoPerformUndo, DoCollateWith>;
 
         class TestCommand : public UndoableCommand {
         private:
-            bool m_isRepeatDelimiter;
-
             mutable std::vector<TestCommandCall> m_expectedCalls;
         public:
             static const CommandType Type;
 
-            static std::unique_ptr<TestCommand> create(const std::string& name, const bool isRepeatDelimiter) {
-                return std::make_unique<TestCommand>(name, isRepeatDelimiter);
+            static std::unique_ptr<TestCommand> create(const std::string& name) {
+                return std::make_unique<TestCommand>(name);
             }
 
-            explicit TestCommand(const std::string& name, const bool isRepeatDelimiter) :
-            UndoableCommand(Type, name),
-            m_isRepeatDelimiter(isRepeatDelimiter) {}
+            explicit TestCommand(const std::string& name) :
+            UndoableCommand(Type, name) {}
 
             ~TestCommand() {
                 ASSERT_TRUE(m_expectedCalls.empty());
@@ -141,25 +137,6 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade*) override {
                 const auto expectedCall = popCall<DoPerformUndo>();
                 return std::make_unique<CommandResult>(expectedCall.returnSuccess);
-            }
-
-            bool doIsRepeatDelimiter() const override {
-                return m_isRepeatDelimiter;
-            }
-
-            std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade*) const override {
-                auto expectedCall = popCall<DoRepeat>();
-                return std::move(expectedCall.repeatCommandToReturn);
-            }
-
-            bool doIsRepeatable(MapDocumentCommandFacade*) const override {
-                if (m_expectedCalls.empty()) {
-                    return false;
-                }
-                if (DoRepeat* expectedCall = std::get_if<DoRepeat>(&m_expectedCalls.back()); expectedCall != nullptr) {
-                    return expectedCall->repeatCommandToReturn != nullptr;
-                }
-                return false;
             }
 
             bool doCollateWith(UndoableCommand* otherCommand) override {
@@ -195,25 +172,6 @@ namespace TrenchBroom {
                 m_expectedCalls.emplace_back(DoCollateWith{returnCanCollate, expectedOtherCommand});
             }
 
-            /**
-             * Sets an expectation that doRepeat() should be called.
-             * If repeatable is true, this creates a TestCommand that doRepeat() will return.
-             * Otherwise, when doRepeat() is called, doRepeat() will return a null std::unique_ptr.
-             *
-             * Returns a non-owning pointer to the TestCommand that was created
-             * if `repeatable` is true, or nullptr otherwise.
-             */
-            TestCommand* expectRepeat(const bool repeatable, const std::string& repeatCommandName = "") {
-                if (repeatable) {
-                    auto* repeatCommand = new TestCommand(repeatCommandName, false);
-                    m_expectedCalls.emplace_back(DoRepeat{std::unique_ptr<UndoableCommand>(repeatCommand)});
-                    return repeatCommand;
-                } else {
-                    m_expectedCalls.emplace_back(DoRepeat{std::unique_ptr<UndoableCommand>(nullptr)});
-                    return nullptr;
-                }
-            }
-
             deleteCopyAndMove(TestCommand)
         };
 
@@ -228,7 +186,7 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName = "test command";
-            auto command = TestCommand::create(commandName, false);
+            auto command = TestCommand::create(commandName);
 
             command->expectDo(true);
             command->expectUndo(true);
@@ -237,7 +195,6 @@ namespace TrenchBroom {
             ASSERT_TRUE(doResult->success());
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(commandName, commandProcessor.undoCommandName());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
@@ -250,7 +207,6 @@ namespace TrenchBroom {
             ASSERT_TRUE(undoResult->success());
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
 
             ASSERT_EQ(commandName, commandProcessor.redoCommandName());
 
@@ -270,7 +226,7 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName = "test command";
-            auto command = TestCommand::create(commandName, false);
+            auto command = TestCommand::create(commandName);
             command->expectDo(true);
             command->expectUndo(false);
 
@@ -278,7 +234,6 @@ namespace TrenchBroom {
             ASSERT_TRUE(doResult->success());
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(commandName, commandProcessor.undoCommandName());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
@@ -291,7 +246,6 @@ namespace TrenchBroom {
             ASSERT_FALSE(undoResult->success());
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
                 {CommandNotif::CommandUndo, commandName},
@@ -308,7 +262,7 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName = "test command";
-            auto command = TestCommand::create(commandName, false);
+            auto command = TestCommand::create(commandName);
             command->expectDo(false);
 
             const auto doResult = commandProcessor.executeAndStore(std::move(command));
@@ -316,202 +270,10 @@ namespace TrenchBroom {
 
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
                 {CommandNotif::CommandDo, commandName},
                 {CommandNotif::CommandDoFailed, commandName}
-            }), observer.popNotifications());
-        }
-
-        TEST_CASE("CommandProcessorTest.repeatAndUndoSingleCommand", "[CommandProcessorTest]") {
-            /*
-             * Execute a successful command, then repeat it successfully, and undo the repeated command
-             * successfully, too.
-             */
-
-            CommandProcessor commandProcessor(nullptr);
-            TestObserver observer(commandProcessor);
-
-            const auto commandName = "test command";
-            auto command = TestCommand::create(commandName, false);
-            command->expectDo(true);
-
-            const auto repeatCommandName = "repeated command";
-            auto* repeatCommand = command->expectRepeat(true, repeatCommandName);
-            repeatCommand->expectDo(true);
-            repeatCommand->expectUndo(true);
-
-            commandProcessor.executeAndStore(std::move(command));
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, commandName},
-                {CommandNotif::CommandDone, commandName},
-                {CommandNotif::TransactionDone, commandName}
-            }), observer.popNotifications());
-
-            const auto repeatResult = commandProcessor.repeat();
-            ASSERT_TRUE(repeatResult->success());
-
-            ASSERT_TRUE(commandProcessor.canUndo());
-            ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ(repeatCommandName, commandProcessor.undoCommandName());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, repeatCommandName},
-                {CommandNotif::CommandDone, repeatCommandName},
-                {CommandNotif::TransactionDone, repeatCommandName}
-            }), observer.popNotifications());
-
-            const auto undoResult = commandProcessor.undo();
-            ASSERT_TRUE(undoResult->success());
-
-            ASSERT_TRUE(commandProcessor.canUndo());
-            ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ(commandName, commandProcessor.undoCommandName());
-            ASSERT_EQ(repeatCommandName, commandProcessor.redoCommandName());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandUndo, repeatCommandName},
-                {CommandNotif::CommandUndone, repeatCommandName},
-                {CommandNotif::TransactionUndone, repeatCommandName}
-            }), observer.popNotifications());
-        }
-
-        TEST_CASE("CommandProcessorTest.repeatSingleCommandTwice", "[CommandProcessorTest]") {
-            /*
-             * Execute a successful command, then repeat it successfully two times
-             */
-
-            CommandProcessor commandProcessor(nullptr);
-            TestObserver observer(commandProcessor);
-
-            const auto commandName = "test command";
-            auto command = TestCommand::create(commandName, false);
-            command->expectDo(true);
-
-            const auto repeatCommandName1 = "repeated command 1";
-            auto* repeatCommand1 = command->expectRepeat(true, repeatCommandName1);
-            repeatCommand1->expectDo(true);
-
-            const auto repeatCommandName2 = "repeated command 2";
-            auto* repeatCommand2 = command->expectRepeat(true, repeatCommandName2);
-            repeatCommand2->expectDo(true);
-
-            commandProcessor.executeAndStore(std::move(command));
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, commandName},
-                {CommandNotif::CommandDone, commandName},
-                {CommandNotif::TransactionDone, commandName}
-            }), observer.popNotifications());
-
-            const auto repeatResult1 = commandProcessor.repeat();
-            ASSERT_TRUE(repeatResult1->success());
-
-            ASSERT_TRUE(commandProcessor.canUndo());
-            ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, repeatCommandName1},
-                {CommandNotif::CommandDone, repeatCommandName1},
-                {CommandNotif::TransactionDone, repeatCommandName1}
-            }), observer.popNotifications());
-
-            const auto repeatResult2 = commandProcessor.repeat();
-            ASSERT_TRUE(repeatResult2->success());
-
-            ASSERT_TRUE(commandProcessor.canUndo());
-            ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, repeatCommandName2},
-                {CommandNotif::CommandDone, repeatCommandName2},
-                {CommandNotif::TransactionDone, repeatCommandName2}
-            }), observer.popNotifications());
-        }
-
-        TEST_CASE("CommandProcessorTest.repeatAndUndoMultipleCommands", "[CommandProcessorTest]") {
-            /*
-             * Execute two successful commands, then repeat them successfully, and undo the repeated commands
-             * successfully, too.
-             */
-
-            CommandProcessor commandProcessor(nullptr);
-            TestObserver observer(commandProcessor);
-
-            const auto commandName1 = "test command 1";
-            auto command1 = TestCommand::create(commandName1, false);
-            command1->expectDo(true);
-
-            const auto commandName2 = "test command 2";
-            auto command2 = TestCommand::create(commandName2, false);
-            command2->expectDo(true);
-            command1->expectCollate(command2.get(), false);
-
-            const auto repeatCommandName1 = "repeated command 1";
-            const auto repeatCommandName2 = "repeated command 2";
-            auto* repeatCommand1 = command1->expectRepeat(true, repeatCommandName1);
-            auto* repeatCommand2 = command2->expectRepeat(true, repeatCommandName2);
-
-            repeatCommand1->expectDo(true);
-            repeatCommand2->expectDo(true);
-
-            commandProcessor.executeAndStore(std::move(command1));
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, commandName1},
-                {CommandNotif::CommandDone, commandName1},
-                {CommandNotif::TransactionDone, commandName1}
-            }), observer.popNotifications());
-
-            commandProcessor.executeAndStore(std::move(command2));
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, commandName2},
-                {CommandNotif::CommandDone, commandName2},
-                {CommandNotif::TransactionDone, commandName2}
-            }), observer.popNotifications());
-
-            const auto repeatResult = commandProcessor.repeat();
-            ASSERT_TRUE(repeatResult->success());
-
-            ASSERT_TRUE(commandProcessor.canUndo());
-            ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandDo, repeatCommandName1},
-                {CommandNotif::CommandDone, repeatCommandName1},
-                {CommandNotif::CommandDo, repeatCommandName2},
-                {CommandNotif::CommandDone, repeatCommandName2},
-                {CommandNotif::TransactionDone, "Repeat 2 Commands"}
-            }), observer.popNotifications());
-
-            repeatCommand2->expectUndo(true);
-            repeatCommand1->expectUndo(true);
-
-            const auto undoResult = commandProcessor.undo();
-            ASSERT_TRUE(undoResult->success());
-
-            ASSERT_TRUE(commandProcessor.canUndo());
-            ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
-
-            ASSERT_EQ(commandName2, commandProcessor.undoCommandName());
-
-            ASSERT_EQ((std::vector<NotificationTuple>{
-                {CommandNotif::CommandUndo, repeatCommandName2},
-                {CommandNotif::CommandUndone, repeatCommandName2},
-                {CommandNotif::CommandUndo, repeatCommandName1},
-                {CommandNotif::CommandUndone, repeatCommandName1},
-                {CommandNotif::TransactionUndone, "Repeat 2 Commands"}
             }), observer.popNotifications());
         }
 
@@ -525,10 +287,10 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName1 = "test command 1";
-            auto command1 = TestCommand::create(commandName1, false);
+            auto command1 = TestCommand::create(commandName1);
 
             const auto commandName2 = "test command 2";
-            auto command2 = TestCommand::create(commandName2, false);
+            auto command2 = TestCommand::create(commandName2);
 
             command1->expectDo(true);
             command2->expectDo(true);
@@ -559,14 +321,12 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(transactionName, commandProcessor.undoCommandName());
 
             ASSERT_TRUE(commandProcessor.undo()->success());
 
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
             ASSERT_EQ(transactionName, commandProcessor.redoCommandName());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
@@ -581,7 +341,6 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(transactionName, commandProcessor.undoCommandName());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
@@ -602,10 +361,10 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName1 = "test command 1";
-            auto command1 = TestCommand::create(commandName1, false);
+            auto command1 = TestCommand::create(commandName1);
 
             const auto commandName2 = "test command 2";
-            auto command2 = TestCommand::create(commandName2, false);
+            auto command2 = TestCommand::create(commandName2);
 
             command1->expectDo(true);
             command2->expectDo(true);
@@ -639,14 +398,12 @@ namespace TrenchBroom {
 
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
 
             // does nothing, but closes the transaction
             commandProcessor.commitTransaction();
 
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
 
             ASSERT_EQ((std::vector<NotificationTuple>{}), observer.popNotifications());
         }
@@ -661,10 +418,10 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto outerCommandName = "outer command";
-            auto outerCommand = TestCommand::create(outerCommandName, false);
+            auto outerCommand = TestCommand::create(outerCommandName);
 
             const auto innerCommandName = "inner command";
-            auto innerCommand = TestCommand::create(innerCommandName, false);
+            auto innerCommand = TestCommand::create(innerCommandName);
 
             outerCommand->expectDo(true);
             innerCommand->expectDo(true);
@@ -703,14 +460,12 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(outerTransactionName, commandProcessor.undoCommandName());
 
             ASSERT_TRUE(commandProcessor.undo()->success());
 
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
             ASSERT_EQ(outerTransactionName, commandProcessor.redoCommandName());
 
             ASSERT_EQ((std::vector<NotificationTuple>{
@@ -731,10 +486,10 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName1 = "test command 1";
-            auto command1 = TestCommand::create(commandName1, false);
+            auto command1 = TestCommand::create(commandName1);
 
             const auto commandName2 = "test command 2";
-            auto command2 = TestCommand::create(commandName2, false);
+            auto command2 = TestCommand::create(commandName2);
 
             command1->expectDo(true);
             command2->expectDo(true);
@@ -757,14 +512,12 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(commandName1, commandProcessor.undoCommandName());
 
             ASSERT_TRUE(commandProcessor.undo()->success());
 
             ASSERT_FALSE(commandProcessor.canUndo());
             ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_FALSE(commandProcessor.canRepeat());
             ASSERT_EQ(commandName1, commandProcessor.redoCommandName());
 
             // NOTE: commandName2 is gone because it was coalesced into commandName1
@@ -785,10 +538,10 @@ namespace TrenchBroom {
             TestObserver observer(commandProcessor);
 
             const auto commandName1 = "test command 1";
-            auto command1 = TestCommand::create(commandName1, false);
+            auto command1 = TestCommand::create(commandName1);
 
             const auto commandName2 = "test command 2";
-            auto command2 = TestCommand::create(commandName2, false);
+            auto command2 = TestCommand::create(commandName2);
 
             command1->expectDo(true);
             command2->expectDo(true);
@@ -815,7 +568,6 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_FALSE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(commandName2, commandProcessor.undoCommandName());
 
             ASSERT_TRUE(commandProcessor.undo()->success());
@@ -828,7 +580,6 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(commandProcessor.canUndo());
             ASSERT_TRUE(commandProcessor.canRedo());
-            ASSERT_TRUE(commandProcessor.canRepeat());
             ASSERT_EQ(commandName1, commandProcessor.undoCommandName());
             ASSERT_EQ(commandName2, commandProcessor.redoCommandName());
         }

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -185,6 +185,10 @@ namespace TrenchBroom {
             document->select(entityNode2);
             CHECK(document->canRepeatCommands());
 
+            // this command will not clear the repeat stack
+            document->setAttribute("this", "that");
+            CHECK(document->canRepeatCommands());
+
             // this command will replace the command on the repeat stack
             document->translateObjects(vm::vec3(-1, -2, -3));
             CHECK(document->canRepeatCommands());
@@ -198,10 +202,6 @@ namespace TrenchBroom {
             document->deselectAll();
             document->select(entityNode1);
             CHECK(document->canRepeatCommands());
-
-            // this command will clear the repeat stack
-            document->setAttribute("this", "that");
-            CHECK_FALSE(document->canRepeatCommands());
         }
     }
 }

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -1,0 +1,207 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Model/BrushNode.h"
+#include "Model/EntityNode.h"
+#include "View/Command.h"
+#include "View/MapDocumentTest.h"
+#include "View/MapDocument.h"
+
+#include <kdl/result.h>
+
+#include <vecmath/approx.h>
+#include <vecmath/bbox_io.h>
+#include <vecmath/mat.h>
+#include <vecmath/mat_ext.h>
+#include <vecmath/mat_io.h>
+#include <vecmath/scalar.h>
+#include <vecmath/vec.h>
+#include <vecmath/vec_io.h>
+
+#include "Catch2.h"
+
+namespace TrenchBroom {
+    namespace View {
+        class RepeatableActionsTest : public MapDocumentTest {};
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.canRepeat") {
+            CHECK_FALSE(document->canRepeatCommands());
+
+            auto* entityNode = new Model::EntityNode();
+            document->addNode(entityNode, document->parentForNodes());
+            CHECK_FALSE(document->canRepeatCommands());
+
+            document->select(entityNode);
+            CHECK_FALSE(document->canRepeatCommands());
+
+            document->duplicateObjects();
+            CHECK(document->canRepeatCommands());
+
+            document->clearRepeatableCommands();
+            CHECK_FALSE(document->canRepeatCommands());
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.repeatTranslate") {
+            auto* entityNode = new Model::EntityNode();
+            document->addNode(entityNode, document->parentForNodes());
+            document->select(entityNode);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            document->translateObjects(vm::vec3(1, 2, 3));
+            CHECK(document->canRepeatCommands());
+
+            REQUIRE(entityNode->origin() == vm::vec3(1, 2, 3));
+            document->repeatCommands();
+            CHECK(entityNode->origin() == vm::vec3(2, 4, 6));
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.repeatRotate") {
+            auto* entityNode = new Model::EntityNode();
+            REQUIRE(entityNode->transform(document->worldBounds(), vm::translation_matrix(vm::vec3(1, 2, 3)), false).is_success());
+
+            document->addNode(entityNode, document->parentForNodes());
+            document->select(entityNode);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            document->rotateObjects(vm::vec3::zero(), vm::vec3::pos_z(), vm::to_radians(90.0));
+            CHECK(document->canRepeatCommands());
+
+            REQUIRE(entityNode->origin() == vm::approx(vm::rotation_matrix(vm::vec3::pos_z(), vm::to_radians(90.0)) * vm::vec3(1, 2, 3)));
+            document->repeatCommands();
+            CHECK(entityNode->origin() == vm::approx(vm::rotation_matrix(vm::vec3::pos_z(), vm::to_radians(180.0)) * vm::vec3(1, 2, 3)));
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.repeatScaleWithBBox") {
+            auto* brushNode1 = createBrushNode();
+
+            document->addNode(brushNode1, document->parentForNodes());
+            document->select(brushNode1);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            const auto oldBounds = brushNode1->logicalBounds();
+            const auto newBounds = vm::bbox3(oldBounds.min, 2.0 * oldBounds.max);
+            document->scaleObjects(oldBounds, newBounds);
+            CHECK(document->canRepeatCommands());
+
+            auto* brushNode2 = createBrushNode();
+            document->addNode(brushNode2, document->parentForNodes());
+            document->select(brushNode2);
+
+            document->repeatCommands();
+            CHECK(brushNode2->logicalBounds() == newBounds);
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.repeatScaleWithFactors") {
+            auto* brushNode1 = createBrushNode();
+
+            document->addNode(brushNode1, document->parentForNodes());
+            document->select(brushNode1);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            document->scaleObjects(brushNode1->logicalBounds().center(), vm::vec3(2, 2, 2));
+            CHECK(document->canRepeatCommands());
+
+            auto* brushNode2 = createBrushNode();
+            document->addNode(brushNode2, document->parentForNodes());
+            document->deselectAll();
+            document->select(brushNode2);
+
+            document->repeatCommands();
+            CHECK(brushNode2->logicalBounds() == brushNode1->logicalBounds());
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.shearObjects") {
+            auto* brushNode1 = createBrushNode();
+            const auto originalBounds = brushNode1->logicalBounds();
+
+            document->addNode(brushNode1, document->parentForNodes());
+            document->select(brushNode1);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            document->shearObjects(originalBounds, vm::vec3::pos_z(), vm::vec3(32, 0, 0));
+            REQUIRE(brushNode1->logicalBounds() != originalBounds);
+            CHECK(document->canRepeatCommands());
+
+            auto* brushNode2 = createBrushNode();
+            document->addNode(brushNode2, document->parentForNodes());
+            document->deselectAll();
+            document->select(brushNode2);
+
+            document->repeatCommands();
+            CHECK(brushNode2->logicalBounds() == brushNode1->logicalBounds());
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.flipObjects") {
+            auto* brushNode1 = createBrushNode();
+            const auto originalBounds = brushNode1->logicalBounds();
+
+            document->addNode(brushNode1, document->parentForNodes());
+            document->select(brushNode1);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            document->flipObjects(originalBounds.max, vm::axis::z);
+            REQUIRE(brushNode1->logicalBounds() != originalBounds);
+            CHECK(document->canRepeatCommands());
+
+            auto* brushNode2 = createBrushNode();
+            document->addNode(brushNode2, document->parentForNodes());
+            document->deselectAll();
+            document->select(brushNode2);
+
+            document->repeatCommands();
+            CHECK(brushNode2->logicalBounds() == brushNode1->logicalBounds());
+        }
+
+        TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.selectionClears") {
+            auto* entityNode1 = new Model::EntityNode();
+            document->addNode(entityNode1, document->parentForNodes());
+
+            auto* entityNode2 = new Model::EntityNode();
+            document->addNode(entityNode2, document->parentForNodes());
+
+            document->select(entityNode1);
+
+            REQUIRE_FALSE(document->canRepeatCommands());
+            document->translateObjects(vm::vec3(1, 2, 3));
+            REQUIRE(document->canRepeatCommands());
+
+            document->deselectAll();
+            document->select(entityNode2);
+            CHECK(document->canRepeatCommands());
+
+            // this command will replace the command on the repeat stack
+            document->translateObjects(vm::vec3(-1, -2, -3));
+            CHECK(document->canRepeatCommands());
+
+            document->deselectAll();
+            document->select(entityNode1);
+
+            document->repeatCommands();
+            CHECK(entityNode1->origin() == vm::vec3::zero());
+
+            document->deselectAll();
+            document->select(entityNode1);
+            CHECK(document->canRepeatCommands());
+
+            // this command will clear the repeat stack
+            document->setAttribute("this", "that");
+            CHECK_FALSE(document->canRepeatCommands());
+        }
+    }
+}


### PR DESCRIPTION
This is a preparation for #3485. Our strategy to get rid of commands is to replace their effect by just replacing the affected nodes in the node tree. The result is that we will probably have a very small number of commands left. This however would make command repetition impossible, so this PR reimplements that feature independently of commands, which also simplifies the command processor and commands quite a bit.