### PR TITLE
3535: don't reuse NodeReader after parsing fails

### DIFF
--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -41,8 +41,7 @@ namespace TrenchBroom {
 
             static std::vector<Model::Node*> read(const std::string& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
         private:
-            const std::vector<Model::Node*>& read(const vm::bbox3& worldBounds, ParserStatus& status);
-            bool readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
+            static std::vector<Model::Node*> readAsFormat(Model::MapFormat format, const std::string& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
             Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -40,8 +40,8 @@ namespace TrenchBroom {
             NodeReader(const std::string& str, Model::ModelFactory& factory);
 
             static std::vector<Model::Node*> read(const std::string& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
-            const std::vector<Model::Node*>& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private:
+            const std::vector<Model::Node*>& read(const vm::bbox3& worldBounds, ParserStatus& status);
             bool readAsFormat(const vm::bbox3& worldBounds, Model::MapFormat format, ParserStatus& status);
         private: // implement MapReader interface
             Model::ModelFactory& initialize(Model::MapFormat format) override;

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -212,8 +212,7 @@ namespace TrenchBroom {
 
         std::vector<Node*> GameImpl::doParseNodes(const std::string& str, WorldNode& world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::SimpleParserStatus parserStatus(logger);
-            IO::NodeReader reader(str, world);
-            return reader.read(worldBounds, parserStatus);
+            return IO::NodeReader::read(str, world, worldBounds, parserStatus);
         }
 
         std::vector<BrushFace> GameImpl::doParseBrushFaces(const std::string& str, WorldNode& world, const vm::bbox3& worldBounds, Logger& logger) const {

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -744,7 +744,6 @@ namespace TrenchBroom {
             CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
 
-#if 0
         TEST_CASE("BrushFaceTest.nodeReaderGroupConversion", "[BrushFaceTest]") {
             // Data comes from copying a Group in 2020.2
             const std::string data(R"(// entity 0
@@ -781,7 +780,6 @@ namespace TrenchBroom {
             const Brush brush = brushNode->brush();
             CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
-#endif
 
         TEST_CASE("BrushFaceTest.parseFaceAsNode", "[BrushFaceTest]") {
             const std::string data(R"(

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -27,6 +27,8 @@
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceAttributes.h"
+#include "Model/GroupNode.h"
+#include "Model/LayerNode.h"
 #include "Model/MapFormat.h"
 #include "Model/NodeSnapshot.h"
 #include "Model/ParaxialTexCoordSystem.h"
@@ -744,6 +746,44 @@ namespace TrenchBroom {
             REQUIRE(brushNode != nullptr);
 
             Brush brush = brushNode->brush();
+            CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
+        }
+
+        TEST_CASE("BrushFaceTest.nodeReaderGroupConversion", "[BrushFaceTest]") {
+            // Data comes from copying a Group in 2020.2
+            const std::string data(R"(// entity 0
+{
+"classname" "func_group"
+"_tb_type" "_tb_group"
+"_tb_name" "Unnamed"
+"_tb_id" "3"
+// brush 0
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) __TB_empty [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) __TB_empty [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+}
+}
+)");
+
+            const vm::bbox3 worldBounds(4096.0);
+            WorldNode world(MapFormat::Standard);
+
+            IO::TestParserStatus status;
+            IO::NodeReader reader(data, world);
+
+            std::vector<Node*> nodes = reader.read(worldBounds, status);
+
+            auto* groupNode = dynamic_cast<GroupNode*>(nodes.at(0));
+            REQUIRE(groupNode != nullptr);
+
+            auto* brushNode = dynamic_cast<BrushNode*>(groupNode->children().at(0));
+            REQUIRE(brushNode != nullptr);
+
+            const Brush brush = brushNode->brush();
             CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
 

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -541,9 +541,7 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Valve);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
-
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             BrushNode* pyramidLight = static_cast<BrushNode*>(nodes.at(0)->children().at(0));
             REQUIRE(pyramidLight != nullptr);
             
@@ -599,9 +597,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Valve);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             BrushNode* pyramidLight = static_cast<BrushNode*>(nodes.at(0)->children().at(0));
             REQUIRE(pyramidLight != nullptr);
             
@@ -661,9 +658,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Valve);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             BrushNode* brushNode = static_cast<BrushNode*>(nodes.at(0)->children().at(0));
             EXPECT_NE(nullptr, brushNode);
             
@@ -739,9 +735,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             auto* brushNode = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
             REQUIRE(brushNode != nullptr);
 
@@ -774,9 +769,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
 
             auto* groupNode = dynamic_cast<GroupNode*>(nodes.at(0));
             REQUIRE(groupNode != nullptr);
@@ -798,9 +792,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Valve);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            CHECK(reader.read(worldBounds, status).empty());
+            CHECK(IO::NodeReader::read(data, world, worldBounds, status).empty());
         }
     }
 }

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -749,6 +749,7 @@ namespace TrenchBroom {
             CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
 
+#if 0
         TEST_CASE("BrushFaceTest.nodeReaderGroupConversion", "[BrushFaceTest]") {
             // Data comes from copying a Group in 2020.2
             const std::string data(R"(// entity 0
@@ -786,6 +787,7 @@ namespace TrenchBroom {
             const Brush brush = brushNode->brush();
             CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem()) != nullptr);
         }
+#endif
 
         TEST_CASE("BrushFaceTest.parseFaceAsNode", "[BrushFaceTest]") {
             const std::string data(R"(

--- a/common/test/src/Model/BrushNodeTest.cpp
+++ b/common/test/src/Model/BrushNodeTest.cpp
@@ -69,9 +69,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
         }
 
@@ -94,9 +93,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
         }
 
@@ -201,9 +199,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Valve);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
         }
 
@@ -224,9 +221,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_TRUE(nodes.empty());
         }
 
@@ -451,9 +447,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_EQ(0u, nodes.size());
         }
 
@@ -483,9 +478,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status); // assertion failure
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status); // assertion failure
             kdl::vec_clear_and_delete(nodes);
         }
 
