### PR TITLE
3523: Work around kdl::overload bug in MSVC

### DIFF
--- a/common/src/EL/Expression.cpp
+++ b/common/src/EL/Expression.cpp
@@ -107,11 +107,11 @@ namespace TrenchBroom {
         }
 
         bool Expression::optimize() {
-            auto replacement = std::visit(kdl::overload {
+            auto replacement = std::visit(kdl::overload(
                 [](LiteralExpression& e) -> std::optional<LiteralExpression> { return e; },
                 [](VariableExpression&)  -> std::optional<LiteralExpression> { return std::nullopt; },
                 [](auto& e)              -> std::optional<LiteralExpression> { return e.optimize(); }
-            }, *m_expression);
+            ), *m_expression);
             
             if (replacement) {
                 *m_expression = std::move(*replacement);
@@ -180,14 +180,14 @@ namespace TrenchBroom {
         }
         
         size_t Expression::precedence() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [](const BinaryExpression& exp) -> size_t {
                     return exp.precedence();
                 },
                 [](const auto&) -> size_t {
                     return 13u;
                 }
-            }, *m_expression);
+            ), *m_expression);
         }
 
         LiteralExpression::LiteralExpression(Value value) :

--- a/common/src/EL/Value.cpp
+++ b/common/src/EL/Value.cpp
@@ -117,7 +117,7 @@ namespace TrenchBroom {
         m_column(column) {}
         
         ValueType Value::type() const {
-            return std::visit(kdl::overload{
+            return std::visit(kdl::overload(
                 [](const BooleanType&)   { return ValueType::Boolean; },
                 [](const StringType&)    { return ValueType::String; },
                 [](const NumberType&)    { return ValueType::Number; },
@@ -125,8 +125,8 @@ namespace TrenchBroom {
                 [](const MapType&)       { return ValueType::Map; },
                 [](const RangeType&)     { return ValueType::Range; },
                 [](const NullType&)      { return ValueType::Null; },
-                [](const UndefinedType&) { return ValueType::Undefined; },
-            }, m_value);
+                [](const UndefinedType&) { return ValueType::Undefined; }
+            ), m_value);
         }
         
         std::string Value::typeName() const {
@@ -146,7 +146,7 @@ namespace TrenchBroom {
         }
 
         const BooleanType& Value::booleanValue() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const BooleanType& b) -> const BooleanType& { return b; },
                 [&](const StringType&)    -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::String); },
                 [&](const NumberType&)    -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Number); },
@@ -154,12 +154,12 @@ namespace TrenchBroom {
                 [&](const MapType&)       -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Map); },
                 [&](const RangeType&)     -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Range); },
                 [&](const NullType&)      -> const BooleanType& { static const BooleanType b = false; return b; },
-                [&](const UndefinedType&) -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
-            }, m_value);
+                [&](const UndefinedType&) -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Undefined); }
+            ), m_value);
         }
         
         const StringType& Value::stringValue() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const BooleanType&)   -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
                 [&](const StringType& s)  -> const StringType& { return s; },
                 [&](const NumberType&)    -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Number); },
@@ -167,12 +167,12 @@ namespace TrenchBroom {
                 [&](const MapType&)       -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Map); },
                 [&](const RangeType&)     -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Range); },
                 [&](const NullType&)      -> const StringType& { static const StringType s; return s; },
-                [&](const UndefinedType&) -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
-            }, m_value);
+                [&](const UndefinedType&) -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Undefined); }
+            ), m_value);
         }
         
         const NumberType& Value::numberValue() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const BooleanType&)   -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
                 [&](const StringType&)    -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::String); },
                 [&](const NumberType& n)  -> const NumberType& { return n; },
@@ -180,8 +180,8 @@ namespace TrenchBroom {
                 [&](const MapType&)       -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Map); },
                 [&](const RangeType&)     -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Range); },
                 [&](const NullType&)      -> const NumberType& { static const NumberType n = 0.0; return n; },
-                [&](const UndefinedType&) -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
-            }, m_value);
+                [&](const UndefinedType&) -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Undefined); }
+            ), m_value);
         }
         
         IntegerType Value::integerValue() const {
@@ -189,7 +189,7 @@ namespace TrenchBroom {
         }
         
         const ArrayType& Value::arrayValue() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const BooleanType&)   -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
                 [&](const StringType&)    -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::String); },
                 [&](const NumberType&)    -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Number); },
@@ -197,12 +197,12 @@ namespace TrenchBroom {
                 [&](const MapType&)       -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Map); },
                 [&](const RangeType&)     -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Range); },
                 [&](const NullType&)      -> const ArrayType& { static const ArrayType a(0); return a; },
-                [&](const UndefinedType&) -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
-            }, m_value);
+                [&](const UndefinedType&) -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Undefined); }
+            ), m_value);
         }
         
         const MapType& Value::mapValue() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const BooleanType&)   -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
                 [&](const StringType&)    -> const MapType& { throw DereferenceError(describe(), type(), ValueType::String); },
                 [&](const NumberType&)    -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Number); },
@@ -210,12 +210,12 @@ namespace TrenchBroom {
                 [&](const MapType& m)     -> const MapType& { return m; },
                 [&](const RangeType&)     -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Range); },
                 [&](const NullType&)      -> const MapType& { static const MapType m; return m; },
-                [&](const UndefinedType&) -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
-            }, m_value);
+                [&](const UndefinedType&) -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Undefined); }
+            ), m_value);
         }
         
         const RangeType& Value::rangeValue() const {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const BooleanType&)   -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
                 [&](const StringType&)    -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::String); },
                 [&](const NumberType&)    -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Number); },
@@ -223,8 +223,8 @@ namespace TrenchBroom {
                 [&](const MapType&)       -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Map); },
                 [&](const RangeType& r)   -> const RangeType& { return r; },
                 [&](const NullType&)      -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Null); },
