### PR TITLE
2251: Make fly speed adjustable with the scroll wheel

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -193,6 +193,8 @@ Right        #action(Controls/Camera/Move right)
 Up           #action(Controls/Camera/Move up)
 Down         #action(Controls/Camera/Move down)
 
+To adjust the movement speed of the these keyboard shortcuts, you can either go the [preferences](#mouse_input) and adjust the corresponding slider, or you can turn the mouse wheel while holding the right mouse button in the 3D view.
+
 ### Orbiting
 
 The camera orbit mode allows you to rotate the camera about a selectable point. To get an idea as to what this means, imagine that you define a point in the map by clicking on a brush. The point where you clicked will be the center of your camera orbit. Now image a sphere whose center is the point where you just clicked and whose radius is the distance between the camera and the point. Orbiting will move the camera on the surface of that sphere while adjusting the camera's direction so that you keep looking at the same point. Visually, this is the same as rotating the entire map about the orbit center. Of course, you are not actually rotating anything - only the camera's position and direction are modified. Note that, since up and down are always fixed, you cannot cross the north and south poles of the orbit sphere.

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -284,6 +284,10 @@ namespace TrenchBroom {
     }
 
     void PreferenceManager::saveChanges() {
+        if (m_unsavedPreferences.empty()) {
+            return;
+        }
+
         for (auto* pref : m_unsavedPreferences) {
             savePreferenceToCache(pref);
             preferenceDidChangeNotifier(pref->path());

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -154,6 +154,8 @@ namespace TrenchBroom {
 
         extern Preference<float> CameraFov;
 
+        static constexpr auto MinCameraFlyMoveSpeed = 0.1f;
+        static constexpr auto MaxCameraFlyMoveSpeed = 10.0f;
         extern Preference<float> CameraFlyMoveSpeed;
 
         extern Preference<bool> Link2DCameras;

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -88,6 +88,15 @@ namespace TrenchBroom {
                 const auto maxDistance = std::max(vm::intersect_ray_plane(m_camera.viewRay(), orbitPlane) - 32.0f, 0.0f);
                 const auto distance = std::min(factor * scrollDist * moveSpeed(false), maxDistance);
                 m_camera.moveBy(distance * m_camera.direction());
+            } else if (adjustFlySpeed(inputState)) {
+                const auto speed = pref(Preferences::CameraFlyMoveSpeed);
+                // adjust speed by 5% of the current speed per scroll line
+                const auto deltaSpeed = factor * speed * 0.05f * scrollDist;
+                const auto newSpeed = vm::clamp(speed + deltaSpeed, Preferences::MinCameraFlyMoveSpeed, Preferences::MaxCameraFlyMoveSpeed);
+
+                // prefs are only changed when releasing RMB
+                PreferenceManager& prefs = PreferenceManager::instance();
+                prefs.set(Preferences::CameraFlyMoveSpeed, newSpeed);
             } else if (move(inputState)) {
                 if (zoom) {
                     const auto zoomFactor = 1.0f + scrollDist / 50.0f * factor;
@@ -96,6 +105,15 @@ namespace TrenchBroom {
                     const auto moveDirection = pref(Preferences::CameraMoveInCursorDir) ? vm::vec3f(inputState.pickRay().direction) : m_camera.direction();
                     const auto distance = scrollDist * moveSpeed(false);
                     m_camera.moveBy(factor * distance * moveDirection);
+                }
+            }
+        }
+
+        void CameraTool3D::doMouseUp(const InputState& inputState) {
+            if (inputState.mouseButtonsPressed(MouseButtons::MBRight)) {
+                PreferenceManager& prefs = PreferenceManager::instance();
+                if (!prefs.saveInstantly()) {
+                    prefs.saveChanges();
                 }
             }
         }
@@ -154,8 +172,7 @@ namespace TrenchBroom {
         }
 
         bool CameraTool3D::move(const InputState& inputState) const {
-            return ((inputState.mouseButtonsPressed(MouseButtons::MBNone) ||
-                     inputState.mouseButtonsPressed(MouseButtons::MBRight)) &&
+            return (inputState.mouseButtonsPressed(MouseButtons::MBNone) &&
                     inputState.checkModifierKeys(MK_No, MK_No, MK_DontCare));
         }
 
@@ -173,6 +190,11 @@ namespace TrenchBroom {
         bool CameraTool3D::orbit(const InputState& inputState) const {
             return (inputState.mouseButtonsPressed(MouseButtons::MBRight) &&
                     inputState.modifierKeysPressed(ModifierKeys::MKAlt));
+        }
+
+        bool CameraTool3D::adjustFlySpeed(const InputState& inputState) const {
+            return (inputState.mouseButtonsPressed(MouseButtons::MBRight) &&
+                    inputState.checkModifierKeys(MK_No, MK_No, MK_No));
         }
 
         float CameraTool3D::lookSpeedH() const {

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -50,6 +50,7 @@ namespace TrenchBroom {
             const Tool* doGetTool() const override;
 
             void doMouseScroll(const InputState& inputState) override;
+            void doMouseUp(const InputState& inputState) override;
             bool doStartMouseDrag(const InputState& inputState) override;
             bool doMouseDrag(const InputState& inputState) override;
             void doEndMouseDrag(const InputState& inputState) override;
@@ -59,6 +60,7 @@ namespace TrenchBroom {
             bool look(const InputState& inputState) const;
             bool pan(const InputState& inputState) const;
             bool orbit(const InputState& inputState) const;
+            bool adjustFlySpeed(const InputState& inputState) const;
 
             float lookSpeedH() const;
             float lookSpeedV() const;

--- a/common/src/View/MousePreferencePane.cpp
+++ b/common/src/View/MousePreferencePane.cpp
@@ -28,6 +28,7 @@
 #include "View/QtUtils.h"
 
 #include <QCheckBox>
+#include <QLabel>
 
 #include <algorithm>
 
@@ -88,7 +89,7 @@ namespace TrenchBroom {
             m_downKeyEditor = new KeySequenceEdit(1);
             m_downKeyEditor->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
 
-            m_flyMoveSpeedSlider = new SliderWithLabel(256, 512);
+            m_flyMoveSpeedSlider = new SliderWithLabel(0, 100);
             m_flyMoveSpeedSlider->setMaximumWidth(400);
 
             auto* layout = new FormWithSectionsLayout();
@@ -122,6 +123,7 @@ namespace TrenchBroom {
             layout->addRow("Up", m_upKeyEditor);
             layout->addRow("Down", m_downKeyEditor);
             layout->addRow("Speed", m_flyMoveSpeedSlider);
+            layout->addRow("", makeInfo(new QLabel("Turn mouse wheel while holding right mouse button in 3D view to adjust speed on the fly.")));
 
             setLayout(layout);
             setMinimumWidth(400);
@@ -204,7 +206,7 @@ namespace TrenchBroom {
             m_upKeyEditor->setKeySequence(pref(Preferences::CameraFlyUp()));
             m_downKeyEditor->setKeySequence(pref(Preferences::CameraFlyDown()));
 
-            m_flyMoveSpeedSlider->setRatio(pref(Preferences::CameraFlyMoveSpeed));
+            m_flyMoveSpeedSlider->setRatio(pref(Preferences::CameraFlyMoveSpeed) / Preferences::MaxCameraFlyMoveSpeed);
         }
 
         bool MousePreferencePane::doValidate() {
@@ -302,7 +304,7 @@ namespace TrenchBroom {
         }
 
         void MousePreferencePane::flyMoveSpeedChanged(const int /* value */) {
-            const auto ratio = m_flyMoveSpeedSlider->ratio();
+            const auto ratio = Preferences::MaxCameraFlyMoveSpeed * m_flyMoveSpeedSlider->ratio();
             PreferenceManager& prefs = PreferenceManager::instance();
             prefs.set(Preferences::CameraFlyMoveSpeed, ratio);
         }


### PR DESCRIPTION
Closes #2251. This is an alternative implementation (see #3587) to allow easier control over fly move speed in the 3D view. This implementation allows the user to turn the mouse wheel while holding the right mouse button in the 3D view to adjust movement speed on the fly.