### PR TITLE
3618: Refactor LayerNode, GroupNode inheriting from AttributableNode

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -127,6 +127,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/GameFactory.cpp
         ${COMMON_SOURCE_DIR}/Model/GameFileSystem.cpp
         ${COMMON_SOURCE_DIR}/Model/GameImpl.cpp
+        ${COMMON_SOURCE_DIR}/Model/Group.cpp
         ${COMMON_SOURCE_DIR}/Model/GroupNode.cpp
         ${COMMON_SOURCE_DIR}/Model/Hit.cpp
         ${COMMON_SOURCE_DIR}/Model/HitAdapter.cpp
@@ -592,6 +593,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/GameFactory.h
         ${COMMON_SOURCE_DIR}/Model/GameFileSystem.h
         ${COMMON_SOURCE_DIR}/Model/GameImpl.h
+        ${COMMON_SOURCE_DIR}/Model/Group.h
         ${COMMON_SOURCE_DIR}/Model/GroupNode.h
         ${COMMON_SOURCE_DIR}/Model/Hit.h
         ${COMMON_SOURCE_DIR}/Model/HitAdapter.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -138,6 +138,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/IssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/Model/IssueGeneratorRegistry.cpp
         ${COMMON_SOURCE_DIR}/Model/IssueQuickFix.cpp
+        ${COMMON_SOURCE_DIR}/Model/Layer.cpp
         ${COMMON_SOURCE_DIR}/Model/LayerNode.cpp
         ${COMMON_SOURCE_DIR}/Model/LinkSourceIssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/Model/LinkTargetIssueGenerator.cpp
@@ -604,6 +605,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/IssueGeneratorRegistry.h
         ${COMMON_SOURCE_DIR}/Model/IssueQuickFix.h
         ${COMMON_SOURCE_DIR}/Model/IssueType.h
+        ${COMMON_SOURCE_DIR}/Model/Layer.h
         ${COMMON_SOURCE_DIR}/Model/LayerNode.h
         ${COMMON_SOURCE_DIR}/Model/LinkSourceIssueGenerator.h
         ${COMMON_SOURCE_DIR}/Model/LinkTargetIssueGenerator.h

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -185,13 +185,13 @@ namespace TrenchBroom {
             }
 
             Model::LayerNode* layerNode = m_factory->createLayer(name);
-            Model::Entity layerEntity = layerNode->entity();
+            Model::Layer layer = layerNode->layer();
 
