### PR TITLE
3510: optimize Palette::indexedToRgba

### DIFF
--- a/common/src/Assets/Palette.h
+++ b/common/src/Assets/Palette.h
@@ -21,7 +21,6 @@
 #define TrenchBroom_Palette
 
 #include "Color.h"
-#include "Assets/TextureBuffer.h"
 #include "IO/Reader.h"
 
 #include <cassert>
@@ -30,90 +29,32 @@
 
 namespace TrenchBroom {
     namespace IO {
+        class BufferedReader;
         class FileSystem;
         class Path;
     }
 
     namespace Assets {
+        struct PaletteData;
+        class TextureBuffer;
+
         enum class PaletteTransparency {
             Opaque, Index255Transparent
         };
 
         class Palette {
         private:
-            class Data {
-            private:
-                std::vector<unsigned char> m_data;
-            public:
-                Data(std::vector<unsigned char>&& data);
-
-                /**
-                 * Converts the given index buffer to an RGBA image.
-                 *
-                 * @tparam IndexT the index type
-                 * @param indexedImage the index buffer
-                 * @param pixelCount the number of pixels
-                 * @param rgbaImage the pixel buffer
-                 * @param transparency controls whether or not the given index buffer contains a transparent index
-                 * @param averageColor output parameter for the average color of the generated pixel buffer
-                 * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
-                 *     indicates that the image is opaque
-                 */
-                template <typename IndexT>
-                bool indexedToRgba(const std::vector<IndexT>& indexedImage, const size_t pixelCount, unsigned char* rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
-                    auto reader = IO::Reader::from(&indexedImage[0], &indexedImage[0] + pixelCount);
-                    return indexedToRgba(reader, pixelCount, rgbaImage, transparency, averageColor);
-                }
-
-                /**
-                 * Converts the given index buffer to an RGBA image.
-                 *
-                 * @param reader the index buffer reader
-                 * @param pixelCount the number of pixels
-                 * @param rgbaImage the pixel buffer
-                 * @param transparency controls whether or not the given index buffer contains a transparent index
-                 * @param averageColor output parameter for the average color of the generated pixel buffer
-                 * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
-                 *     indicates that the image is opaque
-                 */
-                inline bool indexedToRgba(IO::Reader& reader, const size_t pixelCount, unsigned char* rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
-                    double avg[3];
-                    avg[0] = avg[1] = avg[2] = 0.0;
-                    bool hasTransparency = false;
-                    for (size_t i = 0; i < pixelCount; ++i) {
-                        const size_t index = reader.readSize<unsigned char>();
-                        assert(index < m_data.size());
-                        for (size_t j = 0; j < 3; ++j) {
-                            const unsigned char c = m_data[index * 3 + j];
-                            rgbaImage[i * 4 + j] = c;
-                            avg[j] += static_cast<double>(c);
-                        }
-                        switch (transparency) {
-                            case PaletteTransparency::Opaque:
-                                rgbaImage[i * 4 + 3] = 0xFF;
-                                break;
-                            case PaletteTransparency::Index255Transparent:
-                                rgbaImage[i * 4 + 3] = static_cast<unsigned char>((index == 255) ? 0x00 : 0xFF);
-                                hasTransparency |= (index == 255);
-                                break;
-                        }
-                    }
-
-                    for (size_t i = 0; i < 3; ++i) {
-                        averageColor[i] = static_cast<float>(avg[i] / static_cast<double>(pixelCount) / static_cast<double>(0xFF));
-                    }
-                    averageColor[3] = 1.0f;
-
-                    return hasTransparency;
-                }
-            };
-
-            using DataPtr = std::shared_ptr<Data>;
-            DataPtr m_data;
+            std::shared_ptr<PaletteData> m_data;
         public:
             Palette();
-            Palette(std::vector<unsigned char> data);
+            /**
+             * @throws AssetException if data is not 768 bytes
+             */
+            Palette(const std::vector<unsigned char>& data);
 
+            /**
+             * @throws AssetException if the palette can't be loaded
+             */
             static Palette loadFile(const IO::FileSystem& fs, const IO::Path& path);
             static Palette loadLmp(IO::Reader& reader);
             static Palette loadPcx(IO::Reader& reader);
@@ -123,36 +64,23 @@ namespace TrenchBroom {
             bool initialized() const;
 
             /**
-             * Converts the given index buffer to an RGBA image.
+             * Reads `pixelCount` bytes from `reader` where each byte is a palette index,
+             * and writes `pixelCount` * 4 bytes to `rgbaImage` using the palette to convert
+             * the image to RGBA.
              *
-             * @tparam IndexT the index type
-             * @param indexedImage the index buffer
-             * @param pixelCount the number of pixels
-             * @param rgbaImage the pixel buffer
-             * @param transparency controls whether or not the given index buffer contains a transparent index
+             * Must not be called if `initialized()` is false.
+             *
+             * @param reader the reader to read from; the position will be advanced
+             * @param pixelCount number of pixels (bytes) to read
+             * @param rgbaImage the destination buffer, size must be exactly `pixelCount` * 4 bytes
+             * @param transparency controls whether or not the palette contains a transparent index
              * @param averageColor output parameter for the average color of the generated pixel buffer
              * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
              *     indicates that the image is opaque
-             */
-            template <typename IndexT>
-            bool indexedToRgba(const std::vector<IndexT>& indexedImage, const size_t pixelCount, TextureBuffer& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
-                return m_data->indexedToRgba(indexedImage, pixelCount, rgbaImage.data(), transparency, averageColor);
-            }
-
-            /**
-             * Converts the given index buffer to an RGBA image.
              *
-             * @param reader the index buffer
-             * @param pixelCount the number of pixels
-             * @param rgbaImage the pixel buffer
-             * @param transparency controls whether or not the given index buffer contains a transparent index
-             * @param averageColor output parameter for the average color of the generated pixel buffer
-             * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
-             *     indicates that the image is opaque
+             * @throws ReaderException if reader doesn't have pixelCount bytes available
              */
-            inline bool indexedToRgba(IO::Reader& reader, const size_t pixelCount, TextureBuffer& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
-                return m_data->indexedToRgba(reader, pixelCount, rgbaImage.data(), transparency, averageColor);
-            }
+            bool indexedToRgba(IO::BufferedReader& reader, size_t pixelCount, TextureBuffer& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const;
         };
     }
 }

--- a/common/src/Assets/Palette.h
+++ b/common/src/Assets/Palette.h
@@ -21,6 +21,7 @@
 #define TrenchBroom_Palette
 
 #include "Color.h"
+#include "Assets/TextureBuffer.h"
 #include "IO/Reader.h"
 
 #include <cassert>
@@ -50,7 +51,6 @@ namespace TrenchBroom {
                  * Converts the given index buffer to an RGBA image.
                  *
                  * @tparam IndexT the index type
-                 * @tparam ColorT the pixel type
                  * @param indexedImage the index buffer
                  * @param pixelCount the number of pixels
                  * @param rgbaImage the pixel buffer
@@ -59,8 +59,8 @@ namespace TrenchBroom {
                  * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
                  *     indicates that the image is opaque
                  */
-                template <typename IndexT, typename ColorT>
-                bool indexedToRgba(const std::vector<IndexT>& indexedImage, const size_t pixelCount, std::vector<ColorT>& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
+                template <typename IndexT>
+                bool indexedToRgba(const std::vector<IndexT>& indexedImage, const size_t pixelCount, unsigned char* rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
                     auto reader = IO::Reader::from(&indexedImage[0], &indexedImage[0] + pixelCount);
                     return indexedToRgba(reader, pixelCount, rgbaImage, transparency, averageColor);
                 }
@@ -68,7 +68,6 @@ namespace TrenchBroom {
                 /**
                  * Converts the given index buffer to an RGBA image.
                  *
-                 * @tparam ColorT the pixel type
                  * @param reader the index buffer reader
                  * @param pixelCount the number of pixels
                  * @param rgbaImage the pixel buffer
@@ -77,8 +76,7 @@ namespace TrenchBroom {
                  * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
                  *     indicates that the image is opaque
                  */
-                template <typename ColorT>
-                bool indexedToRgba(IO::Reader& reader, const size_t pixelCount, std::vector<ColorT>& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
+                inline bool indexedToRgba(IO::Reader& reader, const size_t pixelCount, unsigned char* rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
                     double avg[3];
                     avg[0] = avg[1] = avg[2] = 0.0;
                     bool hasTransparency = false;
@@ -95,7 +93,7 @@ namespace TrenchBroom {
                                 rgbaImage[i * 4 + 3] = 0xFF;
                                 break;
                             case PaletteTransparency::Index255Transparent:
-                                rgbaImage[i * 4 + 3] = static_cast<ColorT>((index == 255) ? 0x00 : 0xFF);
+                                rgbaImage[i * 4 + 3] = static_cast<unsigned char>((index == 255) ? 0x00 : 0xFF);
                                 hasTransparency |= (index == 255);
                                 break;
                         }
@@ -128,7 +126,6 @@ namespace TrenchBroom {
              * Converts the given index buffer to an RGBA image.
              *
              * @tparam IndexT the index type
-             * @tparam ColorT the pixel type
              * @param indexedImage the index buffer
              * @param pixelCount the number of pixels
              * @param rgbaImage the pixel buffer
@@ -137,15 +134,14 @@ namespace TrenchBroom {
              * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
              *     indicates that the image is opaque
              */
-            template <typename IndexT, typename ColorT>
-            bool indexedToRgba(const std::vector<IndexT>& indexedImage, const size_t pixelCount, std::vector<ColorT>& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
-                return m_data->indexedToRgba(indexedImage, pixelCount, rgbaImage, transparency, averageColor);
+            template <typename IndexT>
+            bool indexedToRgba(const std::vector<IndexT>& indexedImage, const size_t pixelCount, TextureBuffer& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
+                return m_data->indexedToRgba(indexedImage, pixelCount, rgbaImage.data(), transparency, averageColor);
             }
 
             /**
              * Converts the given index buffer to an RGBA image.
              *
-             * @tparam ColorT the pixel type
              * @param reader the index buffer
              * @param pixelCount the number of pixels
              * @param rgbaImage the pixel buffer
@@ -154,9 +150,8 @@ namespace TrenchBroom {
              * @return true if the given index buffer did contain a transparent index, unless the transparency parameter
              *     indicates that the image is opaque
              */
-            template <typename ColorT>
-            bool indexedToRgba(IO::Reader& reader, const size_t pixelCount, std::vector<ColorT>& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
-                return m_data->indexedToRgba(reader, pixelCount, rgbaImage, transparency, averageColor);
+            inline bool indexedToRgba(IO::Reader& reader, const size_t pixelCount, TextureBuffer& rgbaImage, const PaletteTransparency transparency, Color& averageColor) const {
+                return m_data->indexedToRgba(reader, pixelCount, rgbaImage.data(), transparency, averageColor);
             }
         };
     }

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -21,6 +21,7 @@
 #define TrenchBroom_Texture
 
 #include "Color.h"
+#include "Assets/TextureBuffer.h"
 #include "Renderer/GL.h"
 
 #include <vecmath/forward.h>
@@ -72,7 +73,7 @@ namespace TrenchBroom {
 
         class Texture {
         private:
-            using Buffer = std::vector<unsigned char>;
+            using Buffer = TextureBuffer;
             using BufferList = std::vector<Buffer>;
         private:
             std::string m_name;

--- a/common/src/Assets/TextureBuffer.cpp
+++ b/common/src/Assets/TextureBuffer.cpp
@@ -29,6 +29,26 @@
 
 namespace TrenchBroom {
     namespace Assets {
+        TextureBuffer::TextureBuffer() : m_buffer(), m_size(0) {}
+
+        /**
+         * Note, buffer is created defult-initialized (i.e., uninitialized) on purpose.
+         */
+        TextureBuffer::TextureBuffer(const size_t size) :
+        m_buffer(new unsigned char[size]),
+        m_size(size) {}
+
+        const unsigned char* TextureBuffer::data() const {
+            return m_buffer.get();
+        }
+
+        unsigned char* TextureBuffer::data() {
+            return m_buffer.get();
+        }
+
+        size_t TextureBuffer::size() const {
+            return m_size;
+        }
 
         vm::vec2s sizeAtMipLevel(const size_t width, const size_t height, const size_t level) {
             assert(width > 0);
@@ -59,7 +79,7 @@ namespace TrenchBroom {
             for (size_t level = 0u; level < buffers.size(); ++level) {
                 const auto mipSize = sizeAtMipLevel(width, height, level);
                 const auto numBytes = bytesPerPixel * mipSize.x() * mipSize.y();
-                buffers[level].resize(numBytes);
+                buffers[level] = TextureBuffer(numBytes);
             }
         }
 
@@ -83,7 +103,7 @@ namespace TrenchBroom {
                 auto* newBitmap = FreeImage_Rescale(oldBitmap, newWidth, newHeight, FILTER_BICUBIC);
                 ensure(newBitmap != nullptr, "newBitmap is null");
 
-                buffers[i] = std::vector<unsigned char>(3 * newSize.x() * newSize.y());
+                buffers[i] = TextureBuffer(3 * newSize.x() * newSize.y());
                 auto* newPtr = buffers[i].data();
 
                 FreeImage_ConvertToRawBits(newPtr, newBitmap, newPitch, 24, 0xFF0000, 0x00FF00, 0x0000FF, true);

--- a/common/src/Assets/TextureBuffer.h
+++ b/common/src/Assets/TextureBuffer.h
@@ -24,11 +24,24 @@
 
 #include <vecmath/forward.h>
 
+#include <memory>
 #include <vector>
 
 namespace TrenchBroom {
     namespace Assets {
-        using TextureBuffer = std::vector<unsigned char>;
+        class TextureBuffer {
+        private:
+            std::unique_ptr<unsigned char[]> m_buffer;
+            size_t m_size;
+        public:
+            explicit TextureBuffer();
+            explicit TextureBuffer(size_t size);
+
+            const unsigned char* data() const;
+            unsigned char* data();
+
+            size_t size() const;
+        };
         using TextureBufferList = std::vector<TextureBuffer>;
 
         vm::vec2s sizeAtMipLevel(size_t width, size_t height, size_t level);

--- a/common/src/Assets/TextureManager.cpp
+++ b/common/src/Assets/TextureManager.cpp
@@ -30,6 +30,7 @@
 #include <kdl/vector_utils.h>
 
 #include <algorithm>
+#include <chrono>
 #include <iterator>
 #include <string>
 #include <vector>
@@ -71,8 +72,12 @@ namespace TrenchBroom {
                 const auto it = std::find_if(std::begin(collections), std::end(collections), [&](const auto& c) { return c.path() == path; });
                 if (it == std::end(collections) || !it->loaded()) {
                     try {
+                        const auto startTime = std::chrono::high_resolution_clock::now();
                         auto collection = loader.loadTextureCollection(path);
-                        m_logger.info() << "Loaded texture collection '" << path << "'";
+                        const auto endTime = std::chrono::high_resolution_clock::now();
+
+                        m_logger.info() << "Loaded texture collection '" << path << "' in "
+                                        << std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count() << "ms";
                         addTextureCollection(std::move(collection));
                     } catch (const Exception& e) {
                         addTextureCollection(Assets::TextureCollection(path));

--- a/common/src/IO/M8TextureReader.cpp
+++ b/common/src/IO/M8TextureReader.cpp
@@ -95,8 +95,7 @@ namespace TrenchBroom {
 
                     reader.seekFromBegin(offsets[mipLevel]);
 
-                    Assets::TextureBuffer rgbaImage;
-                    rgbaImage.resize(4 * w * h);
+                    Assets::TextureBuffer rgbaImage(4 * w * h);
 
                     Color averageColor;
                     palette.indexedToRgba(reader, w * h, rgbaImage, Assets::PaletteTransparency::Opaque, averageColor);

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -224,7 +224,7 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<Assets::EntityModel> MdlParser::doInitializeModel(Logger& /* logger */) {
-            auto reader = Reader::from(m_begin, m_end);
+            auto reader = Reader::from(m_begin, m_end).buffer();
 
             const auto ident = reader.readInt<int32_t>();
             const auto version = reader.readInt<int32_t>();
@@ -260,7 +260,7 @@ namespace TrenchBroom {
         }
 
         void MdlParser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-            auto reader = Reader::from(m_begin, m_end);
+            auto reader = Reader::from(m_begin, m_end).buffer();
 
             const auto ident = reader.readInt<int32_t>();
             const auto version = reader.readInt<int32_t>();
@@ -296,7 +296,7 @@ namespace TrenchBroom {
             parseFrame(reader, model, frameIndex, surface, triangles, vertices, skinWidth, skinHeight, origin, scale);
         }
 
-        void MdlParser::parseSkins(Reader& reader, Assets::EntityModelSurface& surface, const size_t count, const size_t width, const size_t height, const int flags) {
+        void MdlParser::parseSkins(BufferedReader& reader, Assets::EntityModelSurface& surface, const size_t count, const size_t width, const size_t height, const int flags) {
             const auto size = width * height;
             const auto transparency = (flags & MF_HOLEY)
                     ? Assets::PaletteTransparency::Index255Transparent

--- a/common/src/IO/MdlParser.h
+++ b/common/src/IO/MdlParser.h
@@ -35,6 +35,7 @@ namespace TrenchBroom {
     }
 
     namespace IO {
+        class BufferedReader;
         class Reader;
 
         class MdlParser : public EntityModelParser {
@@ -67,7 +68,7 @@ namespace TrenchBroom {
             std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
             void doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) override;
 
-            void parseSkins(Reader& reader, Assets::EntityModelSurface& surface, size_t count, size_t width, size_t height, int flags);
+            void parseSkins(BufferedReader& reader, Assets::EntityModelSurface& surface, size_t count, size_t width, size_t height, int flags);
             void skipSkins(Reader& reader, size_t count, size_t width, size_t height, int flags);
 
             MdlSkinVertexList parseVertices(Reader& reader, size_t count);

--- a/common/src/IO/WalTextureReader.cpp
+++ b/common/src/IO/WalTextureReader.cpp
@@ -57,7 +57,7 @@ namespace TrenchBroom {
             }
         }
 
-        Assets::Texture WalTextureReader::readQ2Wal(Reader& reader, const Path& path) const {
+        Assets::Texture WalTextureReader::readQ2Wal(BufferedReader& reader, const Path& path) const {
             static const size_t MaxMipLevels = 4;
             static Color averageColor;
             static Assets::TextureBufferList buffers(MaxMipLevels);
@@ -81,7 +81,7 @@ namespace TrenchBroom {
             return Assets::Texture(textureName(name, path), width, height, averageColor, std::move(buffers), GL_RGBA, Assets::TextureType::Opaque);
         }
 
-        Assets::Texture WalTextureReader::readDkWal(Reader& reader, const Path& path) const {
+        Assets::Texture WalTextureReader::readDkWal(BufferedReader& reader, const Path& path) const {
             static const size_t MaxMipLevels = 9;
             static Color averageColor;
             static Assets::TextureBufferList buffers(MaxMipLevels);
@@ -128,7 +128,7 @@ namespace TrenchBroom {
             return mipLevels;
         }
 
-        bool WalTextureReader::readMips(const Assets::Palette& palette, const size_t mipLevels, const size_t offsets[], const size_t width, const size_t height, Reader& reader, Assets::TextureBufferList& buffers, Color& averageColor, const Assets::PaletteTransparency transparency) {
+        bool WalTextureReader::readMips(const Assets::Palette& palette, const size_t mipLevels, const size_t offsets[], const size_t width, const size_t height, BufferedReader& reader, Assets::TextureBufferList& buffers, Color& averageColor, const Assets::PaletteTransparency transparency) {
             static Color tempColor;
 
             auto hasTransparency = false;

--- a/common/src/IO/WalTextureReader.h
+++ b/common/src/IO/WalTextureReader.h
@@ -41,10 +41,10 @@ namespace TrenchBroom {
             WalTextureReader(const NameStrategy& nameStrategy, const FileSystem& fs, Logger& logger, const Assets::Palette& palette = Assets::Palette());
         private:
             Assets::Texture doReadTexture(std::shared_ptr<File> file) const override;
-            Assets::Texture readQ2Wal(Reader& reader, const Path& path) const;
-            Assets::Texture readDkWal(Reader& reader, const Path& path) const;
+            Assets::Texture readQ2Wal(BufferedReader& reader, const Path& path) const;
+            Assets::Texture readDkWal(BufferedReader& reader, const Path& path) const;
             size_t readMipOffsets(size_t maxMipLevels, size_t offsets[], size_t width, size_t height, Reader& reader) const;
-            static bool readMips(const Assets::Palette& palette, size_t mipLevels, const size_t offsets[], size_t width, size_t height, Reader& reader, Assets::TextureBufferList& buffers, Color& averageColor, Assets::PaletteTransparency transparency);
+            static bool readMips(const Assets::Palette& palette, size_t mipLevels, const size_t offsets[], size_t width, size_t height, BufferedReader& reader, Assets::TextureBufferList& buffers, Color& averageColor, Assets::PaletteTransparency transparency);
         };
     }
 }


### PR DESCRIPTION
- `Palette::indexedToRgba` now requires a BufferedReader
- TextureBuffer is now a class rather than std::vector, to avoid unnecessary memory zeroing
- Time for `loadTextureCollection` of Makkon2.wad (50MB) reduced from 1355ms -> 95ms (msvc2019, RelWithDebInfo build)
- Palette now limited to 256 color RGB (768 byte) palettes, clarified exceptions docs

Fixes #3510