### PR TITLE
3554: clear texture filter when revealTexture() is used

### DIFF
--- a/common/src/View/TextureBrowser.cpp
+++ b/common/src/View/TextureBrowser.cpp
@@ -70,6 +70,7 @@ namespace TrenchBroom {
         }
 
         void TextureBrowser::revealTexture(const Assets::Texture* texture) {
+            setFilterText("");
             m_view->revealTexture(texture);
         }
 


### PR DESCRIPTION
Fixes #3554