### PR TITLE
3577: add compilation task context menu with Move Up/Down/Duplicate/Remove

### DIFF
--- a/common/src/Model/CompilationProfile.cpp
+++ b/common/src/Model/CompilationProfile.cpp
@@ -102,7 +102,6 @@ namespace TrenchBroom {
             auto result = kdl::vec_index_of(m_tasks, [=](const auto& ptr){
                 return ptr.get() == task;
             });
-            assert(result.has_value());
             return result.value();
         }
 

--- a/common/src/Model/CompilationProfile.cpp
+++ b/common/src/Model/CompilationProfile.cpp
@@ -98,6 +98,14 @@ namespace TrenchBroom {
             return m_tasks[index].get();
         }
 
+        size_t CompilationProfile::indexOfTask(CompilationTask* task) const {
+            auto result = kdl::vec_index_of(m_tasks, [=](const auto& ptr){
+                return ptr.get() == task;
+            });
+            assert(result.has_value());
+            return result.value();
+        }
+
         void CompilationProfile::addTask(std::unique_ptr<CompilationTask> task) {
             insertTask(m_tasks.size(), std::move(task));
         }

--- a/common/src/Model/CompilationProfile.h
+++ b/common/src/Model/CompilationProfile.h
@@ -56,6 +56,7 @@ namespace TrenchBroom {
 
             size_t taskCount() const;
             CompilationTask* task(size_t index) const;
+            size_t indexOfTask(CompilationTask* task) const;
 
             void addTask(std::unique_ptr<CompilationTask> task);
             void insertTask(size_t index, std::unique_ptr<CompilationTask> task);

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -112,10 +112,25 @@ namespace TrenchBroom {
             connect(m_nameTxt, &QLineEdit::textChanged, this, &CompilationProfileEditor::nameChanged);
             connect(m_workDirTxt, &QLineEdit::textChanged, this, &CompilationProfileEditor::workDirChanged);
             connect(m_taskList, &ControlListBox::itemSelectionChanged, this, &CompilationProfileEditor::taskSelectionChanged);
+            connect(m_taskList, &CompilationTaskListBox::taskContextMenuRequested, this, [&](const QPoint& globalPos, Model::CompilationTask* task) {
+                const int index = static_cast<int>(m_profile->indexOfTask(task));
+
+                QMenu menu(this);
+                QAction* moveUpAction = menu.addAction(tr("Move Up"), this, [=](){ moveTaskUp(index); });
+                QAction* moveDownAction = menu.addAction(tr("Move Down"), this, [=](){ moveTaskDown(index); });
+                menu.addSeparator();
+                menu.addAction(tr("Duplicate"), this, [=](){ duplicateTask(index); });
+                menu.addAction(tr("Remove"), this, [=](){ removeTask(index); });
+
+                moveUpAction->setEnabled(index > 0);
+                moveDownAction->setEnabled(static_cast<size_t>(index + 1) < m_profile->taskCount());
+
+                menu.exec(globalPos);
+            });
             connect(m_addTaskButton, &QAbstractButton::clicked, this, &CompilationProfileEditor::addTask);
-            connect(m_removeTaskButton, &QAbstractButton::clicked, this, &CompilationProfileEditor::removeTask);
-            connect(m_moveTaskUpButton, &QAbstractButton::clicked, this, &CompilationProfileEditor::moveTaskUp);
-            connect(m_moveTaskDownButton, &QAbstractButton::clicked, this, &CompilationProfileEditor::moveTaskDown);
+            connect(m_removeTaskButton, &QAbstractButton::clicked, this, qOverload<>(&CompilationProfileEditor::removeTask));
+            connect(m_moveTaskUpButton, &QAbstractButton::clicked, this, qOverload<>(&CompilationProfileEditor::moveTaskUp));
+            connect(m_moveTaskDownButton, &QAbstractButton::clicked, this, qOverload<>(&CompilationProfileEditor::moveTaskDown));
 
             return containerPanel;
         }
@@ -170,7 +185,10 @@ namespace TrenchBroom {
         }
 
         void CompilationProfileEditor::removeTask() {
-            const int index = m_taskList->currentRow();
+            removeTask(m_taskList->currentRow());
+        }
+
+        void CompilationProfileEditor::removeTask(const int index) {
             assert(index >= 0);
 
             if (m_profile->taskCount() == 1) {
@@ -190,9 +208,19 @@ namespace TrenchBroom {
             emit profileChanged();
         }
 
+        void CompilationProfileEditor::duplicateTask(const int index) {
+            Model::CompilationTask* task = m_profile->task(static_cast<size_t>(index));
+            m_profile->insertTask(static_cast<size_t>(index) + 1, std::unique_ptr<Model::CompilationTask>(task->clone()));
+            m_taskList->reloadTasks();
+            m_taskList->setCurrentRow(index + 1);
+            emit profileChanged();
+        }
 
         void CompilationProfileEditor::moveTaskUp() {
-            const int index = m_taskList->currentRow();
+            moveTaskUp(m_taskList->currentRow());
+        }
+
+        void CompilationProfileEditor::moveTaskUp(const int index) {
             assert(index > 0);
             m_profile->moveTaskUp(static_cast<size_t>(index));
             m_taskList->reloadTasks();
@@ -201,7 +229,10 @@ namespace TrenchBroom {
         }
 
         void CompilationProfileEditor::moveTaskDown() {
-            const int index = m_taskList->currentRow();
+            moveTaskDown(m_taskList->currentRow());
+        }
+
+        void CompilationProfileEditor::moveTaskDown(const int index) {
             assert(index >= 0 && index < static_cast<int>(m_profile->taskCount()) - 1);
             m_profile->moveTaskDown(static_cast<size_t>(index));
             m_taskList->reloadTasks();

--- a/common/src/View/CompilationProfileEditor.h
+++ b/common/src/View/CompilationProfileEditor.h
@@ -31,6 +31,7 @@ class QStackedWidget;
 namespace TrenchBroom {
     namespace Model {
         class CompilationProfile;
+        class CompilationTask;
     }
 
     namespace View {
@@ -65,8 +66,12 @@ namespace TrenchBroom {
 
             void addTask();
             void removeTask();
+            void removeTask(int index);
+            void duplicateTask(int index);
             void moveTaskUp();
+            void moveTaskUp(int index);
             void moveTaskDown();
+            void moveTaskDown(int index);
 
             void taskSelectionChanged();
         public:

--- a/common/src/View/CompilationTaskListBox.cpp
+++ b/common/src/View/CompilationTaskListBox.cpp
@@ -52,6 +52,8 @@ namespace TrenchBroom {
         m_profile(&profile),
         m_task(&task),
         m_panel(nullptr) {
+            setContextMenuPolicy(Qt::CustomContextMenu); // request customContextMenuRequested() to be emitted
+
             m_panel = new TitledPanel(m_title);
 
             auto* layout = new QVBoxLayout();
@@ -313,7 +315,13 @@ namespace TrenchBroom {
             CompilationTaskEditorFactory factory(m_document, *m_profile, parent);
             auto* task = m_profile->task(index);
             task->accept(factory);
-            return factory.result();
+            auto* renderer = factory.result();
+
+            connect(renderer, &QWidget::customContextMenuRequested, this, [=](const QPoint& pos){
+                emit this->taskContextMenuRequested(renderer->mapToGlobal(pos), task);
+            });
+
+            return renderer;
         }
     }
 }

--- a/common/src/View/CompilationTaskListBox.h
+++ b/common/src/View/CompilationTaskListBox.h
@@ -121,6 +121,8 @@ namespace TrenchBroom {
             class CompilationTaskEditorFactory;
             size_t itemCount() const override;
             ControlListBoxItemRenderer* createItemRenderer(QWidget* parent, size_t index) override;
+        signals:
+            void taskContextMenuRequested(const QPoint& globalPos, Model::CompilationTask* task);
         };
     }
 }


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/239161/98910099-f41e3900-247f-11eb-9258-16edb6badab3.PNG)

Fixes #3577