### PR TITLE
3582: Implement our own QAbstractItemView::SelectedClicked edit trigger 

### DIFF
--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -287,7 +287,10 @@ namespace TrenchBroom {
             layout->addLayout(toolBar, 0);
             setLayout(layout);
 
-            m_table->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::SelectedClicked | QAbstractItemView::AnyKeyPressed);
+            // NOTE: Do not use QAbstractItemView::SelectedClicked.
+            // EntityAttributeTable::mousePressEvent() implements its own version.
+            // See: https://github.com/TrenchBroom/TrenchBroom/issues/3582
+            m_table->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::AnyKeyPressed);
         }
 
         void EntityAttributeGrid::bindObservers() {

--- a/common/src/View/EntityAttributeModel.cpp
+++ b/common/src/View/EntityAttributeModel.cpp
@@ -675,26 +675,6 @@ namespace TrenchBroom {
             return QVariant();
         }
 
-        bool EntityAttributeModel::InsertRow(const size_t pos) {
-            ensure(pos <= m_rows.size(), "insertion position out of bounds");
-
-            auto document = kdl::mem_lock(m_document);
-
-            const std::vector<Model::AttributableNode*> attributables = document->allSelectedAttributableNodes();
-            ensure(!attributables.empty(), "no attributable nodes selected");
-
-            const std::string newKey = AttributeRow::newAttributeNameForAttributableNodes(attributables);
-
-            const Transaction transaction(document);
-            document->setAttribute(newKey, "");
-
-            return true;
-        }
-
-        bool EntityAttributeModel::AppendRow() {
-            return InsertRow(m_rows.size());
-        }
-
         int EntityAttributeModel::rowForName(const std::string& name) const {
             for (size_t i = 0; i < m_rows.size(); ++i) {
                 if (m_rows[i].name() == name) {

--- a/common/src/View/EntityAttributeModel.h
+++ b/common/src/View/EntityAttributeModel.h
@@ -147,8 +147,6 @@ namespace TrenchBroom {
             QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
         private: // helpers
-            bool InsertRow(const size_t pos);
-            bool AppendRow();
             int rowForName(const std::string& name) const;
             bool hasRowWithAttributeName(const std::string& name) const;
             bool renameAttribute(const size_t rowIndex, const std::string& newName, const std::vector<Model::AttributableNode*>& attributables);

--- a/common/src/View/EntityAttributeTable.cpp
+++ b/common/src/View/EntityAttributeTable.cpp
@@ -24,10 +24,12 @@
 #include <QKeyEvent>
 #include <QKeySequence>
 
+#define TABLE_LOG(x)
+
 namespace TrenchBroom {
     namespace View {
         void EntityAttributeTable::finishEditing(QWidget* editor) {
-            qDebug() << "finish editing";
+            TABLE_LOG(qDebug() << "finish editing");
             commitData(editor);
             closeEditor(editor, QAbstractItemDelegate::EditNextItem);
         }
@@ -79,7 +81,7 @@ namespace TrenchBroom {
                     return true;
                 }
 
-                qDebug("not overriding shortcut key %d\n", keyEvent->key());
+                TABLE_LOG(qDebug("not overriding shortcut key %d\n", keyEvent->key()));
             }
             return QTableView::event(event);
         }
@@ -101,7 +103,7 @@ namespace TrenchBroom {
                 && state() != QAbstractItemView::EditingState) {
 
                 // open the editor
-                qDebug("opening editor...");
+                TABLE_LOG(qDebug("opening editor..."));
                 edit(currentIndex());
             } else {
                 QTableView::keyPressEvent(event);

--- a/common/src/View/EntityAttributeTable.h
+++ b/common/src/View/EntityAttributeTable.h
@@ -32,7 +32,11 @@ namespace TrenchBroom {
          */
         class EntityAttributeTable : public QTableView {
             Q_OBJECT
+        private:
+            bool m_mousePressedOnSelectedCell;
         public:
+            explicit EntityAttributeTable(QWidget* parent = nullptr);
+
             static QString insertRowShortcutString();
             static QString removeRowShortcutString();
             void finishEditing(QWidget* editor);
@@ -40,7 +44,9 @@ namespace TrenchBroom {
             bool event(QEvent *event) override;
             void keyPressEvent(QKeyEvent* event) override;
             QStyleOptionViewItem viewOptions() const override;
-
+            void keyboardSearch(const QString& search) override;
+            void mousePressEvent(QMouseEvent* event) override;
+            void mouseReleaseEvent(QMouseEvent* event) override;
         signals:
             void addRowShortcutTriggered();
             void removeRowsShortcutTriggered();


### PR DESCRIPTION
Qt's `QAbstractItemView::SelectedClicked` has an undesirable delay during which keyboard input is ignored. This removes the delay, so when you click on a selected cell, the editor opens immediately on mouseReleaseEvent.

Fixes #3582

To give more precise instructions for reproducing this e.g. in 2020.2:

- New quake map, Valve format
- Select the starting brush
- Select the Valve cell for the "light" worldspawn key
- Wait a second or more
- Click on the selected cell again
- wait 200ms or so (but not long enough that the cell editor opens)
- then type "2", the selection cursor will navigate to the "mapversion 220" value cell, causing the 2 you typed to be lost.

With this PR, the cell editor will open immediately at the point when I wrote "wait 200ms" above.