### PR TITLE
3637: Don't use scientific notation when writing floats

### DIFF
--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -32,6 +32,7 @@
 
 #include <kdl/overload.h>
 #include <kdl/parallel.h>
+#include <kdl/string_format.h>
 #include <kdl/vector_utils.h>
 
 #include <fmt/format.h>
@@ -41,6 +42,37 @@
 #include <utility> // for std::pair
 #include <vector>
 #include <sstream>
+
+namespace TrenchBroom {
+    namespace IO {
+        template <typename F>
+        struct FloatWrapper {
+            F value;
+
+            FloatWrapper(const F i_value) : value(i_value) {}
+        };
+
+        template <typename F>
+        FloatWrapper(const F) -> FloatWrapper<F>;
+    }
+}
+
+namespace fmt {
+    template <typename F>
+    struct formatter<TrenchBroom::IO::FloatWrapper<F>> {
+        constexpr auto parse(format_parse_context& ctx) {
+            return fmt::formatter<F>().parse(ctx);
+        }
+
+        template <typename FormatContext>
+        auto format(const TrenchBroom::IO::FloatWrapper<F>& w, FormatContext& ctx) {
+            std::string buffer;
+            format_to(std::back_inserter(buffer), "{:.17f}", w.value);
+            buffer = kdl::str_trim_decimals(buffer);
+            return format_to(ctx.out(), "{}", buffer);
+        }
+    };
+}
 
 namespace TrenchBroom {
     namespace IO {
@@ -59,15 +91,15 @@ namespace TrenchBroom {
                 const Model::BrushFace::Points& points = face.points();
 
                 fmt::format_to(std::ostreambuf_iterator<char>(stream), "( {} {} {} ) ( {} {} {} ) ( {} {} {} )",
-                               points[0].x(),
-                               points[0].y(),
-                               points[0].z(),
-                               points[1].x(),
-                               points[1].y(),
-                               points[1].z(),
-                               points[2].x(),
-                               points[2].y(),
-                               points[2].z());
+                               FloatWrapper(points[0].x()),
+                               FloatWrapper(points[0].y()),
+                               FloatWrapper(points[0].z()),
+                               FloatWrapper(points[1].x()),
+                               FloatWrapper(points[1].y()),
+                               FloatWrapper(points[1].z()),
+                               FloatWrapper(points[2].x()),
+                               FloatWrapper(points[2].y()),
+                               FloatWrapper(points[2].z()));
             }
 
             void writeTextureInfo(std::ostream& stream, const Model::BrushFace& face) const {
@@ -75,11 +107,11 @@ namespace TrenchBroom {
 
                 fmt::format_to(std::ostreambuf_iterator<char>(stream), " {} {} {} {} {} {}",
                                textureName,
-                               face.attributes().xOffset(),
-                               face.attributes().yOffset(),
-                               face.attributes().rotation(),
-                               face.attributes().xScale(),
-                               face.attributes().yScale());
+                               FloatWrapper(face.attributes().xOffset()),
+                               FloatWrapper(face.attributes().yOffset()),
+                               FloatWrapper(face.attributes().rotation()),
+                               FloatWrapper(face.attributes().xScale()),
+                               FloatWrapper(face.attributes().yScale()));
             }
 
             void writeValveTextureInfo(std::ostream& stream, const Model::BrushFace& face) const {
@@ -90,19 +122,19 @@ namespace TrenchBroom {
                 fmt::format_to(std::ostreambuf_iterator<char>(stream), " {} [ {} {} {} {} ] [ {} {} {} {} ] {} {} {}",
                                textureName,
 
-                               xAxis.x(),
-                               xAxis.y(),
-                               xAxis.z(),
-                               face.attributes().xOffset(),
+                               FloatWrapper(xAxis.x()),
+                               FloatWrapper(xAxis.y()),
+                               FloatWrapper(xAxis.z()),
+                               FloatWrapper(face.attributes().xOffset()),
 
-                               yAxis.x(),
-                               yAxis.y(),
-                               yAxis.z(),
-                               face.attributes().yOffset(),
+                               FloatWrapper(yAxis.x()),
+                               FloatWrapper(yAxis.y()),
+                               FloatWrapper(yAxis.z()),
+                               FloatWrapper(face.attributes().yOffset()),
 
-                               face.attributes().rotation(),
-                               face.attributes().xScale(),
-                               face.attributes().yScale());
+                               FloatWrapper(face.attributes().rotation()),
+                               FloatWrapper(face.attributes().xScale()),
+                               FloatWrapper(face.attributes().yScale()));
             }
         };
 
@@ -126,7 +158,7 @@ namespace TrenchBroom {
                 fmt::format_to(std::ostreambuf_iterator<char>(stream), " {} {} {}",
                                face.attributes().surfaceContents(),
                                face.attributes().surfaceFlags(),
-                               face.attributes().surfaceValue());
+                               FloatWrapper(face.attributes().surfaceValue()));
             }
         };
 

--- a/lib/kdl/include/kdl/string_format.h
+++ b/lib/kdl/include/kdl/string_format.h
@@ -104,6 +104,31 @@ namespace kdl {
     }
 
     /**
+     * Trims the longest suffix after the last '.' consisting only the char '0'. If the string ends with a '.' afterwards,
+     * that '.' is trimmed also.
+     *
+     * @param s the string to trim
+     * @return the trimmed string
+     */
+    inline std::string str_trim_decimals(const std::string_view s) {
+        const auto dot = s.find_last_of('.');
+        if (dot == std::string::npos) {
+            return std::string(s);
+        }
+
+        if (dot == s.length() - 1) {
+            return std::string(s.substr(0, s.length() - 1));
+        }
+
+        auto last = s.substr(dot + 1).find_last_not_of('0');
+        if (last == std::string::npos) {
+            return std::string(s.substr(0, dot));
+        }
+
+        return std::string(s.substr(0, dot + last + 2));
+    }
+
+    /**
      * Convers the given ASCII character to lowercase.
      *
      * @param c the character to convert

--- a/lib/kdl/test/src/string_format_test.cpp
+++ b/lib/kdl/test/src/string_format_test.cpp
@@ -49,6 +49,18 @@ namespace kdl {
         ASSERT_EQ("abc", str_trim("xyxxabczzxzyz", "xyz"));
     }
 
+    TEST_CASE("string_format_test.str_trim_decimals", "[string_format_test]") {
+        ASSERT_EQ("", str_trim_decimals(""));
+        ASSERT_EQ("0", str_trim_decimals("0"));
+        ASSERT_EQ("00", str_trim_decimals("00"));
+        ASSERT_EQ("0", str_trim_decimals("0.0"));
+        ASSERT_EQ("0123", str_trim_decimals("0123."));
+        ASSERT_EQ("0123", str_trim_decimals("0123.0"));
+        ASSERT_EQ("0123.001", str_trim_decimals("0123.001"));
+        ASSERT_EQ("0123.001", str_trim_decimals("0123.0010"));
+        ASSERT_EQ("0123.001", str_trim_decimals("0123.0010000"));
+    }
+
     TEST_CASE("string_format_test.str_to_lower_char", "[string_format_test]") {
         constexpr auto input = " !\"#$%&\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
         constexpr auto expected = " !\"#$%&\\'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";


### PR DESCRIPTION
Closes #3637. This restores the previous behavior and uses fixed format with a precision of 17 to write floats. I think we should discuss if we really need to go up to 17,  or if a lower value is acceptable.