-                [&](const UndefinedType&) -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
-            }, m_value);
+                [&](const UndefinedType&) -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Undefined); }
+            ), m_value);
         }
         
         bool Value::null() const {
@@ -259,7 +259,7 @@ namespace TrenchBroom {
         }
 
         size_t Value::length() const {
-            return std::visit(kdl::overload{
+            return std::visit(kdl::overload(
                 [](const BooleanType&)   -> size_t { return 1u; },
                 [](const StringType& s)  -> size_t { return s.length(); },
                 [](const NumberType&)    -> size_t { return 1u; },
@@ -267,12 +267,12 @@ namespace TrenchBroom {
                 [](const MapType& m)     -> size_t { return m.size(); },
                 [](const RangeType& r)   -> size_t { return r.size(); },
                 [](const NullType&)      -> size_t { return 0u; },
-                [](const UndefinedType&) -> size_t { return 0u; },
-            }, m_value);
+                [](const UndefinedType&) -> size_t { return 0u; }
+            ), m_value);
         }
         
         bool Value::convertibleTo(const ValueType toType) const {
-            return std::visit(kdl::overload{
+            return std::visit(kdl::overload(
                 [&](const BooleanType&) {
                     switch (toType) {
                         case ValueType::Boolean:
@@ -411,12 +411,12 @@ namespace TrenchBroom {
                     }
 
                     return false;
-                },
-            }, m_value);
+                }
+            ), m_value);
         }
         
         Value Value::convertTo(const ValueType toType) const {
-            return std::visit(kdl::overload{
+            return std::visit(kdl::overload(
                 [&](const BooleanType& b) -> Value {
                     switch (toType) {
                         case ValueType::Boolean:
@@ -565,8 +565,8 @@ namespace TrenchBroom {
                     }
 
                     throw ConversionError(describe(), type(), toType);
-                },
-            }, m_value);
+                }
+            ), m_value);
         }
 
         std::string Value::asString(const bool multiline) const {
@@ -576,7 +576,7 @@ namespace TrenchBroom {
         }
         
         void Value::appendToStream(std::ostream& str, const bool multiline, const std::string& indent) const {
-            std::visit(kdl::overload{
+            std::visit(kdl::overload(
                 [&](const BooleanType& b) {
                     str << (b ? "true" : "false");
                 },
@@ -676,8 +676,8 @@ namespace TrenchBroom {
                 },
                 [&](const UndefinedType&) {
                     str << "undefined";
-                },
-            }, m_value);
+                }
+            ), m_value);
         }
 
         static  size_t computeIndex(const long index, const size_t indexableSize) {

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -133,29 +133,29 @@ namespace TrenchBroom {
         void MapReader::onStandardBrushFace(const size_t line, const Model::MapFormat /* format */, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, ParserStatus& status) {
             // NOTE: format is the format we're reading from the .map as which may not be this->format().
             // ModelFactory::createFaceFromStandard() will convert it to this->format().
-            m_factory->createFaceFromStandard(point1, point2, point3, attribs).visit(kdl::overload {
+            m_factory->createFaceFromStandard(point1, point2, point3, attribs).visit(kdl::overload(
                     [&](Model::BrushFace&& face) {
                         face.setFilePosition(line, 1u);
                         onBrushFace(std::move(face), status);
                     },
                     [&](const Model::BrushError e) {
                         status.error(line, kdl::str_to_string("Skipping face: ", e));
-                    },
-            });
+                    }
+            ));
         }
 
         void MapReader::onValveBrushFace(const size_t line, const Model::MapFormat /* format */, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) {
             // NOTE: format is the format we're reading from the .map as which may not be this->format().
             // ModelFactory::createFaceFromValve() will convert it to this->format().
-            m_factory->createFaceFromValve(point1, point2, point3, attribs, texAxisX, texAxisY).visit(kdl::overload {
+            m_factory->createFaceFromValve(point1, point2, point3, attribs, texAxisX, texAxisY).visit(kdl::overload(
                     [&](Model::BrushFace&& face) {
                         face.setFilePosition(line, 1u);
                         onBrushFace(std::move(face), status);
                     },
                     [&](const Model::BrushError e) {
                         status.error(line, kdl::str_to_string("Skipping face: ", e));
-                    },
-                });
+                    }
+                ));
         }
 
         void MapReader::createLayer(const size_t line, const std::vector<Model::EntityAttribute>& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -781,7 +781,7 @@ namespace TrenchBroom {
             // FP error) to `rightFace`.
             BrushFace leftClone = leftFace;
             leftClone.transform(M, true)
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&]() {
                         auto snapshot = std::unique_ptr<TexCoordSystemSnapshot>(leftClone.takeTexCoordSystemSnapshot());
                         rightFace.setAttributes(leftClone.attributes());
@@ -794,8 +794,8 @@ namespace TrenchBroom {
                     },
                     [](const BrushError) {
                         // do nothing
-                    },
-                });
+                    }
+                ));
         }
 
         kdl::result<Brush, BrushError> Brush::createBrushWithNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, const bool uvLock) const {
@@ -810,7 +810,7 @@ namespace TrenchBroom {
 
                     rightFace.setGeometry(right);
                     rightFace.updatePointsFromVertices()
-                        .visit(kdl::overload {
+                        .visit(kdl::overload(
                             [&]() {
                                 if (uvLock) {
                                     applyUVLock(matcher, leftFace, rightFace);
@@ -820,8 +820,8 @@ namespace TrenchBroom {
                                 if (!error) {
                                     error = e;
                                 }
-                            },
-                        });
+                            }
+                        ));
                 }
             });
 
@@ -856,14 +856,14 @@ namespace TrenchBroom {
             for (const auto& geometry : result) {
                 std::optional<BrushError> error;
                 createBrush(factory, worldBounds, defaultTextureName, geometry, subtrahends)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Brush&& brush) {
                             brushes.push_back(std::move(brush));
                         },
                         [&](const BrushError e) {
                             error = e;
-                        },
-                    });
+                        }
+                    ));
 
                 if (error) {
                     return kdl::result<std::vector<Brush>, BrushError>::error(*error);
@@ -933,14 +933,14 @@ namespace TrenchBroom {
 
                 std::optional<BrushError> error;
                 factory.createFace(p0, p1, p2, BrushFaceAttributes(defaultTextureName))
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](BrushFace&& f) {
                             faces.push_back(std::move(f));
                         },
                         [&](const BrushError e) {
                             error = e;
                         }
-                    });
+                    ));
                 
                 if (error) {
                     return kdl::result<Brush, BrushError>::error(*error);

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -85,14 +85,14 @@ namespace TrenchBroom {
             for (const auto& [p1, p2, p3, attrs] : specs) {
                 std::optional<BrushError> error;
                 m_factory->createFace(p1, p2, p3, attrs)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](BrushFace&& face) {
                             faces.push_back(std::move(face));
                         },
                         [&](const BrushError e) {
                             error = e;
-                        },
-                    });
+                        }
+                    ));
 
                 if (error) {
                     return kdl::result<Brush, BrushError>::error(*error);
@@ -128,14 +128,14 @@ namespace TrenchBroom {
 
                 std::optional<BrushError> error;
                 m_factory->createFace(p1, p3, p2, textureName)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](BrushFace&& f) {
                             brushFaces.push_back(std::move(f));
                         },
                         [&](const BrushError e) {
                             error = e;
-                        },
-                    });
+                        }
+                    ));
 
                 if (error) {
                     return kdl::result<Brush, BrushError>::error(*error);

--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -255,7 +255,7 @@ namespace TrenchBroom {
             const NotifyPhysicalBoundsChange boundsChange(this);
 
             return m_brush.transform(worldBounds, transformation, lockTextures)
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&](Brush&& brush) {
                         m_brush = std::move(brush);
                         invalidateIssues();
@@ -265,8 +265,8 @@ namespace TrenchBroom {
                     },
                     [](const BrushError e) {
                         return kdl::result<void, TransformError>::error(TransformError{kdl::str_to_string(e)});
-                    },
-                });
+                    }
+                ));
         }
 
         class BrushNode::Contains : public ConstNodeVisitor, public NodeQuery<bool> {

--- a/common/src/Model/BrushSnapshot.cpp
+++ b/common/src/Model/BrushSnapshot.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
 
         kdl::result<void, SnapshotErrors> BrushSnapshot::doRestore(const vm::bbox3& worldBounds) {
             return Brush::create(worldBounds, std::move(m_faces))
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&](Brush&& b) {
                         m_brushNode->setBrush(std::move(b));
                         return kdl::result<void, SnapshotErrors>::success();
@@ -50,7 +50,7 @@ namespace TrenchBroom {
                     [](const BrushError e) {
                         return kdl::result<void, SnapshotErrors>::error(SnapshotErrors{e});
                     }
-                });
+                ));
         }
     }
 }

