### PR TITLE
Update to latest vecmath and adapt to changes to vec parse function

### DIFF
--- a/common/src/Color.cpp
+++ b/common/src/Color.cpp
@@ -27,17 +27,13 @@
 #include <sstream>
 
 namespace TrenchBroom {
-    bool Color::canParse(const std::string& str) {
-        return vm::can_parse<float, 4>(str) || vm::can_parse<float, 3>(str);
-    }
-
-    Color Color::parse(const std::string& str) {
-        if (vm::can_parse<float, 4>(str)) {
-            const auto v = vm::parse<float, 4>(str);
-            return Color(v.x(), v.y(), v.z(), v.w());
+    std::optional<Color> Color::parse(const std::string& str) {
+        if (const auto c4 = vm::parse<float, 4>(str)) {
+            return Color(c4->x(), c4->y(), c4->z(), c4->w());
+        } else if (const auto c3 = vm::parse<float, 3>(str)) {
+            return Color(c3->x(), c3->y(), c3->z());
         } else {
-            const auto v = vm::parse<float, 3>(str);
-            return Color(v.x(), v.y(), v.z());
+            return std::nullopt;
         }
     }
 

--- a/common/src/Color.h
+++ b/common/src/Color.h
@@ -21,13 +21,13 @@
 
 #include <vecmath/vec.h>
 
+#include <optional>
 #include <string>
 
 namespace TrenchBroom {
     class Color : public vm::vec<float, 4> {
     public:
-        static bool canParse(const std::string& str);
-        static Color parse(const std::string& str);
+        static std::optional<Color> parse(const std::string& str);
         std::string toString() const;
 
         Color();

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -354,13 +354,13 @@ namespace TrenchBroom {
 
             const auto it = std::begin(parts);
             vm::bbox3 result;
-            result.min = vm::parse<FloatType, 3>(kdl::str_join(it, std::next(it, 3), " "));
-            result.max = vm::parse<FloatType, 3>(kdl::str_join(std::next(it, 3), std::end(parts), " "));
+            result.min = vm::parse<FloatType, 3>(kdl::str_join(it, std::next(it, 3), " ")).value_or(vm::vec3::zero());
+            result.max = vm::parse<FloatType, 3>(kdl::str_join(std::next(it, 3), std::end(parts), " ")).value_or(vm::vec3::zero());
             return result;
         }
 
         Color EntParser::parseColor(const tinyxml2::XMLElement& element, const std::string& attributeName, ParserStatus& status) {
-            return Color::parse(parseString(element, attributeName, status));
+            return Color::parse(parseString(element, attributeName, status)).value_or(Color());
         }
 
         std::optional<int> EntParser::parseInteger(const tinyxml2::XMLElement& element, const std::string& attributeName, ParserStatus& /* status */) {

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -202,7 +202,7 @@ namespace TrenchBroom {
 
             const std::vector<Path> defFilePaths = Path::asPaths(value["definitions"].asStringList());
             const std::vector<std::string> modelFormats = value["modelformats"].asStringSet();
-            const Color defaultColor = Color::parse(value["defaultcolor"].stringValue());
+            const Color defaultColor = Color::parse(value["defaultcolor"].stringValue()).value_or(Color());
 
             return Model::EntityConfig(defFilePaths, modelFormats, defaultColor);
         }
@@ -317,7 +317,7 @@ namespace TrenchBroom {
                 defaults.setSurfaceValue(static_cast<float>(value["surfaceValue"].numberValue()));
             }
             if (!value["color"].null()) {
-                defaults.setColor(Color::parse(value["color"].stringValue()));
+                defaults.setColor(Color::parse(value["color"].stringValue()).value_or(Color()));
             }
 
             return defaults;
@@ -509,15 +509,11 @@ namespace TrenchBroom {
         }
 
         std::optional<vm::bbox3> parseSoftMapBoundsString(const std::string& string) {
-            if (!vm::can_parse<double, 6u>(string)) {
-                return std::nullopt;
+            if (const auto v = vm::parse<double, 6u>(string)) {
+                return vm::bbox3(vm::vec3((*v)[0], (*v)[1], (*v)[2]),
+                                 vm::vec3((*v)[3], (*v)[4], (*v)[5]));
             }
-
-            const auto v = vm::parse<double, 6u>(string);
-            const auto bounds = vm::bbox3(vm::vec3(v[0], v[1], v[2]),
-                                          vm::vec3(v[3], v[4], v[5]));
-
-            return { bounds };
+            return std::nullopt;
         }
 
         std::string serializeSoftMapBoundsString(const vm::bbox3& bounds) {

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -102,10 +102,12 @@ namespace TrenchBroom {
             // handle default layer attributes, which are stored in worldspawn
             auto* defaultLayerNode = m_world->defaultLayer();
             for (const Model::EntityProperty& property : properties) {
-                if (property.key() == Model::PropertyKeys::LayerColor && Color::canParse(property.value())) {
-                    auto defaultLayer = defaultLayerNode->layer();
-                    defaultLayer.setColor(Color::parse(property.value()));
-                    defaultLayerNode->setLayer(std::move(defaultLayer));
+                if (property.key() == Model::PropertyKeys::LayerColor) {
+                    if (const auto color = Color::parse(property.value())) {
+                        auto defaultLayer = defaultLayerNode->layer();
+                        defaultLayer.setColor(*color);
+                        defaultLayerNode->setLayer(std::move(defaultLayer));
+                    }
                 } else if (property.hasKeyAndValue(Model::PropertyKeys::LayerOmitFromExport, Model::PropertyValues::LayerOmitFromExportValue)) {
                     auto defaultLayer = defaultLayerNode->layer();
                     defaultLayer.setOmitFromExport(true);

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -286,7 +286,7 @@ namespace TrenchBroom {
                 // order is important here because EntityRotationPolicy::getRotation accesses classname
                 m_cachedProperties = CachedProperties{};
                 m_cachedProperties->classname = classnameValue ? *classnameValue : PropertyValues::NoClassname;
-                m_cachedProperties->origin = originValue ? vm::parse<FloatType, 3>(*originValue, vm::vec3::zero()) : vm::vec3::zero();
+                m_cachedProperties->origin = originValue ? vm::parse<FloatType, 3>(*originValue).value_or(vm::vec3::zero()) : vm::vec3::zero();
                 m_cachedProperties->rotation = EntityRotationPolicy::getRotation(*this);
             }
         }

--- a/common/src/Model/EntityRotationPolicy.cpp
+++ b/common/src/Model/EntityRotationPolicy.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
                 }
                 case RotationType::Euler: {
                     const auto* angleValue = entity.property(info.propertyKey);
-                    const auto angles = angleValue ? vm::parse<FloatType, 3>(*angleValue, vm::vec3::zero()) : vm::vec3::zero();
+                    const auto angles = angleValue ? vm::parse<FloatType, 3>(*angleValue).value_or(vm::vec3::zero()) : vm::vec3::zero();
 
                     // x = -pitch
                     // y =  yaw
@@ -77,7 +77,7 @@ namespace TrenchBroom {
                 }
                 case RotationType::Euler_PositivePitchDown: {
                     const auto* angleValue = entity.property(info.propertyKey);
-                    const auto angles = angleValue ? vm::parse<FloatType, 3>(*angleValue, vm::vec3::zero()) : vm::vec3::zero();
+                    const auto angles = angleValue ? vm::parse<FloatType, 3>(*angleValue).value_or(vm::vec3::zero()) : vm::vec3::zero();
 
                     // x = pitch
                     // y = yaw
@@ -89,7 +89,7 @@ namespace TrenchBroom {
                 }
                 case RotationType::Mangle: {
                     const auto* angleValue = entity.property(info.propertyKey);
-                    const auto angles = angleValue ? vm::parse<FloatType, 3>(*angleValue, vm::vec3::zero()) : vm::vec3::zero();
+                    const auto angles = angleValue ? vm::parse<FloatType, 3>(*angleValue).value_or(vm::vec3::zero()) : vm::vec3::zero();
 
                     // x = yaw
                     // y = -pitch

--- a/common/src/Model/PointFile.cpp
+++ b/common/src/Model/PointFile.cpp
@@ -95,18 +95,18 @@ namespace TrenchBroom {
             if (!stream.eof()) {
                 std::string line;
                 std::getline(stream, line);
-                points.push_back(vm::parse<float, 3>(line));
+                points.push_back(vm::parse<float, 3>(line).value_or(vm::vec3f::zero()));
                 vm::vec3f lastPoint = points.back();
 
                 if (!stream.eof()) {
                     std::getline(stream, line);
-                    vm::vec3f curPoint = vm::parse<float, 3>(line);
+                    vm::vec3f curPoint = vm::parse<float, 3>(line).value_or(vm::vec3f::zero());
                     vm::vec3f refDir = normalize(curPoint - lastPoint);
 
                     while (!stream.eof()) {
                         lastPoint = curPoint;
                         std::getline(stream, line);
-                        curPoint = vm::parse<float, 3>(line);
+                        curPoint = vm::parse<float, 3>(line).value_or(vm::vec3f::zero());
 
                         const vm::vec3f dir = normalize(curPoint - lastPoint);
                         if (std::acos(dot(dir, refDir)) > Threshold) {

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -66,14 +66,13 @@ namespace TrenchBroom {
         if (!in.isString()) {
             return false;
         }
-        const std::string inStdString = in.toString().toStdString();
 
-        if (!Color::canParse(inStdString)) {
-            return false;
+        if (const auto color = Color::parse(in.toString().toStdString())) {
+            *out = *color;
+            return true;
         }
 
-        *out = Color::parse(inStdString);
-        return true;
+        return false;
     }
 
     bool PreferenceSerializerV1::readFromJSON(const QJsonValue& in, float* out) const {

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -208,9 +208,9 @@ namespace TrenchBroom {
 
             const std::string str = m_colorEditor->text().toStdString();
             if (!kdl::str_is_blank(str)) {
-                if (Color::canParse(str)) {
+                if (const auto color = Color::parse(str)) {
                     Model::ChangeBrushFaceAttributesRequest request;
-                    request.setColor(Color::parse(str));
+                    request.setColor(*color);
                     if (!document->setFaceAttributes(request)) {
                         updateControls();
                     }

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1565,8 +1565,9 @@ namespace TrenchBroom {
             bool ok = false;
             const QString str = QInputDialog::getText(this, "Move Camera", "Enter a position (x y z) for the camera.", QLineEdit::Normal, "0.0 0.0 0.0", &ok);
             if (ok) {
-                const vm::vec3 position = vm::parse<FloatType, 3>(str.toStdString());
-                m_mapView->moveCameraToPosition(position, true);
+                if (const auto position = vm::parse<FloatType, 3>(str.toStdString())) {
+                    m_mapView->moveCameraToPosition(*position, true);
+                }
             }
         }
 
@@ -1748,8 +1749,9 @@ namespace TrenchBroom {
             bool ok = false;
             const QString str = QInputDialog::getText(this, "Window Size", "Enter Size (W H)", QLineEdit::Normal, "1920 1080", &ok);
             if (ok) {
-                const auto size = vm::parse<int, 2>(str.toStdString());
-                resize(size.x(), size.y());
+                if (const auto size = vm::parse<int, 2>(str.toStdString())) {
+                    resize(size->x(), size->y());
+                }
             }
         }
 

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -125,17 +125,13 @@ namespace TrenchBroom {
 
         static std::optional<vm::vec3> parseVec(const QString& qString) {
             const std::string string = qString.toStdString();
-            
-            if (vm::can_parse<double, 3u>(string)) {
-                return { vm::parse<double, 3u>(string) };
+            if (const auto vec = vm::parse<double, 3u>(string)) {
+                return *vec;
+            } else if (const auto val = vm::parse<double, 1u>(string)) {
+                return vm::vec3::fill(val->x());
+            } else {
+                return std::nullopt;
             }
-
-            if (vm::can_parse<double, 1u>(string)) {
-                const double fillValue = vm::parse<double, 1u>(string).x();
-                return { vm::vec3::fill(fillValue) };
-            }
-
-            return std::nullopt;
         }
 
         std::optional<vm::bbox3> MapPropertiesEditor::parseLineEdits() {

--- a/common/src/View/MoveObjectsToolPage.cpp
+++ b/common/src/View/MoveObjectsToolPage.cpp
@@ -89,10 +89,10 @@ namespace TrenchBroom {
         }
 
         void MoveObjectsToolPage::applyMove() {
-            const vm::vec3 delta = vm::parse<FloatType, 3>(m_offset->text().toStdString());
-
-            auto document = kdl::mem_lock(m_document);
-            document->translateObjects(delta);
+            if (const auto delta = vm::parse<FloatType, 3>(m_offset->text().toStdString())) {
+                auto document = kdl::mem_lock(m_document);
+                document->translateObjects(*delta);
+            }
         }
     }
 }

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -167,8 +167,9 @@ namespace TrenchBroom {
         }
 
         void RotateObjectsToolPage::centerChanged() {
-            const auto center = vm::parse<FloatType, 3>(m_recentlyUsedCentersList->currentText().toStdString());
-            m_tool->setRotationCenter(center);
+            if (const auto center = vm::parse<FloatType, 3>(m_recentlyUsedCentersList->currentText().toStdString())) {
+                m_tool->setRotationCenter(*center);
+            }
         }
 
         void RotateObjectsToolPage::resetCenterClicked() {

--- a/common/src/View/ScaleObjectsToolPage.cpp
+++ b/common/src/View/ScaleObjectsToolPage.cpp
@@ -124,13 +124,14 @@ namespace TrenchBroom {
             return kdl::mem_lock(m_document)->hasSelectedNodes();
         }
 
-        vm::vec3 ScaleObjectsToolPage::getScaleFactors() const {
+        std::optional<vm::vec3> ScaleObjectsToolPage::getScaleFactors() const {
             switch (m_scaleFactorsOrSize->currentIndex()) {
                 case 0: {
                     auto document = kdl::mem_lock(m_document);
-                    const auto desiredSize = vm::parse<FloatType, 3>(m_sizeTextBox->text().toStdString());
-
-                    return desiredSize / document->selectionBounds().size();
+                    if (const auto desiredSize = vm::parse<FloatType, 3>(m_sizeTextBox->text().toStdString())) {
+                        return *desiredSize / document->selectionBounds().size();
+                    }
+                    return std::nullopt;
                 }
                 default:
                     return vm::parse<FloatType, 3>(m_factorsTextBox->text().toStdString());
@@ -148,9 +149,9 @@ namespace TrenchBroom {
 
             auto document = kdl::mem_lock(m_document);
             const auto box = document->selectionBounds();
-            const auto scaleFactors = getScaleFactors();
-
-            document->scaleObjects(box.center(), scaleFactors);
+            if (const auto scaleFactors = getScaleFactors()) {
+                document->scaleObjects(box.center(), *scaleFactors);
+            }
         }
     }
 }

--- a/common/src/View/ScaleObjectsToolPage.h
+++ b/common/src/View/ScaleObjectsToolPage.h
@@ -24,6 +24,7 @@
 #include <vecmath/forward.h>
 
 #include <memory>
+#include <optional>
 
 #include <QWidget>
 
@@ -61,7 +62,7 @@ namespace TrenchBroom {
             void updateGui();
 
             bool canScale() const;
-            vm::vec3 getScaleFactors() const;
+            std::optional<vm::vec3> getScaleFactors() const;
 
             void selectionDidChange(const Selection& selection);
 


### PR DESCRIPTION
vm::parse now returns an optional and the can_parse function was removed.

I made this change because I need to write a similar parse function for matrices, and I don't want to deal with can_parse and such.