### PR TITLE
3592: fix NodeCollection::hasBrushesRecursively() and brushesRecursively()

### DIFF
--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -95,8 +95,8 @@ namespace TrenchBroom {
             // that stops after finding the first brush
             for (const auto* node : m_nodes) {
                 const auto hasBrush = node->accept(kdl::overload(
-                    [](auto&&, BrushNode*) -> bool { return true; },
-                    [](auto&& thisLambda, auto* other) -> bool {
+                    [](auto&&, const BrushNode*) -> bool { return true; },
+                    [](auto&& thisLambda, const auto* other) -> bool {
                         for (const auto* child : other->children()) {
                             if (child->accept(thisLambda)) {
                                 return true;

--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -95,7 +95,7 @@ namespace TrenchBroom {
             // that stops after finding the first brush
             for (const auto* node : m_nodes) {
                 const auto hasBrush = node->accept(kdl::overload(
-                    [](BrushNode*) -> bool { return true; },
+                    [](auto&&, BrushNode*) -> bool { return true; },
                     [](auto&& thisLambda, auto* other) -> bool {
                         for (const auto* child : other->children()) {
                             if (child->accept(thisLambda)) {
@@ -153,7 +153,7 @@ namespace TrenchBroom {
             auto brushes = std::vector<BrushNode*>{};
             for (auto* node : m_nodes) {
                 node->accept(kdl::overload(
-                    [&](BrushNode* brush) -> void { brushes.push_back(brush); },
+                    [&](auto&&, BrushNode* brush) -> void { brushes.push_back(brush); },
                     [] (auto&& thisLambda, auto* other) -> void {
                         for (auto* child : other->children()) {
                             child->accept(thisLambda);

--- a/common/src/Model/NodeVisitor.h
+++ b/common/src/Model/NodeVisitor.h
@@ -114,7 +114,13 @@ namespace TrenchBroom {
 
             template <typename N>
             void doVisit(N* node) {
-                if constexpr(std::is_invocable_v<L, const L&, N*>) {
+                constexpr bool invokableWithLambdaAndNode = std::is_invocable_v<L, const L&, N*>;
+                constexpr bool invokableWithNode = std::is_invocable_v<L, N*>;
+
+                static_assert(!(invokableWithNode && invokableWithLambdaAndNode),
+                              "Visitor implements both lambda and non-lambda overloads for the given node type");
+
+                if constexpr(invokableWithLambdaAndNode) {
                     if constexpr(NodeLambdaHasResult_v<L>) {
                         NodeLambdaVisitorResult<L>::setResult(m_lambda(m_lambda, node));
                     } else {
@@ -145,7 +151,13 @@ namespace TrenchBroom {
 
             template <typename N>
             void doVisit(const N* node) {
-                if constexpr(std::is_invocable_v<L, const L&, const N*>) {
+                constexpr bool invokableWithLambdaAndNode = std::is_invocable_v<L, const L&, const N*>;
+                constexpr bool invokableWithNode = std::is_invocable_v<L, const N*>;
+
+                static_assert(!(invokableWithNode && invokableWithLambdaAndNode),
+                              "Visitor implements both lambda and non-lambda overloads for the given node type");
+
+                if constexpr(invokableWithLambdaAndNode) {
                     if constexpr(NodeLambdaHasResult_v<L>) {
                         NodeLambdaVisitorResult<L>::setResult(m_lambda(m_lambda, node));
                     } else {

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -607,7 +607,11 @@ namespace TrenchBroom {
 
             Model::GroupNode* group = document->groupSelection("Group");
             ASSERT_EQ((std::vector<Model::Node*> {ent1}), group->children());
+            ASSERT_EQ((std::vector<Model::Node*> {brush1}), ent1->children());
             ASSERT_EQ((std::vector<Model::Node*> {group}), document->selectedNodes().nodes());
+            CHECK(document->selectedNodes().brushesRecursively() == std::vector<Model::BrushNode*>{brush1});
+            CHECK(document->selectedNodes().hasBrushesRecursively());
+            CHECK(!document->selectedNodes().hasBrushes());
 
             document->ungroupSelection();
             ASSERT_EQ((std::vector<Model::Node*> {brush1}), document->selectedNodes().nodes());


### PR DESCRIPTION
Add test. Add static assertion to catch the bug.

Fixes #3592