### PR TITLE
Fail if unable to find pandoc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,12 +98,12 @@ if(NOT GIT_FOUND)
 endif()
 
 # Find Pandoc
-if (NOT PANDOC_PATH AND NOT PANDOC_PATH-NOTFOUND)
+if (NOT PANDOC_PATH)
     find_program(PANDOC_PATH NAMES "pandoc" DOC "Pandoc program location")
-    if(PANDOC_PATH-NOTFOUND)
-        message(FATAL_ERROR "Could not find pandoc")
-    else()
+    if(PANDOC_FOUND)
         message(STATUS "Found Pandoc: ${PANDOC_PATH}")
+    else()
+        message(FATAL_ERROR "Could not find pandoc")
     endif()
 endif()
 


### PR DESCRIPTION
Fail the build for real if pandoc cannot be found.

`find_program(... NAMES "pandoc")` will set `PANDOC_FOUND` if it finds it.

Current code would print this when looking for pandoc:

    -- Found Pandoc: PANDOC_PATH-NOTFOUND