--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -376,13 +376,13 @@ namespace TrenchBroom {
             void doVisit(EntityNode*) override {}
             void doVisit(BrushNode* brush) override {
                 brush->transform(m_worldBounds, m_transformation, m_lockTextures)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         []() {},
                         [&](TransformError&& e) {
                             m_error = std::move(e);
                             cancel();
-                        },
-                    });
+                        }
+                    ));
             }
         };
 

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -156,14 +156,14 @@ namespace TrenchBroom {
 
                 const Model::BrushBuilder builder(world.get(), worldBounds, defaultFaceAttribs());
                 builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName).
-                    visit(kdl::overload {
+                    visit(kdl::overload(
                         [&](Brush&& b) {
                             world->defaultLayer()->addChild(world->createBrush(std::move(b)));
                         },
                         [&](const Model::BrushError e) {
                             logger.error() << "Could not create default brush: " << e;
                         }
-                    });
+                    ));
 
                 if (format == MapFormat::Valve || format == MapFormat::Quake2_Valve || format == MapFormat::Quake3_Valve) {
                     world->addOrUpdateAttribute(AttributeNames::ValveVersion, "220");

--- a/common/src/Model/GroupSnapshot.cpp
+++ b/common/src/Model/GroupSnapshot.cpp
@@ -50,10 +50,10 @@ namespace TrenchBroom {
             SnapshotErrors errors;
             for (NodeSnapshot* snapshot : m_snapshots) {
                 snapshot->restore(worldBounds)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         []() {},
                         [&](const SnapshotErrors& e) { kdl::vec_append(errors, e); }
-                    });
+                    ));
             }
             return errors.empty()
                 ? kdl::result<void, SnapshotErrors>::success()

--- a/common/src/Model/Snapshot.cpp
+++ b/common/src/Model/Snapshot.cpp
@@ -40,10 +40,10 @@ namespace TrenchBroom {
             SnapshotErrors errors;
             for (NodeSnapshot* snapshot : m_nodeSnapshots) {
                 snapshot->restore(worldBounds)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         []() {},
                         [&](const SnapshotErrors& e) { kdl::vec_append(errors, e); }
-                    });
+                    ));
             }
             return errors.empty()
                 ? kdl::result<void, SnapshotErrors>::success()

--- a/common/src/Model/TransformObjectVisitor.cpp
+++ b/common/src/Model/TransformObjectVisitor.cpp
@@ -45,13 +45,13 @@ namespace TrenchBroom {
 
         void TransformObjectVisitor::transform(Object* object) {
             object->transform(m_worldBounds, m_transformation, m_lockTextures)
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     []() {},
                     [&](TransformError&& e) {
                         m_error = std::move(e);
                         cancel();
-                    },
-                });
+                    }
+                ));
         }
     }
 }

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -365,7 +365,7 @@ namespace TrenchBroom {
 
         // Reload m_cache
         readV2SettingsFromPath(m_preferencesFilePath)
-            .visit(kdl::overload {
+            .visit(kdl::overload(
                 [&](std::map<IO::Path, QJsonValue>&& prefs) {
                     m_cache = std::move(prefs);
                 },
@@ -379,7 +379,7 @@ namespace TrenchBroom {
                 [&] (const PreferenceErrors::NoFilePresent&) {
                     m_cache = {};
                 }
-            });
+            ));
 
         invalidatePreferences();
 

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -51,7 +51,7 @@ namespace TrenchBroom {
                 const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
                 
                 builder.createBrush(*m_polyhedron, document->currentTextureName())
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& b) {
                             updateBrush(document->world()->createBrush(std::move(b)));
                         },
@@ -59,7 +59,7 @@ namespace TrenchBroom {
                             updateBrush(nullptr);
                             document->error() << "Could not update brush: " << e;
                         }
-                    });
+                    ));
             } else {
                 updateBrush(nullptr);
             }

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             const auto builder = Model::BrushBuilder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
 
             builder.createCuboid(bounds, document->currentTextureName())
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&](Model::Brush&& b) {
                         updateBrush(document->world()->createBrush(std::move(b)));
                     },
@@ -51,7 +51,7 @@ namespace TrenchBroom {
                         updateBrush(nullptr);
                         document->error() << "Could not update brush: " << e;
                     }