@@ -534,9 +528,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status); // assertion failure
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status); // assertion failure
             kdl::vec_clear_and_delete(nodes);
         }
 
@@ -561,9 +554,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status); // assertion failure
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status); // assertion failure
             kdl::vec_clear_and_delete(nodes);
         }
 
@@ -656,9 +648,8 @@ namespace TrenchBroom {
             WorldNode world(Model::MapFormat::Valve);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
             ASSERT_TRUE(nodes.at(0)->hasChildren());
             ASSERT_EQ(2u, nodes.at(0)->children().size());
@@ -755,9 +746,8 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            ASSERT_NO_THROW(reader.read(worldBounds, status));
+            ASSERT_NO_THROW(IO::NodeReader::read(data, world, worldBounds, status));
         }
 
         TEST_CASE("BrushNodeTest.loadBrushFail_2491", "[BrushNodeTest]") {
@@ -778,9 +768,8 @@ namespace TrenchBroom {
             )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            ASSERT_NO_THROW(reader.read(worldBounds, status));
+            ASSERT_NO_THROW(IO::NodeReader::read(data, world, worldBounds, status));
         }
 
         TEST_CASE("BrushNodeTest.loadBrushFail_2686", "[BrushNodeTest]") {
@@ -819,9 +808,8 @@ namespace TrenchBroom {
             )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            ASSERT_NO_THROW(reader.read(worldBounds, status));
+            ASSERT_NO_THROW(IO::NodeReader::read(data, world, worldBounds, status));
         }
     }
 }

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -1752,9 +1752,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             EXPECT_EQ(1u, nodes.size());
 
             Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -1772,9 +1771,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             EXPECT_EQ(1u, nodes.size());
 
             const Brush& brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -2434,9 +2432,8 @@ namespace TrenchBroom {
             WorldNode world(MapFormat::Standard);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             EXPECT_EQ(1u, nodes.size());
 
             Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -2501,9 +2498,8 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            auto nodes = reader.read(worldBounds, status);
+            auto nodes = IO::NodeReader::read(data, world, worldBounds, status);
             EXPECT_EQ(1u, nodes.size());
 
             Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -2544,9 +2540,8 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            std::vector<Node*> nodes = reader.read(worldBounds, status);
+            std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
 
             Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -2880,9 +2875,8 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            auto nodes = reader.read(worldBounds, status);
+            auto nodes = IO::NodeReader::read(data, world, worldBounds, status);
             REQUIRE(nodes.size() == 1u);
 
             Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -2961,9 +2955,8 @@ namespace TrenchBroom {
             REQUIRE(!data.empty());
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            auto nodes = reader.read(worldBounds, status);
+            auto nodes = IO::NodeReader::read(data, world, worldBounds, status);
             REQUIRE(!nodes.empty());
 
             std::vector<vm::vec3> points;
@@ -3048,9 +3041,8 @@ namespace TrenchBroom {
             REQUIRE(!data.empty());
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, world);
 
-            const std::vector<Node*> nodes = reader.read(worldBounds, status);
+            const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             REQUIRE(nodes.size() == 28);
 
             std::vector<vm::vec3> points;

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -112,8 +112,7 @@ namespace TrenchBroom {
 
         std::vector<Node*> TestGame::doParseNodes(const std::string& str, WorldNode& world, const vm::bbox3& worldBounds, Logger& /* logger */) const {
             IO::TestParserStatus status;
-            IO::NodeReader reader(str, world);
-            return reader.read(worldBounds, status);
+            return IO::NodeReader::read(str, world, worldBounds, status);
         }
 
         std::vector<BrushFace> TestGame::doParseBrushFaces(const std::string& str, WorldNode& world, const vm::bbox3& worldBounds, Logger& /* logger */) const {


### PR DESCRIPTION
Fixes #3535

This is a good example of the problem with exceptions..

The underlying bug was in the way `NodeReader::read`/`NodeReader::readAsFormat` tried to reuse the NodeReader for multiple parse attempts. What would happen is `MapReader::m_brushParent` would get set to point at some node (the Group, I think) during a parse attempt. The parsing would fail, an exception would be thrown and caught in `NodeReader::readAsFormat`. The `m_brushParent` would be left as a dangling pointer when `NodeReader::readAsFormat` deletes the currently parsed nodes, then it would be accessed on a subsequent parse attempt and crash.