### PR TITLE
Remove result factories

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -318,7 +318,7 @@ namespace TrenchBroom {
 
                         onBrush(parent, brushNode, status);
 
-                        return kdl::void_result;
+                        return kdl::void_success;
                     }
                 ).handle_errors(
                     [&](const Model::BrushError e) {

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -131,8 +131,6 @@ namespace TrenchBroom {
                 .and_then([&](Model::BrushFace&& face) {
                     face.setFilePosition(line, 1u);
                     onBrushFace(std::move(face), status);
-                    
-                    return kdl::void_success;
                 }).handle_errors([&](const Model::BrushError e) {
                     status.error(line, kdl::str_to_string("Skipping face: ", e));
                 });
@@ -143,8 +141,6 @@ namespace TrenchBroom {
             .and_then([&](Model::BrushFace&& face) {
                 face.setFilePosition(line, 1u);
                 onBrushFace(std::move(face), status);
-
-                return kdl::void_success;
             }).handle_errors([&](const Model::BrushError e) {
                 status.error(line, kdl::str_to_string("Skipping face: ", e));
             });
@@ -316,8 +312,6 @@ namespace TrenchBroom {
                         setExtraAttributes(brushNode, extraAttributes);
 
                         onBrush(parent, brushNode, status);
-
-                        return kdl::void_success;
                     }
                 ).handle_errors(
                     [&](const Model::BrushError e) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -142,7 +142,7 @@ namespace TrenchBroom {
             
             assert(checkFaceLinks());
 
-            return kdl::void_result;
+            return kdl::void_success;
         }
         
         const vm::bbox3& Brush::bounds() const {
@@ -261,7 +261,7 @@ namespace TrenchBroom {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
-                        return kdl::void_result;
+                        return kdl::void_success;
 #if defined(__GNUC__) && !defined(__clang__) && !defined(_MSC_VER) && __GNUC__ == 8
 #pragma GCC diagnostic pop
 #endif

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -97,7 +97,7 @@ namespace TrenchBroom {
         kdl::result<Brush, BrushError> Brush::create(const vm::bbox3& worldBounds, std::vector<BrushFace> faces) {
             Brush brush(std::move(faces));
             return brush.updateGeometryFromFaces(worldBounds)
-                .and_then([&]() { return kdl::result<Brush, BrushError>(std::move(brush)); });
+                .and_then([&]() { return std::move(brush); });
         }
 
         kdl::result<void, BrushError> Brush::updateGeometryFromFaces(const vm::bbox3& worldBounds) {
@@ -794,8 +794,6 @@ namespace TrenchBroom {
                         rightFace.copyTexCoordSystemFromFace(*snapshot, leftClone.attributes(), leftClone.boundary(), WrapStyle::Rotation);
                     }
                     rightFace.resetTexCoordSystemCache();
-
-                    return kdl::void_success;
                 }).handle_errors([](const BrushError) {
                     // do nothing
                 });
@@ -817,7 +815,6 @@ namespace TrenchBroom {
                             if (uvLock) {
                                 applyUVLock(matcher, leftFace, rightFace);
                             }
-                            return kdl::void_success;
                         }).handle_errors([&](const BrushError e) {
                             if (!error) {
                                 error = e;
@@ -920,7 +917,7 @@ namespace TrenchBroom {
                 for (const auto* subtrahend : subtrahends) {
                     brush.cloneInvertedFaceAttributesFrom(*subtrahend);
                 }
-                return kdl::result<Brush>{std::move(brush)};
+                return std::move(brush);
             });
         }
 

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -90,7 +90,7 @@ namespace TrenchBroom {
                     ));
 
                 if (error) {
-                    return kdl::result<Brush, BrushError>::error(*error);
+                    return *error;
                 }
             }
 
@@ -133,7 +133,7 @@ namespace TrenchBroom {
                     ));
 
                 if (error) {
-                    return kdl::result<Brush, BrushError>::error(*error);
+                    return *error;
                 }
             }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -463,7 +463,6 @@ namespace TrenchBroom {
             return setPoints(m_points[0], m_points[1], m_points[2])
                 .and_then([&]() {
                     m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
-                    return kdl::void_success;
                 });
         }
 
@@ -500,7 +499,6 @@ namespace TrenchBroom {
                     const auto offsetChange = desriedCoords - currentCoords;
                     m_attributes.setOffset(correct(modOffset(m_attributes.offset() + offsetChange), 4));
                 }
-                return kdl::void_success;
             });
         }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -154,9 +154,9 @@ namespace TrenchBroom {
             Points points = {{ vm::correct(point0), vm::correct(point1), vm::correct(point2) }};
             const auto [result, plane] = vm::from_points(points[0], points[1], points[2]);
             if (result) {
-                return kdl::result<BrushFace, BrushError>::success(BrushFace(points, plane, attributes, std::move(texCoordSystem)));
+                return BrushFace(points, plane, attributes, std::move(texCoordSystem));
             } else {
-                return kdl::result<BrushFace, BrushError>::error(BrushError::InvalidFace);
+                return BrushError::InvalidFace;
             }
         }
 
