### PR TITLE
3564: Fix inconsistent API in kdl

### DIFF
--- a/common/src/Assets/TextureManager.cpp
+++ b/common/src/Assets/TextureManager.cpp
@@ -94,7 +94,7 @@ namespace TrenchBroom {
             }
 
             updateTextures();
-            kdl::vec_append(m_toRemove, std::move(collections));
+            m_toRemove = kdl::vec_concat(std::move(m_toRemove), std::move(collections));
         }
 
         void TextureManager::setTextureCollections(std::vector<TextureCollection> collections) {

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -218,8 +218,8 @@ namespace TrenchBroom {
             }
 
             if (kdl::ci::str_is_equal(token.data(), "@include")) {
-                const auto includedClassInfos = parseInclude(status);
-                kdl::vec_append(classInfos, includedClassInfos);
+                auto includedClassInfos = parseInclude(status);
+                classInfos = kdl::vec_concat(classInfos, std::move(includedClassInfos));
             } else {
                 if (auto classInfo = parseClassInfo(status)) {
                     classInfos.push_back(std::move(*classInfo));

--- a/common/src/IO/FileSystem.cpp
+++ b/common/src/IO/FileSystem.cpp
@@ -171,8 +171,7 @@ namespace TrenchBroom {
                 result = kdl::vec_concat(std::move(result), m_next->_getDirectoryContents(directoryPath));
             }
 
-            kdl::vec_sort_and_remove_duplicates(result);
-            return result;
+            return kdl::vec_sort_and_remove_duplicates(std::move(result));
         }
 
         std::shared_ptr<File> FileSystem::_openFile(const Path& path) const {

--- a/common/src/IO/FileSystem.cpp
+++ b/common/src/IO/FileSystem.cpp
@@ -168,7 +168,7 @@ namespace TrenchBroom {
         std::vector<Path> FileSystem::_getDirectoryContents(const Path& directoryPath) const {
             auto result = doGetDirectoryContents(directoryPath);
             if (m_next) {
-                kdl::vec_append(result, m_next->_getDirectoryContents(directoryPath));
+                result = kdl::vec_concat(std::move(result), m_next->_getDirectoryContents(directoryPath));
             }
 
             kdl::vec_sort_and_remove_duplicates(result);

--- a/common/src/IO/FileSystem.h
+++ b/common/src/IO/FileSystem.h
@@ -148,8 +148,7 @@ namespace TrenchBroom {
 
                     std::vector<Path> result;
                     _findItems(searchPath, matcher, recurse, result);
-                    kdl::vec_sort_and_remove_duplicates(result);
-                    return result;
+                    return kdl::vec_sort_and_remove_duplicates(std::move(result));
                 } catch (const PathException& e) {
                     throw FileSystemException("Invalid path: '" + searchPath.asString() + "'", e);
                 }

--- a/common/src/IO/Quake3ShaderFileSystem.cpp
+++ b/common/src/IO/Quake3ShaderFileSystem.cpp
@@ -61,7 +61,7 @@ namespace TrenchBroom {
                     try {
                         Quake3ShaderParser parser(bufferedReader.stringView());
                         SimpleParserStatus status(m_logger, file->path().asString());
-                        kdl::vec_append(result, parser.parse(status));
+                        result = kdl::vec_concat(std::move(result), parser.parse(status));
                     } catch (const ParserException& e) {
                         m_logger.warn() << "Skipping malformed shader file " << path << ": " << e.what();
                     }
@@ -78,7 +78,7 @@ namespace TrenchBroom {
             auto allImages = std::vector<Path>();
             for (const auto& path : m_textureSearchPaths) {
                 if (next().directoryExists(path)) {
-                    kdl::vec_append(allImages, next().findItemsRecursively(path, FileExtensionMatcher(extensions)));
+                    allImages = kdl::vec_concat(std::move(allImages), next().findItemsRecursively(path, FileExtensionMatcher(extensions)));
                 }
             }
 

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -299,8 +299,8 @@ namespace TrenchBroom {
             auto oldSorted = m_attributes.attributes();
             auto newSorted = newAttributes;
 
-            kdl::sort(oldSorted);
-            kdl::sort(newSorted);
+            kdl::col_sort(oldSorted);
+            kdl::col_sort(newSorted);
 
             auto oldIt = std::begin(oldSorted);
             auto oldEnd = std::end(oldSorted);

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -643,19 +643,19 @@ namespace TrenchBroom {
 
         void AttributableNode::removeLinkSource(AttributableNode* attributable) {
             ensure(attributable != nullptr, "attributable is null");
-            kdl::vec_erase(m_linkSources, attributable);
+            m_linkSources = kdl::vec_erase(std::move(m_linkSources), attributable);
             invalidateIssues();
         }
 
         void AttributableNode::removeLinkTarget(AttributableNode* attributable) {
             ensure(attributable != nullptr, "attributable is null");
-            kdl::vec_erase(m_linkTargets, attributable);
+            m_linkTargets = kdl::vec_erase(std::move(m_linkTargets), attributable);
             invalidateIssues();
         }
 
         void AttributableNode::removeKillSource(AttributableNode* attributable) {
             ensure(attributable != nullptr, "attributable is null");
-            kdl::vec_erase(m_killSources, attributable);
+            m_killSources = kdl::vec_erase(std::move(m_killSources), attributable);
             invalidateIssues();
         }
 
@@ -670,7 +670,7 @@ namespace TrenchBroom {
 
         void AttributableNode::removeKillTarget(AttributableNode* attributable) {
             ensure(attributable != nullptr, "attributable is null");
-            kdl::vec_erase(m_killTargets, attributable);
+            m_killTargets = kdl::vec_erase(std::move(m_killTargets), attributable);
         }
 
         bool operator==(const AttributableNode& lhs, const AttributableNode& rhs) {

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -296,11 +296,8 @@ namespace TrenchBroom {
         }
 
         void AttributableNode::updateAttributeIndex(const std::vector<EntityAttribute>& newAttributes) {
-            auto oldSorted = m_attributes.attributes();
-            auto newSorted = newAttributes;
-
-            kdl::col_sort(oldSorted);
-            kdl::col_sort(newSorted);
+            const auto oldSorted = kdl::col_sort(m_attributes.attributes());
+            const auto newSorted = kdl::col_sort(newAttributes);
 
             auto oldIt = std::begin(oldSorted);
             auto oldEnd = std::end(oldSorted);

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -245,7 +245,7 @@ namespace TrenchBroom {
         kdl::result<Brush, BrushError> Brush::clip(const vm::bbox3& worldBounds, BrushFace face) const {
             std::vector<BrushFace> faces;
             faces.reserve(faceCount() + 1u);
-            kdl::vec_append(faces, m_faces);
+            faces = kdl::vec_concat(std::move(faces), m_faces);
             faces.push_back(std::move(face));
             return Brush::create(worldBounds, std::move(faces));
         }
@@ -749,7 +749,7 @@ namespace TrenchBroom {
             // TODO: When there are multiple choices of moving verts (unmovedVerts.size() + movedVerts.size() > 3)
             // we should sort them somehow. This can be seen if you select and move 3/5 verts of a pentagon;
             // which of the 3 moving verts currently gets UV lock is arbitrary.
-            kdl::vec_append(referenceVerts, movedVerts);
+            referenceVerts = kdl::vec_concat(std::move(referenceVerts), movedVerts);
 
             if (referenceVerts.size() < 3) {
                 // Can't create a transform as there are not enough verts

--- a/common/src/Model/CompilationConfig.cpp
+++ b/common/src/Model/CompilationConfig.cpp
@@ -92,7 +92,7 @@ namespace TrenchBroom {
 
         void CompilationConfig::removeProfile(const size_t index) {
             assert(index < profileCount());
-            kdl::vec_erase_at(m_profiles, index);
+            m_profiles = kdl::vec_erase_at(std::move(m_profiles), index);
         }
     }
 }

--- a/common/src/Model/CompilationProfile.cpp
+++ b/common/src/Model/CompilationProfile.cpp
@@ -118,7 +118,7 @@ namespace TrenchBroom {
 
         void CompilationProfile::removeTask(const size_t index) {
             assert(index < taskCount());
-            kdl::vec_erase_at(m_tasks, index);
+            m_tasks = kdl::vec_erase_at(std::move(m_tasks), index);
         }
 
         void CompilationProfile::moveTaskUp(const size_t index) {

--- a/common/src/Model/GameEngineConfig.cpp
+++ b/common/src/Model/GameEngineConfig.cpp
@@ -96,7 +96,7 @@ namespace TrenchBroom {
 
         void GameEngineConfig::removeProfile(const size_t index) {
             assert(index < profileCount());
-            kdl::vec_erase_at(m_profiles, index);
+            m_profiles = kdl::vec_erase_at(std::move(m_profiles), index);
         }
     }
 }

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -195,7 +195,7 @@ namespace TrenchBroom {
                 }
             }
 
-            kdl::sort(m_names, kdl::cs::string_less());
+            kdl::col_sort(m_names, kdl::cs::string_less());
 
             if (!errors.empty()) {
                 throw errors;

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -195,7 +195,7 @@ namespace TrenchBroom {
                 }
             }
 
-            kdl::col_sort(m_names, kdl::cs::string_less());
+            m_names = kdl::col_sort(std::move(m_names), kdl::cs::string_less());
 
             if (!errors.empty()) {
                 throw errors;

--- a/common/src/Model/GameFileSystem.cpp
+++ b/common/src/Model/GameFileSystem.cpp
@@ -116,7 +116,7 @@ namespace TrenchBroom {
             if (IO::Disk::directoryExists(searchPath)) {
                 const IO::DiskFileSystem diskFS(searchPath);
                 auto packages = diskFS.findItems(IO::Path(""), IO::FileExtensionMatcher(packageExtensions));
-                kdl::vec_sort(packages, IO::Path::Less<kdl::ci::string_less>());
+                packages = kdl::vec_sort(std::move(packages), IO::Path::Less<kdl::ci::string_less>());
 
                 for (const auto& packagePath : packages) {
                     try {

--- a/common/src/Model/GroupSnapshot.cpp
+++ b/common/src/Model/GroupSnapshot.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
                 snapshot->restore(worldBounds)
                     .visit(kdl::overload(
                         []() {},
-                        [&](const SnapshotErrors& e) { kdl::vec_append(errors, e); }
+                        [&](const SnapshotErrors& e) { errors = kdl::vec_concat(std::move(errors), e); }
                     ));
             }
             return errors.empty()

--- a/common/src/Model/IssueGeneratorRegistry.cpp
+++ b/common/src/Model/IssueGeneratorRegistry.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
             std::vector<IssueQuickFix*> result;
             for (const IssueGenerator* generator : m_generators) {
                 if ((generator->type() & issueTypes) != 0)
-                    kdl::vec_append(result, generator->quickFixes());
+                    result = kdl::vec_concat(std::move(result), generator->quickFixes());
             }
             return result;
         }

--- a/common/src/Model/MissingModIssueGenerator.cpp
+++ b/common/src/Model/MissingModIssueGenerator.cpp
@@ -86,7 +86,7 @@ namespace TrenchBroom {
                     if (issue->type() == MissingModIssue::Type) {
                         const MissingModIssue* modIssue = static_cast<const MissingModIssue*>(issue);
                         const std::string& missingMod = modIssue->mod();
-                        kdl::vec_erase(mods, missingMod);
+                        mods = kdl::vec_erase(std::move(mods), missingMod);
                     }
                 }
                 return mods;

--- a/common/src/Model/ModelUtils.cpp
+++ b/common/src/Model/ModelUtils.cpp
@@ -55,8 +55,7 @@ namespace TrenchBroom {
                     layers.push_back(layer);
                 }
             }
-            kdl::vec_sort_and_remove_duplicates(layers);
-            return layers;
+            return kdl::vec_sort_and_remove_duplicates(std::move(layers));
         }
 
         GroupNode* findContainingGroup(Node* node) {
@@ -92,8 +91,7 @@ namespace TrenchBroom {
             for (auto* node : nodes) {
                 collectWithParents(node->parent(), result);
             }
-            kdl::vec_sort_and_remove_duplicates(result);
-            return result;
+            return kdl::vec_sort_and_remove_duplicates(std::move(result));
         }
 
         std::vector<Node*> collectParents(const std::map<Node*, std::vector<Node*>>& nodes) {
@@ -102,8 +100,7 @@ namespace TrenchBroom {
                 Node* parent = entry.first;
                 collectWithParents(parent, result);
             }
-            kdl::vec_sort_and_remove_duplicates(result);
-            return result;
+            return kdl::vec_sort_and_remove_duplicates(std::move(result));
         }
 
         std::vector<Node*> collectChildren(const std::map<Node*, std::vector<Node*>>& nodes) {

--- a/common/src/Model/ModelUtils.cpp
+++ b/common/src/Model/ModelUtils.cpp
@@ -109,8 +109,7 @@ namespace TrenchBroom {
         std::vector<Node*> collectChildren(const std::map<Node*, std::vector<Node*>>& nodes) {
             std::vector<Node*> result;
             for (const auto& entry : nodes) {
-                const std::vector<Node*>& children = entry.second;
-                kdl::vec_append(result, children);
+                result = kdl::vec_concat(std::move(result), entry.second);
             }
             return result;
         }
@@ -118,7 +117,7 @@ namespace TrenchBroom {
         std::vector<Node*> collectDescendants(const std::vector<Node*>& nodes) {
             auto result = std::vector<Node*>{};
             for (auto* node : nodes) {
-                kdl::vec_append(result, collectNodes(node->children()));
+                result = kdl::vec_concat(std::move(result), collectNodes(node->children()));
             }
             return result;
         }

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -218,7 +218,7 @@ namespace TrenchBroom {
             childWillBeRemoved(child);
             // nodeWillChange();
             child->setParent(nullptr);
-            kdl::vec_erase(m_children, child);
+            m_children = kdl::vec_erase(std::move(m_children), child);
             childWasRemoved(child);
             // nodeDidChange();
         }

--- a/common/src/Model/PointEntityWithBrushesIssueGenerator.cpp
+++ b/common/src/Model/PointEntityWithBrushesIssueGenerator.cpp
@@ -67,7 +67,7 @@ namespace TrenchBroom {
                     nodesToReparent[node->parent()] = node->children();
 
                     affectedNodes.push_back(node);
-                    kdl::vec_append(affectedNodes, node->children());
+                    affectedNodes = kdl::vec_concat(std::move(affectedNodes), node->children());
                 }
 
                 facade->deselectAll();

--- a/common/src/Model/Polyhedron_ConvexHull.h
+++ b/common/src/Model/Polyhedron_ConvexHull.h
@@ -52,7 +52,7 @@ namespace TrenchBroom {
         template <typename T, typename FP, typename VP>
         void Polyhedron<T,FP,VP>::addPoints(std::vector<vm::vec<T,3>> points) {
             if (!points.empty()) {
-                kdl::vec_sort_and_remove_duplicates(points);
+                points = kdl::vec_sort_and_remove_duplicates(std::move(points));
                 
                 const auto planeEpsilon = computePlaneEpsilon(points);
                 for (const auto& point : points) {

--- a/common/src/Model/Snapshot.cpp
+++ b/common/src/Model/Snapshot.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
                 snapshot->restore(worldBounds)
                     .visit(kdl::overload(
                         []() {},
-                        [&](const SnapshotErrors& e) { kdl::vec_append(errors, e); }
+                        [&](const SnapshotErrors& e) { errors = kdl::vec_concat(std::move(errors), e); }
                     ));
             }
             return errors.empty()

--- a/common/src/Model/WorldNode.cpp
+++ b/common/src/Model/WorldNode.cpp
@@ -312,12 +312,12 @@ namespace TrenchBroom {
         }
 
         void WorldNode::doFindAttributableNodesWithAttribute(const std::string& name, const std::string& value, std::vector<Model::AttributableNode*>& result) const {
-            kdl::vec_append(result,
+            result = kdl::vec_concat(std::move(result), 
                 m_attributableIndex->findAttributableNodes(AttributableNodeIndexQuery::exact(name), value));
         }
 
         void WorldNode::doFindAttributableNodesWithNumberedAttribute(const std::string& prefix, const std::string& value, std::vector<Model::AttributableNode*>& result) const {
-            kdl::vec_append(result,
+            result = kdl::vec_concat(std::move(result), 
                 m_attributableIndex->findAttributableNodes(AttributableNodeIndexQuery::numbered(prefix), value));
         }
 

--- a/common/src/Renderer/IndexRangeMap.cpp
+++ b/common/src/Renderer/IndexRangeMap.cpp
@@ -79,8 +79,8 @@ namespace TrenchBroom {
 
         void IndexRangeMap::IndicesAndCounts::add(const IndicesAndCounts& other, [[maybe_unused]] const bool dynamicGrowth) {
             assert(dynamicGrowth || indices.capacity() >= indices.size() + other.indices.size());
-            kdl::vec_append(indices, other.indices);
-            kdl::vec_append(counts, other.counts);
+            indices = kdl::vec_concat(std::move(indices), other.indices);
+            counts = kdl::vec_concat(std::move(counts), other.counts);
         }
 
         void IndexRangeMap::Size::inc(const PrimType primType, const size_t count) {

--- a/common/src/Renderer/IndexedVertexList.h
+++ b/common/src/Renderer/IndexedVertexList.h
@@ -69,7 +69,7 @@ namespace TrenchBroom {
 
             void addVertices(const typename T::Vertex::List& vertices) {
                 assert(m_allowDynamicGrowth || vertices.size() <= m_vertices.capacity() - m_vertices.size());
-                kdl::vec_append(m_vertices, vertices);
+                m_vertices = kdl::vec_concat(std::move(m_vertices), vertices);
             }
 
             void addPrimitive(const typename T::Vertex::List& vertices) {
@@ -81,9 +81,9 @@ namespace TrenchBroom {
                 assert(m_allowDynamicGrowth || primitives.vertices().size() <= m_vertices.capacity() - m_vertices.size());
                 assert(m_allowDynamicGrowth || primitives.indices().size() <= m_indices.capacity() - m_indices.size());
                 assert(m_allowDynamicGrowth || primitives.counts().size() <= m_counts.capacity() - m_counts.size());
-                kdl::vec_append(m_vertices, primitives.vertices());
-                kdl::vec_append(m_indices, primitives.indices());
-                kdl::vec_append(m_counts, primitives.counts());
+                m_vertices = kdl::vec_concat(std::move(m_vertices), primitives.vertices());
+                m_indices = kdl::vec_concat(std::move(m_indices), primitives.indices());
+                m_counts = kdl::vec_concat(std::move(m_counts), primitives.counts());
                 m_primStart = m_vertices.size();
             }
 

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -527,7 +527,7 @@ namespace TrenchBroom {
                 
                 const auto toBrush = [](const auto& handle) { return handle.node(); };
                 auto brushes = kdl::vec_concat(kdl::vec_transform(selection.selectedBrushFaces(), toBrush), kdl::vec_transform(selection.deselectedBrushFaces(), toBrush));
-                kdl::vec_sort_and_remove_duplicates(brushes);
+                brushes = kdl::vec_sort_and_remove_duplicates(std::move(brushes));
                 invalidateBrushesInRenderers(Renderer_All, brushes);
             }
         }

--- a/common/src/Renderer/TextureFont.cpp
+++ b/common/src/Renderer/TextureFont.cpp
@@ -149,7 +149,7 @@ namespace TrenchBroom {
 
             void makeQuads(const std::string& str, const float x) {
                 const auto offset = m_offset + vm::vec2f(x, m_y);
-                kdl::vec_append(m_vertices, m_font.quads(str, m_clockwise, offset));
+                m_vertices = kdl::vec_concat(std::move(m_vertices), m_font.quads(str, m_clockwise, offset));
 
                 m_y -= m_sizes[m_index].y();
                 m_index++;

--- a/common/src/Renderer/VertexListBuilder.h
+++ b/common/src/Renderer/VertexListBuilder.h
@@ -163,7 +163,7 @@ namespace TrenchBroom {
 
                 const size_t index = currentIndex();
                 const size_t count = vertices.size();
-                kdl::vec_append(m_vertices, vertices);
+                m_vertices = kdl::vec_concat(std::move(m_vertices), vertices);
 
                 return Range(index, count);
             }

--- a/common/src/View/CameraLinkHelper.cpp
+++ b/common/src/View/CameraLinkHelper.cpp
@@ -50,7 +50,7 @@ namespace TrenchBroom {
 
         void CameraLinkHelper::removeCamera(Renderer::Camera* camera) {
             ensure(camera != nullptr, "camera is null");
-            kdl::vec_erase(m_cameras, camera);
+            m_cameras = kdl::vec_erase(std::move(m_cameras), camera);
             camera->cameraDidChangeNotifier.removeObserver(this, &CameraLinkHelper::cameraDidChange);
         }
 

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -221,7 +221,7 @@ namespace TrenchBroom {
                 std::vector<vm::vec3> result;
                 for (size_t i = 0; i < m_numPoints; ++i) {
                     const std::vector<vm::vec3>& helpVectors = m_points[i].helpVectors;
-                    kdl::vec_append(result, helpVectors);
+                    result = kdl::vec_concat(std::move(result), helpVectors);
                 }
 
                 return result;

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -309,8 +309,7 @@ namespace TrenchBroom {
                 result.push_back(vm::get_abs_max_component_axis(normal));
             }
 
-            kdl::vec_sort_and_remove_duplicates(result);
-            return result;
+            return kdl::vec_sort_and_remove_duplicates(std::move(result));
         }
 
         std::vector<const Model::BrushFace*> ClipToolController3D::selectIncidentFaces(const Model::BrushNode* brushNode, const Model::BrushFace& face, const vm::vec3& hitPoint) {

--- a/common/src/View/CompilationVariables.cpp
+++ b/common/src/View/CompilationVariables.cpp
@@ -48,7 +48,7 @@ namespace TrenchBroom {
 
             std::vector<std::string> mods;
             mods.push_back(document->defaultMod());
-            kdl::vec_append(mods, document->mods());
+            mods = kdl::vec_concat(std::move(mods), document->mods());
 
             using namespace CompilationVariableNames;
             declare(MAP_BASE_NAME, EL::Value(filename.deleteExtension().asString()));

--- a/common/src/View/DirectoryTextureCollectionEditor.cpp
+++ b/common/src/View/DirectoryTextureCollectionEditor.cpp
@@ -83,7 +83,7 @@ namespace TrenchBroom {
             // erase back to front
             for (auto sIt = std::rbegin(selections), sEnd = std::rend(selections); sIt != sEnd; ++sIt) {
                 const auto index = static_cast<size_t>(*sIt);
-                kdl::vec_erase_at(enabledCollections, index);
+                enabledCollections = kdl::vec_erase_at(std::move(enabledCollections), index);
             }
 
             auto document = kdl::mem_lock(m_document);
@@ -255,7 +255,7 @@ namespace TrenchBroom {
         std::vector<IO::Path> DirectoryTextureCollectionEditor::availableTextureCollections() const {
             auto document = kdl::mem_lock(m_document);
             auto availableCollections = document->availableTextureCollections();
-            kdl::vec_erase_all(availableCollections, document->enabledTextureCollections());
+            availableCollections = kdl::vec_erase_all(std::move(availableCollections), document->enabledTextureCollections());
             return availableCollections;
         }
 

--- a/common/src/View/DirectoryTextureCollectionEditor.cpp
+++ b/common/src/View/DirectoryTextureCollectionEditor.cpp
@@ -66,7 +66,7 @@ namespace TrenchBroom {
                 enabledCollections.push_back(availableCollections[index]);
             }
 
-            kdl::vec_sort_and_remove_duplicates(enabledCollections);
+            enabledCollections = kdl::vec_sort_and_remove_duplicates(std::move(enabledCollections));
 
             auto document = kdl::mem_lock(m_document);
             document->setEnabledTextureCollections(enabledCollections);

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -407,7 +407,8 @@ namespace TrenchBroom {
                             kdl::skip_iterator(std::begin(quads), std::end(quads), 0, 2),
                             kdl::skip_iterator(std::begin(quads), std::end(quads), 1, 2),
                             kdl::skip_iterator(std::begin(textColor), std::end(textColor), 0, 0));
-                        kdl::vec_append(stringVertices[defaultDescriptor], titleVertices);
+                        auto& allTitleVertices = stringVertices[defaultDescriptor];
+                        allTitleVertices = kdl::vec_concat(std::move(allTitleVertices), titleVertices);
                     }
 
                     for (size_t j = 0; j < group.size(); ++j) {
@@ -425,7 +426,8 @@ namespace TrenchBroom {
                                     kdl::skip_iterator(std::begin(quads), std::end(quads), 0, 2),
                                     kdl::skip_iterator(std::begin(quads), std::end(quads), 1, 2),
                                     kdl::skip_iterator(std::begin(textColor), std::end(textColor), 0, 0));
-                                kdl::vec_append(stringVertices[cellData(cell).fontDescriptor], titleVertices);
+                                auto& allTitleVertices = stringVertices[cellData(cell).fontDescriptor];
+                                allTitleVertices = kdl::vec_concat(std::move(allTitleVertices), titleVertices);
                             }
                         }
                     }

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -166,7 +166,7 @@ namespace TrenchBroom {
 
             auto document = kdl::mem_lock(m_document);
             auto specs = document->allEntityDefinitionFiles();
-            kdl::vec_sort(specs);
+            specs = kdl::vec_sort(std::move(specs));
 
             for (const auto& spec : specs) {
                 const auto& path = spec.path();

--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -174,7 +174,7 @@ namespace TrenchBroom {
                 toRemove.push_back(collections[index]);
             }
 
-            kdl::vec_erase_all(collections, toRemove);
+            collections = kdl::vec_erase_all(std::move(collections), toRemove);
             document->setEnabledTextureCollections(collections);
         }
 

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -135,7 +135,7 @@ namespace TrenchBroom {
                     [&](Model::BrushNode* brush)                      { collectIssues(brush); }
                 ));
 
-                kdl::vec_sort(issues, [](const auto* lhs, const auto* rhs) { return lhs->seqId() > rhs->seqId(); });
+                issues = kdl::vec_sort(std::move(issues), [](const auto* lhs, const auto* rhs) { return lhs->seqId() > rhs->seqId(); });
                 m_tableModel->setIssues(std::move(issues));
             }
         }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -614,8 +614,7 @@ namespace TrenchBroom {
                 ));
             }
 
-            kdl::vec_sort_and_remove_duplicates(nodes);
-            return nodes;
+            return kdl::vec_sort_and_remove_duplicates(std::move(nodes));
         }
 
         const Model::NodeCollection& MapDocument::selectedNodes() const {
@@ -1118,8 +1117,7 @@ namespace TrenchBroom {
                     }
                 }
             ));
-            kdl::vec_sort_and_remove_duplicates(result);
-            return result;
+            return kdl::vec_sort_and_remove_duplicates(std::move(result));
         }
 
         void MapDocument::ungroupSelection() {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -905,7 +905,7 @@ namespace TrenchBroom {
             if (nodes.empty())
                 return nodes;
 
-            kdl::vec_sort(nodes, CompareByAncestry());
+            nodes = kdl::vec_sort(std::move(nodes), CompareByAncestry());
 
             std::vector<Model::Node*> result;
             result.reserve(nodes.size());

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -114,7 +114,7 @@ namespace TrenchBroom {
                 }
             }
 
-            kdl::vec_append(m_selectedBrushFaces, selected);
+            m_selectedBrushFaces = kdl::vec_concat(std::move(m_selectedBrushFaces), selected);
 
             Selection selection;
             selection.addSelectedBrushFaces(selected);
@@ -235,7 +235,7 @@ namespace TrenchBroom {
                 Model::Node* parent = entry.first;
                 const std::vector<Model::Node*>& children = entry.second;
                 parent->addChildren(children);
-                kdl::vec_append(addedNodes, children);
+                addedNodes = kdl::vec_concat(std::move(addedNodes), children);
             }
 
             setEntityDefinitions(addedNodes);
@@ -757,8 +757,8 @@ namespace TrenchBroom {
                 brushNode->brush().moveVertices(m_worldBounds, oldPositions, delta, pref(Preferences::UVLock))
                     .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
-                            const auto newPositions = brush.findClosestVertexPositions(oldPositions + delta);
-                            kdl::vec_append(newVertexPositions, newPositions);
+                            auto newPositions = brush.findClosestVertexPositions(oldPositions + delta);
+                            newVertexPositions = kdl::vec_concat(std::move(newVertexPositions), std::move(newPositions));
                             brushNode->setBrush(std::move(brush));
                         },
                         [&](const Model::BrushError e) {
@@ -786,10 +786,10 @@ namespace TrenchBroom {
                 brushNode->brush().moveEdges(m_worldBounds, oldPositions, delta, pref(Preferences::UVLock))
                     .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
-                            const auto newPositions = brush.findClosestEdgePositions(kdl::vec_transform(oldPositions, [&](const auto& s) {
+                            auto newPositions = brush.findClosestEdgePositions(kdl::vec_transform(oldPositions, [&](const auto& s) {
                                 return s.translate(delta);
                             }));
-                            kdl::vec_append(newEdgePositions, newPositions);
+                            newEdgePositions = kdl::vec_concat(std::move(newEdgePositions), std::move(newPositions));
                             brushNode->setBrush(std::move(brush));
                         },
                         [&](const Model::BrushError e) {
@@ -818,10 +818,10 @@ namespace TrenchBroom {
                 brushNode->brush().moveFaces(m_worldBounds, oldPositions, delta, pref(Preferences::UVLock))
                     .visit(kdl::overload(
                         [&](Model::Brush&& brush) {
-                            const auto newPositions = brush.findClosestFacePositions(kdl::vec_transform(oldPositions, [&](const auto& f) {
+                            auto newPositions = brush.findClosestFacePositions(kdl::vec_transform(oldPositions, [&](const auto& f) {
                                 return f.translate(delta);
                             }));
-                            kdl::vec_append(newFacePositions, newPositions);
+                            newFacePositions = kdl::vec_concat(std::move(newFacePositions), std::move(newPositions));
                             brushNode->setBrush(std::move(brush));
                         },
                         [&](const Model::BrushError e) {

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -178,7 +178,7 @@ namespace TrenchBroom {
                 }
             }
 
-            kdl::vec_erase_all(m_selectedBrushFaces, deselected);
+            m_selectedBrushFaces = kdl::vec_erase_all(std::move(m_selectedBrushFaces), deselected);
 
             Selection selection;
             selection.addDeselectedBrushFaces(deselected);

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1322,8 +1322,7 @@ namespace TrenchBroom {
                     }
                 }
             ));
-            kdl::vec_sort_and_remove_duplicates(result);
-            return result;
+            return kdl::vec_sort_and_remove_duplicates(std::move(result));
         }
 
         void MapViewBase::reparentNodes(const std::vector<Model::Node*>& nodes, Model::Node* newParent, const bool preserveEntities) {

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -186,7 +186,7 @@ namespace TrenchBroom {
         void ModEditor::updateAvailableMods() {
             auto document = kdl::mem_lock(m_document);
             std::vector<std::string> availableMods = document->game()->availableMods();
-            kdl::sort(availableMods, kdl::ci::string_less());
+            kdl::col_sort(availableMods, kdl::ci::string_less());
 
             m_availableMods.clear();
             m_availableMods.reserve(availableMods.size());

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -246,7 +246,7 @@ namespace TrenchBroom {
             std::vector<std::string> mods = document->mods();
             for (QListWidgetItem* item : selections) {
                 const std::string mod = item->text().toStdString();
-                kdl::vec_erase(mods, mod);
+                mods = kdl::vec_erase(std::move(mods), mod);
             }
             document->setMods(mods);
         }

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -185,14 +185,7 @@ namespace TrenchBroom {
 
         void ModEditor::updateAvailableMods() {
             auto document = kdl::mem_lock(m_document);
-            std::vector<std::string> availableMods = document->game()->availableMods();
-            kdl::col_sort(availableMods, kdl::ci::string_less());
-
-            m_availableMods.clear();
-            m_availableMods.reserve(availableMods.size());
-            for (size_t i = 0; i < availableMods.size(); ++i) {
-                m_availableMods.push_back(availableMods[i]);
-            }
+            m_availableMods = kdl::col_sort(document->game()->availableMods(), kdl::ci::string_less());
         }
 
         void ModEditor::updateMods() {

--- a/common/src/View/RecentDocuments.cpp
+++ b/common/src/View/RecentDocuments.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
         void RecentDocuments::removeMenu(QMenu* menu) {
             ensure(menu != nullptr, "menu is null");
             clearMenu(menu);
-            kdl::vec_erase(m_menus, menu);
+            m_menus = kdl::vec_erase(std::move(m_menus), menu);
         }
 
         void RecentDocuments::updatePath(const IO::Path& path) {
@@ -67,7 +67,7 @@ namespace TrenchBroom {
             const size_t oldSize = m_recentDocuments.size();
 
             const IO::Path canonPath = path.makeCanonical();
-            kdl::vec_erase(m_recentDocuments, canonPath);
+            m_recentDocuments = kdl::vec_erase(std::move(m_recentDocuments), canonPath);
 
             if (oldSize > m_recentDocuments.size()) {
                 updateMenus();

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -202,14 +202,14 @@ namespace TrenchBroom {
             if (hit.type() == Resize2DHitType) {
                 const Resize2DHitData& data = hit.target<const Resize2DHitData&>();
                 assert(!data.empty());
-                kdl::vec_append(result, data, collectDragFaces(data[0]));
+                result = kdl::vec_concat(std::move(result), data, collectDragFaces(data[0]));
                 if (data.size() > 1) {
-                    kdl::vec_append(result, collectDragFaces(data[1]));
+                    result = kdl::vec_concat(std::move(result), collectDragFaces(data[1]));
                 }
             } else {
                 const Resize3DHitData& data = hit.target<const Resize3DHitData&>();
                 result.push_back(data);
-                kdl::vec_append(result, collectDragFaces(data));
+                result = kdl::vec_concat(std::move(result), collectDragFaces(data));
             }
 
             return kdl::vec_transform(result, [](const auto& handle) {

--- a/common/src/View/RotateObjectsTool.cpp
+++ b/common/src/View/RotateObjectsTool.cpp
@@ -146,7 +146,7 @@ namespace TrenchBroom {
         }
 
         void RotateObjectsTool::updateRecentlyUsedCenters(const vm::vec3& center) {
-            kdl::vec_erase(m_recentlyUsedCenters, center);
+            m_recentlyUsedCenters = kdl::vec_erase(std::move(m_recentlyUsedCenters), center);
             m_recentlyUsedCenters.push_back(center);
             m_toolPage->setRecentlyUsedCenters(m_recentlyUsedCenters);
         }

--- a/common/src/View/Selection.cpp
+++ b/common/src/View/Selection.cpp
@@ -42,19 +42,19 @@ namespace TrenchBroom {
         }
 
         void Selection::addSelectedNodes(const std::vector<Model::Node*>& nodes) {
-            kdl::vec_append(m_selectedNodes, nodes);
+            m_selectedNodes = kdl::vec_concat(std::move(m_selectedNodes), nodes);
         }
 
         void Selection::addDeselectedNodes(const std::vector<Model::Node*>& nodes) {
-            kdl::vec_append(m_deselectedNodes, nodes);
+            m_deselectedNodes = kdl::vec_concat(std::move(m_deselectedNodes), nodes);
         }
 
         void Selection::addSelectedBrushFaces(const std::vector<Model::BrushFaceHandle>& faces) {
-            kdl::vec_append(m_selectedBrushFaces, faces);
+            m_selectedBrushFaces = kdl::vec_concat(std::move(m_selectedBrushFaces), faces);
         }
 
         void Selection::addDeselectedBrushFaces(const std::vector<Model::BrushFaceHandle>& faces) {
-            kdl::vec_append(m_deselectedBrushFaces, faces);
+            m_deselectedBrushFaces = kdl::vec_concat(std::move(m_deselectedBrushFaces), faces);
         }
     }
 }

--- a/common/src/View/SmartAttributeEditorMatcher.cpp
+++ b/common/src/View/SmartAttributeEditorMatcher.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom {
 
         SmartAttributeEditorKeyMatcher::SmartAttributeEditorKeyMatcher(const std::initializer_list<std::string> patterns) :
         m_patterns(patterns) {
-            kdl::vec_sort_and_remove_duplicates(m_patterns);
+            m_patterns = kdl::vec_sort_and_remove_duplicates(std::move(m_patterns));
         }
 
         bool SmartAttributeEditorKeyMatcher::doMatches(const std::string& name, const std::vector<Model::AttributableNode*>& attributables) const {

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -272,10 +272,10 @@ namespace TrenchBroom {
         void TextureBrowserView::sortTextures(std::vector<const Assets::Texture*>& textures) const {
             switch (m_sortOrder) {
                 case TextureSortOrder::Name:
-                    kdl::vec_sort(textures, CompareByName());
+                    textures = kdl::vec_sort(std::move(textures), CompareByName());
                     break;
                 case TextureSortOrder::Usage:
-                    kdl::vec_sort(textures, CompareByUsageCount());
+                    textures = kdl::vec_sort(std::move(textures), CompareByUsageCount());
                     break;
             }
         }

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -264,9 +264,9 @@ namespace TrenchBroom {
 
         void TextureBrowserView::filterTextures(std::vector<const Assets::Texture*>& textures) const {
             if (m_hideUnused)
-                kdl::vec_erase_if(textures, MatchUsageCount());
+                textures = kdl::vec_erase_if(std::move(textures), MatchUsageCount());
             if (!m_filterText.empty())
-                kdl::vec_erase_if(textures, MatchName(m_filterText));
+                textures = kdl::vec_erase_if(std::move(textures), MatchName(m_filterText));
         }
 
         void TextureBrowserView::sortTextures(std::vector<const Assets::Texture*>& textures) const {

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -505,8 +505,11 @@ namespace TrenchBroom {
                                     kdl::skip_iterator(std::begin(groupNameQuads), std::end(groupNameQuads), 1, 2),
                                     kdl::skip_iterator(std::begin(subTextColor), std::end(subTextColor), 0, 0));
 
-                                kdl::vec_append(stringVertices[cellData(cell).mainTitleFont], textureNameVertices);
-                                kdl::vec_append(stringVertices[cellData(cell).subTitleFont], groupNameVertices);
+                                auto& mainTitleVertices = stringVertices[cellData(cell).mainTitleFont];
+                                mainTitleVertices = kdl::vec_concat(std::move(mainTitleVertices), textureNameVertices);
+
+                                auto& subTitleVertices = stringVertices[cellData(cell).subTitleFont];
+                                subTitleVertices = kdl::vec_concat(std::move(subTitleVertices), groupNameVertices);
                             }
                         }
                     }

--- a/common/src/View/VertexCommand.cpp
+++ b/common/src/View/VertexCommand.cpp
@@ -63,8 +63,8 @@ namespace TrenchBroom {
                 std::vector<vm::vec3> vertices;
                 vertices.reserve(2 * edgeList.size());
                 vm::segment3::get_vertices(std::begin(edgeList), std::end(edgeList), std::back_inserter(vertices));
-                kdl::vec_sort_and_remove_duplicates(vertices);
-                result.insert(std::make_pair(brush, vertices));
+                vertices = kdl::vec_sort_and_remove_duplicates(std::move(vertices));
+                result.insert(std::make_pair(brush, std::move(vertices)));
             }
             return result;
         }
@@ -77,8 +77,8 @@ namespace TrenchBroom {
 
                 std::vector<vm::vec3> vertices;
                 vm::polygon3::get_vertices(std::begin(faceList), std::end(faceList), std::back_inserter(vertices));
-                kdl::vec_sort_and_remove_duplicates(vertices);
-                result.insert(std::make_pair(brush, vertices));
+                vertices = kdl::vec_sort_and_remove_duplicates(std::move(vertices));
+                result.insert(std::make_pair(brush, std::move(vertices)));
             }
             return result;
         }

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -1518,10 +1518,10 @@ namespace TrenchBroom {
             const Brush newBrush = brush.moveVertices(worldBounds, vertexPositions, delta).value();
 
             auto movedVertexPositions = newBrush.findClosestVertexPositions(vertexPositions + delta);
-            kdl::vec_sort_and_remove_duplicates(movedVertexPositions);
+            movedVertexPositions = kdl::vec_sort_and_remove_duplicates(std::move(movedVertexPositions));
 
             auto expectedVertexPositions = vertexPositions + delta;
-            kdl::vec_sort_and_remove_duplicates(expectedVertexPositions);
+            expectedVertexPositions = kdl::vec_sort_and_remove_duplicates(std::move(expectedVertexPositions));
 
             ASSERT_EQ(expectedVertexPositions, movedVertexPositions);
         }

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -1125,11 +1125,11 @@ namespace TrenchBroom {
 
             auto issues = std::vector<Model::Issue*>{};
             document->world()->accept(kdl::overload(
-                [&](auto&& thisLambda, Model::WorldNode* w)  { kdl::vec_append(issues, w->issues(issueGenerators)); w->visitChildren(thisLambda); },
-                [&](auto&& thisLambda, Model::LayerNode* l)  { kdl::vec_append(issues, l->issues(issueGenerators)); l->visitChildren(thisLambda); },
-                [&](auto&& thisLambda, Model::GroupNode* g)  { kdl::vec_append(issues, g->issues(issueGenerators)); g->visitChildren(thisLambda); },
-                [&](auto&& thisLambda, Model::EntityNode* e) { kdl::vec_append(issues, e->issues(issueGenerators)); e->visitChildren(thisLambda); },
-                [&](Model::BrushNode* b)                     { kdl::vec_append(issues, b->issues(issueGenerators)); }
+                [&](auto&& thisLambda, Model::WorldNode* w)  { issues = kdl::vec_concat(std::move(issues), w->issues(issueGenerators)); w->visitChildren(thisLambda); },
+                [&](auto&& thisLambda, Model::LayerNode* l)  { issues = kdl::vec_concat(std::move(issues), l->issues(issueGenerators)); l->visitChildren(thisLambda); },
+                [&](auto&& thisLambda, Model::GroupNode* g)  { issues = kdl::vec_concat(std::move(issues), g->issues(issueGenerators)); g->visitChildren(thisLambda); },
+                [&](auto&& thisLambda, Model::EntityNode* e) { issues = kdl::vec_concat(std::move(issues), e->issues(issueGenerators)); e->visitChildren(thisLambda); },
+                [&](Model::BrushNode* b)                     { issues = kdl::vec_concat(std::move(issues), b->issues(issueGenerators)); }
             ));
 
             REQUIRE(2 == issues.size());

--- a/lib/kdl/include/kdl/collection_utils.h
+++ b/lib/kdl/include/kdl/collection_utils.h
@@ -248,7 +248,7 @@ namespace kdl {
      * @param cmp the comparator to use for comparisons
      */
     template<typename C, typename Compare = std::less<typename C::value_type>>
-    void sort(C& c, const Compare& cmp = Compare()) {
+    void col_sort(C& c, const Compare& cmp = Compare()) {
         std::sort(std::begin(c), std::end(c), cmp);
     }
 }

--- a/lib/kdl/include/kdl/collection_utils.h
+++ b/lib/kdl/include/kdl/collection_utils.h
@@ -248,8 +248,9 @@ namespace kdl {
      * @param cmp the comparator to use for comparisons
      */
     template<typename C, typename Compare = std::less<typename C::value_type>>
-    void col_sort(C& c, const Compare& cmp = Compare()) {
+    C col_sort(C c, const Compare& cmp = Compare()) {
         std::sort(std::begin(c), std::end(c), cmp);
+        return c;
     }
 }
 

--- a/lib/kdl/include/kdl/enum_array.h
+++ b/lib/kdl/include/kdl/enum_array.h
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <utility>
 
 namespace kdl {
     /**

--- a/lib/kdl/include/kdl/invoke.h
+++ b/lib/kdl/include/kdl/invoke.h
@@ -18,6 +18,8 @@
 #ifndef KDL_INVOKE_H
 #define KDL_INVOKE_H
 
+#include <utility>
+
 namespace kdl {
     /**
      * Invokes a lambda when going out of scope.

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -495,7 +495,7 @@ namespace kdl {
 
     /**
      * Returns a vector containing every element of the given vector that passes the given filter.
-     * The elements are copied into the returned vector in the same order as they are in the given vector.
+     * The elements are moved into the returned vector in the same order as they are in the given vector.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type
@@ -508,69 +508,11 @@ namespace kdl {
         typename std::enable_if_t<
             std::is_invocable_v<F, const T&>
         >* = nullptr>
-    std::vector<T, A> vec_filter(const std::vector<T, A>& v, F&& filter) {
+    std::vector<T, A> vec_filter(std::vector<T, A> v, F&& filter) {
         std::vector<T, A> result;
         result.reserve(v.size());
 
-        for (const auto& x : v) {
-            if (filter(x)) {
-                result.push_back(x);
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * Returns a vector containing every element of the given vector that passes the given filter.
-     * The elements are copied into the returned vector in the same order as they are in the given vector.
-     *
-     * This version passes the vector element indices to the filter function.
-     *
-     * @tparam T the type of the vector elements
-     * @tparam A the vector's allocator type
-     * @tparam F the type of the filter to apply, must be of type `bool(const T&, std::size_t)`
-     * @param v the vector
-     * @param filter the filter to apply
-     * @return a vector containing the elements that passed the filter
-     */
-    template<typename T, typename A, typename F,
-        typename std::enable_if_t<
-            std::is_invocable_v<F, const T&, std::size_t>
-        >* = nullptr>
-    std::vector<T, A> vec_filter(const std::vector<T, A>& v, F&& filter) {
-        std::vector<T, A> result;
-        result.reserve(v.size());
-
-        for (std::size_t i = 0u; i < v.size(); ++i) {
-            if (filter(v[i], i)) {
-                result.push_back(v[i]);
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * Returns a vector containing every element of the given vector that passes the given filter.
-     * The elements are moved into the returned vector in the same order as they are in the given vector.
-     *
-     * @tparam T the type of the vector elements
-     * @tparam A the vector's allocator type
-     * @tparam F the type of the filter to apply, must be of type `bool(const T&)`
-     * @param v the vector
-     * @param filter the filter to apply
-     * @return a vector containing the elements that passed the filter
-     */
-    template<typename T, typename A, typename F,
-        typename std::enable_if_t<
-            std::is_invocable_r_v<bool, F, const T&>
-        >* = nullptr>
-    std::vector<T, A> vec_filter(std::vector<T, A>&& v, F&& filter) {
-        std::vector<T, A> result;
-        result.reserve(v.size());
-
-        for (auto&& x : v) {
+        for (auto& x : v) {
             if (filter(x)) {
                 result.push_back(std::move(x));
             }
@@ -594,9 +536,9 @@ namespace kdl {
      */
     template<typename T, typename A, typename F,
         typename std::enable_if_t<
-            std::is_invocable_r_v<bool, F, const T&, std::size_t>
+            std::is_invocable_v<F, const T&, std::size_t>
         >* = nullptr>
-    std::vector<T, A> vec_filter(std::vector<T, A>&& v, F&& filter) {
+    std::vector<T, A> vec_filter(std::vector<T, A> v, F&& filter) {
         std::vector<T, A> result;
         result.reserve(v.size());
 

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -114,7 +114,7 @@ namespace kdl {
      * @return a vector containing the elements of a, but with O as the element type
      */
     template<typename O, typename T, typename A>
-    std::vector<O> vec_element_cast(const std::vector<T, A>& v) {
+    std::vector<O> vec_element_cast(std::vector<T, A> v) {
         if constexpr (std::is_same_v<T, O>) {
             return v;
         } else {
@@ -122,33 +122,6 @@ namespace kdl {
             result.reserve(v.size());
             for (const auto& e : v) {
                 result.push_back(O(e));
-            }
-            return result;
-        }
-    }
-
-    /**
-     * Returns a vector containing elements of type O, each of which is constructed by passing the corresponding
-     * element of v to the constructor of o, e.g. result.push_back(O(e)), where result is the resulting vector, and e
-     * is an element from v. The elements from the given vector will be moved into the result vector.
-     *
-     * Precondition: O must be constructible with an argument of type T
-     *
-     * @tparam O the type of the result vector elements
-     * @tparam T the type of the vector elements
-     * @tparam A the vector's allocator type
-     * @param v the vector to cast
-     * @return a vector containing the elements of a, but with O as the element type
-     */
-    template<typename O, typename T, typename A>
-    std::vector<O> vec_element_cast(std::vector<T, A>&& v) {
-        if constexpr (std::is_same_v<T, O>) {
-            return v;
-        } else {
-            std::vector<O> result;
-            result.reserve(v.size());
-            for (auto&& e : v) {
-                result.push_back(O(std::move(e)));
             }
             return result;
         }

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -384,36 +384,43 @@ namespace kdl {
 
     /**
      * Erases every element from the given vector which is equal to the given value using the erase-remove idiom.
+     * Returns a vector with the remaining elements.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type
      * @tparam X the value type
      * @param v the vector
      * @param x the value to erase
+     * @return a vector with the remaining elements
      */
     template<typename T, typename A, typename X>
-    void vec_erase(std::vector<T, A>& v, const X& x) {
+    std::vector<T, A> vec_erase(std::vector<T, A> v, const X& x) {
         v.erase(std::remove(std::begin(v), std::end(v), x), std::end(v));
+        return v;
     }
 
     /**
      * Erases every element from the given vector for which the given predicate evaluates to true using the erase-remove
      * idiom.
+     * Returns a vector with the remaining elements.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type
      * @tparam P the predicate type
      * @param v the vector
      * @param predicate the predicate
+     * @return a vector with the remaining elements
      */
     template<typename T, typename A, typename P>
-    void vec_erase_if(std::vector<T, A>& v, const P& predicate) {
+    std::vector<T, A> vec_erase_if(std::vector<T, A> v, const P& predicate) {
         v.erase(std::remove_if(std::begin(v), std::end(v), predicate), std::end(v));
+        return v;
     }
 
     /**
      * Erases the element at the given index from the given vector. The element is swapped with the last element of the
      * vector, and then the last element is erased.
+     * Returns a vector with the remaining elements.
      *
      * Precondition: i < v.size()
      *
@@ -421,28 +428,33 @@ namespace kdl {
      * @tparam A the vector's allocator type
      * @param v the vector
      * @param i the index of the element to erase, which must be less than the given vector's size
+     * @return a vector with the remaining elements
      */
     template<typename T, typename A>
-    void vec_erase_at(std::vector<T, A>& v, const typename std::vector<T, A>::size_type i) {
+    std::vector<T, A> vec_erase_at(std::vector<T, A> v, const typename std::vector<T, A>::size_type i) {
         assert(i < v.size());
         auto it = std::next(std::begin(v), static_cast<typename std::vector<T, A>::difference_type>(i));
         v.erase(it);
+        return v;
     }
 
     /**
      * Erases every value from the given vector which is equal to any value in the given collection.
+     * Returns a vector with the remaining elements.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type
      * @tparam C the collection type
      * @param v the vector to erase elements from
      * @param c the collection of values to erase
+     * @return a vector with the remaining elements
      */
     template<typename T, typename A, typename C>
-    void vec_erase_all(std::vector<T, A>& v, const C& c) {
+    std::vector<T, A> vec_erase_all(std::vector<T, A> v, const C& c) {
         for (const auto& x : c) {
-            vec_erase(v, x);
+            v = vec_erase(std::move(v), x);
         }
+        return v;
     }
 
     /**

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -459,39 +459,25 @@ namespace kdl {
 
     /**
      * Sorts the elements of the given vector according to the given comparator.
+     * Returns a vector with the sorted elements.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type
      * @tparam Compare the type of the comparator to use
      * @param v the vector to sort
      * @param cmp the comparator to use for comparisons
+     * @return a vector with the sorted elements
      */
     template<typename T, typename A, typename Compare = std::less<T>>
-    std::vector<T, A>& vec_sort(std::vector<T, A>& v, const Compare& cmp = Compare()) {
+    std::vector<T, A> vec_sort(std::vector<T, A> v, const Compare& cmp = Compare()) {
         std::sort(std::begin(v), std::end(v), cmp);
         return v;
     }
 
     /**
-     * Sorts the elements of the given vector according to the given comparator.
-     * 
-     * Returns the given vector.
-     *
-     * @tparam T the type of the vector elements
-     * @tparam A the vector's allocator type
-     * @tparam Compare the type of the comparator to use
-     * @param v the vector to sort
-     * @param cmp the comparator to use for comparisons
-     */
-    template<typename T, typename A, typename Compare = std::less<T>>
-    std::vector<T, A> vec_sort(std::vector<T, A>&& v, const Compare& cmp = Compare()) {
-        std::sort(std::begin(v), std::end(v), cmp);
-        return std::move(v);
-    }
-
-    /**
      * Sorts the elements of the given vector and removes all duplicate values. A value is a duplicate if it is
      * equivalent to its predecessor in the vector.
+     * Returns a vector with the remaining elements.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -234,62 +234,20 @@ namespace kdl {
     }
 
     /**
-     * Appends the elements from the vectors in argument pack args to the end of v. Each element of function argument
-     * pack args must be a vector with value_type T and allocator A. If a vector is passed by rvalue reference, its
-     * elements will be moved into v, otherwise they will be copied.
-     *
-     * For each of the elements of args, the elements are copied into v in the order in which the appear.
+     * Concatenates the given vectors. Each element of function argument pack args must be a vector with value_type T and allocator A. 
+     * If a vector is passed by rvalue reference, its elements will be moved into the result, otherwise they will be copied.
      *
      * @tparam T the element type
      * @tparam A the allocator type
      * @tparam Args parameter pack containing the vectors to append to v
-     * @param v the vector to append to
-     * @param args the vectors to append to v
+     * @param v the first vector to concatenate
+     * @param args the remaining vectors to concatenate
      */
     template<typename T, typename A, typename... Args>
-    void vec_append(std::vector<T, A>& v, Args&&... args) {
+    std::vector<T,A> vec_concat(std::vector<T, A> v, Args... args) {
         v.reserve(kdl::col_total_size(v, args...));
-        detail::vec_append(v, std::forward<Args>(args)...);
-    }
-
-    /**
-     * Returns a vector that contains all elements from the given vectors first and the elements of rest in the order in
-     * which they appear. If a vector is passed by rvalue reference, its elements will be moved into the resulting
-     * vector, otherwise they will be copied.
-     *
-     * @tparam First the type of the first vector to concatenate, this will be the type of the returned vector
-     * @tparam Rest the types of the further vectors to concatenate
-     * @param first the first vector to concatenate
-     * @param rest further vectors to concatenate
-     * @return a vector containing the elements from the given vectors
-     */
-    template<typename First, typename... Rest>
-    auto vec_concat(const First& first, Rest&& ... rest) {
-        using T = typename First::value_type;
-        using A = typename First::allocator_type;
-        std::vector<T, A> result;
-        vec_append(result, first, std::forward<Rest>(rest)...);
-        return result;
-    }
-
-    /**
-     * Returns a vector that contains all elements from the given vectors first and the elements of rest in the order in
-     * which they appear. If a vector is passed by rvalue reference, its elements will be moved into the resulting
-     * vector, otherwise they will be copied.
-     *
-     * @tparam First the type of the first vector to concatenate, this will be the type of the returned vector
-     * @tparam Rest the types of the further vectors to concatenate
-     * @param first the first vector to concatenate
-     * @param rest further vectors to concatenate
-     * @return a vector containing the elements from the given vectors
-     */
-    template<typename First, typename... Rest>
-    auto vec_concat(First&& first, Rest&& ... rest) {
-        using T = typename First::value_type;
-        using A = typename First::allocator_type;
-        std::vector<T, A> result;
-        vec_append(result, std::move(first), std::forward<Rest>(rest)...);
-        return result;
+        detail::vec_append(v, std::move(args)...);
+        return v;
     }
 
     /**

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -477,36 +477,20 @@ namespace kdl {
     /**
      * Sorts the elements of the given vector and removes all duplicate values. A value is a duplicate if it is
      * equivalent to its predecessor in the vector.
-     * Returns a vector with the remaining elements.
+     * Returns a vector with the remaining sorted elements.
      *
      * @tparam T the type of the vector elements
      * @tparam A the vector's allocator type
      * @tparam Compare the type of the comparator to use
      * @param v the vector to sort and remove duplicates from
      * @param cmp the comparator to use for sorting and for determining equivalence
+     * @return a vector with the remaining sorted elements
      */
     template<typename T, typename A, typename Compare = std::less<T>>
-    std::vector<T, A>& vec_sort_and_remove_duplicates(std::vector<T, A>& v, const Compare& cmp = Compare()) {
+    std::vector<T, A> vec_sort_and_remove_duplicates(std::vector<T, A> v, const Compare& cmp = Compare()) {
         std::sort(std::begin(v), std::end(v), cmp);
         v.erase(std::unique(std::begin(v), std::end(v), kdl::equivalence<T, Compare>(cmp)), std::end(v));
         return v;
-    }
-
-    /**
-     * Sorts the elements of the given vector and removes all duplicate values. A value is a duplicate if it is
-     * equivalent to its predecessor in the vector. Returns the given vector.
-     *
-     * @tparam T the type of the vector elements
-     * @tparam A the vector's allocator type
-     * @tparam Compare the type of the comparator to use
-     * @param v the vector to sort and remove duplicates from
-     * @param cmp the comparator to use for sorting and for determining equivalence
-     */
-    template<typename T, typename A, typename Compare = std::less<T>>
-    std::vector<T, A> vec_sort_and_remove_duplicates(std::vector<T, A>&& v, const Compare& cmp = Compare()) {
-        std::sort(std::begin(v), std::end(v), cmp);
-        v.erase(std::unique(std::begin(v), std::end(v), kdl::equivalence<T, Compare>(cmp)), std::end(v));
-        return std::move(v);
     }
 
     /**

--- a/lib/kdl/test/src/compact_trie_test.cpp
+++ b/lib/kdl/test/src/compact_trie_test.cpp
@@ -192,10 +192,10 @@ namespace kdl {
 
         std::vector<std::string> actual;
         index.get_keys(std::back_inserter(actual));
-        kdl::sort(actual);
+        kdl::col_sort(actual);
 
         std::vector<std::string> expected({ "key", "key2", "key22", "key22bs", "k1" });
-        kdl::sort(expected);
+        kdl::col_sort(expected);
 
         ASSERT_EQ(expected, actual);
     }

--- a/lib/kdl/test/src/compact_trie_test.cpp
+++ b/lib/kdl/test/src/compact_trie_test.cpp
@@ -192,11 +192,9 @@ namespace kdl {
 
         std::vector<std::string> actual;
         index.get_keys(std::back_inserter(actual));
-        kdl::col_sort(actual);
+        actual = kdl::col_sort(std::move(actual));
 
-        std::vector<std::string> expected({ "key", "key2", "key22", "key22bs", "k1" });
-        kdl::col_sort(expected);
-
+        const auto expected = kdl::col_sort(std::vector<std::string>{ "key", "key2", "key22", "key22bs", "k1" });
         ASSERT_EQ(expected, actual);
     }
 }

--- a/lib/kdl/test/src/compact_trie_test.cpp
+++ b/lib/kdl/test/src/compact_trie_test.cpp
@@ -31,8 +31,8 @@ namespace kdl {
     std::vector<std::string> exp(exp_);\
     std::vector<std::string> act;\
     index.find_matches(pattern, std::back_inserter(act));\
-    vec_sort(exp);\
-    vec_sort(act);\
+    exp = vec_sort(std::move(exp));\
+    act = vec_sort(std::move(act));\
     ASSERT_EQ(exp, act);\
 }
 

--- a/lib/kdl/test/src/string_compare_test.cpp
+++ b/lib/kdl/test/src/string_compare_test.cpp
@@ -165,7 +165,7 @@ namespace kdl {
 
         template <typename C>
         C sorted(C c) {
-            kdl::sort(c, string_less());
+            kdl::col_sort(c, string_less());
             return c;
         }
 
@@ -308,7 +308,7 @@ namespace kdl {
 
         template <typename C>
         C sorted(C c) {
-            kdl::sort(c, string_less());
+            kdl::col_sort(c, string_less());
             return c;
         }
 

--- a/lib/kdl/test/src/string_compare_test.cpp
+++ b/lib/kdl/test/src/string_compare_test.cpp
@@ -165,8 +165,7 @@ namespace kdl {
 
         template <typename C>
         C sorted(C c) {
-            kdl::col_sort(c, string_less());
-            return c;
+            return kdl::col_sort(std::move(c), string_less());
         }
 
         TEST_CASE("string_utils_cs_test.sort", "[string_utils_cs_test]") {
@@ -308,8 +307,7 @@ namespace kdl {
 
         template <typename C>
         C sorted(C c) {
-            kdl::col_sort(c, string_less());
-            return c;
+            return kdl::col_sort(std::move(c), string_less());
         }
 
         TEST_CASE("string_utils_ci_test.sort", "[string_utils_ci_test]") {

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -122,35 +122,12 @@ namespace kdl {
         ASSERT_EQ(false, vec_contains(vec({ 1, 2, 3 }), [](const auto& i) { return i == 4; }));
     }
 
-    template <typename T, typename... Args>
-    void test_append(const std::vector<T>& exp, std::vector<T> into, Args&&... args) {
-        vec_append(into, std::forward<Args>(args)...);
-        ASSERT_EQ(exp, into);
-    }
-
-    TEST_CASE("vector_utils_test.vec_append", "[vector_utils_test]") {
-        using vec = std::vector<int>;
-
-        test_append<int>({}, {});
-        test_append<int>({}, {}, vec{});
-        test_append<int>({ 1 }, { 1 });
-        test_append<int>({ 1, 2, 3 }, { 1 }, vec{ 2 }, vec{ 3 });
-    }
-
     template <typename T, typename... R>
     static auto makeVec(T&& t, R... r) {
         std::vector<T> result;
         result.push_back(std::move(t));
         (..., result.push_back(std::forward<R>(r)));
         return result;
-    }
-
-    TEST_CASE("vector_utils_test.vec_append_move", "[vector_utils_test]") {
-        auto v = makeVec(std::make_unique<int>(1));
-        vec_append(v, makeVec(std::make_unique<int>(2)));
-        
-        ASSERT_EQ(1, *v[0]);
-        ASSERT_EQ(2, *v[1]);
     }
 
     TEST_CASE("vector_utils_test.vec_concat", "[vector_utils_test]") {
@@ -160,6 +137,14 @@ namespace kdl {
         ASSERT_EQ(vec({}), vec_concat(vec({}), vec({})));
         ASSERT_EQ(vec({ 1 }), vec_concat(vec({ 1 })));
         ASSERT_EQ(vec({ 1, 2 }), vec_concat(vec({ 1 }), vec({ 2 })));
+    }
+
+    TEST_CASE("vector_utils_test.vec_concat_move", "[vector_utils_test]") {
+        auto v = makeVec(std::make_unique<int>(1));
+        v = vec_concat(std::move(v), makeVec(std::make_unique<int>(2)));
+        
+        ASSERT_EQ(1, *v[0]);
+        ASSERT_EQ(2, *v[1]);
     }
 
     TEST_CASE("vector_utils_test.vec_slice", "[vector_utils_test]") {

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -281,12 +281,15 @@ namespace kdl {
     };
 
     TEST_CASE("vector_utils_test.vec_filter_rvalue", "[vector_utils_test]") {
-        auto vec = std::vector<MoveOnly>{};
-        vec.emplace_back();
-        vec.emplace_back();
-        ASSERT_EQ(2u, vec_filter(std::move(vec), [](const auto&) { return true; }).size());
+        const auto makeVec = []() {
+            auto vec = std::vector<MoveOnly>{};
+            vec.emplace_back();
+            vec.emplace_back();
+            return vec;
+        };
 
-        ASSERT_EQ(1u, vec_filter(std::move(vec), [](const auto&, auto i) { return i % 2u == 1u; }).size());
+        ASSERT_EQ(2u, vec_filter(makeVec(), [](const auto&) { return true; }).size());
+        ASSERT_EQ(1u, vec_filter(makeVec(), [](const auto&, auto i) { return i % 2u == 1u; }).size());
     }
 
     TEST_CASE("vector_utils_test.vec_transform", "[vector_utils_test]") {

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -253,9 +253,7 @@ namespace kdl {
 
     TEST_CASE("vector_utils_test.vec_sort", "[vector_utils_test]") {
         // just a smoke test since we're just forwarding to std::sort
-        auto v = std::vector<int>({ 2, 3, 2, 1 });
-        vec_sort(v);
-        ASSERT_EQ(std::vector<int>({ 1, 2, 2, 3 }), v);
+        ASSERT_EQ(std::vector<int>({ 1, 2, 2, 3 }), vec_sort(std::vector<int>({ 2, 3, 2, 1 })));
     }
 
     TEST_CASE("vector_utils_test.vec_sort_and_remove_duplicates", "[vector_utils_test]") {

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -189,8 +189,10 @@ namespace kdl {
 
     template <typename T>
     void test_erase(const std::vector<T>& exp, std::vector<T> from, const T& x) {
-        vec_erase(from, x);
-        ASSERT_EQ(exp, from);
+        const auto originalFrom = from;
+        ASSERT_EQ(exp, vec_erase(from, x));
+        ASSERT_EQ(originalFrom, from);
+        ASSERT_EQ(exp, vec_erase(std::move(from), x));
     }
 
     TEST_CASE("vector_utils_test.vec_erase", "[vector_utils_test]") {
@@ -203,8 +205,10 @@ namespace kdl {
 
     template <typename T, typename P>
     void test_erase_if(const std::vector<T>& exp, std::vector<T> from, const P& pred) {
-        vec_erase_if(from, pred);
-        ASSERT_EQ(exp, from);
+        const auto originalFrom = from;
+        ASSERT_EQ(exp, vec_erase_if(from, pred));
+        ASSERT_EQ(originalFrom, from);
+        ASSERT_EQ(exp, vec_erase_if(std::move(from), pred));
     }
 
     TEST_CASE("vector_utils_test.vec_erase_if", "[vector_utils_test]") {
@@ -218,8 +222,10 @@ namespace kdl {
 
     template <typename T>
     void test_erase_at(const std::vector<T>& exp, std::vector<T> from, const std::size_t i) {
-        vec_erase_at(from, i);
-        ASSERT_EQ(exp, from);
+        const auto originalFrom = from;
+        ASSERT_EQ(exp, vec_erase_at(from, i));
+        ASSERT_EQ(originalFrom, from);
+        ASSERT_EQ(exp, vec_erase_at(std::move(from), i));
     }
 
     TEST_CASE("vector_utils_test.vec_erase_at", "[vector_utils_test]") {
@@ -230,8 +236,10 @@ namespace kdl {
 
     template <typename T>
     void test_erase_all(const std::vector<T>& exp, std::vector<T> from, const std::vector<T>& which) {
-        vec_erase_all(from, which);
-        ASSERT_EQ(exp, from);
+        const auto originalFrom = from;
+        ASSERT_EQ(exp, vec_erase_all(from, which));
+        ASSERT_EQ(originalFrom, from);
+        ASSERT_EQ(exp, vec_erase_all(std::move(from), which));
     }
 
     TEST_CASE("vector_utils_test.vec_erase_all", "[vector_utils_test]") {

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -258,9 +258,7 @@ namespace kdl {
 
     TEST_CASE("vector_utils_test.vec_sort_and_remove_duplicates", "[vector_utils_test]") {
         // just a smoke test since we're just forwarding to std::sort and std::unique
-        auto v = std::vector<int>({ 2, 3, 2, 1 });
-        vec_sort_and_remove_duplicates(v);
-        ASSERT_EQ(std::vector<int>({ 1, 2, 3 }), v);
+        ASSERT_EQ(std::vector<int>({ 1, 2, 3 }), vec_sort_and_remove_duplicates(std::vector<int>({ 2, 3, 2, 1 })));
     }
 
     TEST_CASE("vector_utils_test.vec_filter", "[vector_utils_test]") {


### PR DESCRIPTION
Closes #3564 

I have taken a look at the functions in KDL and have changed some of them to take their argument by value instead of providing const lvalue / rvalue overloads. I have also gone over the call sites in order to call `std::move` where possible to avoid copies. Most of the functions now adopt a functional style where the return a modified copy of the argument instead of modifying that in place. Exceptions to this are `kdl::vec_clear_to_zero`, `kdl::vec_clear_and_delete` and `kdl::map_clear_and_delete`. These functions make more sense to me if they modify their argument in place.

Another exception is `kdl::transform` which needs a version that takes the vector by const lvalue ref so that it can still be called with a const vector of non-copyable elements. There is a case in the source code where we transform such a vector to a vector of the addresses of the contained elements, and this would become impossible if we take the argument by value, since the argument cannot be copied (because the elements are move only) and it cannot be moved (because the vector is const).