### PR TITLE
3703: Fix "Reload" entity definitions button

### DIFF
--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -276,7 +276,7 @@ namespace TrenchBroom {
             }
 
             std::vector<vm::vec3> getHelpVectors(const InputState& inputState, const vm::vec3& /* clipPoint */) const override {
-                return std::vector<vm::vec3>(1, vm::vec3(inputState.camera().direction()));
+                return std::vector<vm::vec3>{vm::vec3(inputState.camera().direction())};
             }
 
             bool doGetNewClipPointPosition(const InputState& inputState, vm::vec3& position) const override {

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -243,8 +243,7 @@ namespace TrenchBroom {
 
         void EntityDefinitionFileChooser::reloadExternalClicked() {
             auto document = kdl::mem_lock(m_document);
-            const Assets::EntityDefinitionFileSpec& spec = document->entityDefinitionFile();
-            document->setEntityDefinitionFile(spec);
+            document->reloadEntityDefinitions();
         }
     }
 }

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -135,9 +135,9 @@ namespace TrenchBroom {
             ensure(layer != nullptr, "layer is null");
             auto document = kdl::mem_lock(m_document);
             if (!layer->hidden()) {
-                document->hide(std::vector<Model::Node*>(1, layer));
+                document->hide(std::vector<Model::Node*>{layer});
             } else {
-                document->resetVisibility(std::vector<Model::Node*>(1, layer));
+                document->resetVisibility(std::vector<Model::Node*>{layer});
             }
         }
 
@@ -150,9 +150,9 @@ namespace TrenchBroom {
             ensure(layer != nullptr, "layer is null");
             auto document = kdl::mem_lock(m_document);
             if (!layer->locked()) {
-                document->lock(std::vector<Model::Node*>(1, layer));
+                document->lock(std::vector<Model::Node*>{layer});
             } else {
-                document->resetLock(std::vector<Model::Node*>(1, layer));
+                document->resetLock(std::vector<Model::Node*>{layer});
             }
         }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2475,8 +2475,11 @@ namespace TrenchBroom {
         }
 
         void MapDocument::reloadEntityDefinitions() {
-            auto oldSpec = entityDefinitionFile();
-            setEntityDefinitionFile(oldSpec);
+            const std::vector<Model::Node*> nodes(1, m_world.get());
+            Notifier<const std::vector<Model::Node*>&>::NotifyBeforeAndAfter notifyNodes(nodesWillChangeNotifier, nodesDidChangeNotifier, nodes);
+            Notifier<>::NotifyBeforeAndAfter notifyEntityDefinitions(entityDefinitionsWillChangeNotifier, entityDefinitionsDidChangeNotifier);
+
+            info("Reloading entity definitions");
         }
 
         void MapDocument::loadAssets() {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -849,7 +849,7 @@ namespace TrenchBroom {
 
         void MapDocument::select(Model::Node* node) {
             m_repeatStack->clearOnNextPush();
-            executeAndStore(SelectionCommand::select(std::vector<Model::Node*>(1, node)));
+            executeAndStore(SelectionCommand::select(std::vector<Model::Node*>{node}));
         }
 
         void MapDocument::select(const std::vector<Model::BrushFaceHandle>& handles) {
@@ -930,7 +930,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::deselect(Model::Node* node) {
-            deselect(std::vector<Model::Node*>(1, node));
+            deselect(std::vector<Model::Node*>{node});
         }
 
         void MapDocument::deselect(const std::vector<Model::Node*>& nodes) {
@@ -976,7 +976,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::removeNode(Model::Node* node) {
-            removeNodes(std::vector<Model::Node*>(1, node));
+            removeNodes(std::vector<Model::Node*>{node});
         }
 
         std::vector<Model::Node*> MapDocument::addNodes(const std::map<Model::Node*, std::vector<Model::Node*>>& nodes) {
@@ -1294,10 +1294,10 @@ namespace TrenchBroom {
             deselectAll();
             Model::GroupNode* previousGroup = m_editorContext->currentGroup();
             if (previousGroup == nullptr)
-                lock(std::vector<Model::Node*>(1, m_world.get()));
+                lock(std::vector<Model::Node*>{m_world.get()});
             else
-                resetLock(std::vector<Model::Node*>(1, previousGroup));
-            unlock(std::vector<Model::Node*>(1, group));
+                resetLock(std::vector<Model::Node*>{previousGroup});
+            unlock(std::vector<Model::Node*>{group});
             executeAndStore(CurrentGroupCommand::push(group));
         }
 
@@ -1306,14 +1306,14 @@ namespace TrenchBroom {
 
             deselectAll();
             Model::GroupNode* previousGroup = m_editorContext->currentGroup();
-            resetLock(std::vector<Model::Node*>(1, previousGroup));
+            resetLock(std::vector<Model::Node*>{previousGroup});
             executeAndStore(CurrentGroupCommand::pop());
 
             Model::GroupNode* currentGroup = m_editorContext->currentGroup();
             if (currentGroup != nullptr) {
-                unlock(std::vector<Model::Node*>(1, currentGroup));
+                unlock(std::vector<Model::Node*>{currentGroup});
             } else {
-                unlock(std::vector<Model::Node*>(1, m_world.get()));
+                unlock(std::vector<Model::Node*>{m_world.get()});
             }
         }
 
@@ -2464,7 +2464,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::reloadTextureCollections() {
-            const std::vector<Model::Node*> nodes(1, m_world.get());
+            const auto nodes = std::vector<Model::Node*>{m_world.get()};
             Notifier<const std::vector<Model::Node*>&>::NotifyBeforeAndAfter notifyNodes(nodesWillChangeNotifier, nodesDidChangeNotifier, nodes);
             Notifier<>::NotifyBeforeAndAfter notifyTextureCollections(textureCollectionsWillChangeNotifier, textureCollectionsDidChangeNotifier);
 
@@ -2475,7 +2475,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::reloadEntityDefinitions() {
-            const std::vector<Model::Node*> nodes(1, m_world.get());
+            const auto nodes = std::vector<Model::Node*>{m_world.get()};
             Notifier<const std::vector<Model::Node*>&>::NotifyBeforeAndAfter notifyNodes(nodesWillChangeNotifier, nodesDidChangeNotifier, nodes);
             Notifier<>::NotifyBeforeAndAfter notifyEntityDefinitions(entityDefinitionsWillChangeNotifier, entityDefinitionsDidChangeNotifier);
 


### PR DESCRIPTION
Previously, it:

- incorrectly committed a undo/redo transaction
- didn't actually reload entity definitions

Fixes #3703