-            const std::string& layerSortIndex = findAttribute(attributes, Model::AttributeNames::LayerSortIndex);
-            if (!kdl::str_is_blank(layerSortIndex)) {
-                // This is optional (not present on maps saved in TB 2020.1 and earlier)
-                layerEntity.addOrUpdateAttribute(Model::AttributeNames::LayerSortIndex, layerSortIndex);
+            // This is optional (not present on maps saved in TB 2020.1 and earlier)
+            if (const auto layerSortIndex = kdl::str_to_int(findAttribute(attributes, Model::AttributeNames::LayerSortIndex))) {
+                layer.setSortIndex(*layerSortIndex);
             }
+            
             if (findAttribute(attributes, Model::AttributeNames::LayerLocked) == Model::AttributeValues::LayerLockedValue) {
                 layerNode->setLockState(Model::LockState::Lock_Locked);
             }
@@ -199,10 +199,10 @@ namespace TrenchBroom {
                 layerNode->setVisibilityState(Model::VisibilityState::Visibility_Hidden);
             }
             if (findAttribute(attributes, Model::AttributeNames::LayerOmitFromExport) == Model::AttributeValues::LayerOmitFromExportValue) {
-                layerEntity.addOrUpdateAttribute(Model::AttributeNames::LayerOmitFromExport, Model::AttributeValues::LayerOmitFromExportValue);
+                layer.setOmitFromExport(true);
             }
 
-            layerNode->setEntity(std::move(layerEntity));
+            layerNode->setLayer(std::move(layer));
 
             setExtraAttributes(layerNode, extraAttributes);
             m_layers.insert(std::make_pair(layerId, layerNode));

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -86,7 +86,7 @@ namespace TrenchBroom {
         void NodeWriter::writeDefaultLayer() {
             m_serializer->defaultLayer(m_world);
 
-            if (!(m_serializer->exporting() && m_world.defaultLayer()->omitFromExport())) {
+            if (!(m_serializer->exporting() && m_world.defaultLayer()->layer().omitFromExport())) {
                 doWriteNodes(*m_serializer, m_world.defaultLayer()->children());
             }
         }
@@ -98,10 +98,10 @@ namespace TrenchBroom {
             }
         }
 
-        void NodeWriter::writeCustomLayer(const Model::LayerNode* layer) {
-            if (!(m_serializer->exporting() && layer->omitFromExport())) {
-                m_serializer->customLayer(layer);
-                doWriteNodes(*m_serializer, layer->children(), layer);
+        void NodeWriter::writeCustomLayer(const Model::LayerNode* layerNode) {
+            if (!(m_serializer->exporting() && layerNode->layer().omitFromExport())) {
+                m_serializer->customLayer(layerNode);
+                doWriteNodes(*m_serializer, layerNode->children(), layerNode);
             }
         }
 

--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -228,7 +228,7 @@ namespace TrenchBroom {
             return findContainingLayer(this);
         }
 
-        GroupNode* BrushNode::doGetGroup() {
+        GroupNode* BrushNode::doGetContainingGroup() {
             return findContainingGroup(this);
         }
 

--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -224,7 +224,7 @@ namespace TrenchBroom {
             return parent();
         }
 
-        LayerNode* BrushNode::doGetLayer() {
+        LayerNode* BrushNode::doGetContainingLayer() {
             return findContainingLayer(this);
         }
 

--- a/common/src/Model/BrushNode.h
+++ b/common/src/Model/BrushNode.h
@@ -110,7 +110,7 @@ namespace TrenchBroom {
 
             Node* doGetContainer() override;
             LayerNode* doGetContainingLayer() override;
-            GroupNode* doGetGroup() override;
+            GroupNode* doGetContainingGroup() override;
 
             bool doContains(const Node* node) const override;
             bool doIntersects(const Node* node) const override;

--- a/common/src/Model/BrushNode.h
+++ b/common/src/Model/BrushNode.h
@@ -109,7 +109,7 @@ namespace TrenchBroom {
             std::optional<std::tuple<FloatType, size_t>> findFaceHit(const vm::ray3& ray) const;
 
             Node* doGetContainer() override;
-            LayerNode* doGetLayer() override;
+            LayerNode* doGetContainingLayer() override;
             GroupNode* doGetGroup() override;
 
             bool doContains(const Node* node) const override;

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -89,7 +89,7 @@ namespace TrenchBroom {
 
         void EditorContext::pushGroup(Model::GroupNode* groupNode) {
             ensure(groupNode != nullptr, "group is null");
-            assert(m_currentGroup == nullptr || groupNode->group() == m_currentGroup);
+            assert(m_currentGroup == nullptr || groupNode->containingGroup() == m_currentGroup);
 
             if (m_currentGroup != nullptr) {
                 m_currentGroup->close();
@@ -101,7 +101,7 @@ namespace TrenchBroom {
         void EditorContext::popGroup() {
             ensure(m_currentGroup != nullptr, "currentGroup is null");
             m_currentGroup->close();
-            m_currentGroup = m_currentGroup->group();
+            m_currentGroup = m_currentGroup->containingGroup();
             if (m_currentGroup != nullptr) {
                 m_currentGroup->open();
             }
@@ -222,7 +222,7 @@ namespace TrenchBroom {
         }
 
         bool EditorContext::pickable(const Model::GroupNode* groupNode) const {
-            return visible(groupNode) && !groupNode->opened() && groupNode->groupOpened();
+            return visible(groupNode) && !groupNode->opened() && groupNode->containingGroupOpened();
         }
 
         bool EditorContext::pickable(const Model::EntityNode* entityNode) const {
@@ -280,7 +280,7 @@ namespace TrenchBroom {
         }
 
         bool EditorContext::inOpenGroup(const Model::Object* object) const {
-            return object->groupOpened();
+            return object->containingGroupOpened();
         }
     }
 }

--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -233,7 +233,7 @@ namespace TrenchBroom {
             return findContainingLayer(this);
         }
 
-        GroupNode* EntityNode::doGetGroup() {
+        GroupNode* EntityNode::doGetContainingGroup() {
             return findContainingGroup(this);
         }
 

--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -229,7 +229,7 @@ namespace TrenchBroom {
             return parent();
         }
 
-        LayerNode* EntityNode::doGetLayer() {
+        LayerNode* EntityNode::doGetContainingLayer() {
             return findContainingLayer(this);
         }
 

--- a/common/src/Model/EntityNode.h
+++ b/common/src/Model/EntityNode.h
@@ -98,7 +98,7 @@ namespace TrenchBroom {
         private: // implement Object interface
             Node* doGetContainer() override;
             LayerNode* doGetContainingLayer() override;
-            GroupNode* doGetGroup() override;
+            GroupNode* doGetContainingGroup() override;
 
             bool doContains(const Node* node) const override;
             bool doIntersects(const Node* node) const override;

--- a/common/src/Model/EntityNode.h
+++ b/common/src/Model/EntityNode.h
@@ -97,7 +97,7 @@ namespace TrenchBroom {
             vm::vec3 doGetLinkTargetAnchor() const override;
         private: // implement Object interface
             Node* doGetContainer() override;
-            LayerNode* doGetLayer() override;
+            LayerNode* doGetContainingLayer() override;
             GroupNode* doGetGroup() override;
 
             bool doContains(const Node* node) const override;

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -1,0 +1,35 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Group.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        Group::Group(std::string name) :
+        m_name(std::move(name)) {}
+
+        const std::string& Group::name() const {
+            return m_name;
+        }
+
+        void Group::setName(std::string name) {
+            m_name = std::move(name);
+        }
+    }
+}

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -1,0 +1,36 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace TrenchBroom {
+    namespace Model {
+        class Group {
+        private:
+            std::string m_name;
+        public:
+            Group(std::string name);
+
+            const std::string& name() const;
+            void setName(std::string name);
+        };
+    }
+}

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -214,7 +214,7 @@ namespace TrenchBroom {
             return parent();
         }
 
-        LayerNode* GroupNode::doGetLayer() {
+        LayerNode* GroupNode::doGetContainingLayer() {
             return findContainingLayer(this);
         }
 

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -38,16 +38,19 @@
 
 namespace TrenchBroom {
     namespace Model {
-        GroupNode::GroupNode(const std::string& name) :
+        GroupNode::GroupNode(std::string name) :
+        m_group(std::move(name)),
         m_editState(EditState::Closed),
-        m_boundsValid(false) {
-            setName(name);
+        m_boundsValid(false) {}
+
+        const Group& GroupNode::group() const {
+            return m_group;
         }
 
-        void GroupNode::setName(const std::string& name) {
-            auto entity = m_entity;
-            entity.addOrUpdateAttribute(AttributeNames::GroupName, name);
-            setEntity(std::move(entity));
+        Group GroupNode::setGroup(Group group) {
+            using std::swap;
+            swap(m_group, group);
+            return group;
         }
 
         bool GroupNode::opened() const {
@@ -97,9 +100,7 @@ namespace TrenchBroom {
         }
 
         const std::string& GroupNode::doGetName() const {
-            static const auto NoName = std::string("");
-            const auto* value = entity().attribute(AttributeNames::GroupName);
-            return value ? *value : NoName;
+            return m_group.name();
         }
 
         const vm::bbox3& GroupNode::doGetLogicalBounds() const {
@@ -197,17 +198,6 @@ namespace TrenchBroom {
 
         void GroupNode::doAccept(ConstNodeVisitor& visitor) const {
             visitor.visit(this);
-        }
-
-        void GroupNode::doAttributesDidChange(const vm::bbox3& /* oldBounds */) {
-        }
-
-        vm::vec3 GroupNode::doGetLinkSourceAnchor() const {
-            return vm::vec3::zero();
-        }
-
-        vm::vec3 GroupNode::doGetLinkTargetAnchor() const {
-            return vm::vec3::zero();
         }
 
         Node* GroupNode::doGetContainer() {

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -39,7 +39,7 @@
 namespace TrenchBroom {
     namespace Model {
         GroupNode::GroupNode(const std::string& name) :
-        m_editState(Edit_Closed),
+        m_editState(EditState::Closed),
         m_boundsValid(false) {
             setName(name);
         }
@@ -51,26 +51,26 @@ namespace TrenchBroom {
         }
 
         bool GroupNode::opened() const {
-            return m_editState == Edit_Open;
+            return m_editState == EditState::Open;
         }
 
         bool GroupNode::hasOpenedDescendant() const {
-            return m_editState == Edit_DescendantOpen;
+            return m_editState == EditState::DescendantOpen;
         }
 
         bool GroupNode::closed() const {
-            return m_editState == Edit_Closed;
+            return m_editState == EditState::Closed;
         }
 
         void GroupNode::open() {
-            assert(m_editState == Edit_Closed);
-            setEditState(Edit_Open);
+            assert(m_editState == EditState::Closed);
+            setEditState(EditState::Open);
             openAncestors();
         }
 
         void GroupNode::close() {
-            assert(m_editState == Edit_Open);
-            setEditState(Edit_Closed);
+            assert(m_editState == EditState::Open);
+            setEditState(EditState::Closed);
             closeAncestors();
         }
 
@@ -89,11 +89,11 @@ namespace TrenchBroom {
         }
 
         void GroupNode::openAncestors() {
-            setAncestorEditState(Edit_DescendantOpen);
+            setAncestorEditState(EditState::DescendantOpen);
         }
 
         void GroupNode::closeAncestors() {
-            setAncestorEditState(Edit_Closed);
+            setAncestorEditState(EditState::Closed);
         }
 
         const std::string& GroupNode::doGetName() const {

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -218,7 +218,7 @@ namespace TrenchBroom {
             return findContainingLayer(this);
         }
 
-        GroupNode* GroupNode::doGetGroup() {
+        GroupNode* GroupNode::doGetContainingGroup() {
             return findContainingGroup(this);
         }
 

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -94,7 +94,7 @@ namespace TrenchBroom {
             vm::vec3 doGetLinkTargetAnchor() const override;
         private: // implement methods inherited from Object
             Node* doGetContainer() override;
-            LayerNode* doGetLayer() override;
+            LayerNode* doGetContainingLayer() override;
             GroupNode* doGetGroup() override;
 
             bool doContains(const Node* node) const override;

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -35,11 +35,11 @@ namespace TrenchBroom {
     namespace Model {
         class GroupNode : public AttributableNode, public Object {
         private:
-            typedef enum {
-                Edit_Open,
-                Edit_Closed,
-                Edit_DescendantOpen
-            } EditState;
+            enum class EditState {
+                Open,
+                Closed,
+                DescendantOpen
+            };
 
             EditState m_editState;
             mutable vm::bbox3 m_logicalBounds;

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -21,7 +21,8 @@
 
 #include "FloatType.h"
 #include "Macros.h"
-#include "Model/AttributableNode.h"
+#include "Model/Group.h"
+#include "Model/Node.h"
 #include "Model/Object.h"
 
 #include <kdl/result_forward.h>
@@ -33,7 +34,7 @@
 
 namespace TrenchBroom {
     namespace Model {
-        class GroupNode : public AttributableNode, public Object {
+        class GroupNode : public Node, public Object {
         private:
             enum class EditState {
                 Open,
@@ -41,14 +42,16 @@ namespace TrenchBroom {
                 DescendantOpen
             };
 
+            Group m_group;
             EditState m_editState;
             mutable vm::bbox3 m_logicalBounds;
             mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
         public:
-            GroupNode(const std::string& name);
+            GroupNode(std::string name);
 
-            void setName(const std::string& name);
+            const Group& group() const;
+            Group setGroup(Group group);
 
             bool opened() const;
             bool hasOpenedDescendant() const;
@@ -88,10 +91,6 @@ namespace TrenchBroom {
             void doGenerateIssues(const IssueGenerator* generator, std::vector<Issue*>& issues) override;
             void doAccept(NodeVisitor& visitor) override;
             void doAccept(ConstNodeVisitor& visitor) const override;
-        private: // implement AttributableNode interface
-            void doAttributesDidChange(const vm::bbox3& oldBounds) override;
-            vm::vec3 doGetLinkSourceAnchor() const override;
-            vm::vec3 doGetLinkTargetAnchor() const override;
         private: // implement methods inherited from Object
             Node* doGetContainer() override;
             LayerNode* doGetContainingLayer() override;

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -95,7 +95,7 @@ namespace TrenchBroom {
         private: // implement methods inherited from Object
             Node* doGetContainer() override;
             LayerNode* doGetContainingLayer() override;
-            GroupNode* doGetGroup() override;
+            GroupNode* doGetContainingGroup() override;
 
             bool doContains(const Node* node) const override;
             bool doIntersects(const Node* node) const override;

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -1,0 +1,81 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Layer.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        Layer::Layer(const bool defaultLayer, std::string name) :
+        m_defaultLayer(defaultLayer),
+        m_name(std::move(name)),
+        m_omitFromExport(false) {}
+
+        bool Layer::defaultLayer() const {
+            return m_defaultLayer;
+        }
+
+        const std::string& Layer::name() const {
+            return m_name;
+        }
+
+        void Layer::setName(std::string name) {
+            m_name = std::move(name);
+        }
+
+        bool Layer::hasSortIndex() const {
+            return m_sortIndex.has_value();
+        }
+
+        int Layer::sortIndex() const {
+            if (defaultLayer()) {
+                return defaultLayerSortIndex();
+            }
+
+            return m_sortIndex.value_or(invalidSortIndex());
+        }
+        
+        void Layer::setSortIndex(const int sortIndex) {
+            m_sortIndex = sortIndex;
+        }
+
+        const std::optional<Color>& Layer::color() const {
+            return m_color;
+        }
+
+        void Layer::setColor(const Color& color) {
+            m_color = color;
+        }
+
+        bool Layer::omitFromExport() const {
+            return m_omitFromExport;
+        }
+
+        void Layer::setOmitFromExport(const bool omitFromExport) {
+            m_omitFromExport = omitFromExport;
+        }
+
+        int Layer::invalidSortIndex() {
+            return std::numeric_limits<int>::max();
+        }
+
+        int Layer::defaultLayerSortIndex() {
+            return -1;
+        }
+    }
+}

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -1,0 +1,58 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Color.h"
+
+#include <string>
+#include <optional>
+
+namespace TrenchBroom {
+    namespace Model {
+        class Layer {
+        private:
+            bool m_defaultLayer;
+            std::string m_name;
+            std::optional<int> m_sortIndex;
+            std::optional<Color> m_color;
+            bool m_omitFromExport;
+        public:
+            Layer(bool defaultLayer, std::string name);
+
+            bool defaultLayer() const;
+
+            const std::string& name() const;
+            void setName(std::string name);
+
+            bool hasSortIndex() const;
+            int sortIndex() const;
+            void setSortIndex(int sortIndex);
+
+            const std::optional<Color>& color() const;
+            void setColor(const Color& color);
+
+            bool omitFromExport() const;
+            void setOmitFromExport(bool omitFromExport);
+
+            static int invalidSortIndex();
+            static int defaultLayerSortIndex();
+        };
+    }
+}

--- a/common/src/Model/LayerNode.h
+++ b/common/src/Model/LayerNode.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
-#include "Color.h"
 #include "FloatType.h"
 #include "Macros.h"
-#include "Model/AttributableNode.h"
+#include "Model/Layer.h"
+#include "Model/Node.h"
 
 #include <vecmath/bbox.h>
 
@@ -32,34 +32,26 @@
 
 namespace TrenchBroom {
     namespace Model {
-        class LayerNode : public AttributableNode {
+        class LayerNode : public Node {
         private:
+            Layer m_layer;
+
             mutable vm::bbox3 m_logicalBounds;
             mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
         public:
-            LayerNode(const std::string& name);
+            LayerNode(bool defaultLayer, std::string name);
+            LayerNode(std::string name);
 
-            void setName(const std::string& name);
+            const Layer& layer() const;
+            Layer setLayer(Layer layer);
 
             bool isDefaultLayer() const;
-
-            static int invalidSortIndex();
-            static int defaultLayerSortIndex();
-
-            int sortIndex() const;
-            void setSortIndex(int index);
 
             /**
              * Stable sort the given vector using `sortIndex()` as the sort key.
              */
             static void sortLayers(std::vector<LayerNode*>& layers);
-
-            std::optional<Color> layerColor() const;
-            void setLayerColor(const Color& color);
-
-            bool omitFromExport() const;
-            void setOmitFromExport(bool omitFromExport);
         private: // implement Node interface
             const std::string& doGetName() const override;
             const vm::bbox3& doGetLogicalBounds() const override;
@@ -79,10 +71,6 @@ namespace TrenchBroom {
             void doGenerateIssues(const IssueGenerator* generator, std::vector<Issue*>& issues) override;
             void doAccept(NodeVisitor& visitor) override;
             void doAccept(ConstNodeVisitor& visitor) const override;
-        private: // implement AttributableNode interface
-            void doAttributesDidChange(const vm::bbox3& oldBounds) override;
-            vm::vec3 doGetLinkSourceAnchor() const override;
-            vm::vec3 doGetLinkTargetAnchor() const override;
         private:
             void invalidateBounds();
             void validateBounds() const;

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -58,7 +58,7 @@ namespace TrenchBroom {
 
         LayerNode* ModelFactoryImpl::doCreateLayer(const std::string& name) const {
             assert(m_format != MapFormat::Unknown);
-            return new LayerNode(name);
+            return new LayerNode(false, name);
         }
 
         GroupNode* ModelFactoryImpl::doCreateGroup(const std::string& name) const {

--- a/common/src/Model/NodeContents.cpp
+++ b/common/src/Model/NodeContents.cpp
@@ -25,10 +25,11 @@
 
 namespace TrenchBroom {
     namespace Model {
-        NodeContents::NodeContents(std::variant<Layer, Entity, Brush> contents) :
+        NodeContents::NodeContents(std::variant<Layer, Group, Entity, Brush> contents) :
         m_contents(std::move(contents)) {
             std::visit(kdl::overload(
                 [](Layer&) {},
+                [](Group&) {},
                 [](Entity& entity) {
                     entity.setDefinition(nullptr);
                     entity.setModel(nullptr);
@@ -41,11 +42,11 @@ namespace TrenchBroom {
             ), m_contents);
         }
 
-        const std::variant<Layer, Entity, Brush>& NodeContents::get() const {
+        const std::variant<Layer, Group, Entity, Brush>& NodeContents::get() const {
             return m_contents;
         }
 
-        std::variant<Layer, Entity, Brush>& NodeContents::get() {
+        std::variant<Layer, Group, Entity, Brush>& NodeContents::get() {
             return m_contents;
         }
     }

--- a/common/src/Model/NodeContents.cpp
+++ b/common/src/Model/NodeContents.cpp
@@ -25,9 +25,10 @@
 
 namespace TrenchBroom {
     namespace Model {
-        NodeContents::NodeContents(std::variant<Entity, Brush> contents) :
+        NodeContents::NodeContents(std::variant<Layer, Entity, Brush> contents) :
         m_contents(std::move(contents)) {
             std::visit(kdl::overload(
+                [](Layer&) {},
                 [](Entity& entity) {
                     entity.setDefinition(nullptr);
                     entity.setModel(nullptr);
@@ -40,11 +41,11 @@ namespace TrenchBroom {
             ), m_contents);
         }
 
-        const std::variant<Entity, Brush>& NodeContents::get() const {
+        const std::variant<Layer, Entity, Brush>& NodeContents::get() const {
             return m_contents;
         }
 
-        std::variant<Entity, Brush>& NodeContents::get() {
+        std::variant<Layer, Entity, Brush>& NodeContents::get() {
             return m_contents;
         }
     }

--- a/common/src/Model/NodeContents.h
+++ b/common/src/Model/NodeContents.h
@@ -21,6 +21,7 @@
 
 #include "Model/Brush.h"
 #include "Model/Entity.h"
+#include "Model/Layer.h"
 
 #include <variant>
 
@@ -28,16 +29,16 @@ namespace TrenchBroom {
     namespace Model {
         class NodeContents {
         private:
-            std::variant<Entity, Brush> m_contents;
+            std::variant<Layer, Entity, Brush> m_contents;
         public:
             /** Unsets cached and derived information of the given objects, i.e.
              *  - for entities, unsets the entity definition and the model
              *  - for brushes, unsets the textures
              */
-            explicit NodeContents(std::variant<Entity, Brush> contents);
+            explicit NodeContents(std::variant<Layer, Entity, Brush> contents);
 
-            const std::variant<Entity, Brush>& get() const;
-            std::variant<Entity, Brush>& get();
+            const std::variant<Layer, Entity, Brush>& get() const;
+            std::variant<Layer, Entity, Brush>& get();
         };
     }
 }

--- a/common/src/Model/NodeContents.h
+++ b/common/src/Model/NodeContents.h
@@ -21,6 +21,7 @@
 
 #include "Model/Brush.h"
 #include "Model/Entity.h"
+#include "Model/Group.h"
 #include "Model/Layer.h"
 
 #include <variant>
@@ -29,16 +30,16 @@ namespace TrenchBroom {
     namespace Model {
         class NodeContents {
         private:
-            std::variant<Layer, Entity, Brush> m_contents;
+            std::variant<Layer, Group, Entity, Brush> m_contents;
         public:
             /** Unsets cached and derived information of the given objects, i.e.
              *  - for entities, unsets the entity definition and the model
              *  - for brushes, unsets the textures
              */
-            explicit NodeContents(std::variant<Layer, Entity, Brush> contents);
+            explicit NodeContents(std::variant<Layer, Group, Entity, Brush> contents);
 
-            const std::variant<Layer, Entity, Brush>& get() const;
-            std::variant<Layer, Entity, Brush>& get();
+            const std::variant<Layer, Group, Entity, Brush>& get() const;
+            std::variant<Layer, Group, Entity, Brush>& get();
         };
     }
 }

--- a/common/src/Model/Object.cpp
+++ b/common/src/Model/Object.cpp
@@ -42,21 +42,21 @@ namespace TrenchBroom {
             return const_cast<Object*>(this)->containingLayer();
         }
 
-        GroupNode* Object::group() {
-            return doGetGroup();
+        GroupNode* Object::containingGroup() {
+            return doGetContainingGroup();
         }
 
-        const GroupNode* Object::group() const {
-            return const_cast<Object*>(this)->group();
+        const GroupNode* Object::containingGroup() const {
+            return const_cast<Object*>(this)->containingGroup();
         }
 
-        bool Object::grouped() const {
-            return group() != nullptr;
+        bool Object::containedInGroup() const {
+            return containingGroup() != nullptr;
         }
 
-        bool Object::groupOpened() const {
-            const auto* containingGroup = group();
-            return containingGroup == nullptr || containingGroup->opened();
+        bool Object::containingGroupOpened() const {
+            const auto* group = containingGroup();
+            return group == nullptr || group->opened();
         }
 
         bool Object::contains(const Node* node) const {

--- a/common/src/Model/Object.cpp
+++ b/common/src/Model/Object.cpp
@@ -34,12 +34,12 @@ namespace TrenchBroom {
             return const_cast<Object*>(this)->container();
         }
 
-        LayerNode* Object::layer() {
-            return doGetLayer();
+        LayerNode* Object::containingLayer() {
+            return doGetContainingLayer();
         }
 
-        const LayerNode* Object::layer() const {
-            return const_cast<Object*>(this)->layer();
+        const LayerNode* Object::containingLayer() const {
+            return const_cast<Object*>(this)->containingLayer();
         }
 
         GroupNode* Object::group() {

--- a/common/src/Model/Object.h
+++ b/common/src/Model/Object.h
@@ -39,18 +39,18 @@ namespace TrenchBroom {
             LayerNode* containingLayer();
             const LayerNode* containingLayer() const;
 
-            GroupNode* group();
-            const GroupNode* group() const;
+            GroupNode* containingGroup();
+            const GroupNode* containingGroup() const;
 
-            bool grouped() const;
-            bool groupOpened() const;
+            bool containedInGroup() const;
+            bool containingGroupOpened() const;
 
             bool contains(const Node* object) const;
             bool intersects(const Node* object) const;
         private: // subclassing interface
             virtual Node* doGetContainer() = 0;
             virtual LayerNode* doGetContainingLayer() = 0;
-            virtual GroupNode* doGetGroup() = 0;
+            virtual GroupNode* doGetContainingGroup() = 0;
 
             virtual bool doContains(const Node* node) const = 0;
             virtual bool doIntersects(const Node* node) const = 0;

--- a/common/src/Model/Object.h
+++ b/common/src/Model/Object.h
@@ -36,8 +36,8 @@ namespace TrenchBroom {
             Node* container();
             const Node* container() const;
 
-            LayerNode* layer();
-            const LayerNode* layer() const;
+            LayerNode* containingLayer();
+            const LayerNode* containingLayer() const;
 
             GroupNode* group();
             const GroupNode* group() const;
@@ -49,7 +49,7 @@ namespace TrenchBroom {
             bool intersects(const Node* object) const;
         private: // subclassing interface
             virtual Node* doGetContainer() = 0;
-            virtual LayerNode* doGetLayer() = 0;
+            virtual LayerNode* doGetContainingLayer() = 0;
             virtual GroupNode* doGetGroup() = 0;
 
             virtual bool doContains(const Node* node) const = 0;

--- a/common/src/Model/WorldNode.cpp
+++ b/common/src/Model/WorldNode.cpp
@@ -127,9 +127,9 @@ namespace TrenchBroom {
         }
 
         void WorldNode::createDefaultLayer() {
-            m_defaultLayer = createLayer("Default Layer");
+            m_defaultLayer = new LayerNode(true, "Default Layer");
             addChild(m_defaultLayer);
-            assert(m_defaultLayer->sortIndex() == LayerNode::defaultLayerSortIndex());
+            assert(m_defaultLayer->layer().sortIndex() == Layer::defaultLayerSortIndex());
         }
 
         const AttributableNodeIndex& WorldNode::attributableNodeIndex() const {

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -215,7 +215,7 @@ namespace TrenchBroom {
 
                 for (const Model::EntityNode* entity : m_entities) {
                     if (m_showHiddenEntities || m_editorContext.visible(entity)) {
-                        if (entity->group() == nullptr || entity->group() == m_editorContext.currentGroup()) {
+                        if (entity->containingGroup() == nullptr || entity->containingGroup() == m_editorContext.currentGroup()) {
                             if (m_showOccludedOverlays)
                                 renderService.setShowOccludedObjects();
                             else

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -213,7 +213,7 @@ namespace TrenchBroom {
 
         bool GroupRenderer::shouldRenderGroup(const Model::GroupNode* group) const {
             const auto& currentGroup = m_editorContext.currentGroup();
-            const auto* parentGroup = group->group();
+            const auto* parentGroup = group->containingGroup();
             return parentGroup == currentGroup && m_editorContext.visible(group);
         }
 

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -104,8 +104,8 @@ namespace TrenchBroom {
             QAction* unlockAllLayersAction = popupMenu.addAction(tr("Unlock All Layers"), this, &LayerEditor::onUnlockAllLayers);
             QAction* lockAllLayersAction = popupMenu.addAction(tr("Lock All Layers"), this, &LayerEditor::onLockAllLayers);
             popupMenu.addSeparator();
-            QAction* renameLayerAction = popupMenu.addAction(tr("Rename layer"), this, &LayerEditor::onRenameLayer);
-            QAction* removeLayerAction = popupMenu.addAction(tr("Remove layer"), this, &LayerEditor::onRemoveLayer);
+            QAction* renameLayerAction = popupMenu.addAction(tr("Rename Layer"), this, &LayerEditor::onRenameLayer);
+            QAction* removeLayerAction = popupMenu.addAction(tr("Remove Layer"), this, &LayerEditor::onRemoveLayer);
 
             makeActiveAction->setEnabled(canSetCurrentLayer(layerNode));
             moveSelectionToLayerAction->setEnabled(canMoveSelectionToLayer());

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -126,7 +126,7 @@ namespace TrenchBroom {
             m_activeButton->setChecked(document->currentLayer() == m_layer);
             m_lockButton->setChecked(m_layer->locked());
             m_hiddenButton->setChecked(m_layer->hidden());
-            m_omitFromExportButton->setVisible(m_layer->omitFromExport());
+            m_omitFromExportButton->setVisible(m_layer->layer().omitFromExport());
         }
 
         Model::LayerNode* LayerListBoxWidget::layer() const {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1408,14 +1408,14 @@ namespace TrenchBroom {
                     [&](Model::GroupNode* group) {
                         assert(group->selected());
 
-                        if (!group->grouped()) {
+                        if (!group->containedInGroup()) {
                             nodesToMove.push_back(group);
                             nodesToSelect.push_back(group);
                         }
                     },
                     [&](Model::EntityNode* entity) {
                         assert(entity->selected());
-                        if (!entity->grouped()) {
+                        if (!entity->containedInGroup()) {
                             nodesToMove.push_back(entity);
                             nodesToSelect.push_back(entity);
                         }
@@ -1423,7 +1423,7 @@ namespace TrenchBroom {
                     [&](Model::BrushNode* brush) {
                         assert(brush->selected());
 
-                        if (!brush->grouped()) {
+                        if (!brush->containedInGroup()) {
                             auto* entity = brush->entity();
                             if (entity == m_world.get()) {
                                 nodesToMove.push_back(brush);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -136,17 +136,19 @@ namespace TrenchBroom {
          */        
         template <typename N, typename L>
         static std::optional<std::vector<std::pair<Model::Node*, Model::NodeContents>>> applyToNodeContents(const std::vector<N*>& nodes, L lambda) {
+            using NodeContentType = std::variant<Model::Layer, Model::Entity, Model::Brush>;
+
             auto newNodes = std::vector<std::pair<Model::Node*, Model::NodeContents>>{};
             newNodes.reserve(nodes.size());
 
             bool success = true;
             std::transform(std::begin(nodes), std::end(nodes), std::back_inserter(newNodes), [&](auto* node) {
-                std::variant<Model::Entity, Model::Brush> nodeContents = node->accept(kdl::overload(
-                    [](const Model::WorldNode* worldNode)   -> std::variant<Model::Entity, Model::Brush> { return worldNode->entity(); },
-                    [](const Model::LayerNode* layerNode)   -> std::variant<Model::Entity, Model::Brush> { return layerNode->entity(); },
-                    [](const Model::GroupNode* groupNode)   -> std::variant<Model::Entity, Model::Brush> { return groupNode->entity(); },
-                    [](const Model::EntityNode* entityNode) -> std::variant<Model::Entity, Model::Brush> { return entityNode->entity(); },
-                    [](const Model::BrushNode* brushNode)   -> std::variant<Model::Entity, Model::Brush> { return brushNode->brush(); }
+                NodeContentType nodeContents = node->accept(kdl::overload(
+                    [](const Model::WorldNode* worldNode)   -> NodeContentType { return worldNode->entity(); },
+                    [](const Model::LayerNode* layerNode)   -> NodeContentType { return layerNode->layer(); },
+                    [](const Model::GroupNode* groupNode)   -> NodeContentType { return groupNode->entity(); },
+                    [](const Model::EntityNode* entityNode) -> NodeContentType { return entityNode->entity(); },
+                    [](const Model::BrushNode* brushNode)   -> NodeContentType { return brushNode->brush(); }
                 ));
 
                 success = success && std::visit(lambda, nodeContents);
@@ -1285,6 +1287,7 @@ namespace TrenchBroom {
             
             const auto commandName = kdl::str_plural("Rename ", m_selectedNodes.groupCount(), "Group", "Groups");
             applyAndSwap(*this, commandName, m_selectedNodes.groups(), kdl::overload(
+                [] (Model::Layer&)         { return true; },
                 [&](Model::Entity& entity) { entity.addOrUpdateAttribute(Model::AttributeNames::GroupName, name); return true; },
                 [] (Model::Brush&)         { return true; }
             ));
@@ -1319,17 +1322,18 @@ namespace TrenchBroom {
             }
         }
 
-        void MapDocument::renameLayer(Model::LayerNode* layer, const std::string& name) {
-            applyAndSwap(*this, "Rename Layer", std::vector<Model::Node*>{layer}, kdl::overload(
-                [&](Model::Entity& entity) { entity.addOrUpdateAttribute(Model::AttributeNames::LayerName, name); return true; },
-                [] (Model::Brush&)         { return true; }
+        void MapDocument::renameLayer(Model::LayerNode* layerNode, const std::string& name) {
+            applyAndSwap(*this, "Rename Layer", std::vector<Model::Node*>{layerNode}, kdl::overload(
+                [&](Model::Layer& layer) { layer.setName(name); return true; },
+                [] (Model::Entity&)      { return true; },
+                [] (Model::Brush&)       { return true; }
             ));
         }
 
-        bool MapDocument::moveLayerByOne(Model::LayerNode* layer, MoveDirection direction) {
+        bool MapDocument::moveLayerByOne(Model::LayerNode* layerNode, MoveDirection direction) {
             const std::vector<Model::LayerNode*> sorted = m_world->customLayersUserSorted();
 
-            const auto maybeIndex = kdl::vec_index_of(sorted, layer);
+            const auto maybeIndex = kdl::vec_index_of(sorted, layerNode);
             if (!maybeIndex.has_value()) {
                 return false;
             }
@@ -1339,20 +1343,20 @@ namespace TrenchBroom {
                 return false;
             }
             
-            Model::LayerNode* neighbour = sorted.at(static_cast<size_t>(newIndex));           
-            const int ourSortIndex = layer->sortIndex();
-            const int neighbourSortIndex = neighbour->sortIndex();
+            Model::LayerNode* neighbourNode = sorted.at(static_cast<size_t>(newIndex));
+            auto layer = layerNode->layer();
+            auto neighbourLayer = neighbourNode->layer();
+
+            const int layerSortIndex = layer.sortIndex();
+            const int neighbourSortIndex = neighbourLayer.sortIndex();
 
             // Swap the sort indices of `layer` and `neighbour`
-            auto layerEntity = layer->entity();
-            auto neighbourEntity = neighbour->entity();
-
-            layerEntity.addOrUpdateAttribute(Model::AttributeNames::LayerSortIndex, std::to_string(neighbourSortIndex));
-            neighbourEntity.addOrUpdateAttribute(Model::AttributeNames::LayerSortIndex, std::to_string(ourSortIndex));
+            layer.setSortIndex(neighbourSortIndex);
+            neighbourLayer.setSortIndex(layerSortIndex);
 
             swapNodeContents("Swap Layer Positions", {
-                {layer, Model::NodeContents(std::move(layerEntity))}, 
-                {neighbour, Model::NodeContents(std::move(neighbourEntity))}
+                {layerNode, Model::NodeContents(std::move(layer))}, 
+                {neighbourNode, Model::NodeContents(std::move(neighbourLayer))}
             });
 
             return true;
@@ -1516,15 +1520,12 @@ namespace TrenchBroom {
             executeAndStore(SetVisibilityCommand::show(selectedNodes));
         }
 
-        void MapDocument::setOmitLayerFromExport(Model::LayerNode* layer, const bool omitFromExport) {
-            auto entity = layer->entity();
-            if (omitFromExport) {
-                entity.addOrUpdateAttribute(Model::AttributeNames::LayerOmitFromExport, Model::AttributeValues::LayerOmitFromExportValue);
-                swapNodeContents("Omit Layer From Export", {{layer, Model::NodeContents(std::move(entity))}});
-            } else {
-                entity.removeAttribute(Model::AttributeNames::LayerOmitFromExport);
-                swapNodeContents("Include Layer In Export", {{layer, Model::NodeContents(std::move(entity))}});
-            }
+        void MapDocument::setOmitLayerFromExport(Model::LayerNode* layerNode, const bool omitFromExport) {
+            const auto commandName = omitFromExport ? "Omit Layer from Export" : "Include Layer in Export";
+
+            auto layer = layerNode->layer();
+            layer.setOmitFromExport(omitFromExport);
+            swapNodeContents(commandName, {{layerNode, Model::NodeContents(std::move(layer))}});
         }
 
         void MapDocument::hide(const std::vector<Model::Node*> nodes) {
@@ -1644,6 +1645,7 @@ namespace TrenchBroom {
             }
 
             const auto success = applyAndSwap(*this, commandName, nodesToTransform, kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [&](Model::Entity& entity) {
                     entity.transform(transformation);
                     return true;
@@ -1930,6 +1932,7 @@ namespace TrenchBroom {
 
         bool MapDocument::setAttribute(const std::string& name, const std::string& value) {
             return applyAndSwap(*this, "Set Property", allSelectedAttributableNodes(), kdl::overload(
+                [] (Model::Layer&)         { return true; },
                 [&](Model::Entity& entity) { entity.addOrUpdateAttribute(name, value); return true; },
                 [] (Model::Brush&)         { return true; }
             ));
@@ -1937,6 +1940,7 @@ namespace TrenchBroom {
 
         bool MapDocument::renameAttribute(const std::string& oldName, const std::string& newName) {
             return applyAndSwap(*this, "Rename Property", allSelectedAttributableNodes(), kdl::overload(
+                [] (Model::Layer&)         { return true; },
                 [&](Model::Entity& entity) { entity.renameAttribute(oldName, newName); return true; },
                 [] (Model::Brush&)         { return true; }
             ));
@@ -1944,6 +1948,7 @@ namespace TrenchBroom {
 
         bool MapDocument::removeAttribute(const std::string& name) {
             return applyAndSwap(*this, "Remove Property", allSelectedAttributableNodes(), kdl::overload(
+                [] (Model::Layer&)         { return true; },
                 [&](Model::Entity& entity) { entity.removeAttribute(name); return true; },
                 [] (Model::Brush&)         { return true; }
             ));
@@ -1951,7 +1956,8 @@ namespace TrenchBroom {
 
         bool MapDocument::convertEntityColorRange(const std::string& name, Assets::ColorRange::Type range) {
             return applyAndSwap(*this, "Convert Color", allSelectedAttributableNodes(), kdl::overload(
-                [&](Model::Entity& entity) { 
+                [] (Model::Layer&) { return true; },
+                [&](Model::Entity& entity) {
                     if (const auto* oldValue = entity.attribute(name)) {
                         entity.addOrUpdateAttribute(name, Model::convertEntityColor(*oldValue, range));
                     }
@@ -1963,6 +1969,7 @@ namespace TrenchBroom {
 
         bool MapDocument::updateSpawnflag(const std::string& name, const size_t flagIndex, const bool setFlag) {
             return applyAndSwap(*this, setFlag ? "Set Spawnflag" : "Unset Spawnflag", m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [&](Model::Entity& entity) {
                     const auto* strValue = entity.attribute(name);
                     int intValue = strValue ? kdl::str_to_int(*strValue).value_or(0) : 0;
@@ -1979,6 +1986,7 @@ namespace TrenchBroom {
 
         bool MapDocument::resizeBrushes(const std::vector<vm::polygon3>& faces, const vm::vec3& delta) {
             return applyAndSwap(*this, "Resize Brushes", m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&)       { return true; },
                 [] (Model::Entity&)      { return true; },
                 [&](Model::Brush& brush) {
                     const auto faceIndex = brush.findFace(faces);
@@ -2053,6 +2061,7 @@ namespace TrenchBroom {
             size_t failedBrushCount = 0;
 
             applyAndSwap(*this, "Snap Brush Vertices", m_selectedNodes.brushesRecursively(), kdl::overload(
+                [] (Model::Layer&)  { return true; },
                 [] (Model::Entity&) { return true; },
                 [&](Model::Brush& originalBrush) {
                     if (originalBrush.canSnapVertices(m_worldBounds, snapTo)) {
@@ -2084,6 +2093,7 @@ namespace TrenchBroom {
         MapDocument::MoveVerticesResult MapDocument::moveVertices(std::vector<vm::vec3> vertexPositions, const vm::vec3& delta) {
             auto newVertexPositions = std::vector<vm::vec3>{};
             auto newNodes = applyToNodeContents(m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [] (Model::Entity&) { return true; },
                 [&](Model::Brush& brush) {
                     const auto verticesToMove = kdl::vec_filter(vertexPositions, [&](const auto& vertex) { return brush.hasVertex(vertex); });
@@ -2124,6 +2134,7 @@ namespace TrenchBroom {
         bool MapDocument::moveEdges(std::vector<vm::segment3> edgePositions, const vm::vec3& delta) {
             auto newEdgePositions = std::vector<vm::segment3>{};
             auto newNodes = applyToNodeContents(m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [] (Model::Entity&) { return true; },
                 [&](Model::Brush& brush) {
                     const auto edgesToMove = kdl::vec_filter(edgePositions, [&](const auto& edge) { return brush.hasEdge(edge); });
@@ -2161,6 +2172,7 @@ namespace TrenchBroom {
         bool MapDocument::moveFaces(std::vector<vm::polygon3> facePositions, const vm::vec3& delta) {
             auto newFacePositions = std::vector<vm::polygon3>{};
             auto newNodes = applyToNodeContents(m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [] (Model::Entity&) { return true; },
                 [&](Model::Brush& brush) {
                     const auto facesToMove = kdl::vec_filter(facePositions, [&](const auto& face) { return brush.hasFace(face); });
@@ -2197,6 +2209,7 @@ namespace TrenchBroom {
 
         bool MapDocument::addVertex(const vm::vec3& vertexPosition) {
             auto newNodes = applyToNodeContents(m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [] (Model::Entity&) { return true; },
                 [&](Model::Brush& brush) {
                     if (!brush.canAddVertex(m_worldBounds, vertexPosition)) {
@@ -2219,6 +2232,7 @@ namespace TrenchBroom {
 
         bool MapDocument::removeVertices(const std::string& commandName, std::vector<vm::vec3> vertexPositions) {
             auto newNodes = applyToNodeContents(m_selectedNodes.nodes(), kdl::overload(
+                [] (Model::Layer&) { return true; },
                 [] (Model::Entity&) { return true; },
                 [&](Model::Brush& brush) {
                     const auto verticesToRemove = kdl::vec_filter(vertexPositions, [&](const auto& vertex) { return brush.hasVertex(vertex); });

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -369,7 +369,7 @@ namespace TrenchBroom {
             void renameLayer(Model::LayerNode* layer, const std::string& name);
         private:
             enum class MoveDirection { Up, Down };
-            bool moveLayerByOne(Model::LayerNode* layer, MoveDirection direction);
+            bool moveLayerByOne(Model::LayerNode* layerNode, MoveDirection direction);
         public:
             void moveLayer(Model::LayerNode* layer, int offset);
             bool canMoveLayer(Model::LayerNode* layer, int offset) const;
@@ -379,7 +379,7 @@ namespace TrenchBroom {
             bool canHideLayers(const std::vector<Model::LayerNode*>& layers) const;
             void isolateLayers(const std::vector<Model::LayerNode*>& layers);
             bool canIsolateLayers(const std::vector<Model::LayerNode*>& layers) const;
-            void setOmitLayerFromExport(Model::LayerNode* layer, bool omitFromExport);
+            void setOmitLayerFromExport(Model::LayerNode* layerNode, bool omitFromExport);
         public: // modifying transient node attributes, declared in MapFacade interface
             void isolate();
             void hide(std::vector<Model::Node*> nodes) override; // Don't take the nodes by reference!

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -310,7 +310,7 @@ namespace TrenchBroom {
 
                 pair.second = node->accept(kdl::overload(
                     [&](Model::WorldNode* worldNode)   -> Model::NodeContents { return Model::NodeContents(worldNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
-                    [&](Model::LayerNode* layerNode)   -> Model::NodeContents { return Model::NodeContents(layerNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
+                    [&](Model::LayerNode* layerNode)   -> Model::NodeContents { return Model::NodeContents(layerNode->setLayer(std::get<Model::Layer>(std::move(contents)))); },
                     [&](Model::GroupNode* groupNode)   -> Model::NodeContents { return Model::NodeContents(groupNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
                     [&](Model::EntityNode* entityNode) -> Model::NodeContents { return Model::NodeContents(entityNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
                     [&](Model::BrushNode* brushNode)   -> Model::NodeContents { return Model::NodeContents(brushNode->setBrush(std::get<Model::Brush>(std::move(contents)))); }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -311,7 +311,7 @@ namespace TrenchBroom {
                 pair.second = node->accept(kdl::overload(
                     [&](Model::WorldNode* worldNode)   -> Model::NodeContents { return Model::NodeContents(worldNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
                     [&](Model::LayerNode* layerNode)   -> Model::NodeContents { return Model::NodeContents(layerNode->setLayer(std::get<Model::Layer>(std::move(contents)))); },
-                    [&](Model::GroupNode* groupNode)   -> Model::NodeContents { return Model::NodeContents(groupNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
+                    [&](Model::GroupNode* groupNode)   -> Model::NodeContents { return Model::NodeContents(groupNode->setGroup(std::get<Model::Group>(std::move(contents)))); },
                     [&](Model::EntityNode* entityNode) -> Model::NodeContents { return Model::NodeContents(entityNode->setEntity(std::get<Model::Entity>(std::move(contents)))); },
                     [&](Model::BrushNode* brushNode)   -> Model::NodeContents { return Model::NodeContents(brushNode->setBrush(std::get<Model::Brush>(std::move(contents)))); }
                 ));

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -472,7 +472,7 @@ namespace TrenchBroom {
 
             // open groups
             std::vector<Model::GroupNode*> groups;
-            for (Model::GroupNode* group = document->currentGroup(); group != nullptr; group = group->group()) {
+            for (Model::GroupNode* group = document->currentGroup(); group != nullptr; group = group->containingGroup()) {
                 groups.push_back(group);
             }
             if (!groups.empty()) {

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -987,7 +987,7 @@ namespace TrenchBroom {
             }
             mergeGroupAction->setEnabled(canMergeGroups());
 
-            QAction* renameAction = menu.addAction(tr("Rename"), mapFrame, &MapFrame::renameSelectedGroups);
+            QAction* renameAction = menu.addAction(tr("Rename Groups"), mapFrame, &MapFrame::renameSelectedGroups);
             renameAction->setEnabled(mapFrame->canRenameSelectedGroups());
 
             if (newGroup != nullptr && newGroup != currentGroup) {

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -144,10 +144,10 @@ namespace TrenchBroom {
             CHECK(worldNode->entity().hasAttribute("message"));
             CHECK(*worldNode->entity().attribute("message") == "yay");
 
-            CHECK(!defaultLayer->layerColor().has_value());
+            CHECK(!defaultLayer->layer().color().has_value());
             CHECK(!defaultLayer->locked());
             CHECK(!defaultLayer->hidden());
-            CHECK(!defaultLayer->omitFromExport());
+            CHECK(!defaultLayer->layer().omitFromExport());
         }
 
         TEST_CASE("WorldReaderTest.parseDefaultLayerAttributes", "[WorldReaderTest]") {
@@ -173,11 +173,10 @@ namespace TrenchBroom {
             auto* defaultLayer = dynamic_cast<Model::LayerNode*>(world->children().at(0));
             REQUIRE(defaultLayer != nullptr);
 
-            REQUIRE(defaultLayer->layerColor().has_value());
-            CHECK(defaultLayer->layerColor().value() == Color(0.0f, 1.0f, 0.0f));
+            CHECK(defaultLayer->layer().color().value() == Color(0.0f, 1.0f, 0.0f));
             CHECK(defaultLayer->locked());
             CHECK(defaultLayer->hidden());
-            CHECK(defaultLayer->omitFromExport());
+            CHECK(defaultLayer->layer().omitFromExport());
         }
 
         TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity", "[WorldReaderTest]") {
@@ -206,12 +205,12 @@ namespace TrenchBroom {
             CHECK(*worldNode->entity().attribute("message") == "yay");
 
             ASSERT_EQ(1u, worldNode->childCount());
-            Model::LayerNode* defaultLayer = dynamic_cast<Model::LayerNode*>(worldNode->children().front());
-            ASSERT_NE(nullptr, defaultLayer);
-            ASSERT_EQ(1u, defaultLayer->childCount());
-            ASSERT_EQ(Model::LayerNode::defaultLayerSortIndex(), defaultLayer->sortIndex());
+            Model::LayerNode* defaultLayerNode = dynamic_cast<Model::LayerNode*>(worldNode->children().front());
+            ASSERT_NE(nullptr, defaultLayerNode);
+            ASSERT_EQ(1u, defaultLayerNode->childCount());
+            ASSERT_EQ(Model::Layer::defaultLayerSortIndex(),  defaultLayerNode->layer().sortIndex());
 
-            Model::EntityNode* entityNode = static_cast<Model::EntityNode*>(defaultLayer->children().front());
+            Model::EntityNode* entityNode = static_cast<Model::EntityNode*>(defaultLayerNode->children().front());
             CHECK(entityNode->entity().hasAttribute("classname"));
             CHECK(*entityNode->entity().attribute("classname") == "info_player_deathmatch");
             CHECK(entityNode->entity().hasAttribute("origin"));
@@ -720,18 +719,18 @@ namespace TrenchBroom {
 
             ASSERT_EQ(2u, world->childCount());
 
-            Model::LayerNode* defaultLayer = dynamic_cast<Model::LayerNode*>(world->children().at(0));
-            Model::LayerNode* myLayer      = dynamic_cast<Model::LayerNode*>(world->children().at(1));
-            ASSERT_NE(nullptr, defaultLayer);
-            ASSERT_NE(nullptr, myLayer);
+            Model::LayerNode* defaultLayerNode = dynamic_cast<Model::LayerNode*>(world->children().at(0));
+            Model::LayerNode* myLayerNode      = dynamic_cast<Model::LayerNode*>(world->children().at(1));
+            ASSERT_NE(nullptr, defaultLayerNode);
+            ASSERT_NE(nullptr, myLayerNode);
 
-            CHECK(defaultLayer->sortIndex() == Model::LayerNode::defaultLayerSortIndex());
-            CHECK(myLayer->sortIndex()      == 0); // The layer didn't have a sort index (saved in an older version of TB), so it's assigned 0           
+            CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
+            CHECK(myLayerNode->layer().sortIndex() == 0); // The layer didn't have a sort index (saved in an older version of TB), so it's assigned 0           
 
-            ASSERT_EQ(2u, defaultLayer->childCount());
-            ASSERT_EQ(1u, myLayer->childCount());
-            CHECK(!myLayer->hidden());
-            CHECK(!myLayer->locked());
+            ASSERT_EQ(2u, defaultLayerNode->childCount());
+            ASSERT_EQ(1u, myLayerNode->childCount());
+            CHECK(!myLayerNode->hidden());
+            CHECK(!myLayerNode->locked());
         }
 
         TEST_CASE("WorldReaderTest.parseLayersWithReverseSort", "[WorldReaderTest]") {
@@ -766,29 +765,29 @@ namespace TrenchBroom {
             REQUIRE(world->childCount() == 3u);
 
             // NOTE: They are listed in world->children() in file order, not sort index order
-            auto* defaultLayer = dynamic_cast<Model::LayerNode*>(world->children().at(0));
-            auto* sort1     = dynamic_cast<Model::LayerNode*>(world->children().at(1));
-            auto* sort0     = dynamic_cast<Model::LayerNode*>(world->children().at(2));
+            auto* defaultLayerNode = dynamic_cast<Model::LayerNode*>(world->children().at(0));
+            auto* sortNode1        = dynamic_cast<Model::LayerNode*>(world->children().at(1));
+            auto* sortNode0        = dynamic_cast<Model::LayerNode*>(world->children().at(2));
 
-            REQUIRE(defaultLayer != nullptr);
-            REQUIRE(sort0 != nullptr);
-            REQUIRE(sort1 != nullptr);            
+            REQUIRE(defaultLayerNode != nullptr);
+            REQUIRE(sortNode0 != nullptr);
+            REQUIRE(sortNode1 != nullptr);            
 
-            CHECK(sort0->name() == "Sort Index 0");
-            CHECK(sort1->name() == "Sort Index 1");
+            CHECK(sortNode0->name() == "Sort Index 0");
+            CHECK(sortNode1->name() == "Sort Index 1");
 
-            CHECK(defaultLayer->sortIndex() == Model::LayerNode::defaultLayerSortIndex());
-            CHECK(sort0->sortIndex()     == 0);
-            CHECK(sort1->sortIndex()     == 1);            
+            CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
+            CHECK(sortNode0->layer().sortIndex()        == 0);
+            CHECK(sortNode1->layer().sortIndex()        == 1);            
 
-            CHECK(sort0->hidden());
-            CHECK(!sort1->hidden());
+            CHECK(sortNode0->hidden());
+            CHECK(!sortNode1->hidden());
 
-            CHECK(!sort0->locked());
-            CHECK(sort1->locked());
+            CHECK(!sortNode0->locked());
+            CHECK(sortNode1->locked());
 
-            CHECK(sort0->omitFromExport());
-            CHECK(!sort1->omitFromExport());
+            CHECK(sortNode0->layer().omitFromExport());
+            CHECK(!sortNode1->layer().omitFromExport());
         }
 
         TEST_CASE("WorldReaderTest.parseLayersWithReversedSortIndicesWithGaps", "[WorldReaderTest]") {
@@ -827,25 +826,25 @@ namespace TrenchBroom {
             ASSERT_EQ(4u, world->childCount());
 
             // NOTE: They are listed in world->children() in file order, not sort index order
-            auto* defaultLayer = dynamic_cast<Model::LayerNode*>(world->children().at(0));
-            auto* sort5        = dynamic_cast<Model::LayerNode*>(world->children().at(1));
-            auto* sort3        = dynamic_cast<Model::LayerNode*>(world->children().at(2));
-            auto* sort1        = dynamic_cast<Model::LayerNode*>(world->children().at(3));            
+            auto* defaultLayerNode = dynamic_cast<Model::LayerNode*>(world->children().at(0));
+            auto* sortNode5        = dynamic_cast<Model::LayerNode*>(world->children().at(1));
+            auto* sortNode3        = dynamic_cast<Model::LayerNode*>(world->children().at(2));
+            auto* sortNode1        = dynamic_cast<Model::LayerNode*>(world->children().at(3));            
           
-            REQUIRE(nullptr != defaultLayer);
-            REQUIRE(nullptr != sort1);
-            REQUIRE(nullptr != sort3);
-            REQUIRE(nullptr != sort5);
+            REQUIRE(nullptr != defaultLayerNode);
+            REQUIRE(nullptr != sortNode1);
+            REQUIRE(nullptr != sortNode3);
+            REQUIRE(nullptr != sortNode5);
 
-            CHECK(sort1->name() == "Sort Index 1");
-            CHECK(sort3->name() == "Sort Index 3");
-            CHECK(sort5->name() == "Sort Index 5");
+            CHECK(sortNode1->name() == "Sort Index 1");
+            CHECK(sortNode3->name() == "Sort Index 3");
+            CHECK(sortNode5->name() == "Sort Index 5");
 
-            CHECK(defaultLayer->sortIndex() == Model::LayerNode::defaultLayerSortIndex());
+            CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
             // We allow gaps in sort indices so they remain 1, 3, 5
-            CHECK(sort1->sortIndex()        == 1);
-            CHECK(sort3->sortIndex()        == 3);
-            CHECK(sort5->sortIndex()        == 5);
+            CHECK(sortNode1->layer().sortIndex() == 1);
+            CHECK(sortNode3->layer().sortIndex() == 3);
+            CHECK(sortNode5->layer().sortIndex() == 5);
         }
 
         TEST_CASE("WorldReaderTest.parseLayersWithSortIndicesWithGapsAndDuplicates", "[WorldReaderTest]") {
@@ -905,36 +904,36 @@ namespace TrenchBroom {
             ASSERT_EQ(7u, world->childCount());
 
             // NOTE: They are listed in world->children() in file order, not sort index order
-            auto* defaultLayer = dynamic_cast<Model::LayerNode*>(world->children().at(0));
-            auto* sortMinusOne = dynamic_cast<Model::LayerNode*>(world->children().at(1));
-            auto* sort8        = dynamic_cast<Model::LayerNode*>(world->children().at(2));
-            auto* sort8second  = dynamic_cast<Model::LayerNode*>(world->children().at(3));
-            auto* sort10       = dynamic_cast<Model::LayerNode*>(world->children().at(4));
-            auto* sort10second = dynamic_cast<Model::LayerNode*>(world->children().at(5));
-            auto* sort12       = dynamic_cast<Model::LayerNode*>(world->children().at(6));            
+            auto* defaultLayerNode = dynamic_cast<Model::LayerNode*>(world->children().at(0));
+            auto* sortMinusOneNode = dynamic_cast<Model::LayerNode*>(world->children().at(1));
+            auto* sortNode8        = dynamic_cast<Model::LayerNode*>(world->children().at(2));
+            auto* sortNode8second  = dynamic_cast<Model::LayerNode*>(world->children().at(3));
+            auto* sortNode10       = dynamic_cast<Model::LayerNode*>(world->children().at(4));
+            auto* sortNode10second = dynamic_cast<Model::LayerNode*>(world->children().at(5));
+            auto* sortNode12       = dynamic_cast<Model::LayerNode*>(world->children().at(6));            
           
-            REQUIRE(nullptr != defaultLayer);
-            REQUIRE(nullptr != sortMinusOne);
-            REQUIRE(nullptr != sort8);
-            REQUIRE(nullptr != sort8second);
-            REQUIRE(nullptr != sort10);
-            REQUIRE(nullptr != sort10second);
-            REQUIRE(nullptr != sort12);
+            REQUIRE(nullptr != defaultLayerNode);
+            REQUIRE(nullptr != sortMinusOneNode);
+            REQUIRE(nullptr != sortNode8);
+            REQUIRE(nullptr != sortNode8second);
+            REQUIRE(nullptr != sortNode10);
+            REQUIRE(nullptr != sortNode10second);
+            REQUIRE(nullptr != sortNode12);
 
-            CHECK(sortMinusOne->name() == "Sort Index -1");
-            CHECK(sort8->name()        == "Sort Index 8");
-            CHECK(sort8second->name()  == "Sort Index 8 (second)");
-            CHECK(sort10->name()       == "Sort Index 10");
-            CHECK(sort10second->name() == "Sort Index 10 (second)");
-            CHECK(sort12->name()       == "Sort Index 12");
+            CHECK(sortMinusOneNode->name() == "Sort Index -1");
+            CHECK(sortNode8->name()        == "Sort Index 8");
+            CHECK(sortNode8second->name()  == "Sort Index 8 (second)");
+            CHECK(sortNode10->name()       == "Sort Index 10");
+            CHECK(sortNode10second->name() == "Sort Index 10 (second)");
+            CHECK(sortNode12->name()       == "Sort Index 12");
 
-            CHECK(defaultLayer->sortIndex() == Model::LayerNode::defaultLayerSortIndex());
-            CHECK(sortMinusOne->sortIndex() == 13); // This one was invalid so it got moved to the end
-            CHECK(sort8->sortIndex()        == 8);
-            CHECK(sort8second->sortIndex()  == 14); // This one was invalid so it got moved to the end
-            CHECK(sort10->sortIndex()       == 10);
-            CHECK(sort10second->sortIndex() == 15); // This one was invalid so it got moved to the end
-            CHECK(sort12->sortIndex()       == 12);
+            CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
+            CHECK(sortMinusOneNode->layer().sortIndex() == 13); // This one was invalid so it got moved to the end
+            CHECK(sortNode8->layer().sortIndex()        == 8);
+            CHECK(sortNode8second->layer().sortIndex()  == 14); // This one was invalid so it got moved to the end
+            CHECK(sortNode10->layer().sortIndex()       == 10);
+            CHECK(sortNode10second->layer().sortIndex() == 15); // This one was invalid so it got moved to the end
+            CHECK(sortNode12->layer().sortIndex()       == 12);
         }
 
         TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer", "[WorldReaderTest]") {

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -130,6 +130,12 @@ namespace TrenchBroom {
             checkBoundsIntegral(brush);
         }
 
+        static void setLayerSortIndex(Model::LayerNode& layerNode, int sortIndex) {
+            auto layer = layerNode.layer();
+            layer.setSortIndex(sortIndex);
+            layerNode.setLayer(layer);
+        }
+
         TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.flip") {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
             Model::BrushNode* brush1 = document->world()->createBrush(builder.createCuboid(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(30.0, 31.0, 31.0)), "texture").value());
@@ -1210,10 +1216,10 @@ namespace TrenchBroom {
         }
 
         TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.defaultLayerSortIndexImmutable", "[LayerTest]") {
-            Model::LayerNode* defaultLayer = document->world()->defaultLayer();
+            Model::LayerNode* defaultLayerNode = document->world()->defaultLayer();
+            setLayerSortIndex(*defaultLayerNode, 555);
 
-            defaultLayer->setSortIndex(555);
-            CHECK(defaultLayer->sortIndex() == Model::LayerNode::defaultLayerSortIndex());
+            CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
         }
 
         TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.renameLayer", "[LayerTest]") {
@@ -1469,53 +1475,53 @@ namespace TrenchBroom {
             document->selectAllNodes();
             document->deleteObjects();
 
-            auto* layer0 = document->world()->createLayer("layer0");
-            auto* layer1 = document->world()->createLayer("layer1");
-            auto* layer2 = document->world()->createLayer("laeyr2");
+            auto* layerNode0 = document->world()->createLayer("layer0");
+            auto* layerNode1 = document->world()->createLayer("layer1");
+            auto* layerNode2 = document->world()->createLayer("layer2");
 
-            document->addNode(layer0, document->world());
-            document->addNode(layer1, document->world());
-            document->addNode(layer2, document->world());
+            setLayerSortIndex(*layerNode0, 0);
+            setLayerSortIndex(*layerNode1, 1);
+            setLayerSortIndex(*layerNode2, 2);
 
-            layer0->setSortIndex(0);
-            layer1->setSortIndex(1);
-            layer2->setSortIndex(2);
+            document->addNode(layerNode0, document->world());
+            document->addNode(layerNode1, document->world());
+            document->addNode(layerNode2, document->world());
 
             SECTION("check canMoveLayer") {
                 // defaultLayer() can never be moved
                 CHECK(!document->canMoveLayer(document->world()->defaultLayer(), 1));
-                CHECK( document->canMoveLayer(layer0,  0));
-                CHECK(!document->canMoveLayer(layer0, -1));
-                CHECK( document->canMoveLayer(layer0,  1));
-                CHECK( document->canMoveLayer(layer0,  2));
-                CHECK(!document->canMoveLayer(layer0,  3));
+                CHECK( document->canMoveLayer(layerNode0,  0));
+                CHECK(!document->canMoveLayer(layerNode0, -1));
+                CHECK( document->canMoveLayer(layerNode0,  1));
+                CHECK( document->canMoveLayer(layerNode0,  2));
+                CHECK(!document->canMoveLayer(layerNode0,  3));
             }
 
             SECTION("moveLayer by 0 has no effect") {
-                document->moveLayer(layer0, 0);
-                CHECK(layer0->sortIndex() == 0);
+                document->moveLayer(layerNode0, 0);
+                CHECK(layerNode0->layer().sortIndex() == 0);
             }
             SECTION("moveLayer by invalid negative amount is clamped") {
-                document->moveLayer(layer0, -1000);
-                CHECK(layer0->sortIndex() == 0);
+                document->moveLayer(layerNode0, -1000);
+                CHECK(layerNode0->layer().sortIndex() == 0);
             }
             SECTION("moveLayer by 1") {
-                document->moveLayer(layer0, 1);
-                CHECK(layer1->sortIndex() == 0);
-                CHECK(layer0->sortIndex() == 1);
-                CHECK(layer2->sortIndex() == 2);
+                document->moveLayer(layerNode0, 1);
+                CHECK(layerNode1->layer().sortIndex() == 0);
+                CHECK(layerNode0->layer().sortIndex() == 1);
+                CHECK(layerNode2->layer().sortIndex() == 2);
             }
             SECTION("moveLayer by 2") {
-                document->moveLayer(layer0, 2);
-                CHECK(layer1->sortIndex() == 0);
-                CHECK(layer2->sortIndex() == 1);
-                CHECK(layer0->sortIndex() == 2);
+                document->moveLayer(layerNode0, 2);
+                CHECK(layerNode1->layer().sortIndex() == 0);
+                CHECK(layerNode2->layer().sortIndex() == 1);
+                CHECK(layerNode0->layer().sortIndex() == 2);
             }
             SECTION("moveLayer by invalid positive amount is clamped") {
-                document->moveLayer(layer0, 1000);
-                CHECK(layer1->sortIndex() == 0);
-                CHECK(layer2->sortIndex() == 1);
-                CHECK(layer0->sortIndex() == 2);
+                document->moveLayer(layerNode0, 1000);
+                CHECK(layerNode1->layer().sortIndex() == 0);
+                CHECK(layerNode2->layer().sortIndex() == 1);
+                CHECK(layerNode0->layer().sortIndex() == 2);
             }
         }
 


### PR DESCRIPTION
Closes #3618. This PR refactors `LayerNode` and `GroupNode` by extracting separate `Layer` and `Group` classes and removes the inheritance from `AttributableNode`.