### PR TITLE
2607: Keep layer and group IDs persistent

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -242,6 +242,8 @@ namespace TrenchBroom {
             }
 
             Model::LayerNode* layerNode = new Model::LayerNode(std::move(layer));
+            layerNode->setPersistentId(layerId);
+
             if (findProperty(propeties, Model::PropertyKeys::LayerLocked) == Model::PropertyValues::LayerLockedValue) {
                 layerNode->setLockState(Model::LockState::Lock_Locked);
             }
@@ -284,6 +286,7 @@ namespace TrenchBroom {
             }
 
             Model::GroupNode* groupNode = new Model::GroupNode(Model::Group(name));
+            groupNode->setPersistentId(groupId);
             setExtraAttributes(groupNode, extraAttributes);
 
             storeNode(groupNode, properties, status);

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -219,13 +219,13 @@ namespace TrenchBroom {
                 return;
             }
 
-            const long rawId = std::atol(idStr.c_str());
-            if (rawId <= 0) {
+            const auto rawId = kdl::str_to_size(idStr);
+            if (!rawId || *rawId <= 0u) {
                 status.error(line, kdl::str_to_string("Skipping layer entity: '", idStr, "' is not a valid id"));
                 return;
             }
 
-            const Model::IdType layerId = static_cast<Model::IdType>(rawId);
+            const Model::IdType layerId = static_cast<Model::IdType>(*rawId);
             if (m_layers.count(layerId) > 0) {
                 status.error(line, kdl::str_to_string("Skipping layer entity: layer with id '", idStr, "' already exists"));
                 return;
@@ -271,13 +271,13 @@ namespace TrenchBroom {
                 return;
             }
 
-            const long rawId = std::atol(idStr.c_str());
-            if (rawId <= 0) {
+            const auto rawId = kdl::str_to_size(idStr);
+            if (!rawId || *rawId <= 0) {
                 status.error(line, kdl::str_to_string("Skipping group entity: '", idStr, "' is not a valid id"));
                 return;
             }
 
-            const Model::IdType groupId = static_cast<Model::IdType>(rawId);
+            const Model::IdType groupId = static_cast<Model::IdType>(*rawId);
             if (m_groups.count(groupId) > 0) {
                 status.error(line, kdl::str_to_string("Skipping group entity: group with id '", idStr, "' already exists"));
                 return;
@@ -327,9 +327,8 @@ namespace TrenchBroom {
         MapReader::ParentInfo::Type MapReader::storeNode(Model::Node* node, const std::vector<Model::EntityProperty>& properties, ParserStatus& status) {
             const std::string& layerIdStr = findProperty(properties, Model::PropertyKeys::Layer);
             if (!kdl::str_is_blank(layerIdStr)) {
-                const long rawId = std::atol(layerIdStr.c_str());
-                if (rawId > 0) {
-                    const Model::IdType layerId = static_cast<Model::IdType>(rawId);
+                if (const auto rawId = kdl::str_to_size(layerIdStr)) {
+                    const Model::IdType layerId = static_cast<Model::IdType>(*rawId);
                     Model::LayerNode* layer = kdl::map_find_or_default(m_layers, layerId,
                         static_cast<Model::LayerNode*>(nullptr));
                     if (layer != nullptr)
@@ -343,9 +342,8 @@ namespace TrenchBroom {
             } else {
                 const std::string& groupIdStr = findProperty(properties, Model::PropertyKeys::Group);
                 if (!kdl::str_is_blank(groupIdStr)) {
-                    const long rawId = std::atol(groupIdStr.c_str());
-                    if (rawId > 0) {
-                        const Model::IdType groupId = static_cast<Model::IdType>(rawId);
+                if (const auto rawId = kdl::str_to_size(groupIdStr)) {
+                        const Model::IdType groupId = static_cast<Model::IdType>(*rawId);
                         Model::GroupNode* group = kdl::map_find_or_default(m_groups, groupId,
                             static_cast<Model::GroupNode*>(nullptr));
                         if (group != nullptr)

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -37,23 +37,6 @@
 
 namespace TrenchBroom {
     namespace IO {
-        const std::string& NodeSerializer::IdManager::getId(const Model::Node* t) const {
-            auto it = m_ids.find(t);
-            if (it == std::end(m_ids)) {
-                it = m_ids.insert(std::make_pair(t, idToString(makeId()))).first;
-            }
-            return it->second;
-        }
-
-        Model::IdType NodeSerializer::IdManager::makeId() const {
-            static Model::IdType currentId = 1;
-            return currentId++;
-        }
-
-        std::string NodeSerializer::IdManager::idToString(const Model::IdType nodeId) const {
-            return kdl::str_to_string(nodeId);
-        }
-
         NodeSerializer::NodeSerializer() :
         m_entityNo(0),
         m_brushNo(0),
@@ -219,8 +202,8 @@ namespace TrenchBroom {
             auto properties = std::vector<Model::EntityProperty>{};
             node->accept(kdl::overload(
                 [](const Model::WorldNode*) {},
-                [&](const Model::LayerNode* layer) { properties.push_back(Model::EntityProperty(Model::PropertyKeys::Layer, m_layerIds.getId(layer))); },
-                [&](const Model::GroupNode* group) { properties.push_back(Model::EntityProperty(Model::PropertyKeys::Group, m_groupIds.getId(group))); },
+                [&](const Model::LayerNode* layerNode) { properties.push_back(Model::EntityProperty(Model::PropertyKeys::Layer, kdl::str_to_string(*layerNode->persistentId()))); },
+                [&](const Model::GroupNode* groupNode) { properties.push_back(Model::EntityProperty(Model::PropertyKeys::Group, kdl::str_to_string(*groupNode->persistentId()))); },
                 [](const Model::EntityNode*) {},
                 [](const Model::BrushNode*) {}
             ));
@@ -233,7 +216,7 @@ namespace TrenchBroom {
                 Model::EntityProperty(Model::PropertyKeys::Classname, Model::PropertyValues::LayerClassname),
                 Model::EntityProperty(Model::PropertyKeys::GroupType, Model::PropertyValues::GroupTypeLayer),
                 Model::EntityProperty(Model::PropertyKeys::LayerName, layerNode->name()),
-                Model::EntityProperty(Model::PropertyKeys::LayerId, m_layerIds.getId(layerNode)),
+                Model::EntityProperty(Model::PropertyKeys::LayerId, kdl::str_to_string(*layerNode->persistentId())),
             };
 
             const auto& layer = layerNode->layer();
@@ -252,12 +235,12 @@ namespace TrenchBroom {
             return result;
         }
 
-        std::vector<Model::EntityProperty> NodeSerializer::groupProperties(const Model::GroupNode* group) {
+        std::vector<Model::EntityProperty> NodeSerializer::groupProperties(const Model::GroupNode* groupNode) {
             return {
                 Model::EntityProperty(Model::PropertyKeys::Classname, Model::PropertyValues::GroupClassname),
                 Model::EntityProperty(Model::PropertyKeys::GroupType, Model::PropertyValues::GroupTypeGroup),
-                Model::EntityProperty(Model::PropertyKeys::GroupName, group->name()),
-                Model::EntityProperty(Model::PropertyKeys::GroupId, m_groupIds.getId(group)),
+                Model::EntityProperty(Model::PropertyKeys::GroupName, groupNode->name()),
+                Model::EntityProperty(Model::PropertyKeys::GroupId, kdl::str_to_string(*groupNode->persistentId())),
             };
         }
 

--- a/common/src/IO/NodeSerializer.h
+++ b/common/src/IO/NodeSerializer.h
@@ -56,20 +56,6 @@ namespace TrenchBroom {
         protected:
             using ObjectNo = unsigned int;
         private:
-            class IdManager {
-            private:
-                using IdMap = std::unordered_map<const Model::Node*, std::string>;
-                mutable IdMap m_ids;
-            public:
-                const std::string& getId(const Model::Node* t) const;
-            private:
-                Model::IdType makeId() const;
-                std::string idToString(const Model::IdType nodeId) const;
-            };
-
-            IdManager m_layerIds;
-            IdManager m_groupIds;
-
             ObjectNo m_entityNo;
             ObjectNo m_brushNo;
 
@@ -118,10 +104,10 @@ namespace TrenchBroom {
         private:
             void brushFace(const Model::BrushFace& face);
         public:
-            std::vector<Model::EntityProperty> parentProperties(const Model::Node* node);
+            std::vector<Model::EntityProperty> parentProperties(const Model::Node* groupNode);
         private:
             std::vector<Model::EntityProperty> layerProperties(const Model::LayerNode* layerNode);
-            std::vector<Model::EntityProperty> groupProperties(const Model::GroupNode* group);
+            std::vector<Model::EntityProperty> groupProperties(const Model::GroupNode* groupNode);
         protected:
             std::string escapeEntityProperties(const std::string& str) const;
         private:

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -77,6 +77,14 @@ namespace TrenchBroom {
             closeAncestors();
         }
 
+        const std::optional<IdType>& GroupNode::persistentId() const {
+            return m_persistentId;
+        }
+
+        void GroupNode::setPersistentId(const IdType persistentId) {
+            m_persistentId = persistentId;
+        }
+
         void GroupNode::setEditState(const EditState editState) {
             m_editState = editState;
         }

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -22,6 +22,7 @@
 #include "FloatType.h"
 #include "Macros.h"
 #include "Model/Group.h"
+#include "Model/IdType.h"
 #include "Model/Node.h"
 #include "Model/Object.h"
 
@@ -29,6 +30,7 @@
 
 #include <vecmath/bbox.h>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -47,6 +49,12 @@ namespace TrenchBroom {
             mutable vm::bbox3 m_logicalBounds;
             mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
+
+            /**
+             * The ID used to serialize group nodes (see MapReader and NodeSerializer). This is set by MapReader when a
+             * layer is read, or by WorldNode when a group is added that doesn't yet have a persistent ID.
+             */
+            std::optional<IdType> m_persistentId;
         public:
             explicit GroupNode(Group group);
 
@@ -58,6 +66,9 @@ namespace TrenchBroom {
             bool closed() const;
             void open();
             void close();
+
+            const std::optional<IdType>& persistentId() const;
+            void setPersistentId(IdType persistentId);
         private:
             void setEditState(EditState editState);
             void setAncestorEditState(EditState editState);

--- a/common/src/Model/LayerNode.cpp
+++ b/common/src/Model/LayerNode.cpp
@@ -65,6 +65,14 @@ namespace TrenchBroom {
             });
         }
 
+        const std::optional<IdType>& LayerNode::persistentId() const {
+            return m_persistentId;
+        }
+
+        void LayerNode::setPersistentId(const IdType persistentId) {
+            m_persistentId = persistentId;
+        }
+
         const std::string& LayerNode::doGetName() const {
             return layer().name();
         }

--- a/common/src/Model/LayerNode.h
+++ b/common/src/Model/LayerNode.h
@@ -21,14 +21,15 @@
 
 #include "FloatType.h"
 #include "Macros.h"
+#include "Model/IdType.h"
 #include "Model/Layer.h"
 #include "Model/Node.h"
 
 #include <vecmath/bbox.h>
 
+#include <optional>
 #include <string>
 #include <vector>
-#include <optional>
 
 namespace TrenchBroom {
     namespace Model {
@@ -39,6 +40,12 @@ namespace TrenchBroom {
             mutable vm::bbox3 m_logicalBounds;
             mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
+
+            /**
+             * The ID used to serialize layer nodes (see MapReader and NodeSerializer). This is set by MapReader when a
+             * layer is read, or by WorldNode when a layer is added that doesn't yet have a persistent ID.
+             */
+            std::optional<IdType> m_persistentId;
         public:
             explicit LayerNode(Layer layer);
 
@@ -51,6 +58,9 @@ namespace TrenchBroom {
              * Stable sort the given vector using `sortIndex()` as the sort key.
              */
             static void sortLayers(std::vector<LayerNode*>& layers);
+
+            const std::optional<IdType>& persistentId() const;
+            void setPersistentId(IdType persistentId);
         private: // implement Node interface
             const std::string& doGetName() const override;
             const vm::bbox3& doGetLogicalBounds() const override;

--- a/common/src/Model/WorldNode.h
+++ b/common/src/Model/WorldNode.h
@@ -22,6 +22,7 @@
 #include "FloatType.h"
 #include "Macros.h"
 #include "Model/EntityNodeBase.h"
+#include "Model/IdType.h"
 #include "Model/MapFormat.h"
 #include "Model/Node.h"
 
@@ -53,6 +54,8 @@ namespace TrenchBroom {
             using NodeTree = AABBTree<FloatType, 3, Node*>;
             std::unique_ptr<NodeTree> m_nodeTree;
             bool m_updateNodeTree;
+
+            IdType m_nextPersistentId = 1;
         public:
             WorldNode(Entity entity, MapFormat mapFormat);
             ~WorldNode() override;

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/Model/TestGame.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Model/TestGame.h"
         "${COMMON_TEST_SOURCE_DIR}/Model/TexCoordSystemTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/Model/WorldNodeTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Renderer/AllocationTrackerTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Renderer/CameraTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Renderer/VertexTest.cpp"

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -41,6 +41,8 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
+#include <fmt/format.h>
+
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -291,30 +293,30 @@ R"(// entity 0
             writer.writeMap();
 
             const std::string actual = str.str();
-            const std::string expected =
+            const std::string expected = fmt::format(
 R"(// entity 0
-{
+{{
 "classname" "worldspawn"
-}
+}}
 // entity 1
-{
+{{
 "classname" "func_group"
 "_tb_type" "_tb_layer"
 "_tb_name" "Custom Layer"
-"_tb_id" "*"
+"_tb_id" "{}"
 "_tb_layer_sort_index" "0"
 // brush 0
-{
+{{
 ( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none 0 0 0 1 1
-}
-}
-)";
-            CHECK_THAT(actual, MatchesGlob(expected));
+}}
+}}
+)", *layerNode->persistentId());
+            CHECK(actual == expected);
         }
 
         TEST_CASE("NodeWriterTest.writeWorldspawnWithCustomLayerWithSortIndex", "[NodeWriterTest]") {
@@ -335,24 +337,24 @@ R"(// entity 0
             writer.writeMap();
 
             const std::string actual = str.str();
-            const std::string expected =
+            const std::string expected = fmt::format(
 R"(// entity 0
-{
+{{
 "classname" "worldspawn"
-}
+}}
 // entity 1
-{
+{{
 "classname" "func_group"
 "_tb_type" "_tb_layer"
 "_tb_name" "Custom Layer"
-"_tb_id" "*"
+"_tb_id" "{}"
 "_tb_layer_sort_index" "1"
 "_tb_layer_locked" "1"
 "_tb_layer_hidden" "1"
 "_tb_layer_omit_from_export" "1"
-}
-)";
-            CHECK_THAT(actual, MatchesGlob(expected));
+}}
+)", *layerNode->persistentId());
+            CHECK(actual == expected);
         }
 
         TEST_CASE("NodeWriterTest.writeMapWithGroupInDefaultLayer", "[NodeWriterTest]") {
@@ -372,29 +374,29 @@ R"(// entity 0
             writer.writeMap();
 
             const std::string actual = str.str();
-            const std::string expected =
+            const std::string expected = fmt::format(
 R"(// entity 0
-{
+{{
 "classname" "worldspawn"
-}
+}}
 // entity 1
-{
+{{
 "classname" "func_group"
 "_tb_type" "_tb_group"
 "_tb_name" "Group"
-"_tb_id" "*"
+"_tb_id" "{}"
 // brush 0
-{
+{{
 ( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none 0 0 0 1 1
-}
-}
-)";
-            CHECK_THAT(actual, MatchesGlob(expected));
+}}
+}}
+)", *groupNode->persistentId());
+            CHECK(actual == expected);
         }
 
         TEST_CASE("NodeWriterTest.writeMapWithGroupInCustomLayer", "[NodeWriterTest]") {
@@ -417,37 +419,37 @@ R"(// entity 0
             writer.writeMap();
 
             const std::string actual = str.str();
-            const std::string expected =
+            const std::string expected = fmt::format(
 R"(// entity 0
-{
+{{
 "classname" "worldspawn"
-}
+}}
 // entity 1
-{
+{{
 "classname" "func_group"
 "_tb_type" "_tb_layer"
 "_tb_name" "Custom Layer"
-"_tb_id" "*"
-}
+"_tb_id" "{0}"
+}}
 // entity 2
-{
+{{
 "classname" "func_group"
 "_tb_type" "_tb_group"
 "_tb_name" "Group"
-"_tb_id" "*"
-"_tb_layer" "*"
+"_tb_id" "{1}"
+"_tb_layer" "{0}"
 // brush 0
-{
+{{
 ( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none 0 0 0 1 1
-}
-}
-)";
-            CHECK_THAT(actual, MatchesGlob(expected));
+}}
+}}
+)", *layerNode->persistentId(), *groupNode->persistentId());
+            CHECK(actual == expected);
         }
 
         TEST_CASE("NodeWriterTest.writeMapWithNestedGroupInCustomLayer", "[NodeWriterTest]") {
@@ -473,8 +475,79 @@ R"(// entity 0
             writer.writeMap();
 
             const std::string actual = str.str();
-            const std::string expected =
+            const std::string expected = fmt::format(
 R"(// entity 0
+{{
+"classname" "worldspawn"
+}}
+// entity 1
+{{
+"classname" "func_group"
+"_tb_type" "_tb_layer"
+"_tb_name" "Custom Layer"
+"_tb_id" "{0}"
+}}
+// entity 2
+{{
+"classname" "func_group"
+"_tb_type" "_tb_group"
+"_tb_name" "Outer Group"
+"_tb_id" "{1}"
+"_tb_layer" "{0}"
+}}
+// entity 3
+{{
+"classname" "func_group"
+"_tb_type" "_tb_group"
+"_tb_name" "Inner Group"
+"_tb_id" "{2}"
+"_tb_group" "{1}"
+// brush 0
+{{
+( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
+( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none 0 0 0 1 1
+( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none 0 0 0 1 1
+( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none 0 0 0 1 1
+( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none 0 0 0 1 1
+( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none 0 0 0 1 1
+}}
+}}
+)", *layerNode->persistentId(), *outerGroupNode->persistentId(), *innerGroupNode->persistentId());
+            CHECK(actual == expected);
+        }
+
+        TEST_CASE("NodeWriterTest.ensureLayerAndGroupPersistentIDs", "[NodeWriterTest]") {
+            const vm::bbox3 worldBounds(8192.0);
+
+            Model::WorldNode map(Model::Entity(), Model::MapFormat::Standard);
+
+            Model::LayerNode* layerNode1 = new Model::LayerNode(Model::Layer("Custom Layer 1"));
+            layerNode1->setPersistentId(1u);
+            map.addChild(layerNode1);
+
+            Model::GroupNode* outerGroupNode = new Model::GroupNode(Model::Group("Outer Group"));
+            outerGroupNode->setPersistentId(21u);
+            layerNode1->addChild(outerGroupNode);
+
+            Model::GroupNode* innerGroupNode = new Model::GroupNode(Model::Group("Inner Group"));
+            innerGroupNode->setPersistentId(7u);
+            outerGroupNode->addChild(innerGroupNode);
+
+            Model::LayerNode* layerNode2 = new Model::LayerNode(Model::Layer("Custom Layer 2"));
+            layerNode2->setPersistentId(12u);
+            map.addChild(layerNode2);
+
+            Model::BrushBuilder builder(map.mapFormat(), worldBounds);
+            Model::BrushNode* brushNode = new Model::BrushNode(builder.createCube(64.0, "none").value());
+            innerGroupNode->addChild(brushNode);
+
+            std::stringstream str;
+            NodeWriter writer(map, str);
+            writer.writeMap();
+
+            const std::string actual = str.str();
+            const std::string expected =
+                R"(// entity 0
 {
 "classname" "worldspawn"
 }
@@ -482,24 +555,24 @@ R"(// entity 0
 {
 "classname" "func_group"
 "_tb_type" "_tb_layer"
-"_tb_name" "Custom Layer"
-"_tb_id" "*"
+"_tb_name" "Custom Layer 1"
+"_tb_id" "1"
 }
 // entity 2
 {
 "classname" "func_group"
 "_tb_type" "_tb_group"
 "_tb_name" "Outer Group"
-"_tb_id" "*"
-"_tb_layer" "*"
+"_tb_id" "21"
+"_tb_layer" "1"
 }
 // entity 3
 {
 "classname" "func_group"
 "_tb_type" "_tb_group"
 "_tb_name" "Inner Group"
-"_tb_id" "*"
-"_tb_group" "*"
+"_tb_id" "7"
+"_tb_group" "21"
 // brush 0
 {
 ( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
@@ -510,8 +583,15 @@ R"(// entity 0
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none 0 0 0 1 1
 }
 }
+// entity 4
+{
+"classname" "func_group"
+"_tb_type" "_tb_layer"
+"_tb_name" "Custom Layer 2"
+"_tb_id" "12"
+}
 )";
-            CHECK_THAT(actual, MatchesGlob(expected));
+            CHECK(actual == expected);
         }
 
         TEST_CASE("NodeWriterTest.exportMapWithOmittedLayers", "[NodeWriterTest]") {
@@ -660,38 +740,38 @@ R"(// entity 0
             writer.writeNodes(nodes);
 
             const std::string actual = str.str();
-            const std::string expected =
+            const std::string expected = fmt::format(
 R"(// entity 0
-{
+{{
 "classname" "worldspawn"
 // brush 0
-{
+{{
 ( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) some 0 0 0 1 1
 ( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) some 0 0 0 1 1
 ( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) some 0 0 0 1 1
 ( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) some 0 0 0 1 1
 ( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) some 0 0 0 1 1
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) some 0 0 0 1 1
-}
-}
+}}
+}}
 // entity 1
-{
+{{
 "classname" "func_group"
 "_tb_type" "_tb_group"
 "_tb_name" "Inner Group"
-"_tb_id" "*"
+"_tb_id" "{}"
 // brush 0
-{
+{{
 ( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none 0 0 0 1 1
 ( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none 0 0 0 1 1
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none 0 0 0 1 1
-}
-}
-)";
-            CHECK_THAT(actual, MatchesGlob(expected));
+}}
+}}
+)", *innerGroupNode->persistentId());
+            CHECK(actual == expected);
         }
 
         TEST_CASE("NodeWriterTest.writeFaces", "[NodeWriterTest]") {

--- a/common/test/src/Model/WorldNodeTest.cpp
+++ b/common/test/src/Model/WorldNodeTest.cpp
@@ -1,0 +1,131 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Model/Entity.h"
+#include "Model/Group.h"
+#include "Model/GroupNode.h"
+#include "Model/Layer.h"
+#include "Model/LayerNode.h"
+#include "Model/MapFormat.h"
+#include "Model/WorldNode.h"
+
+#include "Catch2.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        TEST_CASE("WorldNodeTest.persistentIdOfDefaultLayer", "[WorldNodeTest]") {
+            auto worldNode = WorldNode{Entity{}, MapFormat::Standard};
+            CHECK(worldNode.defaultLayer()->persistentId() == std::nullopt);
+        }
+
+        TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingLayer", "[WorldNodeTest]") {
+            auto worldNode = WorldNode{Entity{}, MapFormat::Standard};
+            auto* initialLayerNode = new LayerNode{Layer{ "name"}};
+
+            REQUIRE(initialLayerNode->persistentId() == std::nullopt);
+            worldNode.addChild(initialLayerNode);
+            CHECK(initialLayerNode->persistentId() == 1u);
+
+            SECTION("Adding a layer node that already has a persistent ID") {
+                const auto id = *initialLayerNode->persistentId() + 10u;
+
+                auto* layerNodeWithId = new LayerNode{Layer{"name"}};
+                layerNodeWithId->setPersistentId(id);
+
+                worldNode.addChild(layerNodeWithId);
+                CHECK(layerNodeWithId->persistentId() == id);
+
+                auto* layerNodeWithoutId = new LayerNode{Layer{"name"}};
+
+                worldNode.addChild(layerNodeWithoutId);
+                REQUIRE(layerNodeWithoutId->persistentId() != std::nullopt);
+                CHECK(*layerNodeWithoutId->persistentId() == id + 1u);
+
+                SECTION("Adding a layer node that already has a lower persistent ID") {
+                    const auto lowerId = id - 1u;
+
+                    auto* layerNodeWithLowerId = new LayerNode{Layer{"name"}};
+                    layerNodeWithLowerId->setPersistentId(lowerId);
+
+                    worldNode.addChild(layerNodeWithLowerId);
+                    REQUIRE(layerNodeWithLowerId->persistentId() == lowerId);
+
+                    layerNodeWithoutId = new LayerNode{Layer{"name"}};
+
+                    worldNode.addChild(layerNodeWithoutId);
+                    REQUIRE(layerNodeWithoutId->persistentId() != std::nullopt);
+                    CHECK(*layerNodeWithoutId->persistentId() == id + 2u);
+                }
+            }
+        }
+
+        TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingGroup", "[WorldNodeTest]") {
+            auto worldNode = WorldNode{Entity{}, MapFormat::Standard};
+            auto* initialGroupNode = new GroupNode{Group{ "name"}};
+
+            REQUIRE(initialGroupNode->persistentId() == std::nullopt);
+            worldNode.defaultLayer()->addChild(initialGroupNode);
+            CHECK(initialGroupNode->persistentId() == 1u);
+
+            SECTION("Adding a layer node that already has a persistent ID") {
+                const auto id = *initialGroupNode->persistentId() + 10u;
+
+                auto* groupNodeWithId = new GroupNode{Group{ "name"}};
+                groupNodeWithId->setPersistentId(id);
+
+                worldNode.defaultLayer()->addChild(groupNodeWithId);
+                CHECK(groupNodeWithId->persistentId() == id);
+
+                auto* groupNodeWithoutId = new GroupNode{Group{ "name"}};
+
+                worldNode.defaultLayer()->addChild(groupNodeWithoutId);
+                REQUIRE(groupNodeWithoutId->persistentId() != std::nullopt);
+                CHECK(*groupNodeWithoutId->persistentId() == id + 1u);
+
+                SECTION("Adding a layer node that already has a lower persistent ID") {
+                    const auto lowerId = id - 1u;
+
+                    auto* groupNodeWithLowerId = new GroupNode{Group{ "name"}};
+                    groupNodeWithLowerId->setPersistentId(lowerId);
+
+                    worldNode.defaultLayer()->addChild(groupNodeWithLowerId);
+                    REQUIRE(groupNodeWithLowerId->persistentId() == lowerId);
+
+                    groupNodeWithoutId = new GroupNode{Group{ "name"}};
+
+                    worldNode.defaultLayer()->addChild(groupNodeWithoutId);
+                    REQUIRE(groupNodeWithoutId->persistentId() != std::nullopt);
+                    CHECK(*groupNodeWithoutId->persistentId() == id + 2u);
+                }
+            }
+        }
+
+        TEST_CASE("WorldNodeTest.setPersistentIdsWhenAddingLayersAndGroups", "[WorldNodeTest]") {
+            auto worldNode = WorldNode{Entity{}, MapFormat::Standard};
+
+            auto* layerNode = new LayerNode{Layer{"name"}};
+            worldNode.addChild(layerNode);
+            CHECK(layerNode->persistentId() == 1u);
+
+            auto* groupNode = new GroupNode{Group{"name"}};
+            layerNode->addChild(groupNode);
+            CHECK(groupNode->persistentId() == 2u);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2607.

Previously, layer and group IDs would be regenerated for every save, with the consequence of the numbers potentially changing unnecessarily, which produces diff noise. This PR keeps the numbers persistent.