### PR TITLE
3512: Configure Obj writer for exporting (so omitted layers are omitted)

### DIFF
--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -113,6 +113,8 @@ namespace TrenchBroom {
         m_world(world),
         m_serializer(std::move(serializer)) {}
 
+        NodeWriter::~NodeWriter() = default;
+
         void NodeWriter::setExporting(const bool exporting) {
             m_serializer->setExporting(exporting);
         }

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -21,6 +21,7 @@
 
 #include "IO/MapFileSerializer.h"
 #include "IO/MapStreamSerializer.h"
+#include "IO/NodeSerializer.h"
 #include "Model/AssortNodesVisitor.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -108,9 +108,9 @@ namespace TrenchBroom {
         m_world(world),
         m_serializer(MapStreamSerializer::create(m_world.format(), stream)) {}
 
-        NodeWriter::NodeWriter(const Model::WorldNode& world, NodeSerializer* serializer) :
+        NodeWriter::NodeWriter(const Model::WorldNode& world, std::unique_ptr<NodeSerializer> serializer) :
         m_world(world),
-        m_serializer(serializer) {}
+        m_serializer(std::move(serializer)) {}
 
         void NodeWriter::setExporting(const bool exporting) {
             m_serializer->setExporting(exporting);

--- a/common/src/IO/NodeWriter.h
+++ b/common/src/IO/NodeWriter.h
@@ -49,7 +49,7 @@ namespace TrenchBroom {
         public:
             NodeWriter(const Model::WorldNode& world, FILE* stream);
             NodeWriter(const Model::WorldNode& world, std::ostream& stream);
-            NodeWriter(const Model::WorldNode& world, NodeSerializer* serializer);
+            NodeWriter(const Model::WorldNode& world, std::unique_ptr<NodeSerializer> serializer);
 
             void setExporting(bool exporting);
             void writeMap();

--- a/common/src/IO/NodeWriter.h
+++ b/common/src/IO/NodeWriter.h
@@ -20,8 +20,6 @@
 #ifndef TrenchBroom_NodeWriter
 #define TrenchBroom_NodeWriter
 
-#include "IO/NodeSerializer.h"
-
 #include <cstdio> // FILE*
 #include <map>
 #include <memory>
@@ -38,6 +36,8 @@ namespace TrenchBroom {
     }
 
     namespace IO {
+        class NodeSerializer;
+
         class NodeWriter {
         private:
             using EntityBrushesMap = std::map<Model::EntityNode*, std::vector<Model::BrushNode*>>;

--- a/common/src/IO/NodeWriter.h
+++ b/common/src/IO/NodeWriter.h
@@ -50,6 +50,7 @@ namespace TrenchBroom {
             NodeWriter(const Model::WorldNode& world, FILE* stream);
             NodeWriter(const Model::WorldNode& world, std::ostream& stream);
             NodeWriter(const Model::WorldNode& world, std::unique_ptr<NodeSerializer> serializer);
+            ~NodeWriter();
 
             void setExporting(bool exporting);
             void writeMap();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -198,9 +198,12 @@ namespace TrenchBroom {
 
         void GameImpl::doExportMap(WorldNode& world, const Model::ExportFormat format, const IO::Path& path) const {
             switch (format) {
-                case Model::ExportFormat::WavefrontObj:
-                    IO::NodeWriter(world, new IO::ObjFileSerializer(path)).writeMap();
+                case Model::ExportFormat::WavefrontObj: {
+                    IO::NodeWriter writer(world, std::make_unique<IO::ObjFileSerializer>(path));
+                    writer.setExporting(true);
+                    writer.writeMap();
                     break;
+                }
                 case Model::ExportFormat::Map:
                     doWriteMap(world, path, true);
                     break;


### PR DESCRIPTION
Also fix confusing NodeWriter constructor that took ownership of a raw ptr.

Fixes #3512