### PR TITLE
3675: Configurable Antialiasing

### DIFF
--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -130,6 +130,7 @@ namespace TrenchBroom {
 
         Preference<int> TextureMinFilter(IO::Path("Renderer/Texture mode min filter"), 0x2700);
         Preference<int> TextureMagFilter(IO::Path("Renderer/Texture mode mag filter"), 0x2600);
+        Preference<bool>  EnableMSAA(IO::Path("Renderer/Enable multisampling"), true);
 
         Preference<bool> TextureLock(IO::Path("Editor/Texture lock"), true);
         Preference<bool> UVLock(IO::Path("Editor/UV lock"), false);

--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -130,7 +130,7 @@ namespace TrenchBroom {
 
         Preference<int> TextureMinFilter(IO::Path("Renderer/Texture mode min filter"), 0x2700);
         Preference<int> TextureMagFilter(IO::Path("Renderer/Texture mode mag filter"), 0x2600);
-        Preference<bool>  EnableMSAA(IO::Path("Renderer/Enable multisampling"), true);
+        Preference<bool> EnableMSAA(IO::Path("Renderer/Enable multisampling"), true);
 
         Preference<bool> TextureLock(IO::Path("Editor/Texture lock"), true);
         Preference<bool> UVLock(IO::Path("Editor/UV lock"), false);

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -123,6 +123,7 @@ namespace TrenchBroom {
 
         extern Preference<int> TextureMinFilter;
         extern Preference<int> TextureMagFilter;
+        extern Preference<bool> EnableMSAA;
 
         extern Preference<bool> TextureLock;
         extern Preference<bool> UVLock;

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -20,6 +20,7 @@
 #include "CellView.h"
 
 #include "Preferences.h"
+#include "PreferenceManager.h"
 #include "View/CellLayout.h"
 #include "View/RenderView.h"
 
@@ -298,7 +299,11 @@ namespace TrenchBroom {
         }
 
         void CellView::setupGL() {
-            glAssert(glEnable(GL_MULTISAMPLE))
+            if (pref(Preferences::EnableMSAA)) {
+                glAssert(glEnable(GL_MULTISAMPLE))
+            } else {
+                glAssert(glDisable(GL_MULTISAMPLE))
+            }
             glAssert(glEnable(GL_BLEND))
             glAssert(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA))
             glAssert(glEnable(GL_CULL_FACE))

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -885,7 +885,11 @@ namespace TrenchBroom {
             const int height = static_cast<int>(viewport.height * r);
             glAssert(glViewport(x, y, width, height))
 
-            glAssert(glEnable(GL_MULTISAMPLE))
+            if (pref(Preferences::EnableMSAA)) {
+                glAssert(glEnable(GL_MULTISAMPLE))
+            } else {
+                glAssert(glDisable(GL_MULTISAMPLE))
+            }
             glAssert(glEnable(GL_BLEND))
             glAssert(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA))
             glAssert(glShadeModel(GL_SMOOTH))

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -201,7 +201,11 @@ namespace TrenchBroom {
 
             glAssert(glViewport(x, y, width, height))
 
-            glAssert(glEnable(GL_MULTISAMPLE))
+            if (pref(Preferences::EnableMSAA)) {
+                glAssert(glEnable(GL_MULTISAMPLE))
+            } else {
+                glAssert(glDisable(GL_MULTISAMPLE))
+            }
             glAssert(glEnable(GL_BLEND))
             glAssert(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA))
             glAssert(glShadeModel(GL_SMOOTH))

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -134,6 +134,9 @@ namespace TrenchBroom {
                 m_textureModeCombo->addItem(QString::fromStdString(textureMode.name));
             }
 
+            m_enableMsaa = new QCheckBox();
+            m_enableMsaa->setToolTip("Enable multisampling");
+
             m_textureBrowserIconSizeCombo = new QComboBox();
             m_textureBrowserIconSizeCombo->addItem("25%");
             m_textureBrowserIconSizeCombo->addItem("50%");
@@ -166,6 +169,7 @@ namespace TrenchBroom {
             layout->addRow("FOV", m_fovSlider);
             layout->addRow("Show axes", m_showAxes);
             layout->addRow("Texture mode", m_textureModeCombo);
+            layout->addRow("Enable multisampling", m_enableMsaa);
 
             layout->addSection("Texture Browser");
             layout->addRow("Icon size", m_textureBrowserIconSizeCombo);
@@ -185,6 +189,7 @@ namespace TrenchBroom {
             connect(m_gridAlphaSlider, &SliderWithLabel::valueChanged, this, &ViewPreferencePane::gridAlphaChanged);
             connect(m_fovSlider, &SliderWithLabel::valueChanged, this, &ViewPreferencePane::fovChanged);
             connect(m_showAxes, &QCheckBox::stateChanged, this, &ViewPreferencePane::showAxesChanged);
+            connect(m_enableMsaa, &QCheckBox::stateChanged, this, &ViewPreferencePane::enableMsaaChanged);
             connect(m_themeCombo, QOverload<int>::of(&QComboBox::activated), this, &ViewPreferencePane::themeChanged);
             connect(m_textureModeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ViewPreferencePane::textureModeChanged);
             connect(m_textureBrowserIconSizeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ViewPreferencePane::textureBrowserIconSizeChanged);
@@ -202,6 +207,7 @@ namespace TrenchBroom {
             prefs.resetToDefault(Preferences::GridAlpha);
             prefs.resetToDefault(Preferences::CameraFov);
             prefs.resetToDefault(Preferences::ShowAxes);
+            prefs.resetToDefault(Preferences::EnableMSAA);
             prefs.resetToDefault(Preferences::TextureMinFilter);
             prefs.resetToDefault(Preferences::TextureMagFilter);
             prefs.resetToDefault(Preferences::Theme);
@@ -219,6 +225,7 @@ namespace TrenchBroom {
             m_textureModeCombo->setCurrentIndex(int(textureModeIndex));
 
             m_showAxes->setChecked(pref(Preferences::ShowAxes));
+            m_enableMsaa->setChecked(pref(Preferences::EnableMSAA));
             m_themeCombo->setCurrentIndex(findThemeIndex(pref(Preferences::Theme)));
 
             const auto textureBrowserIconSize = pref(Preferences::TextureBrowserIconSize);
@@ -291,6 +298,12 @@ namespace TrenchBroom {
             const auto value = state == Qt::Checked;
             auto& prefs = PreferenceManager::instance();
             prefs.set(Preferences::ShowAxes, value);
+        }
+
+        void ViewPreferencePane::enableMsaaChanged(const int state) {
+            const auto value = state == Qt::Checked;
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::EnableMSAA, value);
         }
 
         void ViewPreferencePane::textureModeChanged(const int value) {

--- a/common/src/View/ViewPreferencePane.h
+++ b/common/src/View/ViewPreferencePane.h
@@ -37,6 +37,7 @@ namespace TrenchBroom {
             SliderWithLabel* m_fovSlider;
             QCheckBox* m_showAxes;
             QComboBox* m_textureModeCombo;
+            QCheckBox* m_enableMsaa;
             QComboBox* m_themeCombo;
             QComboBox* m_textureBrowserIconSizeCombo;
             QComboBox* m_rendererFontSizeCombo;
@@ -61,6 +62,7 @@ namespace TrenchBroom {
             void gridAlphaChanged(int value);
             void fovChanged(int value);
             void showAxesChanged(int state);
+            void enableMsaaChanged(int state);
             void textureModeChanged(int index);
             void themeChanged(int index);
             void textureBrowserIconSizeChanged(int index);


### PR DESCRIPTION
Implemented #3675.

Change of this setting does not require restarting the app because the GL_MULTISAMPLE option is being set before rendering each frame at ::setupGL.

<details>

<summary>GIF demonstration</summary>

![Peek 2021-01-15 15-47](https://user-images.githubusercontent.com/11665564/104729139-0dc25200-5749-11eb-8958-56f9650a8248.gif)

</details>