@@ -463,7 +463,7 @@ namespace TrenchBroom {
             return setPoints(m_points[0], m_points[1], m_points[2])
                 .and_then([&]() {
                     m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
-                    return kdl::result<void, BrushError>::success();
+                    return kdl::void_result;
                 });
         }
 
@@ -500,7 +500,7 @@ namespace TrenchBroom {
                     const auto offsetChange = desriedCoords - currentCoords;
                     m_attributes.setOffset(correct(modOffset(m_attributes.offset() + offsetChange), 4));
                 }
-                return kdl::result<void, BrushError>::success();
+                return kdl::void_result;
             });
         }
 
@@ -616,9 +616,9 @@ namespace TrenchBroom {
             const auto [result, plane] = vm::from_points(m_points[0], m_points[1], m_points[2]);
             if (result) {
                 m_boundary = plane;
-                return kdl::result<void, BrushError>::success();
+                return kdl::void_result;
             } else {
-                return kdl::result<void, BrushError>::error(BrushError::InvalidFace);
+                return BrushError::InvalidFace;
             }
         }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -463,7 +463,7 @@ namespace TrenchBroom {
             return setPoints(m_points[0], m_points[1], m_points[2])
                 .and_then([&]() {
                     m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
-                    return kdl::void_result;
+                    return kdl::void_success;
                 });
         }
 
@@ -500,7 +500,7 @@ namespace TrenchBroom {
                     const auto offsetChange = desriedCoords - currentCoords;
                     m_attributes.setOffset(correct(modOffset(m_attributes.offset() + offsetChange), 4));
                 }
-                return kdl::void_result;
+                return kdl::void_success;
             });
         }
 
