### PR TITLE
2210: Initial setup to deploy manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,16 @@ jobs:
             cmakebuild/*.7z.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload compiled manual
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ matrix.os == 'ubuntu-16.04' && matrix.gcc-package == 'g++-8' }}
+        with:
+          # I've created a SSH key pair following https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key
+          # The TrenchBroom/TrenchBroom repo has a repository secret ACTIONS_DEPLOY_KEY set to the SSH private key
+          # The TrenchBroom/manual repo has a deploy key set to the SSH public key
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: TrenchBroom/manual # Repo to deploy to
+          publish_branch: gh-pages # Branch to deploy to
+          publish_dir: ./build/app/gen-manual # Source directory tree
+          destination_dir: latest # Deploy to this directory in target repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload compiled manual
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ matrix.os == 'ubuntu-16.04' && matrix.gcc-package == 'g++-8' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-16.04' && matrix.gcc-package == 'g++-8' }}
         with:
           # I've created a SSH key pair following https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key
           # The TrenchBroom/TrenchBroom repo has a repository secret ACTIONS_DEPLOY_KEY set to the SSH private key


### PR DESCRIPTION
Fixes #2210

For the first pass of this I'm just deploying the Linux manual (iirc it's identical, or almost, to the Windows one).

The idea is, when doing the CI build for a tag, we push the compiled manual to: https://github.com/TrenchBroom/manual/tree/gh-pages/latest

which is visible here: https://trenchbroom.github.io/manual/latest/

I made the pull request before adding the "tag" condition, which is why it deployed the initial copy of the manual there.

