### PR TITLE
3516: fix copy/paste of faces

### DIFF
--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -103,8 +103,23 @@ namespace TrenchBroom {
             MapReader(const char* begin, const char* end);
             explicit MapReader(const std::string& str);
 
+            /**
+             * Attempts to parse as one or more entities, in the given format.
+             *
+             * @throws ParserException if parsing fails
+             */
             void readEntities(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
+            /**
+             * Attempts to parse as one or more brushes (in the given format) without any enclosing entity.
+             *
+             * @throws ParserException if parsing fails
+             */
             void readBrushes(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
+            /**
+             * Attempts to parse as one or more brush faces (in the given format).
+             *
+             * @throws ParserException if parsing fails
+             */
             void readBrushFaces(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapParser interface
             void onFormatSet(Model::MapFormat format) override;

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             static std::vector<Model::Node*> read(const std::string& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
             const std::vector<Model::Node*>& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private:
-            void readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
+            bool readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
         private: // implement MapReader interface
             Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -746,5 +746,19 @@ namespace TrenchBroom {
             Brush brush = brushNode->brush();
             CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
+
+        TEST_CASE("BrushFaceTest.parseFaceAsNode", "[BrushFaceTest]") {
+            const std::string data(R"(
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+)");
+
+            const vm::bbox3 worldBounds(4096.0);
+            WorldNode world(MapFormat::Valve);
+
+            IO::TestParserStatus status;
+            IO::NodeReader reader(data, world);
+
+            CHECK(reader.read(worldBounds, status).empty());
+        }
     }
 }


### PR DESCRIPTION
The root bug was m_game->parseNodes was not throwing when parsing failed so we would never even try to parse as faces.

Fixes #3516