### PR TITLE
3504: Compilation run: log when working dir doesn't exist

### DIFF
--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -33,6 +33,8 @@
 #include <string>
 
 #include <QtGlobal>
+#include <QDir>
+#include <QMetaEnum>
 #include <QProcess>
 
 namespace TrenchBroom {
@@ -192,7 +194,9 @@ namespace TrenchBroom {
         }
 
         void CompilationRunToolTaskRunner::processErrorOccurred(const QProcess::ProcessError processError) {
-            m_context << "#### Error " << processError << " occurred when communicating with process\n\n";
+            m_context << "#### Error '"
+                      << QMetaEnum::fromType<QProcess::ProcessError>().valueToKey(processError)
+                      << "' occurred when communicating with process\n\n";
             emit error();
         }
 
@@ -266,7 +270,13 @@ namespace TrenchBroom {
             bindEvents(m_currentTask->get());
 
             emit compilationStarted();
-            *m_context << "#### Using working directory '" << m_context->variableValue(CompilationVariableNames::WORK_DIR_PATH) << "'\n";
+
+            const std::string workDir = m_context->variableValue(CompilationVariableNames::WORK_DIR_PATH);
+            if (!QDir(QString::fromStdString(workDir)).exists()) {
+                *m_context << "#### Non-existent working directory '" << workDir << "'\n";
+            } else {
+                *m_context << "#### Using working directory '" << workDir << "'\n";
+            }
             m_currentTask->get()->execute();
         }
 

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -273,7 +273,7 @@ namespace TrenchBroom {
 
             const std::string workDir = m_context->variableValue(CompilationVariableNames::WORK_DIR_PATH);
             if (!QDir(QString::fromStdString(workDir)).exists()) {
-                *m_context << "#### Non-existent working directory '" << workDir << "'\n";
+                *m_context << "#### Error: working directory '" << workDir << "' does not exist\n";
             } else {
                 *m_context << "#### Using working directory '" << workDir << "'\n";
             }


### PR DESCRIPTION
Also log QProcess::ProcessError enum as text.

![Capture](https://user-images.githubusercontent.com/239161/99030548-8ed75000-2532-11eb-9d81-be81da95fdb8.PNG)


Fixes #3504