### PR TITLE
3611: Make brush modifications in place

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -242,12 +242,9 @@ namespace TrenchBroom {
             }
         }
 
-        kdl::result<Brush, BrushError> Brush::clip(const vm::bbox3& worldBounds, BrushFace face) const {
-            std::vector<BrushFace> faces;
-            faces.reserve(faceCount() + 1u);
-            faces = kdl::vec_concat(std::move(faces), m_faces);
-            faces.push_back(std::move(face));
-            return Brush::create(worldBounds, std::move(faces));
+        kdl::result<void, BrushError> Brush::clip(const vm::bbox3& worldBounds, BrushFace face) {
+            m_faces.push_back(std::move(face));
+            return updateGeometryFromFaces(worldBounds);
         }
 
         kdl::result<Brush, BrushError> Brush::moveBoundary(const vm::bbox3& worldBounds, const size_t faceIndex, const vm::vec3& delta, const bool lockTexture) const {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -261,16 +261,15 @@ namespace TrenchBroom {
                 });
         }
 
-        kdl::result<Brush, BrushError> Brush::expand(const vm::bbox3& worldBounds, const FloatType delta, const bool lockTexture) const {
-            auto faces = m_faces;
-            for (auto& face : faces) {
+        kdl::result<void, BrushError> Brush::expand(const vm::bbox3& worldBounds, const FloatType delta, const bool lockTexture) {
+            for (auto& face : m_faces) {
                 const vm::vec3 moveAmount = face.boundary().normal * delta;
                 if (!face.transform(vm::translation_matrix(moveAmount), lockTexture)) {
-                    return kdl::result<Brush, BrushError>::error(BrushError::InvalidFace);
+                    return kdl::result<void, BrushError>::error(BrushError::InvalidFace);
                 }
             }
 
-            return Brush::create(worldBounds, std::move(faces));
+            return updateGeometryFromFaces(worldBounds);
         }
 
         size_t Brush::vertexCount() const {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -878,15 +878,14 @@ namespace TrenchBroom {
             return updateGeometryFromFaces(worldBounds);
         }
 
-        kdl::result<Brush, BrushError> Brush::transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, const bool lockTextures) const {
-            auto faces = m_faces;
-            for (auto& face : faces) {
+        kdl::result<void, BrushError> Brush::transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, const bool lockTextures) {
+            for (auto& face : m_faces) {
                 if (const auto transformResult = face.transform(transformation, lockTextures); !transformResult) {
-                    return kdl::result<Brush, BrushError>::error(BrushError::InvalidFace);
+                    return kdl::result<void, BrushError>::error(BrushError::InvalidFace);
                 }
             }
             
-            return Brush::create(worldBounds, std::move(faces));
+            return updateGeometryFromFaces(worldBounds);
         }
 
         bool Brush::contains(const vm::bbox3& bounds) const {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -873,8 +873,9 @@ namespace TrenchBroom {
             return subtract(factory, worldBounds, defaultTextureName, std::vector<const Brush*>{&subtrahend});
         }
 
-        kdl::result<Brush, BrushError> Brush::intersect(const vm::bbox3& worldBounds, const Brush& brush) const {
-            return Brush::create(worldBounds, kdl::vec_concat(m_faces, brush.faces()));
+        kdl::result<void, BrushError> Brush::intersect(const vm::bbox3& worldBounds, const Brush& brush) {
+            m_faces = kdl::vec_concat(std::move(m_faces), brush.faces());
+            return updateGeometryFromFaces(worldBounds);
         }
 
         kdl::result<Brush, BrushError> Brush::transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, const bool lockTextures) const {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -90,7 +90,7 @@ namespace TrenchBroom {
             void cloneFaceAttributesFrom(const Brush& brush);
             void cloneInvertedFaceAttributesFrom(const Brush& brush);
         public: // clipping
-            kdl::result<Brush, BrushError> clip(const vm::bbox3& worldBounds, BrushFace face) const;
+            kdl::result<void, BrushError> clip(const vm::bbox3& worldBounds, BrushFace face);
         public: // move face along normal
             /**
              * Translates a face by the given delta.

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -141,24 +141,24 @@ namespace TrenchBroom {
 
             // vertex operations
             bool canMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertices, const vm::vec3& delta) const;
-            kdl::result<Brush, BrushError> moveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, bool uvLock = false) const;
+            kdl::result<void, BrushError> moveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, bool uvLock = false);
 
             bool canAddVertex(const vm::bbox3& worldBounds, const vm::vec3& position) const;
-            kdl::result<Brush, BrushError> addVertex(const vm::bbox3& worldBounds, const vm::vec3& position) const;
+            kdl::result<void, BrushError> addVertex(const vm::bbox3& worldBounds, const vm::vec3& position);
 
             bool canRemoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions) const;
-            kdl::result<Brush, BrushError> removeVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions) const;
+            kdl::result<void, BrushError> removeVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions);
 
             bool canSnapVertices(const vm::bbox3& worldBounds, FloatType snapTo) const;
-            kdl::result<Brush, BrushError> snapVertices(const vm::bbox3& worldBounds, FloatType snapTo, bool uvLock = false) const;
+            kdl::result<void, BrushError> snapVertices(const vm::bbox3& worldBounds, FloatType snapTo, bool uvLock = false);
 
             // edge operations
             bool canMoveEdges(const vm::bbox3& worldBounds, const std::vector<vm::segment3>& edgePositions, const vm::vec3& delta) const;
-            kdl::result<Brush, BrushError> moveEdges(const vm::bbox3& worldBounds, const std::vector<vm::segment3>& edgePositions, const vm::vec3& delta, bool uvLock = false) const;
+            kdl::result<void, BrushError> moveEdges(const vm::bbox3& worldBounds, const std::vector<vm::segment3>& edgePositions, const vm::vec3& delta, bool uvLock = false);
 
             // face operations
             bool canMoveFaces(const vm::bbox3& worldBounds, const std::vector<vm::polygon3>& facePositions, const vm::vec3& delta) const;
-            kdl::result<Brush, BrushError> moveFaces(const vm::bbox3& worldBounds, const std::vector<vm::polygon3>& facePositions, const vm::vec3& delta, bool uvLock = false) const;
+            kdl::result<void, BrushError> moveFaces(const vm::bbox3& worldBounds, const std::vector<vm::polygon3>& facePositions, const vm::vec3& delta, bool uvLock = false);
         private:
             struct CanMoveVerticesResult {
             public:
@@ -172,7 +172,7 @@ namespace TrenchBroom {
             };
 
             CanMoveVerticesResult doCanMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, vm::vec3 delta, bool allowVertexRemoval) const;
-            kdl::result<Brush, BrushError> doMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, bool lockTexture) const;
+            kdl::result<void, BrushError> doMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, bool lockTexture);
             /**
              * Tries to find 3 vertices in `left` and `right` that are related according to the PolyhedronMatcher, and
              * generates an affine transform for them which can then be used to implement UV lock.
@@ -202,7 +202,7 @@ namespace TrenchBroom {
              * @param rightFace the face of the right polyhedron
              */
             static void applyUVLock(const PolyhedronMatcher<BrushGeometry>& matcher, const BrushFace& leftFace, BrushFace& rightFace);
-            kdl::result<Brush, BrushError> createBrushWithNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, bool uvLock = false) const;
+            kdl::result<void, BrushError> updateFacesFromGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, bool uvLock = false);
         public:
             // CSG operations
             /**

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -95,17 +95,17 @@ namespace TrenchBroom {
             /**
              * Translates a face by the given delta.
              *
-             * The face is only translated if the resulting brush has the same number of faces as this brush. If the
-             * resulting brush becomes invalid, an error is returned.
+             * The face is only translated if the brush has the same number of faces as this brush. If the
+             * brush becomes invalid, an error is returned.
              *
              * @param worldBounds the world bounds
              * @param faceIndex the index of the face to translate
              * @param delta the vector by which to translate the face
              * @param lockTexture whether textures should be locked
              *
-             * @return a result containing either the resulting brush or an error
+             * @return a void result or an error
              */
-            kdl::result<Brush, BrushError> moveBoundary(const vm::bbox3& worldBounds, size_t faceIndex, const vm::vec3& delta, bool lockTexture) const;
+            kdl::result<void, BrushError> moveBoundary(const vm::bbox3& worldBounds, size_t faceIndex, const vm::vec3& delta, bool lockTexture);
 
             /**
              * Moves all faces by `delta` units along their normals; negative values shrink the brush. If the resulting

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -226,16 +226,16 @@ namespace TrenchBroom {
             kdl::result<void, BrushError> intersect(const vm::bbox3& worldBounds, const Brush& brush);
 
             /**
-             * Applies the given transformation to this brush and returns the resulting brush.
+             * Applies the given transformation to this brush.
              *
-             * If the resulting brush is invalid, an error is returned.
+             * If the brush becomes invalid, an error is returned.
              *
              * @param worldBounds the world bounds
              * @param transformation the transformation to apply
              * @param lockTextures whether textures should be locked
-             * @return the transformed brush or an error if the operation fails
+             * @return a void result or an error if the operation fails
              */
-            kdl::result<Brush, BrushError> transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) const;
+            kdl::result<void, BrushError> transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures);
         public:
             bool contains(const vm::bbox3& bounds) const;
             bool contains(const Brush& brush) const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -108,16 +108,16 @@ namespace TrenchBroom {
             kdl::result<void, BrushError> moveBoundary(const vm::bbox3& worldBounds, size_t faceIndex, const vm::vec3& delta, bool lockTexture);
 
             /**
-             * Moves all faces by `delta` units along their normals; negative values shrink the brush. If the resulting
+             * Moves all faces by `delta` units along their normals; negative values shrink the brush. If the
              * brush becomes invalid, an error is returned.
              *
              * @param worldBounds the world bounds
              * @param delta the distance by which to move the faces
              * @param lockTexture whether textures should be locked
              *
-             * @return a result containing either the resulting brush or an error
+             * @return a void result or an error
              */
-            kdl::result<Brush, BrushError> expand(const vm::bbox3& worldBounds, FloatType delta, bool lockTexture) const;
+            kdl::result<void, BrushError> expand(const vm::bbox3& worldBounds, FloatType delta, bool lockTexture);
         public:
             // geometry access
             size_t vertexCount() const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -215,15 +215,15 @@ namespace TrenchBroom {
             kdl::result<std::vector<Brush>, BrushError> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const Brush& subtrahend) const;
 
             /**
-             * Intersects this brush with the given brush and returns the resulting brush.
+             * Intersects this brush with the given brush.
              *
              * If the resulting brush is invalid, an error is returned.
              *
              * @param worldBounds the world bounds
              * @param brush the brush to intersect this brush with
-             * @return the intersection brush or an error if the operation fails
+             * @return a void result or an error if the operation fails
              */
-            kdl::result<Brush, BrushError> intersect(const vm::bbox3& worldBounds, const Brush& brush) const;
+            kdl::result<void, BrushError> intersect(const vm::bbox3& worldBounds, const Brush& brush);
 
             /**
              * Applies the given transformation to this brush and returns the resulting brush.

--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -232,25 +232,6 @@ namespace TrenchBroom {
             return findContainingGroup(this);
         }
 
-        kdl::result<void, TransformError> BrushNode::doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) {
-            const NotifyNodeChange nodeChange(this);
-            const NotifyPhysicalBoundsChange boundsChange(this);
-
-            return m_brush.transform(worldBounds, transformation, lockTextures)
-                .visit(kdl::overload(
-                    [&](Brush&& brush) {
-                        m_brush = std::move(brush);
-                        invalidateIssues();
-                        invalidateVertexCache();
-
-                        return kdl::result<void, TransformError>::success();
-                    },
-                    [](const BrushError e) {
-                        return kdl::result<void, TransformError>::error(TransformError{kdl::str_to_string(e)});
-                    }
-                ));
-        }
-
         bool BrushNode::doContains(const Node* node) const {
             return node->accept(kdl::overload(
                 [](const WorldNode*)          { return false; },

--- a/common/src/Model/BrushNode.h
+++ b/common/src/Model/BrushNode.h
@@ -112,8 +112,6 @@ namespace TrenchBroom {
             LayerNode* doGetLayer() override;
             GroupNode* doGetGroup() override;
 
-            kdl::result<void, TransformError> doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) override;
-
             bool doContains(const Node* node) const override;
             bool doIntersects(const Node* node) const override;
         public: // renderer cache

--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -237,33 +237,6 @@ namespace TrenchBroom {
             return findContainingGroup(this);
         }
 
-        kdl::result<void, TransformError> EntityNode::doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) {
-            if (hasChildren()) {
-                const NotifyNodeChange nodeChange(this);
-
-                for (auto* child : children()) {
-                    const auto result = child->accept(kdl::overload(
-                        [] (WorldNode*)  { return kdl::result<void, TransformError>::success(); },
-                        [] (LayerNode*)  { return kdl::result<void, TransformError>::success(); },
-                        [] (GroupNode*)  { return kdl::result<void, TransformError>::success(); },
-                        [] (EntityNode*) { return kdl::result<void, TransformError>::success(); },
-                        [&](BrushNode* brush) {
-                            return brush->transform(worldBounds, transformation, lockTextures);
-                        }
-                    ));
-                    if (!result.is_success()) {
-                        return result;
-                    }
-                }
-            } else {
-                auto entity = m_entity;
-                entity.transform(transformation);
-                setEntity(std::move(entity));
-            }
-
-            return kdl::result<void, TransformError>::success();
-        }
-
         bool EntityNode::doContains(const Node* node) const {
             return boundsContainNode(logicalBounds(), node);
         }

--- a/common/src/Model/EntityNode.h
+++ b/common/src/Model/EntityNode.h
@@ -100,7 +100,6 @@ namespace TrenchBroom {
             LayerNode* doGetLayer() override;
             GroupNode* doGetGroup() override;
 
-            kdl::result<void, TransformError> doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) override;
             bool doContains(const Node* node) const override;
             bool doIntersects(const Node* node) const override;
         private:

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -222,33 +222,6 @@ namespace TrenchBroom {
             return findContainingGroup(this);
         }
 
-        kdl::result<void, TransformError> GroupNode::doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, const bool lockTextures) {
-            for (auto* child : children()) {
-                auto result = child->accept(kdl::overload(
-                    [](Model::WorldNode*) {
-                        return kdl::result<void, Model::TransformError>::success();
-                    },
-                    [](Model::LayerNode*) {
-                        return kdl::result<void, Model::TransformError>::success();
-                    },
-                    [&](Model::GroupNode* group) {
-                        return group->transform(worldBounds, transformation, lockTextures);
-                    },
-                    [&](Model::EntityNode* entity) {
-                        return entity->transform(worldBounds, transformation, lockTextures);
-                    },
-                    [&](Model::BrushNode* brush) {
-                        return brush->transform(worldBounds, transformation, lockTextures);
-                    }
-                ));
-                if (result.is_error()) {
-                    return result;
-                }
-            }
-
-            return kdl::result<void, TransformError>::success();
-        }
-
         bool GroupNode::doContains(const Node* node) const {
             return boundsContainNode(logicalBounds(), node);
         }

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -97,7 +97,6 @@ namespace TrenchBroom {
             LayerNode* doGetLayer() override;
             GroupNode* doGetGroup() override;
 
-            kdl::result<void, TransformError> doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) override;
             bool doContains(const Node* node) const override;
             bool doIntersects(const Node* node) const override;
         private:

--- a/common/src/Model/Object.cpp
+++ b/common/src/Model/Object.cpp
@@ -21,17 +21,8 @@
 
 #include "Model/GroupNode.h"
 
-#include <kdl/result.h>
-
-#include <iostream>
-
 namespace TrenchBroom {
     namespace Model {
-        std::ostream& operator<<(std::ostream& str, const TransformError& e) {
-            str << e.msg;
-            return str;
-        }
-
         Object::Object() {}
         Object::~Object() {}
 
@@ -66,10 +57,6 @@ namespace TrenchBroom {
         bool Object::groupOpened() const {
             const auto* containingGroup = group();
             return containingGroup == nullptr || containingGroup->opened();
-        }
-
-        kdl::result<void, TransformError> Object::transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) {
-            return doTransform(worldBounds, transformation, lockTextures);
         }
 
         bool Object::contains(const Node* node) const {

--- a/common/src/Model/Object.h
+++ b/common/src/Model/Object.h
@@ -21,22 +21,11 @@
 
 #include "FloatType.h"
 
-#include <kdl/result_forward.h>
-
-#include <iosfwd>
-#include <string>
-
 namespace TrenchBroom {
     namespace Model {
         class GroupNode;
         class LayerNode;
         class Node;
-
-        struct TransformError {
-            std::string msg;
-            
-            friend std::ostream& operator<<(std::ostream& str, const TransformError& e);
-        };
 
         class Object {
         protected:
@@ -56,18 +45,6 @@ namespace TrenchBroom {
             bool grouped() const;
             bool groupOpened() const;
 
-            /**
-             * Transforms this object by the given transformation.
-             *
-             * If the transformation fails, then this object may be partially transformed, but it will be in a valid
-             * state. In that case, an error is returned.
-             *
-             * @param worldBounds the world bounds
-             * @param transformation the transformation to apply
-             * @param lockTextures whether textures should be locked
-             * @return nothing or an error indicating why the operation failed
-             */
-            kdl::result<void, TransformError> transform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures);
             bool contains(const Node* object) const;
             bool intersects(const Node* object) const;
         private: // subclassing interface
@@ -75,7 +52,6 @@ namespace TrenchBroom {
             virtual LayerNode* doGetLayer() = 0;
             virtual GroupNode* doGetGroup() = 0;
 
-            virtual kdl::result<void, TransformError> doTransform(const vm::bbox3& worldBounds, const vm::mat4x4& transformation, bool lockTextures) = 0;
             virtual bool doContains(const Node* node) const = 0;
             virtual bool doIntersects(const Node* node) const = 0;
         };

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -750,22 +750,17 @@ namespace TrenchBroom {
             const auto& worldBounds = document->worldBounds();
 
             const auto clip = [&](auto* node, const auto& p1, const auto& p2, const auto& p3, auto& brushMap) {
+                auto brush = node->brush();
                 world->createFace(p1, p2, p3, document->currentTextureName())
-                    .and_then(
-                        [&](Model::BrushFace&& clipFace) {
-                            setFaceAttributes(node->brush().faces(), clipFace);
-                            return node->brush().clip(worldBounds, std::move(clipFace));
-                        }
-                    ).and_then(
-                        [&](Model::Brush&& brush) {
+                    .and_then([&](Model::BrushFace&& clipFace) {
+                            setFaceAttributes(brush.faces(), clipFace);
+                            return brush.clip(worldBounds, std::move(clipFace));
+                    }).and_then([&]() {
                             brushMap[node->parent()].push_back(new Model::BrushNode(std::move(brush)));
                             return kdl::void_result;
-                        }
-                    ).handle_errors(
-                        [&](const Model::BrushError e) {
+                    }).handle_errors([&](const Model::BrushError e) {
                             document->error() << "Could not clip brush: " << e;
-                        }
-                    );
+                    });
             };
 
             if (canClip()) {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1994,22 +1994,17 @@ namespace TrenchBroom {
         bool MapDocument::resizeBrushes(const std::vector<vm::polygon3>& faces, const vm::vec3& delta) {
             return applyAndSwap(*this, "Resize Brushes", m_selectedNodes.nodes(), kdl::overload(
                 [] (Model::Entity&)      { return true; },
-                [&](Model::Brush& originalBrush) {
-                    const auto faceIndex = originalBrush.findFace(faces);
+                [&](Model::Brush& brush) {
+                    const auto faceIndex = brush.findFace(faces);
                     if (!faceIndex) {
                         // we allow resizing only some of the brushes
                         return true;
                     }
 
-                    return originalBrush.moveBoundary(m_worldBounds, *faceIndex, delta, pref(Preferences::TextureLock))
+                    return brush.moveBoundary(m_worldBounds, *faceIndex, delta, pref(Preferences::TextureLock))
                         .visit(kdl::overload(
-                            [&](Model::Brush&& newBrush) -> bool {
-                                if (m_worldBounds.contains(newBrush.bounds())) {
-                                    originalBrush = std::move(newBrush);
-                                    return true;
-                                } else {
-                                    return false;
-                                }
+                            [&]() -> bool {
+                                return m_worldBounds.contains(brush.bounds());
                             },
                             [&](const Model::BrushError e) -> bool {
                                 error() << "Could not resize brush: " << e;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1838,16 +1838,9 @@ namespace TrenchBroom {
                 Model::BrushNode* brushNode = *it;
                 const Model::Brush& brush = brushNode->brush();
                 valid = intersection.intersect(m_worldBounds, brush)
-                    .visit(kdl::overload(
-                        [&](Model::Brush&& b) {
-                            intersection = std::move(b);
-                            return true;
-                        },
-                        [&](const Model::BrushError e) {
-                            error() << "Could not intersect brushes: " << e;
-                            return false;
-                        }
-                    ));
+                    .handle_errors([&](const Model::BrushError e) {
+                        error() << "Could not intersect brushes: " << e;
+                    });
             }
 
             const std::vector<Model::Node*> toRemove(std::begin(brushes), std::end(brushes));

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1648,18 +1648,11 @@ namespace TrenchBroom {
                     entity.transform(transformation);
                     return true;
                 },
-                [&](Model::Brush& oldBrush)   {
-                    return oldBrush.transform(m_worldBounds, transformation, pref(Preferences::TextureLock))
-                        .visit(kdl::overload(
-                            [&](auto&& newBrush) {
-                                oldBrush = std::move(newBrush);
-                                return true;
-                            },
-                            [&](Model::BrushError e) {
-                                error() << "Could not transform brush: " << e;
-                                return false;
-                            }
-                        ));
+                [&](Model::Brush& brush)   {
+                    return brush.transform(m_worldBounds, transformation, pref(Preferences::TextureLock))
+                        .handle_errors([&](const Model::BrushError e) {
+                            error() << "Could not transform brush: " << e;
+                        });
                 }
             ));
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1877,13 +1877,13 @@ namespace TrenchBroom {
             std::vector<Model::Node*> toRemove;
 
             for (Model::BrushNode* brushNode : brushNodes) {
-                const Model::Brush& brush = brushNode->brush();
+                const auto& originalBrush = brushNode->brush();
+                Model::Brush shrunkenBrush = originalBrush;
 
-                // make an shrunken copy of brush
-                brush.expand(m_worldBounds, -1.0 * static_cast<FloatType>(m_grid->actualSize()), true)
+                shrunkenBrush.expand(m_worldBounds, -1.0 * static_cast<FloatType>(m_grid->actualSize()), true)
                     .and_then(
-                        [&](const Model::Brush& shrunken) {
-                            return brush.subtract(*m_world, m_worldBounds, currentTextureName(), shrunken);
+                        [&]() {
+                            return originalBrush.subtract(*m_world, m_worldBounds, currentTextureName(), shrunkenBrush);
                         }
                     ).visit(kdl::overload(
                         [&](const std::vector<Model::Brush>& fragments) {

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -409,17 +409,18 @@ namespace TrenchBroom {
 
                 const bool success = oldBrush.moveBoundary(worldBounds, dragFaceIndex, delta, lockTextures)
                     .and_then(
-                        [&](const Model::Brush& newBrush) {
+                        [&](Model::Brush newBrush) {
                             auto clipFace = oldBrush.face(dragFaceIndex);
                             clipFace.invert();
-                            return newBrush.clip(worldBounds, std::move(clipFace));
-                        }
-                    ).and_then(
-                        [&](Model::Brush&& newBrush) {
-                            auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
-                            newNodes[brushNode->parent()].push_back(newBrushNode);
-                            newDragHandles.emplace_back(newBrushNode, newDragFaceNormal);
-                            return kdl::void_result;
+
+                            return newBrush.clip(worldBounds, std::move(clipFace))
+                                .and_then(
+                                    [&]() {
+                                        auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
+                                        newNodes[brushNode->parent()].push_back(newBrushNode);
+                                        newDragHandles.emplace_back(newBrushNode, newDragFaceNormal);
+                                        return kdl::void_result;
+                                    });
                         }
                     ).handle_errors(
                         [&](const Model::BrushError e) {
@@ -466,33 +467,27 @@ namespace TrenchBroom {
                 const auto& dragFace = dragFaceHandle.face();
                 auto* brushNode = dragFaceHandle.node();
 
-                const auto& brush = brushNode->brush();
-                const auto newDragFaceIndex = brush.findFace(dragFace.boundary());
+                auto newBrush = brushNode->brush();
+                const auto newDragFaceIndex = newBrush.findFace(dragFace.boundary());
                 if (!newDragFaceIndex) {
                     kdl::map_clear_and_delete(newNodes);
                     return false;
                 }
 
-                auto clipFace = brush.face(*newDragFaceIndex);
+                auto clipFace = newBrush.face(*newDragFaceIndex);
                 clipFace.invert();
                 
                 const bool success = clipFace.transform(vm::translation_matrix(delta), lockTextures)
-                    .and_then(
-                        [&]() {
-                            return brush.clip(worldBounds, std::move(clipFace));
-                        }
-                    ).and_then(
-                        [&](Model::Brush&& newBrush) {
-                            auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
-                            newNodes[brushNode->parent()].push_back(newBrushNode);
-                            newDragHandles.emplace_back(newBrushNode, clipFace.boundary().normal);
-                            return kdl::void_result;
-                        }
-                    ).handle_errors(
-                        [&](const Model::BrushError e) {
-                            document->error() << "Could not extrude inwards: " << e;
-                        }
-                    );
+                    .and_then([&]() {
+                        return newBrush.clip(worldBounds, std::move(clipFace));
+                    }).and_then([&]() {
+                        auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
+                        newNodes[brushNode->parent()].push_back(newBrushNode);
+                        newDragHandles.emplace_back(newBrushNode, clipFace.boundary().normal);
+                        return kdl::void_result;
+                    }).handle_errors([&](const Model::BrushError e) {
+                        document->error() << "Could not extrude inwards: " << e;
+                    });
 
                 if (!success) {
                     kdl::map_clear_and_delete(newNodes);

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -695,7 +695,8 @@ namespace TrenchBroom {
                     }).value();
 
             auto testTransform = [&](const vm::mat4x4& transform){
-                const Brush standardCube = startingCube.transform(worldBounds, transform, true).value();
+                auto standardCube = startingCube;
+                REQUIRE(standardCube.transform(worldBounds, transform, true).is_success());
                 CHECK(dynamic_cast<const ParaxialTexCoordSystem*>(&standardCube.face(0).texCoordSystem()));
 
                 const Brush valveCube = standardCube.convertToParallel();

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -522,7 +522,7 @@ namespace TrenchBroom {
             const vm::vec3 p9(+16.0, +16.0, +32.0);
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, p9 - p8).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, p9 - p8).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + (p9 - p8));
             
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -538,7 +538,7 @@ namespace TrenchBroom {
             assertTexture("bottom", brush, p1, p3, p7, p5);
 
             oldVertexPositions = std::move(newVertexPositions);
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, p8 - p9).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, p8 - p9).is_success());
             newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + (p8 - p9));
             
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -569,7 +569,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({top});
             auto delta = vm::vec3(0.0, 0.0, -32.0);
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -606,7 +606,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -682,7 +682,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -757,7 +757,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -830,7 +830,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -901,7 +901,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -970,7 +970,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(0u, newVertexPositions.size());
@@ -1038,7 +1038,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -1109,7 +1109,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(0u, newVertexPositions.size());
@@ -1176,7 +1176,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p7 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -1244,7 +1244,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p7});
             auto delta = p8 - p7;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -1313,7 +1313,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p6});
             auto delta = p9 - p6;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -1382,7 +1382,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p8});
             auto delta = p9 - p8;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -1453,7 +1453,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p9});
             auto delta = p10 - p9;
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(0u, newVertexPositions.size());
@@ -1508,14 +1508,14 @@ namespace TrenchBroom {
             EXPECT_FALSE(brush.canMoveVertices(worldBounds, allVertexPositions, vm::vec3(8192, 0, 0)));
         }
 
-        static void assertCanMoveVertices(const Brush& brush, const std::vector<vm::vec3> vertexPositions, const vm::vec3 delta) {
+        static void assertCanMoveVertices(Brush brush, const std::vector<vm::vec3> vertexPositions, const vm::vec3 delta) {
             const vm::bbox3 worldBounds(4096.0);
 
             ASSERT_TRUE(brush.canMoveVertices(worldBounds, vertexPositions, delta));
 
-            const Brush newBrush = brush.moveVertices(worldBounds, vertexPositions, delta).value();
+            REQUIRE(brush.moveVertices(worldBounds, vertexPositions, delta).is_success());
 
-            auto movedVertexPositions = newBrush.findClosestVertexPositions(vertexPositions + delta);
+            auto movedVertexPositions = brush.findClosestVertexPositions(vertexPositions + delta);
             movedVertexPositions = kdl::vec_sort_and_remove_duplicates(std::move(movedVertexPositions));
 
             auto expectedVertexPositions = vertexPositions + delta;
@@ -1526,13 +1526,13 @@ namespace TrenchBroom {
 
         // "Move point" tests
 
-        static void assertMovingVerticesDeletes(const Brush& brush, const std::vector<vm::vec3> vertexPositions, const vm::vec3 delta) {
+        static void assertMovingVerticesDeletes(Brush brush, const std::vector<vm::vec3> vertexPositions, const vm::vec3 delta) {
             const vm::bbox3 worldBounds(4096.0);
 
             ASSERT_TRUE(brush.canMoveVertices(worldBounds, vertexPositions, delta));
 
-            const Brush newBrush = brush.moveVertices(worldBounds, vertexPositions, delta).value();
-            const std::vector<vm::vec3> movedVertexPositions = newBrush.findClosestVertexPositions(vertexPositions + delta);
+            REQUIRE(brush.moveVertices(worldBounds, vertexPositions, delta).is_success());
+            const std::vector<vm::vec3> movedVertexPositions = brush.findClosestVertexPositions(vertexPositions + delta);
             ASSERT_TRUE(movedVertexPositions.empty());
         }
 
@@ -1578,29 +1578,30 @@ namespace TrenchBroom {
 
             // More detailed testing of the last assertion
             {
+                auto brushCopy = brush;
                 std::vector<vm::vec3> temp(baseQuadVertexPositions);
                 std::reverse(temp.begin(), temp.end());
                 const std::vector<vm::vec3> flippedBaseQuadVertexPositions(temp);
 
                 const vm::vec3 delta(0.0, 0.0, -129.0);
 
-                ASSERT_EQ(5u, brush.faceCount());
-                ASSERT_TRUE(brush.findFace(vm::polygon3(baseQuadVertexPositions)));
-                ASSERT_FALSE(brush.findFace(vm::polygon3(flippedBaseQuadVertexPositions)));
-                ASSERT_TRUE(brush.findFace(vm::vec3::neg_z()));
-                ASSERT_FALSE(brush.findFace(vm::vec3::pos_z()));
+                ASSERT_EQ(5u, brushCopy.faceCount());
+                ASSERT_TRUE(brushCopy.findFace(vm::polygon3(baseQuadVertexPositions)));
+                ASSERT_FALSE(brushCopy.findFace(vm::polygon3(flippedBaseQuadVertexPositions)));
+                ASSERT_TRUE(brushCopy.findFace(vm::vec3::neg_z()));
+                ASSERT_FALSE(brushCopy.findFace(vm::vec3::pos_z()));
 
                 const auto oldVertexPositions = std::vector<vm::vec3>({peakPosition});
-                ASSERT_TRUE(brush.canMoveVertices(worldBounds, oldVertexPositions, delta));
-                Brush newBrush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
-                const auto newVertexPositions = newBrush.findClosestVertexPositions(oldVertexPositions + delta);
+                ASSERT_TRUE(brushCopy.canMoveVertices(worldBounds, oldVertexPositions, delta));
+                REQUIRE(brushCopy.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
+                const auto newVertexPositions = brushCopy.findClosestVertexPositions(oldVertexPositions + delta);
                 ASSERT_EQ(oldVertexPositions + delta, newVertexPositions);
 
-                ASSERT_EQ(5u, newBrush.faceCount());
-                ASSERT_FALSE(newBrush.findFace(vm::polygon3(baseQuadVertexPositions)));
-                ASSERT_TRUE(newBrush.findFace(vm::polygon3(flippedBaseQuadVertexPositions)));
-                ASSERT_FALSE(newBrush.findFace(vm::vec3::neg_z()));
-                ASSERT_TRUE(newBrush.findFace(vm::vec3::pos_z()));
+                ASSERT_EQ(5u, brushCopy.faceCount());
+                ASSERT_FALSE(brushCopy.findFace(vm::polygon3(baseQuadVertexPositions)));
+                ASSERT_TRUE(brushCopy.findFace(vm::polygon3(flippedBaseQuadVertexPositions)));
+                ASSERT_FALSE(brushCopy.findFace(vm::vec3::neg_z()));
+                ASSERT_TRUE(brushCopy.findFace(vm::vec3::pos_z()));
             }
 
             assertCanMoveVertex(brush, peakPosition, vm::vec3(256.0, 0.0, -127.0));
@@ -1647,7 +1648,7 @@ namespace TrenchBroom {
             Brush brush = builder.createCube(64.0, "asdf").value();
 
 
-            brush = brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, +32.0, +32.0))).value();
+            CHECK(brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, +32.0, +32.0))).is_success());
 
             ASSERT_EQ(7u, brush.vertexCount());
             ASSERT_TRUE (brush.hasVertex(vm::vec3(-32.0, -32.0, -32.0)));
@@ -1660,7 +1661,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush.hasVertex(vm::vec3(+32.0, +32.0, +32.0)));
 
 
-            brush = brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, +32.0, -32.0))).value();
+            CHECK(brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, +32.0, -32.0))).is_success());
 
             ASSERT_EQ(6u, brush.vertexCount());
             ASSERT_TRUE (brush.hasVertex(vm::vec3(-32.0, -32.0, -32.0)));
@@ -1673,7 +1674,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush.hasVertex(vm::vec3(+32.0, +32.0, +32.0)));
 
 
-            brush = brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, -32.0, +32.0))).value();
+            CHECK(brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, -32.0, +32.0))).is_success());
 
             ASSERT_EQ(5u, brush.vertexCount());
             ASSERT_TRUE (brush.hasVertex(vm::vec3(-32.0, -32.0, -32.0)));
