### PR TITLE
Configurable entity / texture browser colors.

### DIFF
--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -143,7 +143,8 @@ namespace TrenchBroom {
 
         Preference<int> BrowserFontSize(IO::Path("Browser/Font size"), 13);
         Preference<Color> BrowserTextColor(IO::Path("Browser/Text color"), Color(1.0f, 1.0f, 1.0f, 1.0f));
-        Preference<Color> BrowserSubTextColor(IO::Path("Browser/Text color"), Color(0.65f, 0.65f, 0.65f, 1.0f));
+        Preference<Color> BrowserSubTextColor(IO::Path("Browser/Group text color"), Color(0.14f, 0.14f, 0.14f, 1.0f));
+        Preference<Color> BrowserBackgroundColor(IO::Path("Browser/Background color"), Color(0.14f, 0.14f, 0.14f, 1.0f));
         Preference<Color> BrowserGroupBackgroundColor(IO::Path("Browser/Group background color"), Color(0.8f, 0.8f, 0.8f, 0.8f));
         Preference<float> TextureBrowserIconSize(IO::Path("Texture Browser/Icon size"), 1.0f);
         Preference<Color> TextureBrowserDefaultColor(IO::Path("Texture Browser/Default color"), Color(0.0f, 0.0f, 0.0f, 0.0f));
@@ -300,6 +301,7 @@ namespace TrenchBroom {
                 &BrowserFontSize,
                 &BrowserTextColor,
                 &BrowserSubTextColor,
+                &BrowserBackgroundColor,
                 &BrowserGroupBackgroundColor,
                 &TextureBrowserIconSize,
                 &TextureBrowserDefaultColor,

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -134,6 +134,7 @@ namespace TrenchBroom {
         extern Preference<int> BrowserFontSize;
         extern Preference<Color> BrowserTextColor;
         extern Preference<Color> BrowserSubTextColor;
+        extern Preference<Color> BrowserBackgroundColor;
         extern Preference<Color> BrowserGroupBackgroundColor;
         extern Preference<float> TextureBrowserIconSize;
         extern Preference<Color> TextureBrowserDefaultColor;

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -241,6 +241,11 @@ namespace TrenchBroom {
             return false;
         }
 
+        const Color& EntityBrowserView::getBackgroundColor() {
+            PreferenceManager& prefs = PreferenceManager::instance();
+            return prefs.get(Preferences::BrowserBackgroundColor);
+        }
+
         template <typename Vertex>
         struct CollectBoundsVertices {
             const vm::mat4x4f& transformation;

--- a/common/src/View/EntityBrowserView.h
+++ b/common/src/View/EntityBrowserView.h
@@ -105,6 +105,7 @@ namespace TrenchBroom {
             void doClear() override;
             void doRender(Layout& layout, float y, float height) override;
             bool doShouldRenderFocusIndicator() const override;
+            const Color& getBackgroundColor() override;
 
             void renderBounds(Layout& layout, float y, float height);
 

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -216,11 +216,15 @@ namespace TrenchBroom {
         }
 
         void RenderView::clearBackground() {
-            PreferenceManager& prefs = PreferenceManager::instance();
-            const Color& backgroundColor = prefs.get(Preferences::BackgroundColor);
+            const auto backgroundColor = getBackgroundColor();
 
             glAssert(glClearColor(backgroundColor.r(), backgroundColor.g(), backgroundColor.b(), backgroundColor.a()));
             glAssert(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT))
+        }
+
+        const Color& RenderView::getBackgroundColor() {
+            PreferenceManager& prefs = PreferenceManager::instance();
+            return prefs.get(Preferences::BackgroundColor);
         }
 
         void RenderView::renderFocusIndicator() {

--- a/common/src/View/RenderView.h
+++ b/common/src/View/RenderView.h
@@ -90,6 +90,7 @@ namespace TrenchBroom {
             // called by initializeGL by default
             virtual bool doInitializeGL();
         private:
+            virtual const Color& getBackgroundColor();
             virtual void doUpdateViewport(int x, int y, int width, int height);
             virtual bool doShouldRenderFocusIndicator() const = 0;
             virtual void doRender() = 0;

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -307,6 +307,11 @@ namespace TrenchBroom {
             return false;
         }
 
+        const Color& TextureBrowserView::getBackgroundColor() {
+            PreferenceManager& prefs = PreferenceManager::instance();
+            return prefs.get(Preferences::BrowserBackgroundColor);
+        }
+
         void TextureBrowserView::renderBounds(Layout& layout, const float y, const float height) {
             using BoundsVertex = Renderer::GLVertexTypes::P2C4::Vertex;
             std::vector<BoundsVertex> vertices;
@@ -451,6 +456,7 @@ namespace TrenchBroom {
 
             const std::vector<Color> textColor{ pref(Preferences::BrowserTextColor) };
             const std::vector<Color> subTextColor{ pref(Preferences::BrowserSubTextColor) };
+            const std::vector<Color> groupTextColor{ Color(textColor[0].r(), textColor[0].g(), textColor[0].b(), 0.75f) };
 
             StringMap stringVertices;
             for (size_t i = 0; i < layout.size(); ++i) {
@@ -467,7 +473,7 @@ namespace TrenchBroom {
                             quads.size() / 2,
                             kdl::skip_iterator(std::begin(quads), std::end(quads), 0, 2),
                             kdl::skip_iterator(std::begin(quads), std::end(quads), 1, 2),
-                            kdl::skip_iterator(std::begin(textColor), std::end(textColor), 0, 0));
+                            kdl::skip_iterator(std::begin(subTextColor), std::end(subTextColor), 0, 0));
                         auto& vertices = stringVertices[defaultDescriptor];
                         vertices.insert(std::end(vertices), std::begin(titleVertices), std::end(titleVertices));
                     }
@@ -503,7 +509,7 @@ namespace TrenchBroom {
                                     groupNameQuads.size() / 2,
                                     kdl::skip_iterator(std::begin(groupNameQuads), std::end(groupNameQuads), 0, 2),
                                     kdl::skip_iterator(std::begin(groupNameQuads), std::end(groupNameQuads), 1, 2),
-                                    kdl::skip_iterator(std::begin(subTextColor), std::end(subTextColor), 0, 0));
+                                    kdl::skip_iterator(std::begin(groupTextColor), std::end(groupTextColor), 0, 0));
 
                                 auto& mainTitleVertices = stringVertices[cellData(cell).mainTitleFont];
                                 mainTitleVertices = kdl::vec_concat(std::move(mainTitleVertices), textureNameVertices);

--- a/common/src/View/TextureBrowserView.h
+++ b/common/src/View/TextureBrowserView.h
@@ -107,6 +107,7 @@ namespace TrenchBroom {
             void doClear() override;
             void doRender(Layout& layout, float y, float height) override;
             bool doShouldRenderFocusIndicator() const override;
+            const Color& getBackgroundColor() override;
 
             void renderBounds(Layout& layout, float y, float height);
             const Color& textureColor(const Assets::Texture& texture) const;

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -187,6 +187,11 @@ namespace TrenchBroom {
             return false;
         }
 
+        const Color& UVView::getBackgroundColor() {
+            PreferenceManager& prefs = PreferenceManager::instance();
+            return prefs.get(Preferences::BrowserBackgroundColor);
+        }
+
         void UVView::setupGL(Renderer::RenderContext& renderContext) {
             const Renderer::Camera::Viewport& viewport = renderContext.camera().viewport();
             const qreal r = devicePixelRatioF();

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -98,6 +98,7 @@ namespace TrenchBroom {
             void doUpdateViewport(int x, int y, int width, int height) override;
             void doRender() override;
             bool doShouldRenderFocusIndicator() const override;
+            const Color& getBackgroundColor() override;
 
             void setupGL(Renderer::RenderContext& renderContext);
 

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -151,6 +151,15 @@ namespace TrenchBroom {
             m_textureBrowserIconSizeCombo->addItem("300%");
             m_textureBrowserIconSizeCombo->setToolTip("Sets the icon size in the texture browser.");
 
+            m_browserBackgroundColorButton = new ColorButton();
+            m_browserBackgroundColorButton->setToolTip("Sets the background color of texture / entity browsers and UV editor.");
+            m_browserGroupBackgroundColorButton = new ColorButton();
+            m_browserGroupBackgroundColorButton->setToolTip("Sets the background color of group titles in texture / entity browsers.");
+            m_browserTextColorButton = new ColorButton();
+            m_browserTextColorButton->setToolTip("Sets the text color of texture / entity browsers.");
+            m_browserSubTextColorButton = new ColorButton();
+            m_browserSubTextColorButton->setToolTip("Sets the text color of group titles in texture / entity browsers.");
+
             m_rendererFontSizeCombo = new QComboBox();
             m_rendererFontSizeCombo->setEditable(true);
             m_rendererFontSizeCombo->setToolTip("Sets the font size for various labels in the editing views.");
@@ -180,6 +189,10 @@ namespace TrenchBroom {
             layout->addRow("Edges", m_edgeColorButton);
 
             layout->addSection("Texture Browser");
+            layout->addRow("Text", m_browserTextColorButton);
+            layout->addRow("Background", m_browserBackgroundColorButton);
+            layout->addRow("Group text", m_browserSubTextColorButton);
+            layout->addRow("Group background", m_browserGroupBackgroundColorButton);
             layout->addRow("Icon size", m_textureBrowserIconSizeCombo);
 
             layout->addSection("Fonts");
@@ -203,6 +216,10 @@ namespace TrenchBroom {
             connect(m_themeCombo, QOverload<int>::of(&QComboBox::activated), this, &ViewPreferencePane::themeChanged);
             connect(m_textureModeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ViewPreferencePane::textureModeChanged);
             connect(m_textureBrowserIconSizeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ViewPreferencePane::textureBrowserIconSizeChanged);
+            connect(m_browserBackgroundColorButton, &ColorButton::colorChanged, this, &ViewPreferencePane::browserBackgroundColorChanged);
+            connect(m_browserGroupBackgroundColorButton, &ColorButton::colorChanged, this, &ViewPreferencePane::browserGroupBackgroundColorChanged);
+            connect(m_browserTextColorButton, &ColorButton::colorChanged, this, &ViewPreferencePane::browserTextColorChanged);
+            connect(m_browserSubTextColorButton, &ColorButton::colorChanged, this, &ViewPreferencePane::browserSubTextColorChanged);
             connect(m_rendererFontSizeCombo, &QComboBox::currentTextChanged, this, &ViewPreferencePane::rendererFontSizeChanged);
         }
 
@@ -223,6 +240,10 @@ namespace TrenchBroom {
             prefs.resetToDefault(Preferences::GridColor2D);
             prefs.resetToDefault(Preferences::EdgeColor);
             prefs.resetToDefault(Preferences::Theme);
+            prefs.resetToDefault(Preferences::BrowserBackgroundColor);
+            prefs.resetToDefault(Preferences::BrowserGroupBackgroundColor);
+            prefs.resetToDefault(Preferences::BrowserTextColor);
+            prefs.resetToDefault(Preferences::BrowserSubTextColor);
             prefs.resetToDefault(Preferences::TextureBrowserIconSize);
             prefs.resetToDefault(Preferences::RendererFontSize);
         }
@@ -242,6 +263,11 @@ namespace TrenchBroom {
             m_gridColorButton->setColor(toQColor(pref(Preferences::GridColor2D)));
             m_edgeColorButton->setColor(toQColor(pref(Preferences::EdgeColor)));
             m_themeCombo->setCurrentIndex(findThemeIndex(pref(Preferences::Theme)));
+
+            m_browserBackgroundColorButton->setColor(toQColor(pref(Preferences::BrowserBackgroundColor)));
+            m_browserGroupBackgroundColorButton->setColor(toQColor(pref(Preferences::BrowserGroupBackgroundColor)));
+            m_browserTextColorButton->setColor(toQColor(pref(Preferences::BrowserTextColor)));
+            m_browserSubTextColorButton->setColor(toQColor(pref(Preferences::BrowserSubTextColor)));
 
             const auto textureBrowserIconSize = pref(Preferences::TextureBrowserIconSize);
             if (textureBrowserIconSize == 0.25f) {
@@ -347,6 +373,30 @@ namespace TrenchBroom {
         void ViewPreferencePane::themeChanged(int /*index*/) {
             auto& prefs = PreferenceManager::instance();
             prefs.set(Preferences::Theme, m_themeCombo->currentText());
+        }
+
+        void ViewPreferencePane::browserBackgroundColorChanged(const QColor& color) {
+            const auto value = Color(fromQColor(color), 1.0f);
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::BrowserBackgroundColor, value);
+        }
+
+        void ViewPreferencePane::browserGroupBackgroundColorChanged(const QColor& color) {
+            const auto value = Color(fromQColor(color), 1.0f);
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::BrowserGroupBackgroundColor, value);
+        }
+
+        void ViewPreferencePane::browserTextColorChanged(const QColor& color) {
+            const auto value = Color(fromQColor(color), 1.0f);
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::BrowserTextColor, value);
+        }
+
+        void ViewPreferencePane::browserSubTextColorChanged(const QColor& color) {
+            const auto value = Color(fromQColor(color), 1.0f);
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::BrowserSubTextColor, value);
         }
 
         void ViewPreferencePane::textureBrowserIconSizeChanged(const int index) {

--- a/common/src/View/ViewPreferencePane.h
+++ b/common/src/View/ViewPreferencePane.h
@@ -44,6 +44,10 @@ namespace TrenchBroom {
             ColorButton* m_edgeColorButton;
             QComboBox* m_themeCombo;
             QComboBox* m_textureBrowserIconSizeCombo;
+            ColorButton* m_browserBackgroundColorButton;
+            ColorButton* m_browserGroupBackgroundColorButton;
+            ColorButton* m_browserTextColorButton;
+            ColorButton* m_browserSubTextColorButton;
             QComboBox* m_rendererFontSizeCombo;
         public:
             explicit ViewPreferencePane(QWidget* parent = nullptr);
@@ -71,6 +75,10 @@ namespace TrenchBroom {
             void gridColorChanged(const QColor& color);
             void edgeColorChanged(const QColor& color);
             void themeChanged(int index);
+            void browserBackgroundColorChanged(const QColor& color);
+            void browserGroupBackgroundColorChanged(const QColor& color);
+            void browserTextColorChanged(const QColor& color);
+            void browserSubTextColorChanged(const QColor& color);
             void textureBrowserIconSizeChanged(int index);
             void rendererFontSizeChanged(const QString& text);
         };


### PR DESCRIPTION
This makes text / background / group text / group background colors of texture / entity browsers configurable in the Preferences.

Helpful when you want to have a bright background in the editing views and be able to see texture and entity names in the texture / entity browsers at the same time...

![trenchbroom-browser-colors](https://user-images.githubusercontent.com/7252064/99689242-d06a7c80-2a97-11eb-85e4-e2d7e0add9d3.jpg)

![trenchbroom-browser-colors-preferences](https://user-images.githubusercontent.com/7252064/99689251-d3fe0380-2a97-11eb-8765-3b361963130f.jpg)

