### PR TITLE
"Move Textures" action: take negative texture scale into account when generating texture offsets.

### DIFF
--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -181,11 +181,11 @@ namespace TrenchBroom {
             }
 
             // Flip offset direction when texture scale is negative
-            if (std::signbit(attribs.scale().x()) == 1) {
-                actualOffset[0] *= -1;
+            if (attribs.scale().x() < 0.0f) {
+                actualOffset[0] *= -1.0f;
             }
-            if (std::signbit(attribs.scale().y()) == 1) {
-                actualOffset[1] *= -1;
+            if (attribs.scale().y() < 0.0f) {
+                actualOffset[1] *= -1.0f;
             }
 
             attribs.setOffset(attribs.offset() + actualOffset);

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -180,6 +180,13 @@ namespace TrenchBroom {
                 actualOffset[yIndex] = +offset.y();
             }
 
+            // Flip offset direction when texture scale is negative
+            if (std::signbit(attribs.scale().x()) == 1) {
+                actualOffset[0] *= -1;
+            }
+            if (std::signbit(attribs.scale().y()) == 1) {
+                actualOffset[1] *= -1;
+            }
 
             attribs.setOffset(attribs.offset() + actualOffset);
         }


### PR DESCRIPTION
This fixes face textures being moved in opposite-to-expected direction when corresponding texture scale was negative.