@@ -1686,7 +1687,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush.hasVertex(vm::vec3(+32.0, +32.0, +32.0)));
 
 
-            brush = brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(-32.0, -32.0, -32.0))).value();
+            CHECK(brush.removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(-32.0, -32.0, -32.0))).is_success());
 
             ASSERT_EQ(4u, brush.vertexCount());
             ASSERT_FALSE(brush.hasVertex(vm::vec3(-32.0, -32.0, -32.0)));
@@ -1731,7 +1732,7 @@ namespace TrenchBroom {
 
                         Brush brush = builder.createBrush(vertices, "asdf").value();
                         ASSERT_TRUE(brush.canRemoveVertices(worldBounds, toRemove));
-                        brush = brush.removeVertices(worldBounds, toRemove).value();
+                        CHECK(brush.removeVertices(worldBounds, toRemove).is_success());
 
                         for (size_t l = 0; l < 8; ++l) {
                             if (l != i && l != j && l != k) {
@@ -1773,15 +1774,15 @@ namespace TrenchBroom {
             const std::vector<Node*> nodes = IO::NodeReader::read(data, world, worldBounds, status);
             EXPECT_EQ(1u, nodes.size());
 
-            const Brush& brush = static_cast<BrushNode*>(nodes.front())->brush();
+            Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
             ASSERT_TRUE(brush.canSnapVertices(worldBounds, gridSize));
 
-            Brush newBrush = brush.snapVertices(worldBounds, gridSize).value();
-            ASSERT_TRUE(newBrush.fullySpecified());
+            CHECK(brush.snapVertices(worldBounds, gridSize).is_success());
+            ASSERT_TRUE(brush.fullySpecified());
 
             // Ensure they were actually snapped
             {
-                for (const Model::BrushVertex* vertex : newBrush.vertices()) {
+                for (const Model::BrushVertex* vertex : brush.vertices()) {
                     const vm::vec3& pos = vertex->position();
                     ASSERT_TRUE(vm::is_integral(pos, 0.001));
                 }
@@ -1826,7 +1827,7 @@ namespace TrenchBroom {
             const auto originalEdge = vm::segment(p1, p2);
             auto oldEdgePositions = std::vector<vm::segment3>({originalEdge});
             auto delta = p1_2 - p1;
-            brush = brush.moveEdges(worldBounds, oldEdgePositions, delta).value();
+            CHECK(brush.moveEdges(worldBounds, oldEdgePositions, delta).is_success());
             auto newEdgePositions = brush.findClosestEdgePositions(kdl::vec_transform(oldEdgePositions, [&](const auto& s) {
                 return s.translate(delta);
             }));
@@ -1847,7 +1848,7 @@ namespace TrenchBroom {
 
             oldEdgePositions = std::move(newEdgePositions);
             delta = p1 - p1_2;
-            brush = brush.moveEdges(worldBounds, oldEdgePositions, delta).value();
+            CHECK(brush.moveEdges(worldBounds, oldEdgePositions, delta).is_success());
             newEdgePositions = brush.findClosestEdgePositions(kdl::vec_transform(oldEdgePositions, [&](const auto& s) {
                 return s.translate(delta);
             }));
@@ -1863,7 +1864,7 @@ namespace TrenchBroom {
             assertTexture("bottom", brush, p1, p3, p7, p5);
         }
 
-        static void assertCanMoveEdges(const Brush& brush, const std::vector<vm::segment3> edges, const vm::vec3 delta) {
+        static void assertCanMoveEdges(Brush brush, const std::vector<vm::segment3> edges, const vm::vec3 delta) {
             const vm::bbox3 worldBounds(4096.0);
 
             std::vector<vm::segment3> expectedMovedEdges;
@@ -1872,8 +1873,8 @@ namespace TrenchBroom {
             }
 
             ASSERT_TRUE(brush.canMoveEdges(worldBounds, edges, delta));
-            const auto newBrush = brush.moveEdges(worldBounds, edges, delta).value();
-            const auto movedEdges = newBrush.findClosestEdgePositions(kdl::vec_transform(edges, [&](const auto& s) { return s.translate(delta); }));
+            CHECK(brush.moveEdges(worldBounds, edges, delta).is_success());
+            const auto movedEdges = brush.findClosestEdgePositions(kdl::vec_transform(edges, [&](const auto& s) { return s.translate(delta); }));
             ASSERT_EQ(expectedMovedEdges, movedEdges);
         }
 
@@ -1891,8 +1892,8 @@ namespace TrenchBroom {
 
             BrushBuilder builder(&world, worldBounds);
             Brush brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName).value();
-            brush = brush.addVertex(worldBounds, edge.start()).value();
-            brush = brush.addVertex(worldBounds, edge.end()).value();
+            CHECK(brush.addVertex(worldBounds, edge.start()).is_success());
+            CHECK(brush.addVertex(worldBounds, edge.end()).is_success());
 
             ASSERT_EQ(10u, brush.vertexCount());
 
@@ -1917,10 +1918,10 @@ namespace TrenchBroom {
 
             BrushBuilder builder(&world, worldBounds);
             Brush brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName).value();
-            brush = brush.addVertex(worldBounds, edge1.start()).value();
-            brush = brush.addVertex(worldBounds, edge1.end()).value();
-            brush = brush.addVertex(worldBounds, edge2.start()).value();
-            brush = brush.addVertex(worldBounds, edge2.end()).value();
+            CHECK(brush.addVertex(worldBounds, edge1.start()).is_success());
+            CHECK(brush.addVertex(worldBounds, edge1.end()).is_success());
+            CHECK(brush.addVertex(worldBounds, edge2.start()).is_success());
+            CHECK(brush.addVertex(worldBounds, edge2.end()).is_success());
 
             ASSERT_EQ(12u, brush.vertexCount());
 
@@ -1954,7 +1955,7 @@ namespace TrenchBroom {
 
             auto oldFacePositions = std::vector<vm::polygon3>({face});
             auto delta = vm::vec3(-16.0, -16.0, 0.0);
-            brush = brush.moveFaces(worldBounds, oldFacePositions, delta).value();
+            CHECK(brush.moveFaces(worldBounds, oldFacePositions, delta).is_success());
             auto newFacePositions = brush.findClosestFacePositions(kdl::vec_transform(oldFacePositions, [&](const auto& f) { return f.translate(delta); }));
 
             ASSERT_EQ(1u, newFacePositions.size());
@@ -1965,7 +1966,7 @@ namespace TrenchBroom {
 
             oldFacePositions = std::move(newFacePositions);
             delta = vm::vec3(16.0, 16.0, 0.0);
-            brush = brush.moveFaces(worldBounds, oldFacePositions, delta).value();
+            CHECK(brush.moveFaces(worldBounds, oldFacePositions, delta).is_success());
             newFacePositions = brush.findClosestFacePositions(kdl::vec_transform(oldFacePositions, [&](const auto& f) { return f.translate(delta); }));
 
             ASSERT_EQ(1u, newFacePositions.size());
@@ -1992,7 +1993,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush.canMoveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(0.0, 128.0, 0.0)));
         }
 
-        static void assertCanMoveFaces(const Brush& brush, const std::vector<vm::polygon3> movingFaces, const vm::vec3 delta) {
+        static void assertCanMoveFaces(Brush brush, const std::vector<vm::polygon3> movingFaces, const vm::vec3 delta) {
             const vm::bbox3 worldBounds(4096.0);
 
             std::vector<vm::polygon3> expectedMovedFaces;
@@ -2001,8 +2002,8 @@ namespace TrenchBroom {
             }
 
             ASSERT_TRUE(brush.canMoveFaces(worldBounds, movingFaces, delta));
-            const auto newBrush = brush.moveFaces(worldBounds, movingFaces, delta).value();
-            const auto movedFaces = newBrush.findClosestFacePositions(kdl::vec_transform(movingFaces, [&](const auto& f) { return f.translate(delta); }));
+            CHECK(brush.moveFaces(worldBounds, movingFaces, delta).is_success());
+            const auto movedFaces = brush.findClosestFacePositions(kdl::vec_transform(movingFaces, [&](const auto& f) { return f.translate(delta); }));
             ASSERT_EQ(expectedMovedFaces, movedFaces);
         }
 
@@ -2262,8 +2263,8 @@ namespace TrenchBroom {
 
             BrushBuilder builder(&world, worldBounds);
             Brush brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName).value();
-            brush = brush.addVertex(worldBounds, edge.start()).value();
-            brush = brush.addVertex(worldBounds, edge.end()).value();
+            CHECK(brush.addVertex(worldBounds, edge.start()).is_success());
+            CHECK(brush.addVertex(worldBounds, edge.end()).is_success());
 
             ASSERT_EQ(10u, brush.vertexCount());
 
@@ -2334,8 +2335,11 @@ namespace TrenchBroom {
             ASSERT_TRUE(brush.canMoveFaces(worldBounds, {polygonToMove}, delta));
 
             // move top face by x=+8
-            const auto changed = brush.moveFaces(worldBounds, {polygonToMove}, delta, false).value();
-            const auto changedWithUVLock = brush.moveFaces(worldBounds, {polygonToMove}, delta, true).value();
+            auto changed = brush;
+            auto changedWithUVLock = brush;
+
+            REQUIRE(changed.moveFaces(worldBounds, {polygonToMove}, delta, false).is_success());
+            REQUIRE(changedWithUVLock.moveFaces(worldBounds, {polygonToMove}, delta, true).is_success());
 
             // The move should be equivalent to shearing by this matrix
             const auto M = vm::shear_bbox_matrix(brush.bounds(), vm::vec3::pos_z(), delta);
@@ -2439,7 +2443,7 @@ namespace TrenchBroom {
 
             auto oldVertexPositions = std::vector<vm::vec3>({p});
             auto delta = 4.0 * 16.0 * vm::vec3::neg_y();
-            brush = brush.moveVertices(worldBounds, oldVertexPositions, delta).value();
+            CHECK(brush.moveVertices(worldBounds, oldVertexPositions, delta).is_success());
             auto newVertexPositions = brush.findClosestVertexPositions(oldVertexPositions + delta);
 
             ASSERT_EQ(1u, newVertexPositions.size());
@@ -2578,7 +2582,7 @@ namespace TrenchBroom {
 
             // delete the vertex
             ASSERT_TRUE(brush.canRemoveVertices(worldBounds, std::vector<vm::vec3d>{p7}));
-            brush = brush.removeVertices(worldBounds, std::vector<vm::vec3d>{p7}).value();
+            CHECK(brush.removeVertices(worldBounds, std::vector<vm::vec3d>{p7}).is_success());
 
             // assert the structure and textures
 

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -411,7 +411,7 @@ namespace TrenchBroom {
                 vm::vec3(8.0, 0.0, 0.0),
                 vm::vec3(8.0, 0.0, 1.0),
                 vm::vec3(8.0, 1.0, 0.0));
-            brush = brush.clip(worldBounds, clip).value();
+            CHECK(brush.clip(worldBounds, clip).is_success());
 
             CHECK(brush.faceCount() == 6u);
             CHECK(brush.findFace(left.boundary()));

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -53,11 +53,11 @@
 
 namespace TrenchBroom {
     namespace Model {
-        static bool canMoveBoundary(const Brush& brush, const vm::bbox3& worldBounds, const size_t faceIndex, const vm::vec3& delta) {
+        static bool canMoveBoundary(Brush brush, const vm::bbox3& worldBounds, const size_t faceIndex, const vm::vec3& delta) {
             return brush.moveBoundary(worldBounds, faceIndex, delta, false)
                 .visit(kdl::overload(
-                    [&](const Brush& b) {
-                        return worldBounds.contains(b.bounds());
+                    [&]() {
+                        return worldBounds.contains(brush.bounds());
                     },
                     [](const BrushError) {
                         return false;
@@ -446,7 +446,7 @@ namespace TrenchBroom {
             CHECK(canMoveBoundary(brush, worldBounds, *topFaceIndex, vm::vec3(0.0, 0.0, +1.0)));
             CHECK(canMoveBoundary(brush, worldBounds, *topFaceIndex, vm::vec3(0.0, 0.0, -5.0)));
 
-            brush = brush.moveBoundary(worldBounds, *topFaceIndex, vm::vec3(0.0, 0.0, 1.0), false).value();
+            CHECK(brush.moveBoundary(worldBounds, *topFaceIndex, vm::vec3(0.0, 0.0, 1.0), false).is_success());
             CHECK(worldBounds.contains(brush.bounds()));
             
             CHECK(brush.faces().size() == 6u);

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -473,9 +473,7 @@ namespace TrenchBroom {
             const BrushBuilder builder(&world, worldBounds);
 
             Brush brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture").value();
-            const auto expandResult = brush1.expand(worldBounds, 6, true);
-            CHECK(expandResult.is_success());
-            brush1 = expandResult.value();
+            CHECK(brush1.expand(worldBounds, 6, true).is_success());
 
             const vm::bbox3 expandedBBox(vm::vec3(-70, -70, -70), vm::vec3(70, 70, 70));
             
@@ -489,9 +487,7 @@ namespace TrenchBroom {
             const BrushBuilder builder(&world, worldBounds);
 
             Brush brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture").value();
-            const auto expandResult = brush1.expand(worldBounds, -32, true);
-            CHECK(expandResult.is_success());
-            brush1 = expandResult.value();
+            CHECK(brush1.expand(worldBounds, -32, true).is_success());
 
             const vm::bbox3 expandedBBox(vm::vec3(-32, -32, -32), vm::vec3(32, 32, 32));
 

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -944,14 +944,20 @@ namespace TrenchBroom {
             ASSERT_THROW(document->throwExceptionDuringCommand(), CommandProcessorException);
         }
 
+        static void transform(Model::BrushNode* brushNode, const vm::bbox3& worldBounds, const vm::mat4x4& transform) {
+            auto brush = brushNode->brush();
+            REQUIRE(brush.transform(worldBounds, transform, false).is_success());
+            brushNode->setBrush(std::move(brush));
+        }
+
         TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.selectTouching") {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
             Model::BrushNode* brush1 = document->world()->createBrush(builder.createCube(64.0, "none").value());
             Model::BrushNode* brush2 = document->world()->createBrush(builder.createCube(64.0, "none").value());
             Model::BrushNode* brush3 = document->world()->createBrush(builder.createCube(64.0, "none").value());
 
-            REQUIRE(brush2->transform(document->worldBounds(), vm::translation_matrix(vm::vec3(10.0, 0.0, 0.0)), false));
-            REQUIRE(brush3->transform(document->worldBounds(), vm::translation_matrix(vm::vec3(100.0, 0.0, 0.0)), false));
+            transform(brush2, document->worldBounds(), vm::translation_matrix(vm::vec3(10.0, 0.0, 0.0)));
+            transform(brush3, document->worldBounds(), vm::translation_matrix(vm::vec3(100.0, 0.0, 0.0)));
 
             document->addNode(brush1, document->parentForNodes());
             document->addNode(brush2, document->parentForNodes());
@@ -1009,8 +1015,8 @@ namespace TrenchBroom {
             Model::BrushNode* brush2 = document->world()->createBrush(builder.createCube(64.0, "none").value());
             Model::BrushNode* brush3 = document->world()->createBrush(builder.createCube(64.0, "none").value());
 
-            REQUIRE(brush2->transform(document->worldBounds(), vm::translation_matrix(vm::vec3(0.0, 0.0, -500.0)), false));
-            REQUIRE(brush3->transform(document->worldBounds(), vm::translation_matrix(vm::vec3(100.0, 0.0, 0.0)), false));
+            transform(brush2, document->worldBounds(), vm::translation_matrix(vm::vec3(0.0, 0.0, -500.0)));
+            transform(brush3, document->worldBounds(), vm::translation_matrix(vm::vec3(100.0, 0.0, 0.0)));
 
             document->addNode(brush1, document->parentForNodes());
             document->addNode(brush2, document->parentForNodes());

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -72,8 +72,10 @@ namespace TrenchBroom {
         }
 
         TEST_CASE_METHOD(RepeatableActionsTest, "RepeatableActionsTest.repeatRotate") {
-            auto* entityNode = new Model::EntityNode();
-            REQUIRE(entityNode->transform(document->worldBounds(), vm::translation_matrix(vm::vec3(1, 2, 3)), false).is_success());
+            auto entity = Model::Entity();
+            entity.transform(vm::translation_matrix(vm::vec3(1, 2, 3)));
+
+            auto* entityNode = new Model::EntityNode(std::move(entity));
 
             document->addNode(entityNode, document->parentForNodes());
             document->select(entityNode);

--- a/common/test/src/View/SwapNodeContentsCommandTest.cpp
+++ b/common/test/src/View/SwapNodeContentsCommandTest.cpp
@@ -55,7 +55,8 @@ namespace TrenchBroom {
             document->addNode(brushNode, document->parentForNodes());
             
             const auto originalBrush = brushNode->brush();
-            const auto modifiedBrush = brushNode->brush().transform(document->worldBounds(), vm::translation_matrix(vm::vec3(16, 0, 0)), false).value();
+            auto modifiedBrush = originalBrush;
+            REQUIRE(modifiedBrush.transform(document->worldBounds(), vm::translation_matrix(vm::vec3(16, 0, 0)), false).is_success());
 
             auto nodesToSwap = std::vector<std::pair<Model::Node*, Model::NodeContents>>{};
             nodesToSwap.emplace_back(brushNode, modifiedBrush);
@@ -78,7 +79,8 @@ namespace TrenchBroom {
             document->addNode(brushNode, document->parentForNodes());
             
             const auto& originalBrush = brushNode->brush();
-            auto modifiedBrush = originalBrush.transform(document->worldBounds(), vm::translation_matrix(vm::vec3(16, 0, 0)), false).value();
+            auto modifiedBrush = originalBrush;
+            REQUIRE(modifiedBrush.transform(document->worldBounds(), vm::translation_matrix(vm::vec3(16, 0, 0)), false).is_success());
 
             auto nodesToSwap = std::vector<std::pair<Model::Node*, Model::NodeContents>>{};
             nodesToSwap.emplace_back(brushNode, std::move(modifiedBrush));


### PR DESCRIPTION
Closes #3006 

A while back, I changed all functions that modify a brush to return a new copy of it. The idea was to prevent brushes from going into an invalid state when an operation fails. But now this is no longer important since we always modify node contents after creating a copy, and only if the operation succeeds, do we move the copy back into the node. And since it's easier to avoid unnecessary copies when modifying objects in place, I decided to undo the previous change here. Furthermore, `Entity` already modifies itself in place, so this PR makes the two classes behave consistently in this regard.