-                });
+                ));
         }
 
     }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1517,7 +1517,7 @@ namespace TrenchBroom {
         bool MapDocument::createBrush(const std::vector<vm::vec3>& points) {
             Model::BrushBuilder builder(m_world.get(), m_worldBounds, m_game->defaultFaceAttribs());
             return builder.createBrush(points, currentTextureName())
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&](Model::Brush&& b) {
                         Model::BrushNode* brushNode = m_world->createBrush(std::move(b));
                         
@@ -1531,7 +1531,7 @@ namespace TrenchBroom {
                         error() << "Could not create brush: " << e;
                         return false;
                     }
-                });
+                ));
         }
 
         bool MapDocument::csgConvexMerge() {
@@ -1563,7 +1563,7 @@ namespace TrenchBroom {
 
             const Model::BrushBuilder builder(m_world.get(), m_worldBounds, m_game->defaultFaceAttribs());
             return builder.createBrush(polyhedron, currentTextureName())
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&](Model::Brush&& b) {
                         for (const Model::BrushNode* selectedBrushNode : selectedNodes().brushes()) {
                             b.cloneFaceAttributesFrom(selectedBrushNode->brush());
@@ -1594,8 +1594,8 @@ namespace TrenchBroom {
                     [&](const Model::BrushError e) {
                         error() << "Could not create brush: " << e;
                         return false;
-                    },
-                });
+                    }
+                ));
         }
 
         bool MapDocument::csgSubtract() {
@@ -1617,7 +1617,7 @@ namespace TrenchBroom {
             for (Model::BrushNode* minuendNode : minuendNodes) {
                 const Model::Brush& minuend = minuendNode->brush();
                 minuend.subtract(*m_world, m_worldBounds, currentTextureName(), subtrahends)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](const std::vector<Model::Brush>& brushes) {
                             if (!brushes.empty()) {
                                 const std::vector<Model::BrushNode*> resultNodes = kdl::vec_transform(std::move(brushes), [&](auto b) { return m_world->createBrush(std::move(b)); });
@@ -1626,8 +1626,8 @@ namespace TrenchBroom {
                         },
                         [&](const Model::BrushError e) {
                             error() << "Could not create brush: " << e;
-                        },
-                    });
+                        }
+                    ));
                 toRemove.push_back(minuendNode);
             }
 
@@ -1652,7 +1652,7 @@ namespace TrenchBroom {
                 Model::BrushNode* brushNode = *it;
                 const Model::Brush& brush = brushNode->brush();
                 valid = intersection.intersect(m_worldBounds, brush)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& b) {
                             intersection = std::move(b);
                             return true;
@@ -1660,8 +1660,8 @@ namespace TrenchBroom {
                         [&](const Model::BrushError e) {
                             error() << "Could not intersect brushes: " << e;
                             return false;
-                        },
-                    });
+                        }
+                    ));
             }
 
             const std::vector<Model::Node*> toRemove(std::begin(brushes), std::end(brushes));
@@ -1699,7 +1699,7 @@ namespace TrenchBroom {
                         [&](const Model::Brush& shrunken) {
                             return brush.subtract(*m_world, m_worldBounds, currentTextureName(), shrunken);
                         }
-                    ).visit(kdl::overload {
+                    ).visit(kdl::overload(
                         [&](const std::vector<Model::Brush>& fragments) {
                             auto fragmentNodes = kdl::vec_transform(std::move(fragments), [](auto&& b) {
                                 return new Model::BrushNode(std::move(b));
@@ -1710,8 +1710,8 @@ namespace TrenchBroom {
                         },
                         [&](const Model::BrushError e) {
                             error() << "Could not hollow brush: " << e;
-                        },
-                    });
+                        }
+                    ));
                 
             }
 

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -630,7 +630,7 @@ namespace TrenchBroom {
                 }
 
                 const bool success = original.moveBoundary(m_worldBounds, *faceIndex, delta, pref(Preferences::TextureLock))
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& copy) -> bool {
                             if (m_worldBounds.contains(copy.bounds())) {
                                 result.push_back(copy.face(*faceIndex).polygon());
@@ -645,7 +645,7 @@ namespace TrenchBroom {
                             error() << "Could not resize brush: " << e;
                             return false;
                         }
-                    });
+                    ));
 
                 if (!success) {
                     return std::nullopt;
@@ -730,7 +730,7 @@ namespace TrenchBroom {
             for (Model::BrushNode* brushNode : brushNodes) {
                 if (brushNode->brush().canSnapVertices(m_worldBounds, snapTo)) {
                     brushNode->brush().snapVertices(m_worldBounds, snapTo, pref(Preferences::UVLock))
-                        .visit(kdl::overload {
+                        .visit(kdl::overload(
                             [&](Model::Brush&& brush) {
                                 brushNode->setBrush(std::move(brush));
                                 succeededBrushCount += 1;
@@ -738,8 +738,8 @@ namespace TrenchBroom {
                             [&](const Model::BrushError e) {
                                 error() << "Could not snap vertices: " << e;
                                 failedBrushCount += 1;
-                            },
-                        });
+                            }
+                        ));
                 } else {
                     failedBrushCount += 1;
                 }
@@ -770,7 +770,7 @@ namespace TrenchBroom {
                 const std::vector<vm::vec3>& oldPositions = entry.second;
                 
                 brushNode->brush().moveVertices(m_worldBounds, oldPositions, delta, pref(Preferences::UVLock))
-                    .visit(kdl::overload{
+                    .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
                             const auto newPositions = brush.findClosestVertexPositions(oldPositions + delta);
                             kdl::vec_append(newVertexPositions, newPositions);
@@ -778,8 +778,8 @@ namespace TrenchBroom {
                         },
                         [&](const Model::BrushError e) {
                             error() << "Could not move vertices: " << e;
-                        },
-                    });
+                        }
+                    ));
             }
 
             invalidateSelectionBounds();
@@ -800,7 +800,7 @@ namespace TrenchBroom {
                 Model::BrushNode* brushNode = entry.first;
                 const std::vector<vm::segment3>& oldPositions = entry.second;
                 brushNode->brush().moveEdges(m_worldBounds, oldPositions, delta, pref(Preferences::UVLock))
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
                             const auto newPositions = brush.findClosestEdgePositions(kdl::vec_transform(oldPositions, [&](const auto& s) {
                                 return s.translate(delta);
@@ -810,8 +810,8 @@ namespace TrenchBroom {
                         },
                         [&](const Model::BrushError e) {
                             error() << "Couild not move edges: " << e;
-                        },
-                    });
+                        }
+                    ));
             }
 
             invalidateSelectionBounds();
@@ -833,7 +833,7 @@ namespace TrenchBroom {
                 const std::vector<vm::polygon3>& oldPositions = entry.second;
                 
                 brushNode->brush().moveFaces(m_worldBounds, oldPositions, delta, pref(Preferences::UVLock))
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
                             const auto newPositions = brush.findClosestFacePositions(kdl::vec_transform(oldPositions, [&](const auto& f) {
                                 return f.translate(delta);
@@ -843,8 +843,8 @@ namespace TrenchBroom {
                         },
                         [&](const Model::BrushError e) {
                             error() << "Could not move faces: " << e;
-                        },
-                    });
+                        }
+                    ));
             }
 
             invalidateSelectionBounds();
