### PR TITLE
3589: fix findOutermostClosedGroup

### DIFF
--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -53,6 +53,14 @@ namespace TrenchBroom {
             return m_editState == Edit_Open;
         }
 
+        bool GroupNode::hasOpenedDescendant() const {
+            return m_editState == Edit_DescendantOpen;
+        }
+
+        bool GroupNode::closed() const {
+            return m_editState == Edit_Closed;
+        }
+
         void GroupNode::open() {
             assert(m_editState == Edit_Closed);
             setEditState(Edit_Open);
@@ -82,10 +90,6 @@ namespace TrenchBroom {
 
         void GroupNode::closeAncestors() {
             setAncestorEditState(Edit_Closed);
-        }
-
-        bool GroupNode::hasOpenedDescendant() const {
-            return m_editState == Edit_DescendantOpen;
         }
 
         const std::string& GroupNode::doGetName() const {

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -53,6 +53,7 @@ namespace TrenchBroom {
 
             bool opened() const;
             bool hasOpenedDescendant() const;
+            bool closed() const;
             void open();
             void close();
         private:

--- a/common/src/Model/ModelUtils.cpp
+++ b/common/src/Model/ModelUtils.cpp
@@ -73,9 +73,8 @@ namespace TrenchBroom {
                 [](WorldNode*)                            -> GroupNode* { return nullptr; },
                 [](LayerNode*)                            -> GroupNode* { return nullptr; },
                 [](auto&& thisLambda, GroupNode* group)   -> GroupNode* {
-                    const std::optional<GroupNode*> parentResult = group->visitParent(thisLambda);
-                    if (parentResult && parentResult.value() != nullptr) {
-                        return parentResult.value();
+                    if (GroupNode* parentResult = group->visitParent(thisLambda).value_or(nullptr)) {
+                        return parentResult;
                     }
                     // we didn't find a result searching the parent chain, so either return
                     // this group (if it's closed) or nullptr to indicate no result

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -569,6 +569,16 @@ namespace TrenchBroom {
             ASSERT_EQ(inner, innerEnt1->parent());
             ASSERT_EQ(inner, innerEnt2->parent());
 
+            CHECK(document->currentGroup() == nullptr);
+            CHECK(!outer->opened());
+            CHECK(!inner->opened());
+
+            CHECK(Model::findOutermostClosedGroup(innerEnt1) == outer);
+            CHECK(Model::findOutermostClosedGroup(outerEnt1) == outer);
+
+            CHECK(Model::findContainingGroup(innerEnt1) == inner);
+            CHECK(Model::findContainingGroup(outerEnt1) == outer);
+
             // open the outer group and ungroup the inner group
             document->openGroup(outer);
             document->select(inner);


### PR DESCRIPTION
Fixes #3589

First I factored out the `!(group->opened() || group->hasOpenedDescendant())` condition to be `group->closed()` for readability.

Note that I have to both check for a non-empty optional, and check that the contained `GroupNode*` is non-null.