### PR TITLE
Fix compiler launch scripts

### DIFF
--- a/cmake/launch-c.in
+++ b/cmake/launch-c.in
@@ -2,7 +2,7 @@
 
 # Xcode generator doesn't include the compiler as the
 # first argument, Ninja and Makefiles do. Handle both cases.
-if [[ "$1" = "${CMAKE_C_COMPILER}" ]] ; then
+if [ "$1" = "${CMAKE_C_COMPILER}" ] ; then
     shift
 fi
 

--- a/cmake/launch-cxx.in
+++ b/cmake/launch-cxx.in
@@ -2,7 +2,7 @@
 
 # Xcode generator doesn't include the compiler as the
 # first argument, Ninja and Makefiles do. Handle both cases.
-if [[ "$1" = "${CMAKE_CXX_COMPILER}" ]] ; then
+if [ "$1" = "${CMAKE_CXX_COMPILER}" ] ; then
     shift
 fi
 


### PR DESCRIPTION
When using ccache under macOS or Linux, we generate scripts that launch
the system compilers. This is due to a limitiation in Xcode's build system
that prevents it from using ccache, but we apply this to all generators on
macOS and Linux anyway.

The scripts contain a syntax error that prevents them from working on Linux.