@@ -616,7 +616,7 @@ namespace TrenchBroom {
             const auto [result, plane] = vm::from_points(m_points[0], m_points[1], m_points[2]);
             if (result) {
                 m_boundary = plane;
-                return kdl::void_result;
+                return kdl::void_success;
             } else {
                 return BrushError::InvalidFace;
             }

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -368,10 +368,10 @@ namespace TrenchBroom {
 
         // Reload m_cache
         readV2SettingsFromPath(m_preferencesFilePath)
-            .visit(kdl::overload(
-                [&](std::map<IO::Path, QJsonValue>&& prefs) {
+            .and_then([&](std::map<IO::Path, QJsonValue>&& prefs) {
                     m_cache = std::move(prefs);
-                },
+                    return kdl::void_success;
+            }).handle_errors(kdl::overload(
                 [&] (const PreferenceErrors::FileReadError&) {
                     // This happens e.g. if you don't have read permissions for m_preferencesFilePath
                     showErrorAndDisableFileReadWrite(tr("A file IO error occurred while attempting to read the preference file:"), tr("ensure the file is readable"));

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -662,10 +662,10 @@ namespace TrenchBroom {
     PreferencesResult readV2SettingsFromPath(const QString& path) {
         QFile file(path);
         if (!file.exists()) {
-            return PreferencesResult::error(PreferenceErrors::NoFilePresent{});
+            return PreferenceErrors::NoFilePresent{};
         }
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            return PreferencesResult::error(PreferenceErrors::FileReadError{});
+            return PreferenceErrors::FileReadError{};
         }
 
         return parseV2SettingsFromJSON(file.readAll());
@@ -702,7 +702,7 @@ namespace TrenchBroom {
         const QJsonDocument document = QJsonDocument::fromJson(jsonData, &error);
 
         if (error.error != QJsonParseError::NoError || !document.isObject()) {
-            return PreferencesResult::error(PreferenceErrors::JsonParseError{error});
+            return PreferenceErrors::JsonParseError{error};
         }
 
         const QJsonObject object = document.object();
@@ -713,7 +713,7 @@ namespace TrenchBroom {
 
             result[IO::pathFromQString(key)] = value;
         }
-        return PreferencesResult::success(result);
+        return result;
     }
 
     QByteArray writeV2SettingsToJSON(const std::map<IO::Path, QJsonValue>& v2Prefs) {

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -370,7 +370,6 @@ namespace TrenchBroom {
         readV2SettingsFromPath(m_preferencesFilePath)
             .and_then([&](std::map<IO::Path, QJsonValue>&& prefs) {
                     m_cache = std::move(prefs);
-                    return kdl::void_success;
             }).handle_errors(kdl::overload(
                 [&] (const PreferenceErrors::FileReadError&) {
                     // This happens e.g. if you don't have read permissions for m_preferencesFilePath

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -756,7 +756,7 @@ namespace TrenchBroom {
                             return brush.clip(worldBounds, std::move(clipFace));
                     }).and_then([&]() {
                             brushMap[node->parent()].push_back(new Model::BrushNode(std::move(brush)));
-                            return kdl::void_result;
+                            return kdl::void_success;
                     }).handle_errors([&](const Model::BrushError e) {
                             document->error() << "Could not clip brush: " << e;
                     });

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -756,7 +756,6 @@ namespace TrenchBroom {
                             return brush.clip(worldBounds, std::move(clipFace));
                     }).and_then([&]() {
                             brushMap[node->parent()].push_back(new Model::BrushNode(std::move(brush)));
-                            return kdl::void_success;
                     }).handle_errors([&](const Model::BrushError e) {
                             document->error() << "Could not clip brush: " << e;
                     });

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -52,7 +52,6 @@ namespace TrenchBroom {
                 builder.createBrush(*m_polyhedron, document->currentTextureName())
                     .and_then([&](Model::Brush&& b) {
                         updateBrush(new Model::BrushNode(std::move(b)));
-                        return kdl::void_success;
                     }).handle_errors([&](const Model::BrushError e) {
                         updateBrush(nullptr);
                         document->error() << "Could not update brush: " << e;

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -30,7 +30,6 @@
 #include "View/MapDocument.h"
 
 #include <kdl/memory_utils.h>
-#include <kdl/overload.h>
 #include <kdl/result.h>
 
 namespace TrenchBroom {
@@ -44,15 +43,13 @@ namespace TrenchBroom {
             const auto builder = Model::BrushBuilder(document->world()->mapFormat(), document->worldBounds(), game->defaultFaceAttribs());
 
             builder.createCuboid(bounds, document->currentTextureName())
-                .visit(kdl::overload(
-                    [&](Model::Brush&& b) {
-                        updateBrush(new Model::BrushNode(std::move(b)));
-                    },
-                    [&](const Model::BrushError e) {
-                        updateBrush(nullptr);
-                        document->error() << "Could not update brush: " << e;
-                    }
-                ));
+                .and_then([&](Model::Brush&& b) {
+                    updateBrush(new Model::BrushNode(std::move(b)));
+                    return kdl::void_success;
+                }).handle_errors([&](const Model::BrushError e) {
+                    updateBrush(nullptr);
+                    document->error() << "Could not update brush: " << e;
+                });
         }
 
     }

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -45,7 +45,6 @@ namespace TrenchBroom {
             builder.createCuboid(bounds, document->currentTextureName())
                 .and_then([&](Model::Brush&& b) {
                     updateBrush(new Model::BrushNode(std::move(b)));
-                    return kdl::void_success;
                 }).handle_errors([&](const Model::BrushError e) {
                     updateBrush(nullptr);
                     document->error() << "Could not update brush: " << e;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -906,7 +906,7 @@ namespace TrenchBroom {
 
                 return brushBuilder.createBrush(tallVertices, Model::BrushFaceAttributes::NoTextureName)
                     .and_then([](Model::Brush&& brush) {
-                        return kdl::result<std::unique_ptr<Model::BrushNode>>{std::make_unique<Model::BrushNode>(std::move(brush))};
+                        return std::make_unique<Model::BrushNode>(std::move(brush));
                     });
             }).and_then([&](const std::vector<std::unique_ptr<Model::BrushNode>>& tallBrushes) {
                 // delete the original selection brushes before searching for the objects to select
@@ -917,8 +917,6 @@ namespace TrenchBroom {
                     Model::collectContainedNodes(std::vector<Model::Node*>{world()}, kdl::vec_transform(tallBrushes, [](const auto& b) { return b.get(); })), 
                     [&](const auto* node) { return editorContext().selectable(node); });
                 select(nodesToSelect);
-
-                return kdl::void_success;
             }).handle_errors([&](const Model::BrushError& e) {
                 logger().error() << "Could not create selection brush: " << e;
             });
@@ -1714,8 +1712,6 @@ namespace TrenchBroom {
                     deselectAll();
                     addNode(brushNode, parentForNodes());
                     select(brushNode);
-
-                    return kdl::void_success;
                 }).handle_errors([&](const Model::BrushError e) {
                     error() << "Could not create brush: " << e;
                 });
@@ -1775,8 +1771,6 @@ namespace TrenchBroom {
                     addNode(brushNode, parentNode);
                     removeNodes(toRemove);
                     select(brushNode);
-                    
-                    return kdl::void_success;
                 }).handle_errors([&](const Model::BrushError e) {
                     error() << "Could not create brush: " << e;
                 });
@@ -1818,8 +1812,6 @@ namespace TrenchBroom {
                 const auto added = addNodes(toAdd);
                 removeNodes(toRemove);
                 select(added);
-
-                return kdl::void_success;
             }).handle_errors([&](const Model::BrushError& e) {
                 error() << "Could not create brush: " << e;
             });
@@ -1896,8 +1888,6 @@ namespace TrenchBroom {
                 const auto added = addNodes(toAdd);
                 removeNodes(toRemove);
                 select(added);
-
-                return kdl::void_success;
             }).handle_errors([&](const Model::BrushError& e) {
                 error() << "Could not hollow brush: " << e;
             });
@@ -1926,8 +1916,6 @@ namespace TrenchBroom {
 
                 const auto addedNodes = addNodes(toAdd);
                 select(addedNodes);
-
-                return kdl::void_success;
             }).handle_errors([&](const Model::BrushError e) {
                 error() << "Could not clip brushes: " << e;
             });
@@ -2086,7 +2074,6 @@ namespace TrenchBroom {
                         originalBrush.snapVertices(m_worldBounds, snapTo, pref(Preferences::UVLock))
                             .and_then([&]() {
                                 succeededBrushCount += 1;
-                                return kdl::void_success;
                             }).handle_errors([&](const Model::BrushError e) {
                                 error() << "Could not snap vertices: " << e;
                                 failedBrushCount += 1;
@@ -2128,7 +2115,6 @@ namespace TrenchBroom {
                         .and_then([&]() {
                             auto newPositions = brush.findClosestVertexPositions(verticesToMove + delta);
                             newVertexPositions = kdl::vec_concat(std::move(newVertexPositions), std::move(newPositions));
-                            return kdl::void_success;
                         }).handle_errors([&](const Model::BrushError e) {
                             error() << "Could not move brush vertices: " << e;
                         });
@@ -2172,7 +2158,6 @@ namespace TrenchBroom {
                                 return edge.translate(delta);
                             }));
                             newEdgePositions = kdl::vec_concat(std::move(newEdgePositions), std::move(newPositions));
-                            return kdl::void_success;
                         }).handle_errors([&](const Model::BrushError e) {
                             error() << "Could not move brush edges: " << e;
                         });
@@ -2211,7 +2196,6 @@ namespace TrenchBroom {
                                 return face.translate(delta);
                             }));
                             newFacePositions = kdl::vec_concat(std::move(newFacePositions), std::move(newPositions));
-                            return kdl::void_success;
                         }).handle_errors([&](const Model::BrushError e) {
                             error() << "Could not move brush faces: " << e;
                         });

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1925,7 +1925,7 @@ namespace TrenchBroom {
                         return clippedBrush.clip(m_worldBounds, std::move(clipFace));
                     }).and_then([&]() {
                         clippedBrushes[originalBrush->parent()].push_back(new Model::BrushNode(std::move(clippedBrush)));
-                        return kdl::void_result;
+                        return kdl::void_success;
                     }).handle_errors([&](const Model::BrushError e) {
                         error() << "Could not clip brushes: " << e;
                     });
@@ -2098,7 +2098,7 @@ namespace TrenchBroom {
                         originalBrush.snapVertices(m_worldBounds, snapTo, pref(Preferences::UVLock))
                             .and_then([&]() {
                                 succeededBrushCount += 1;
-                                return kdl::void_result;
+                                return kdl::void_success;
                             }).handle_errors([&](const Model::BrushError e) {
                                 error() << "Could not snap vertices: " << e;
                                 failedBrushCount += 1;
@@ -2140,7 +2140,7 @@ namespace TrenchBroom {
                         .and_then([&]() {
                             auto newPositions = brush.findClosestVertexPositions(verticesToMove + delta);
                             newVertexPositions = kdl::vec_concat(std::move(newVertexPositions), std::move(newPositions));
-                            return kdl::void_result;
+                            return kdl::void_success;
                         }).handle_errors([&](const Model::BrushError e) {
                             error() << "Could not move brush vertices: " << e;
                         });
@@ -2184,7 +2184,7 @@ namespace TrenchBroom {
                                 return edge.translate(delta);
                             }));
                             newEdgePositions = kdl::vec_concat(std::move(newEdgePositions), std::move(newPositions));
-                            return kdl::void_result;
+                            return kdl::void_success;
                         }).handle_errors([&](const Model::BrushError e) {
                             error() << "Could not move brush edges: " << e;
                         });
@@ -2223,7 +2223,7 @@ namespace TrenchBroom {
                                 return face.translate(delta);
                             }));
                             newFacePositions = kdl::vec_concat(std::move(newFacePositions), std::move(newPositions));
-                            return kdl::void_result;
+                            return kdl::void_success;
                         }).handle_errors([&](const Model::BrushError e) {
                             error() << "Could not move brush faces: " << e;
                         });

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -42,6 +42,7 @@
 #include <kdl/memory_utils.h>
 #include <kdl/overload.h>
 #include <kdl/result.h>
+#include <kdl/result_for_each.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/vec.h>
@@ -400,7 +401,7 @@ namespace TrenchBroom {
             std::vector<FaceHandle> newDragHandles;
             std::map<Model::Node*, std::vector<Model::Node*>> newNodes;
 
-            for (const auto& dragFaceHandle : dragFaces()) {
+            return kdl::for_each_result(dragFaces(), [&](const auto& dragFaceHandle) {
                 auto* brushNode = dragFaceHandle.node();
 
                 const auto& oldBrush = brushNode->brush();
@@ -408,7 +409,7 @@ namespace TrenchBroom {
                 const auto newDragFaceNormal = oldBrush.face(dragFaceIndex).boundary().normal;
 
                 auto newBrush = oldBrush;
-                const bool success = newBrush.moveBoundary(worldBounds, dragFaceIndex, delta, lockTextures)
+                return newBrush.moveBoundary(worldBounds, dragFaceIndex, delta, lockTextures)
                     .and_then([&]() {
                         auto clipFace = oldBrush.face(dragFaceIndex);
                         clipFace.invert();
@@ -418,24 +419,31 @@ namespace TrenchBroom {
                         newNodes[brushNode->parent()].push_back(newBrushNode);
                         newDragHandles.emplace_back(newBrushNode, newDragFaceNormal);
                         return kdl::void_success;
-                    }).handle_errors(
-                        [&](const Model::BrushError e) {
-                            document->error() << "Could not extrude brush: " << e;
-                        }
-                    );
-
-                if (!success) {
+                    });
+            }).and_then([&]() {
+                document->deselectAll();
+                const auto addedNodes = document->addNodes(newNodes);
+                document->select(addedNodes);
+                m_dragHandles = std::move(newDragHandles);
+                
+                return kdl::void_success;
+            }).handle_errors(
+                [&](const Model::BrushError e) {
+                    document->error() << "Could not extrude brush: " << e;
                     kdl::map_clear_and_delete(newNodes);
-                    return false;
                 }
+            );
+        }
+
+        namespace {
+            struct ResizeError {
+                std::string msg;
+            };
+
+            std::ostream& operator<<(std::ostream& str, const ResizeError& e) {
+                str << e.msg;
+                return str;
             }
-
-            document->deselectAll();
-            const auto addedNodes = document->addNodes(newNodes);
-            document->select(addedNodes);
-            m_dragHandles = std::move(newDragHandles);
-
-            return true;
         }
 
         bool ResizeBrushesTool::splitBrushesInward(const vm::vec3& delta) {
@@ -452,28 +460,26 @@ namespace TrenchBroom {
                 }
             }
 
-            const std::vector<FaceHandle> oldDragHandles = m_dragHandles;
             std::vector<FaceHandle> newDragHandles;
             // This map is to handle the case when the brushes being
             // extruded have different parents (e.g. different brush entities),
             // so each newly created brush should be made a sibling of the brush it was cloned from.
             std::map<Model::Node*, std::vector<Model::Node*>> newNodes;
 
-            for (const auto& dragFaceHandle : dragFaces()) {
+            return kdl::for_each_result(dragFaces(), [&](const auto& dragFaceHandle) -> kdl::result<void, ResizeError, Model::BrushError> {
                 const auto& dragFace = dragFaceHandle.face();
                 auto* brushNode = dragFaceHandle.node();
 
                 auto newBrush = brushNode->brush();
                 const auto newDragFaceIndex = newBrush.findFace(dragFace.boundary());
                 if (!newDragFaceIndex) {
-                    kdl::map_clear_and_delete(newNodes);
-                    return false;
+                    return ResizeError{"Face not found"};
                 }
 
                 auto clipFace = newBrush.face(*newDragFaceIndex);
                 clipFace.invert();
                 
-                const bool success = clipFace.transform(vm::translation_matrix(delta), lockTextures)
+                return clipFace.transform(vm::translation_matrix(delta), lockTextures)
                     .and_then([&]() {
                         return newBrush.clip(worldBounds, std::move(clipFace));
                     }).and_then([&]() {
@@ -481,30 +487,25 @@ namespace TrenchBroom {
                         newNodes[brushNode->parent()].push_back(newBrushNode);
                         newDragHandles.emplace_back(newBrushNode, clipFace.boundary().normal);
                         return kdl::void_success;
-                    }).handle_errors([&](const Model::BrushError e) {
-                        document->error() << "Could not extrude inwards: " << e;
                     });
-
-                if (!success) {
-                    kdl::map_clear_and_delete(newNodes);
-                    return false;
+            }).and_then([&]() -> kdl::result<void, ResizeError> {
+                // Now that the newly split off brushes are ready to insert (but not selected),
+                // resize the original brushes, which are still selected at this point.
+                if (!document->resizeBrushes(dragFaceDescriptors(), delta)) {
+                    return ResizeError{"Resizing failed"};
                 }
-            }
 
-            // Now that the newly split off brushes are ready to insert (but not selected),
-            // resize the original brushes, which are still selected at this point.
-            if (!document->resizeBrushes(dragFaceDescriptors(), delta)) {
+                // Add the newly split off brushes and select them (keeping the original brushes selected).
+                const auto addedNodes = document->addNodes(newNodes);
+                document->select(addedNodes);
+
+                m_dragHandles = kdl::vec_concat(std::move(m_dragHandles), newDragHandles);
+                
+                return kdl::void_success;
+            }).handle_errors([&](const auto& e) {
+                document->error() << "Could not extrude inwards: " << e;
                 kdl::map_clear_and_delete(newNodes);
-                return false;
-            }
-
-            // Add the newly split off brushes and select them (keeping the original brushes selected).
-            const auto addedNodes = document->addNodes(newNodes);
-            document->select(addedNodes);
-
-            m_dragHandles = kdl::vec_concat(oldDragHandles, newDragHandles);
-
-            return true;
+            });
         }
 
         std::vector<vm::polygon3> ResizeBrushesTool::dragFaceDescriptors() const {

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -417,7 +417,7 @@ namespace TrenchBroom {
                         auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                         newNodes[brushNode->parent()].push_back(newBrushNode);
                         newDragHandles.emplace_back(newBrushNode, newDragFaceNormal);
-                        return kdl::void_result;
+                        return kdl::void_success;
                     }).handle_errors(
                         [&](const Model::BrushError e) {
                             document->error() << "Could not extrude brush: " << e;
@@ -480,7 +480,7 @@ namespace TrenchBroom {
                         auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                         newNodes[brushNode->parent()].push_back(newBrushNode);
                         newDragHandles.emplace_back(newBrushNode, clipFace.boundary().normal);
-                        return kdl::void_result;
+                        return kdl::void_success;
                     }).handle_errors([&](const Model::BrushError e) {
                         document->error() << "Could not extrude inwards: " << e;
                     });

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -418,15 +418,12 @@ namespace TrenchBroom {
                         auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                         newNodes[brushNode->parent()].push_back(newBrushNode);
                         newDragHandles.emplace_back(newBrushNode, newDragFaceNormal);
-                        return kdl::void_success;
                     });
             }).and_then([&]() {
                 document->deselectAll();
                 const auto addedNodes = document->addNodes(newNodes);
                 document->select(addedNodes);
                 m_dragHandles = std::move(newDragHandles);
-                
-                return kdl::void_success;
             }).handle_errors(
                 [&](const Model::BrushError e) {
                     document->error() << "Could not extrude brush: " << e;
@@ -486,7 +483,6 @@ namespace TrenchBroom {
                         auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                         newNodes[brushNode->parent()].push_back(newBrushNode);
                         newDragHandles.emplace_back(newBrushNode, clipFace.boundary().normal);
-                        return kdl::void_success;
                     });
             }).and_then([&]() -> kdl::result<void, ResizeError> {
                 // Now that the newly split off brushes are ready to insert (but not selected),

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -282,8 +282,6 @@ namespace TrenchBroom {
                         const Transaction transaction(document, "CSG Convex Merge");
                         deselectAll();
                         document->addNode(new Model::BrushNode(std::move(b)), newParent);
-
-                        return kdl::void_success;
                     }).handle_errors([&](const Model::BrushError e) {
                         document->error() << "Could not create brush: " << e;
                     });

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -681,7 +681,7 @@ namespace TrenchBroom {
                             BrushFace& face = brush.face(i);
                             face.setTexture(&texture);
                         }
-                        return kdl::result<Brush>::success(brush);
+                        return kdl::result<Brush>(std::move(brush));
                     }).value();
 
             auto testTransform = [&](const vm::mat4x4& transform){

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -681,7 +681,7 @@ namespace TrenchBroom {
                             BrushFace& face = brush.face(i);
                             face.setTexture(&texture);
                         }
-                        return kdl::result<Brush>(std::move(brush));
+                        return std::move(brush);
                     }).value();
 
             auto testTransform = [&](const vm::mat4x4& transform){

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/enum_array.h"
     "${KDL_INCLUDE_DIR}/kdl/result.h"
     "${KDL_INCLUDE_DIR}/kdl/result_combine.h"
+    "${KDL_INCLUDE_DIR}/kdl/result_for_each.h"
     "${KDL_INCLUDE_DIR}/kdl/result_forward.h"
     "${KDL_INCLUDE_DIR}/kdl/result_io.h"
     "${KDL_INCLUDE_DIR}/kdl/intrusive_circular_list_forward.h"

--- a/lib/kdl/include/kdl/meta_utils.h
+++ b/lib/kdl/include/kdl/meta_utils.h
@@ -86,6 +86,14 @@ namespace kdl {
         using remainder = meta_type_list<Remainder...>;
     };
 
+    template <typename Subset, typename Superset>
+    struct meta_is_subset {};
+
+    template <typename... Subset, typename... Superset>
+    struct meta_is_subset<meta_type_list<Subset...>, meta_type_list<Superset...>> {
+        static constexpr bool value = (meta_contains<Subset, Superset...>::value && ...);
+    };
+
     namespace detail {
         template <typename Result, typename Cur, typename Remainder>
         struct meta_remove_duplicates_impl {};

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -77,6 +77,9 @@ namespace kdl {
     class [[nodiscard]] result {
     public:
         using value_type = Value;
+
+        template <typename OtherValue>
+        using with_value_type = result<OtherValue, Errors...>;
     private:
         using variant_type = std::variant<value_type, Errors...>;
         variant_type m_value;
@@ -380,6 +383,34 @@ namespace kdl {
         }
 
         /**
+         * Returns a the error contained in this result if it not successful. Otherwise, throws `bad_result_access`.
+         *
+         * @return a std::variant<Errors...> containing a copy of the error in this result
+         *
+         * @throw bad_result_access if this result is an error
+         */
+        auto error() const & {
+            return visit(kdl::overload(
+                [](const value_type&) -> std::variant<Errors...> { throw bad_result_access(); },
+                [](const auto& e)     -> std::variant<Errors...> { return e; }
+            ));
+        }
+
+        /**
+         * Returns a the error contained in this result if it not successful. Otherwise, throws `bad_result_access`.
+         *
+         * @return a std::variant<Errors...> containing the error in this result
+         *
+         * @throw bad_result_access if this result is an error
+         */
+        auto error() && {
+            return visit(kdl::overload(
+                [](const value_type&) -> std::variant<Errors...> { throw bad_result_access(); },
+                [](auto&& e)          -> std::variant<Errors...> { return std::move(e); }
+            ));
+        }
+
+        /**
          * Indicates whether the given result contains a value.
          */
         bool is_success() const {
@@ -440,6 +471,9 @@ namespace kdl {
     class [[nodiscard]] result<void, Errors...> {
     public:
         using value_type = void;
+
+        template <typename OtherValue>
+        using with_value_type = result<OtherValue, Errors...>;
     private:
         using variant_type = std::variant<detail::void_success_value_type, Errors...>;
         variant_type m_value;
@@ -643,6 +677,34 @@ namespace kdl {
                     f(error);
                     return false;
                 }
+            ));
+        }
+
+        /**
+         * Returns a the error contained in this result if it not successful. Otherwise, throws `bad_result_access`.
+         *
+         * @return a std::variant<Errors...> containing a copy of the error in this result
+         *
+         * @throw bad_result_access if this result is an error
+         */
+        auto error() const & {
+            return visit(kdl::overload(
+                []()              -> std::variant<Errors...> { throw bad_result_access(); },
+                [](const auto& e) -> std::variant<Errors...> { return e; }
+            ));
+        }
+
+        /**
+         * Returns a the error contained in this result if it not successful. Otherwise, throws `bad_result_access`.
+         *
+         * @return a std::variant<Errors...> containing the error in this result
+         *
+         * @throw bad_result_access if this result is an error
+         */
+        auto error() && {
+            return visit(kdl::overload(
+                []()         -> std::variant<Errors...> { throw bad_result_access(); },
+                [](auto&& e) -> std::variant<Errors...> { return std::move(e); }
             ));
         }
 

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -686,5 +686,5 @@ namespace kdl {
         }
     };
 
-    constexpr auto void_result = kdl::result<void>();
+    constexpr auto void_success = kdl::result<void>();
 }

--- a/lib/kdl/include/kdl/result_combine.h
+++ b/lib/kdl/include/kdl/result_combine.h
@@ -55,13 +55,13 @@ namespace kdl {
         
         return result.visit(kdl::overload(
             [](value_type&& v) {
-                return result_type::success(std::make_tuple(std::move(v)));
+                return result_type(std::make_tuple(std::move(v)));
             },
             [](const value_type& v) {
-                return result_type::success(std::make_tuple(v));
+                return result_type(std::make_tuple(v));
             },
             [](auto&& e) {
-                return result_type::error(std::forward<decltype(e)>(e));
+                return result_type(std::forward<decltype(e)>(e));
             }
         ));
     }
@@ -99,39 +99,39 @@ namespace kdl {
             [&](first_value_type&& firstValue) {
                 return combine_results(std::forward<MoreResults>(moreResults)...).visit(kdl::overload(
                     [&](typename combined_more_result_type::value_type&& remainingValues) {
-                        return result_type::success(std::tuple_cat(
+                        return result_type(std::tuple_cat(
                             std::make_tuple(std::move(firstValue)),
                             std::move(remainingValues)));
                     },
                     [&](const typename combined_more_result_type::value_type& remainingValues) {
-                        return result_type::success(std::tuple_cat(
+                        return result_type(std::tuple_cat(
                             std::make_tuple(std::move(firstValue)),
                             remainingValues));
                     },
                     [](auto&& combinedError) {
-                        return result_type::error(std::forward<decltype(combinedError)>(combinedError));
+                        return result_type(std::forward<decltype(combinedError)>(combinedError));
                     }
                 ));
             },
             [&](const first_value_type& firstValue) {
                 return combine_results(std::forward<MoreResults>(moreResults)...).visit(kdl::overload(
                     [&](typename combined_more_result_type::value_type&& remainingValues) {
-                        return result_type::success(std::tuple_cat(
+                        return result_type(std::tuple_cat(
                             std::make_tuple(firstValue),
                             std::move(remainingValues)));
                     },
                     [&](const typename combined_more_result_type::value_type& remainingValues) {
-                        return result_type::success(std::tuple_cat(
+                        return result_type(std::tuple_cat(
                             std::make_tuple(firstValue),
                             remainingValues));
                     },
                     [](auto&& combinedError) {
-                        return result_type::error(std::forward<decltype(combinedError)>(combinedError));
+                        return result_type(std::forward<decltype(combinedError)>(combinedError));
                     }
                 ));
             },
             [&](auto&& firstError) {
-                return result_type::error(std::forward<decltype(firstError)>(firstError));
+                return result_type(std::forward<decltype(firstError)>(firstError));
             }
         ));
     }

--- a/lib/kdl/include/kdl/result_for_each.h
+++ b/lib/kdl/include/kdl/result_for_each.h
@@ -1,0 +1,91 @@
+/*
+ Copyright 2020 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "kdl/meta_utils.h"
+#include "kdl/overload.h"
+#include "kdl/result.h"
+
+#include <iterator>
+#include <vector>
+
+namespace kdl {
+
+    /**
+     * Applies the given lambda to each element in the given range and returns the result.
+     *
+     * The given lambda must return a result type.
+     *
+     * - If the lambda returns a void result type, this function returns result<void, error_type>.
+     *   The void (success) case is returned if *all* invocations of the given lambda return void (success).
+     *
+     * - If the given lambda returns a non void result type, returns result<std::vector<value_type>, error_type>.
+     *   The vector is returned if *all* invocations of the given lambda return success values, and contains
+     *   those success values.
+     *
+     * If any invocation of the given lambda fails, processing stops and that failure result is returned.
+     */
+    template <typename I, typename F>
+    auto for_each_result(I cur, I end, F f) {
+        using i_value_type = typename std::iterator_traits<I>::value_type;
+        using f_result_type = std::invoke_result_t<F, i_value_type>;
+        using f_result_value_type = typename f_result_type::value_type;
+
+        if constexpr(std::is_same_v<f_result_value_type, void>) {
+            using result_type = typename f_result_type::template with_value_type<void>;
+
+            while (cur != end) {
+                auto f_result = f(*cur);
+                if (f_result.is_error()) {
+                    return f_result;
+                }
+                ++cur;
+            }
+
+            return result_type{};
+        } else {
+            using vector_type = std::vector<f_result_value_type>;
+            using result_type = typename f_result_type::template with_value_type<vector_type>;
+            using i_category = typename std::iterator_traits<I>::iterator_category;
+
+            auto result_vector = vector_type{};
+            if constexpr(std::is_same_v<i_category, std::random_access_iterator_tag>) {
+                result_vector.reserve(static_cast<std::size_t>(end - cur));
+            }
+
+            while (cur != end) {
+                auto f_result = f(*cur);
+                if (f_result.is_error()) {
+                    return std::visit([](auto&& e) { 
+                        return result_type{std::move(e)};
+                    }, std::move(f_result).error());
+                }
+
+                result_vector.push_back(std::move(f_result).value());
+                ++cur;
+            }
+
+            return result_type{std::move(result_vector)};
+        }
+    }
+
+    template <typename C, typename F>
+    auto for_each_result(C&& c, F f) {
+        return for_each_result(std::begin(c), std::end(c), std::move(f));
+    }
+}

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -326,10 +326,10 @@ namespace kdl {
         CHECK(y.copies == 0u);
     }
 
-    TEST_CASE("result_test.void_result", "[result_test]") {
+    TEST_CASE("result_test.void_success", "[result_test]") {
         kdl::result<void, Error1> r1 = result<int, Error1>(1).and_then(
             [](int) {
-                return void_result;
+                return void_success;
             }
         );
         


### PR DESCRIPTION
This PR makes a couple of changes to reduce the amount of typing necessary when using the `kdl::result` type. See the first commit's description for more details.