@@ -865,14 +865,14 @@ namespace TrenchBroom {
                 const std::vector<Model::BrushNode*>& brushNodes = entry.second;
                 for (Model::BrushNode* brushNode : brushNodes) {
                     brushNode->brush().addVertex(m_worldBounds, position)
-                        .visit(kdl::overload{
+                        .visit(kdl::overload(
                             [&](Model::Brush&& brush) {
                                 brushNode->setBrush(std::move(brush));
                             },
                             [&](const Model::BrushError e) {
                                 error() << "Could not add vertex: " << e;
-                            },
-                        });
+                            }
+                        ));
                 }
             }
 
@@ -891,14 +891,14 @@ namespace TrenchBroom {
                 const std::vector<vm::vec3>& positions = entry.second;
                 
                 brushNode->brush().removeVertices(m_worldBounds, positions)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
                             brushNode->setBrush(std::move(brush));
                         },
                         [&](const Model::BrushError e) {
                             error() << "Could not remove vertex: " << e;
-                        },
-                    });
+                        }
+                    ));
             }
 
             invalidateSelectionBounds();
@@ -907,14 +907,14 @@ namespace TrenchBroom {
         void MapDocumentCommandFacade::restoreSnapshot(Model::Snapshot* snapshot) {
             const auto restoreNodesAndLogErrors = [&]() {
                 snapshot->restoreNodes(m_worldBounds).
-                    visit(kdl::overload {
+                    visit(kdl::overload(
                         []() {},
                         [&](const Model::SnapshotErrors& errors) {
                             for (const auto& e : errors) {
                                 error() << kdl::str_to_string(e);
                             }
                         }
-                    });
+                    ));
             };
         
             if (!m_selectedNodes.empty()) {

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -226,14 +226,14 @@ namespace TrenchBroom {
                 }
 
                 brushBuilder.createBrush(tallVertices, Model::BrushFaceAttributes::NoTextureName)
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& b) {
                             tallBrushes.push_back(document->world()->createBrush(std::move(b)));
                         },
                         [&](const Model::BrushError e) {
                             m_logger->error() << "Could not create selection brush: " << e;
                         }
-                    });
+                    ));
             }
 
             Transaction transaction(document, "Select Tall");

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -282,7 +282,7 @@ namespace TrenchBroom {
                 
                 const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
                 builder.createBrush(polyhedron, document->currentTextureName())
-                    .visit(kdl::overload {
+                    .visit(kdl::overload(
                         [&](Model::Brush&& b) {
                             for (const Model::BrushNode* selectedBrushNode : document->selectedNodes().brushes()) {
                                 b.cloneFaceAttributesFrom(selectedBrushNode->brush());
@@ -295,8 +295,8 @@ namespace TrenchBroom {
                         },
                         [&](const Model::BrushError e) {
                             document->error() << "Could not create brush: " << e;
-                        },
-                    });
+                        }
+                    ));
             }
 
             virtual H getHandlePosition(const Model::Hit& hit) const {

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -53,14 +53,14 @@ namespace TrenchBroom {
     namespace Model {
         static bool canMoveBoundary(const Brush& brush, const vm::bbox3& worldBounds, const size_t faceIndex, const vm::vec3& delta) {
             return brush.moveBoundary(worldBounds, faceIndex, delta, false)
-                .visit(kdl::overload {
+                .visit(kdl::overload(
                     [&](const Brush& b) {
                         return worldBounds.contains(b.bounds());
                     },
                     [](const BrushError) {
                         return false;
-                    },
-                });
+                    }
+                ));
         }
 
         TEST_CASE("BrushTest.constructBrushWithFaces", "[BrushTest]") {

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -204,7 +204,7 @@ namespace TrenchBroom {
 
         const PreferencesResult v2 = readV2SettingsFromPath("fixture/test/preferences-v2.json");
         CHECK(v2.is_success());
-        v2.visit(kdl::overload{
+        v2.visit(kdl::overload(
             [](const std::map<IO::Path, QJsonValue>& prefs) {
                testV2Prefs(prefs);
             },
@@ -217,7 +217,7 @@ namespace TrenchBroom {
             [](const PreferenceErrors::FileReadError&) {
                 FAIL_CHECK();
             }
-        });
+        ));
     }
 
     TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]") {
@@ -228,7 +228,7 @@ namespace TrenchBroom {
         const auto v2Deserialized = parseV2SettingsFromJSON(v2Serialized);
 
         CHECK(v2Deserialized.is_success());
-        v2Deserialized.visit(kdl::overload{
+        v2Deserialized.visit(kdl::overload(
             [&](const std::map<IO::Path, QJsonValue>& prefs) {
                 CHECK(v2 == prefs);
             },
@@ -241,7 +241,7 @@ namespace TrenchBroom {
             [](const PreferenceErrors::FileReadError&) {
                 FAIL_CHECK();
             }
-        });
+        ));
     }
 
     /**

--- a/common/test/src/View/InputEventTest.cpp
+++ b/common/test/src/View/InputEventTest.cpp
@@ -136,16 +136,16 @@ namespace TrenchBroom {
             
             void processEvent(const KeyEvent& act) override {
                 ASSERT_FALSE(m_expectedEvents.empty());
-                std::visit(kdl::overload{
+                std::visit(kdl::overload(
                     [&](const KeyEvent& exp) { ASSERT_EQ(exp, act); },
                     [&](const auto&)       { ASSERT_TRUE(false); }
-                }, m_expectedEvents.front());
+                ), m_expectedEvents.front());
                 m_expectedEvents.pop_front();
             }
             
             void processEvent(const MouseEvent& act) override {
                 ASSERT_FALSE(m_expectedEvents.empty());
-                std::visit(kdl::overload{
+                std::visit(kdl::overload(
                     [&](const MouseEvent& exp) {
                         CHECK(exp.type == act.type);
                         CHECK(exp.button == act.button);
@@ -155,16 +155,16 @@ namespace TrenchBroom {
                         CHECK(exp.scrollDistance == Approx(act.scrollDistance));
                     },
                     [&](const auto&) { ASSERT_TRUE(false); }
-                }, m_expectedEvents.front());
+                ), m_expectedEvents.front());
                 m_expectedEvents.pop_front();
             }
             
             void processEvent(const CancelEvent& act) override {
                 ASSERT_FALSE(m_expectedEvents.empty());
-                std::visit(kdl::overload{
+                std::visit(kdl::overload(
                     [&](const CancelEvent& exp) { ASSERT_EQ(exp, act); },
                     [&](const auto&)        { ASSERT_TRUE(false); }
-                }, m_expectedEvents.front());
+                ), m_expectedEvents.front());
                 m_expectedEvents.pop_front();
             }
             

--- a/lib/kdl/include/kdl/overload.h
+++ b/lib/kdl/include/kdl/overload.h
@@ -28,14 +28,18 @@ namespace kdl {
      * @tparam Ts the lambdas to inherit from
      */
     template<typename... Ts>
-    struct overload : Ts... {
+    struct overload_impl : Ts... {
         using Ts::operator()...;
+        overload_impl(Ts&&... ts) : Ts(std::forward<Ts>(ts))... {}
     };
 
     /**
-     * Deduction guide.
+     * Factory function to create an overload.
      */
-    template<typename... Ts> overload(Ts...) -> overload<Ts...>;
+    template <typename... Ts>
+    auto overload(Ts&&... ts) {
+        return overload_impl<Ts...>{std::forward<Ts>(ts)...};
+    }
 }
 
 #endif //TRENCHBROOM_OVERLOAD_H

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -229,33 +229,33 @@ namespace kdl {
             using Fn_Value  = typename Fn_Result::value_type;
             
             if constexpr (std::is_same_v<Fn_Value, void>) {
-                return visit(kdl::overload {
+                return visit(kdl::overload(
                     [&](const value_type& v) {
-                        return f(v).visit(kdl::overload {
+                        return f(v).visit(kdl::overload(
                             []() {
                                 return Cm_Result::success();
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (const auto& e) { return Cm_Result::error(e); }
-                });
+                ));
             } else {
-                return visit(kdl::overload {
+                return visit(kdl::overload(
                     [&](const value_type& v) {
-                        return f(v).visit(kdl::overload {
+                        return f(v).visit(kdl::overload(
                             [](Fn_Value&& fn_v) {
                                 return Cm_Result::success(std::move(fn_v));
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (const auto& e) { return Cm_Result::error(e); }
-                });
+                ));
             }
         }
         
@@ -273,33 +273,33 @@ namespace kdl {
             using Fn_Value  = typename Fn_Result::value_type;
             
             if constexpr (std::is_same_v<Fn_Value, void>) {
-                return std::move(*this).visit(kdl::overload {
+                return std::move(*this).visit(kdl::overload(
                     [&](value_type&& v) {
-                        return f(std::move(v)).visit(kdl::overload {
+                        return f(std::move(v)).visit(kdl::overload(
                             []() {
                                 return Cm_Result::success();
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (auto&& e) { return Cm_Result::error(e); }
-                });
+                ));
             } else {
-                return std::move(*this).visit(kdl::overload {
+                return std::move(*this).visit(kdl::overload(
                     [&](value_type&& v) {
-                        return f(std::move(v)).visit(kdl::overload {
+                        return f(std::move(v)).visit(kdl::overload(
                             [](Fn_Value&& fn_v) {
                                 return Cm_Result::success(std::move(fn_v));
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (auto&& e) { return Cm_Result::error(e); }
-                });
+                ));
             }
         }
 
@@ -316,7 +316,7 @@ namespace kdl {
          */
         template <typename F>
         bool handle_errors(F&& f) && {
-            return std::move(*this).visit(kdl::overload {
+            return std::move(*this).visit(kdl::overload(
                 [](const value_type&) {
                     return true;
                 },
@@ -324,7 +324,7 @@ namespace kdl {
                     f(std::move(error));
                     return false;
                 }
-            });
+            ));
         }
 
         /**
@@ -340,7 +340,7 @@ namespace kdl {
          */
         template <typename F>
         bool handle_errors(F&& f) const & {
-            return visit(kdl::overload {
+            return visit(kdl::overload(
                 [](const value_type&) {
                     return true;
                 },
@@ -348,7 +348,7 @@ namespace kdl {
                     f(error);
                     return false;
                 }
-            });
+            ));
         }
 
         /**
@@ -359,10 +359,10 @@ namespace kdl {
          * @throw bad_result_access if this result is an error
          */
         auto value() const & {
-            return visit(kdl::overload {
+            return visit(kdl::overload(
                 [](const value_type& v) -> value_type { return v; },
                 [](const auto&)         -> value_type { throw bad_result_access(); }
-            });
+            ));
         }
 
         /**
@@ -373,10 +373,10 @@ namespace kdl {
          * @throw bad_result_access if this result is an error
          */
         auto value() && {
-            return std::move(*this).visit(kdl::overload {
+            return std::move(*this).visit(kdl::overload(
                 [](value_type&& v) -> value_type { return std::move(v); },
                 [](const auto&)    -> value_type { throw bad_result_access(); }
-            });
+            ));
         }
 
         /**
@@ -484,14 +484,14 @@ namespace kdl {
          */
         template <typename Visitor>
         auto visit(Visitor&& visitor) const & {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](const success_value_type&) {
                     return visitor();
                 },
                 [&](const auto& e) {
                     return visitor(e);
                 }
-            }, m_value);
+            ), m_value);
         }
         
         /**
@@ -506,14 +506,14 @@ namespace kdl {
          */
         template <typename Visitor>
         auto visit(Visitor&& visitor) && {
-            return std::visit(kdl::overload {
+            return std::visit(kdl::overload(
                 [&](success_value_type&&) {
                     return visitor();
                 },
                 [&](auto&& e) {
                     return visitor(std::move(e));
                 }
-            }, std::move(m_value));
+            ), std::move(m_value));
         }
         
         /**
@@ -529,33 +529,33 @@ namespace kdl {
             using Fn_Value  = typename Fn_Result::value_type;
             
             if constexpr (std::is_same_v<Fn_Value, void>) {
-                return visit(kdl::overload {
+                return visit(kdl::overload(
                     [&]() {
-                        return f().visit(kdl::overload {
+                        return f().visit(kdl::overload(
                             []() {
                                 return Cm_Result::success();
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (const auto& e) { return Cm_Result::error(e); }
-                });
+                ));
             } else {
-                return visit(kdl::overload {
+                return visit(kdl::overload(
                     [&]() {
-                        return f().visit(kdl::overload {
+                        return f().visit(kdl::overload(
                             [](Fn_Value&& fn_v) {
                                 return Cm_Result::success(std::move(fn_v));
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (const auto& e) { return Cm_Result::error(e); }
-                });
+                ));
             }
         }
         
@@ -572,33 +572,33 @@ namespace kdl {
             using Fn_Value  = typename Fn_Result::value_type;
             
             if constexpr (std::is_same_v<Fn_Value, void>) {
-                return std::move(*this).visit(kdl::overload {
+                return std::move(*this).visit(kdl::overload(
                     [&]() {
-                        return f().visit(kdl::overload {
+                        return f().visit(kdl::overload(
                             []() {
                                 return Cm_Result::success();
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (auto&& e) { return Cm_Result::error(e); }
-                });
+                ));
             } else {
-                return std::move(*this).visit(kdl::overload {
+                return std::move(*this).visit(kdl::overload(
                     [&]() {
-                        return f().visit(kdl::overload {
+                        return f().visit(kdl::overload(
                             [](Fn_Value&& fn_v) {
                                 return Cm_Result::success(std::move(fn_v));
                             },
                             [](auto&& fn_e) {
                                 return Cm_Result::error(std::move(fn_e));
                             }
-                        });
+                        ));
                     },
                     [] (auto&& e) { return Cm_Result::error(e); }
-                });
+                ));
             }
         }
 
@@ -607,7 +607,7 @@ namespace kdl {
          */
         template <typename F>
         bool handle_errors(F&& f) && {
-            return std::move(*this).visit(kdl::overload {
+            return std::move(*this).visit(kdl::overload(
                 []() {
                     return true;
                 },
@@ -615,7 +615,7 @@ namespace kdl {
                     f(std::move(error));
                     return false;
                 }
-            });
+            ));
         }
 
         /**
@@ -623,7 +623,7 @@ namespace kdl {
          */
         template <typename F>
         bool handle_errors(F&& f) const & {
-            return visit(kdl::overload {
+            return visit(kdl::overload(
                 []() {
                     return true;
                 },
@@ -631,7 +631,7 @@ namespace kdl {
                     f(error);
                     return false;
                 }
-            });
+            ));
         }
 
         /**

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -530,19 +530,19 @@ namespace kdl {
             
             if constexpr (std::is_same_v<Fn_Value, void>) {
                 return visit(kdl::overload {
-                [&]() {
-                    return f().visit(kdl::overload {
-                        []() {
-                            return Cm_Result::success();
-                        },
-                        [](auto&& fn_e) {
-                            return Cm_Result::error(std::move(fn_e));
-                        }
-                    });
-                },
-                [] (const auto& e) { return Cm_Result::error(e); }
-            });
-        } else {
+                    [&]() {
+                        return f().visit(kdl::overload {
+                            []() {
+                                return Cm_Result::success();
+                            },
+                            [](auto&& fn_e) {
+                                return Cm_Result::error(std::move(fn_e));
+                            }
+                        });
+                    },
+                    [] (const auto& e) { return Cm_Result::error(e); }
+                });
+            } else {
                 return visit(kdl::overload {
                     [&]() {
                         return f().visit(kdl::overload {

--- a/lib/kdl/include/kdl/result_combine.h
+++ b/lib/kdl/include/kdl/result_combine.h
@@ -54,7 +54,7 @@ namespace kdl {
         using result_type = typename detail::tuple_wrap<std::remove_reference_t<Result>>::result;
         using value_type = typename std::remove_reference_t<Result>::value_type;
         
-        return result.visit(kdl::overload {
+        return result.visit(kdl::overload(
             [](value_type&& v) {
                 return result_type::success(std::make_tuple(std::move(v)));
             },
@@ -64,7 +64,7 @@ namespace kdl {
             [](auto&& e) {
                 return result_type::error(std::forward<decltype(e)>(e));
             }
-        });
+        ));
     }
 
     /**
@@ -96,9 +96,9 @@ namespace kdl {
         using combined_more_result_type = decltype(combine_results(std::forward<MoreResults>(moreResults)...));
         using result_type = typename detail::combine_tuple_results<std::remove_reference_t<FirstResult>, combined_more_result_type>::result;
         
-        return std::forward<FirstResult>(firstResult).visit(kdl::overload {
+        return std::forward<FirstResult>(firstResult).visit(kdl::overload(
             [&](first_value_type&& firstValue) {
-                return combine_results(std::forward<MoreResults>(moreResults)...).visit(kdl::overload {
+                return combine_results(std::forward<MoreResults>(moreResults)...).visit(kdl::overload(
                     [&](typename combined_more_result_type::value_type&& remainingValues) {
                         return result_type::success(std::tuple_cat(
                             std::make_tuple(std::move(firstValue)),
@@ -112,10 +112,10 @@ namespace kdl {
                     [](auto&& combinedError) {
                         return result_type::error(std::forward<decltype(combinedError)>(combinedError));
                     }
-                });
+                ));
             },
             [&](const first_value_type& firstValue) {
-                return combine_results(std::forward<MoreResults>(moreResults)...).visit(kdl::overload {
+                return combine_results(std::forward<MoreResults>(moreResults)...).visit(kdl::overload(
                     [&](typename combined_more_result_type::value_type&& remainingValues) {
                         return result_type::success(std::tuple_cat(
                             std::make_tuple(firstValue),
@@ -129,12 +129,12 @@ namespace kdl {
                     [](auto&& combinedError) {
                         return result_type::error(std::forward<decltype(combinedError)>(combinedError));
                     }
-                });
+                ));
             },
             [&](auto&& firstError) {
                 return result_type::error(std::forward<decltype(firstError)>(firstError));
-            },
-        });
+            }
+        ));
     }
 }
 

--- a/lib/kdl/include/kdl/result_io.h
+++ b/lib/kdl/include/kdl/result_io.h
@@ -32,10 +32,10 @@ namespace kdl {
 
     template <typename... Errors>
     std::ostream& operator<<(std::ostream& str, const result<void, Errors...>& result) {
-        result.visit(kdl::overload {
+        result.visit(kdl::overload(
             [&]()              { str << "void"; },
             [&](const auto& e) { str << e; }
-        });
+        ));
         return str;
     }
 }

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -120,11 +120,11 @@ namespace kdl {
     void test_visit_success_const_lvalue_ref(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
 
-        ASSERT_TRUE(result.visit(overload {
+        ASSERT_TRUE(result.visit(overload(
             [&] (const auto& x) { return x == v; },
             []  (const Error1&) { return false; },
             []  (const Error2&) { return false; }
-        }));
+        )));
     }
     
     /**
@@ -134,18 +134,18 @@ namespace kdl {
     void test_visit_success_rvalue_ref(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
 
-        ASSERT_TRUE(std::move(result).visit(overload {
+        ASSERT_TRUE(std::move(result).visit(overload(
             [&] (auto&&)   { return true; },
             []  (Error1&&) { return false; },
             []  (Error2&&) { return false; }
-        }));
+        )));
         
         typename ResultType::value_type y;
-        std::move(result).visit(overload {
+        std::move(result).visit(overload(
             [&] (auto&& x) { y = std::move(x); },
             []  (Error1&&) {},
             []  (Error2&&) {}
-        });
+        ));
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -157,11 +157,11 @@ namespace kdl {
     void test_visit_error_const_lvalue_ref(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
 
-        ASSERT_TRUE(result.visit(overload {
+        ASSERT_TRUE(result.visit(overload(
             []  (const auto&)   { return false; },
             [&] (const E& x)    { return x == e; },
             []  (const Error2&) { return false; }
-        }));
+        )));
     }
     
     /**
@@ -171,18 +171,18 @@ namespace kdl {
     void test_visit_error_rvalue_ref(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
 
-        ASSERT_TRUE(std::move(result).visit(overload {
+        ASSERT_TRUE(std::move(result).visit(overload(
             []  (auto&&)   { return false; },
             [&] (E&&)      { return true; },
             []  (Error2&&) { return false; }
-        }));
+        )));
         
         E y;
-        std::move(result).visit(overload {
+        std::move(result).visit(overload(
             []  (auto&&)   {},
             [&] (E&& x)    { y = std::move(x); },
             []  (Error2&&) {}
-        });
+        ));
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -201,10 +201,10 @@ namespace kdl {
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
 
-        ASSERT_TRUE(to.visit(overload {
+        ASSERT_TRUE(to.visit(overload(
             [](const ToValueType&) { return true; },
             [](const auto&) { return false; }
-        }));
+        )));
     }
     
     /**
@@ -220,16 +220,16 @@ namespace kdl {
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
 
-        ASSERT_TRUE(to.visit(overload {
+        ASSERT_TRUE(to.visit(overload(
             [](const ToValueType&) { return true; },
             [](const auto&) { return false; }
-        }));
+        )));
 
         ToValueType y;
-        std::move(to).visit(overload {
+        std::move(to).visit(overload(
             [&] (ToValueType&& x) { y = x; },
             [] (auto&&) {}
-        });
+        ));
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -241,10 +241,10 @@ namespace kdl {
     void test_visit_success_with_opt_value() {
         auto result = ResultType::success();
         
-        ASSERT_TRUE(result.visit(overload {
+        ASSERT_TRUE(result.visit(overload(
             []()            { return true; },
             [](const auto&) { return false; }
-        }));
+        )));
     }
 
     /**
@@ -255,12 +255,12 @@ namespace kdl {
     void test_visit_success_const_lvalue_ref_with_opt_value(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
         
-        ASSERT_TRUE(result.visit(overload {
+        ASSERT_TRUE(result.visit(overload(
             []  ()              { return false; },
             [&] (const auto& x) { return x == v; },
             []  (const Error1&) { return false; },
             []  (const Error2&) { return false; }
-        }));
+        )));
     }
 
     /**
@@ -271,20 +271,20 @@ namespace kdl {
     void test_visit_success_rvalue_ref_with_opt_value(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
 
-        ASSERT_TRUE(std::move(result).visit(overload {
+        ASSERT_TRUE(std::move(result).visit(overload(
             []  ()         { return false; },
             [&] (auto&&)   { return true; },
             []  (Error1&&) { return false; },
             []  (Error2&&) { return false; }
-        }));
+        )));
         
         typename ResultType::value_type y;
-        std::move(result).visit(overload {
+        std::move(result).visit(overload(
             [] ()         {},
             [&] (auto&& x) { y = std::move(x); },
             []  (Error1&&) {},
             []  (Error2&&) {}
-        });
+        ));
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -297,11 +297,11 @@ namespace kdl {
     void test_visit_error_const_lvalue_ref_with_opt_value(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
         
-        ASSERT_TRUE(result.visit(overload {
+        ASSERT_TRUE(result.visit(overload(
             []  ()            { return false; },
             []  (const auto&) { return false; },
             [&] (const E& x)  { return x == e; }
-        }));
+        )));
     }
     
     /**
@@ -312,18 +312,18 @@ namespace kdl {
     void test_visit_error_rvalue_ref_with_opt_value(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
 
-        ASSERT_TRUE(std::move(result).visit(overload {
+        ASSERT_TRUE(std::move(result).visit(overload(
             [] ()       { return false; },
             []  (auto&&) { return false; },
             [&] (E&&)    { return true; }
-        }));
+        )));
 
         E y;
-        std::move(result).visit(overload {
+        std::move(result).visit(overload(
             []  ()       {},
             []  (auto&&) {},
             [&] (E&& x)  { y = std::move(x); }
-        });
+        ));
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -428,7 +428,7 @@ namespace kdl {
         auto r3 = R2::error(Error2{});
         
         CHECK(combine_results(r1, r2).is_success());
-        CHECK(combine_results(r1, r2).visit(kdl::overload {
+        CHECK(combine_results(r1, r2).visit(kdl::overload(
             [](const std::tuple<int, double>& t) {
                 CHECK(t == std::make_tuple(1, 2.0));
                 return true;
@@ -436,10 +436,10 @@ namespace kdl {
             [](const auto&) {
                 return false;
             }
-        }));
+        )));
         
         CHECK(combine_results(r1, r3).is_error());
-        CHECK(combine_results(r1, r3).visit(kdl::overload {
+        CHECK(combine_results(r1, r3).visit(kdl::overload(
             [](const std::tuple<int, double>&) {
                 return false;
             },
@@ -449,10 +449,10 @@ namespace kdl {
             [](const auto&) {
                 return false;
             }
-        }));
+        )));
 
         CHECK(combine_results(r1, R2::success(2.0)).is_success());
-        CHECK(combine_results(r1, R2::success(2.0)).visit(kdl::overload {
+        CHECK(combine_results(r1, R2::success(2.0)).visit(kdl::overload(
             [](const std::tuple<int, double>& t) {
                 CHECK(t == std::make_tuple(1, 2.0));
                 return true;
@@ -460,10 +460,10 @@ namespace kdl {
             [](const auto&) {
                 return false;
             }
-        }));
+        )));
         
         CHECK(combine_results(r1, R2::error(Error2{})).is_error());
-        CHECK(combine_results(r1, R2::error(Error2{})).visit(kdl::overload {
+        CHECK(combine_results(r1, R2::error(Error2{})).visit(kdl::overload(
             [](const std::tuple<int, double>&) {
                 return false;
             },
@@ -473,6 +473,6 @@ namespace kdl {
             [](const auto&) {
                 return false;
             }
-        }));
+        )));
     }
 }


### PR DESCRIPTION
The previous, deduction guide-based approach exposes a bug in MSVC when
the resulting overload instance is captured in a variable. So we use an
alternative implementation that uses a function to construct the
overloaded struct.

See https://developercommunity2.visualstudio.com/t/Capturing-lambdas-in-function-object-res/475396?entry=problem&dialog=comment&viewtype=all