### PR TITLE
Add map_Kd output to MTL files in OBJ export

### DIFF
--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -39,9 +39,10 @@ namespace TrenchBroom {
         verts(std::move(i_verts)),
         texture(std::move(i_texture)) {}
 
-        ObjFileSerializer::ObjFileSerializer(const Path& path) :
+        ObjFileSerializer::ObjFileSerializer(const Path& path, const Path& gamepath) :
         m_objPath(path),
         m_mtlPath(path.replaceExtension("mtl")),
+		m_gamePath(gamepath),
         m_objFile(m_objPath, true),
         m_mtlFile(m_mtlPath, true),
         m_stream(m_objFile.file),
@@ -76,7 +77,9 @@ namespace TrenchBroom {
             }
 
             for (const std::string& texture : textureNames) {
-                std::fprintf(m_mtlStream, "newmtl %s\n", texture.c_str());
+				std::fprintf(m_mtlStream, "newmtl %s\n", texture.c_str());
+				std::fprintf(m_mtlStream, "map_Kd %s%s%s\n\n", m_gamePath.asString().c_str(), "\\textures\\", texture.c_str());
+
             }
         }
 

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -103,6 +103,7 @@ namespace TrenchBroom {
 
             Path m_objPath;
             Path m_mtlPath;
+			Path m_gamePath;
 
             IO::OpenFile m_objFile;
             IO::OpenFile m_mtlFile;
@@ -117,7 +118,7 @@ namespace TrenchBroom {
             Object m_currentObject;
             ObjectList m_objects;
         public:
-            explicit ObjFileSerializer(const Path& path);
+            explicit ObjFileSerializer(const Path& path, const Path& gamepath);
         private:
             void doBeginFile() override;
             void doEndFile() override;

--- a/common/src/IO/TextureReader.cpp
+++ b/common/src/IO/TextureReader.cpp
@@ -61,7 +61,15 @@ namespace TrenchBroom {
 
         std::string TextureReader::PathSuffixNameStrategy::doGetTextureName(const std::string& /* textureName */, const Path& path) const {
             if (m_prefixLength < path.length()) {
-                return path.suffix(path.length() - m_prefixLength).deleteExtension().asString("/");
+				if (path.asString().find(".D") != std::string::npos) { //we have a mip texture, probably, so remove extension
+					return path.suffix(path.length() - m_prefixLength).deleteExtension().asString();
+				} else {//normal texture (png, tga, etc). Return path with correct separator based on OS
+#ifdef WIN32
+					return path.suffix(path.length() - m_prefixLength).asString("\\");
+#else
+					return path.suffix(path.length() - m_prefixLength).asString("/");
+#endif
+				}
             } else {
                 return "";
             }
@@ -78,7 +86,7 @@ namespace TrenchBroom {
             return m_name;
         }
 
-        TextureReader::TextureReader(const NameStrategy& nameStrategy, const FileSystem& fs, Logger& logger) :
+        TextureReader::TextureReader(const NameStrategy& nameStrategy, const FileSystem& fs, Logger& logger):
         m_nameStrategy(nameStrategy.clone()),
         m_fs(fs),
         m_logger(logger) {}

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -199,7 +199,7 @@ namespace TrenchBroom {
         void GameImpl::doExportMap(WorldNode& world, const Model::ExportFormat format, const IO::Path& path) const {
             switch (format) {
                 case Model::ExportFormat::WavefrontObj:
-                    IO::NodeWriter(world, new IO::ObjFileSerializer(path)).writeMap();
+                    IO::NodeWriter(world, new IO::ObjFileSerializer(path, m_gamePath)).writeMap();
                     break;
                 case Model::ExportFormat::Map:
                     doWriteMap(world, path, true);


### PR DESCRIPTION
Allows you to open trenchbroom-exported OBJs in blender (and presumably other 3d software as well though that's the only one i've tested so far) without having to re-apply the textures every time which can help cut down on iteration times when making models or maps for applications like games that dont have direct .map import