### PR TITLE
3679: Add libqt5svg5-dev to list of debian dependencies

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -94,7 +94,7 @@ TrenchBroom depends on:
 If you have a debian-based distribution, open a command prompt and execute this command to install required dependencies:
 
 ```bash
-sudo apt-get install g++-7 qt5-default freeglut3-dev libglew-dev mesa-common-dev build-essential libglm-dev libxxf86vm-dev libfreeimage-dev libfreetype6-dev pandoc cmake p7zip-full ninja-build
+sudo apt-get install g++-7 qt5-default libqt5svg5-dev freeglut3-dev libglew-dev mesa-common-dev build-essential libglm-dev libxxf86vm-dev libfreeimage-dev libfreetype6-dev pandoc cmake p7zip-full ninja-build
 ```
 
 Or, on Fedora:


### PR DESCRIPTION
Closes #3679