### PR TITLE
3561: Use double for mouse coordinates

### DIFF
--- a/common/src/Renderer/Camera.cpp
+++ b/common/src/Renderer/Camera.cpp
@@ -156,8 +156,8 @@ namespace TrenchBroom {
             return vm::ray3f(m_position, m_direction);
         }
 
-        vm::ray3f Camera::pickRay(const int x, const int y) const {
-            return doGetPickRay(unproject(static_cast<float>(x), static_cast<float>(y), 0.5f));
+        vm::ray3f Camera::pickRay(const float x, const float y) const {
+            return doGetPickRay(unproject(x, y, 0.5f));
         }
 
         vm::ray3f Camera::pickRay(const vm::vec3f& point) const {
@@ -180,7 +180,7 @@ namespace TrenchBroom {
             return m_position + distance * direction();
         }
 
-        vm::vec3f Camera::defaultPoint(const int x, const int y) const {
+        vm::vec3f Camera::defaultPoint(const float x, const float y) const {
             const vm::ray3f ray = pickRay(x, y);
             return defaultPoint(ray);
         }

--- a/common/src/Renderer/Camera.h
+++ b/common/src/Renderer/Camera.h
@@ -109,13 +109,13 @@ namespace TrenchBroom {
             void frustumPlanes(vm::plane3f& topPlane, vm::plane3f& rightPlane, vm::plane3f& bottomPlane, vm::plane3f& leftPlane) const;
 
             vm::ray3f viewRay() const;
-            vm::ray3f pickRay(int x, int y) const;
+            vm::ray3f pickRay(float x, float y) const;
             vm::ray3f pickRay(const vm::vec3f& point) const;
             float distanceTo(const vm::vec3f& point) const;
             float squaredDistanceTo(const vm::vec3f& point) const;
             float perpendicularDistanceTo(const vm::vec3f& point) const;
             vm::vec3f defaultPoint(const float distance = DefaultPointDistance) const;
-            vm::vec3f defaultPoint(int x, int y) const;
+            vm::vec3f defaultPoint(float x, float y) const;
 
             template <typename T>
             static vm::vec<T,3> defaultPoint(const vm::ray<T,3>& ray, const T distance = T(DefaultPointDistance)) {

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             return out;
         }
         
-        MouseEvent::MouseEvent(const Type i_type, const Button i_button, const WheelAxis i_wheelAxis, const int i_posX, const int i_posY, const float i_scrollDistance):
+        MouseEvent::MouseEvent(const Type i_type, const Button i_button, const WheelAxis i_wheelAxis, const float i_posX, const float i_posY, const float i_scrollDistance):
         type(i_type),
         button(i_button),
         wheelAxis(i_wheelAxis),
@@ -209,8 +209,8 @@ namespace TrenchBroom {
         InputEventRecorder::InputEventRecorder() :
         m_dragging(false),
         m_anyMouseButtonDown(false),
-        m_lastClickX(0),
-        m_lastClickY(0),
+        m_lastClickX(0.0f),
+        m_lastClickY(0.0f),
         m_lastClickTime(std::chrono::high_resolution_clock::now()),
         m_nextMouseUpIsRMB(false),
         m_nextMouseUpIsDblClick(false) {}
@@ -223,8 +223,8 @@ namespace TrenchBroom {
         void InputEventRecorder::recordEvent(const QMouseEvent& qEvent) {
                   auto type = getEventType(qEvent);
                   auto button = getButton(qEvent);
-            const auto posX = qEvent.x();
-            const auto posY = qEvent.y();
+            const auto posX = static_cast<float>(qEvent.localPos().x());
+            const auto posY = static_cast<float>(qEvent.localPos().y());
 
             const auto wheelAxis = MouseEvent::WheelAxis::None;
             const float scrollDistance = 0.0f;
@@ -307,9 +307,9 @@ namespace TrenchBroom {
         }
 
         void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent) {
-            // These are the mouse X and Y position, not the wheel delta
-            const int posX = qtEvent.x();
-            const int posY = qtEvent.y();
+            // These are the mouse X and Y position, not the wheel delta, in points relative to top left of widget.
+            const auto posX = static_cast<float>(qtEvent.x());
+            const auto posY = static_cast<float>(qtEvent.y());
             
             // Number of "lines" to scroll
             QPointF scrollDistance = scrollLinesForEvent(qtEvent);
@@ -339,8 +339,8 @@ namespace TrenchBroom {
             m_queue.processEvents(processor);
         }
 
-        bool InputEventRecorder::isDrag(int posX, int posY) const {
-            static const auto MinDragDistance = 2;
+        bool InputEventRecorder::isDrag(const float posX, const float posY) const {
+            static const auto MinDragDistance = 2.0f;
             return std::abs(posX - m_lastClickX) > MinDragDistance || std::abs(posY - m_lastClickY) > MinDragDistance;
         }
 

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -216,15 +216,15 @@ namespace TrenchBroom {
         m_nextMouseUpIsDblClick(false) {}
 
 
-        void InputEventRecorder::recordEvent(const QKeyEvent* wxEvent) {
-            m_queue.enqueueEvent(std::make_unique<KeyEvent>(getEventType(wxEvent)));
+        void InputEventRecorder::recordEvent(const QKeyEvent& qEvent) {
+            m_queue.enqueueEvent(std::make_unique<KeyEvent>(getEventType(qEvent)));
         }
 
-        void InputEventRecorder::recordEvent(const QMouseEvent* wxEvent) {
-                  auto type = getEventType(wxEvent);
-                  auto button = getButton(wxEvent);
-            const auto posX = wxEvent->x();
-            const auto posY = wxEvent->y();
+        void InputEventRecorder::recordEvent(const QMouseEvent& qEvent) {
+                  auto type = getEventType(qEvent);
+                  auto button = getButton(qEvent);
+            const auto posX = qEvent.x();
+            const auto posY = qEvent.y();
 
             const auto wheelAxis = MouseEvent::WheelAxis::None;
             const float scrollDistance = 0.0f;
@@ -232,7 +232,7 @@ namespace TrenchBroom {
             if (type == MouseEvent::Type::Down) {
                 // macOS: apply Ctrl+click = right click emulation
                 // (Implemented ourselves rather than using Qt's implementation to work around Qt bug, see Main.cpp)
-                if (wxEvent->modifiers() & Qt::MetaModifier) {
+                if (qEvent.modifiers() & Qt::MetaModifier) {
                     button = MouseEvent::Button::Right;
                     m_nextMouseUpIsRMB = true;
                 }
@@ -296,20 +296,20 @@ namespace TrenchBroom {
             }
         }
         
-        QPointF InputEventRecorder::scrollLinesForEvent(const QWheelEvent* qtEvent) {
-            // TODO: support pixel scrolling via qtEvent->pixelDelta()?
+        QPointF InputEventRecorder::scrollLinesForEvent(const QWheelEvent& qtEvent) {
+            // TODO: support pixel scrolling via qtEvent.pixelDelta()?
             const int linesPerStep = QApplication::wheelScrollLines();
-            const QPointF angleDelta = QPointF(qtEvent->angleDelta()); // in eighths-of-degrees
+            const QPointF angleDelta = QPointF(qtEvent.angleDelta()); // in eighths-of-degrees
             constexpr float EighthsOfDegreesPerStep = 120.0f; // see: https://doc.qt.io/qt-5/qwheelevent.html#angleDelta
 
             const QPointF lines = (angleDelta / EighthsOfDegreesPerStep) * linesPerStep;
             return lines;
         }
 
-        void InputEventRecorder::recordEvent(const QWheelEvent* qtEvent) {
+        void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent) {
             // These are the mouse X and Y position, not the wheel delta
-            const int posX = qtEvent->x();
-            const int posY = qtEvent->y();
+            const int posX = qtEvent.x();
+            const int posY = qtEvent.y();
             
             // Number of "lines" to scroll
             QPointF scrollDistance = scrollLinesForEvent(qtEvent);
@@ -321,7 +321,7 @@ namespace TrenchBroom {
 #ifdef __APPLE__
                 false;
 #else
-                qtEvent->modifiers().testFlag(Qt::AltModifier);
+                qtEvent.modifiers().testFlag(Qt::AltModifier);
 #endif
             if (swapXY) {
                 scrollDistance = QPointF(scrollDistance.y(), scrollDistance.x());
@@ -344,41 +344,41 @@ namespace TrenchBroom {
             return std::abs(posX - m_lastClickX) > MinDragDistance || std::abs(posY - m_lastClickY) > MinDragDistance;
         }
 
-        KeyEvent::Type InputEventRecorder::getEventType(const QKeyEvent* wxEvent) {
-            const auto wxType = wxEvent->type();
-            if (wxType == QEvent::KeyPress) {
+        KeyEvent::Type InputEventRecorder::getEventType(const QKeyEvent& qEvent) {
+            const auto qEventType = qEvent.type();
+            if (qEventType == QEvent::KeyPress) {
                 return KeyEvent::Type::Down;
-            } else if (wxType == QEvent::KeyRelease) {
+            } else if (qEventType == QEvent::KeyRelease) {
                 return KeyEvent::Type::Up;
             } else {
-                throw std::runtime_error("Unexpected wxEvent type");
+                throw std::runtime_error("Unexpected qEvent type");
             }
         }
 
-        MouseEvent::Type InputEventRecorder::getEventType(const QMouseEvent* wxEvent) {
-            if (wxEvent->type() == QEvent::MouseButtonPress) {
+        MouseEvent::Type InputEventRecorder::getEventType(const QMouseEvent& qEvent) {
+            if (qEvent.type() == QEvent::MouseButtonPress) {
                 return MouseEvent::Type::Down;
-            } else if (wxEvent->type() == QEvent::MouseButtonRelease) {
+            } else if (qEvent.type() == QEvent::MouseButtonRelease) {
                 return MouseEvent::Type::Up;
-            } else if (wxEvent->type() == QEvent::MouseButtonDblClick) {
+            } else if (qEvent.type() == QEvent::MouseButtonDblClick) {
                 return MouseEvent::Type::DoubleClick;
-            } else if (wxEvent->type() == QEvent::MouseMove) {
+            } else if (qEvent.type() == QEvent::MouseMove) {
                 return MouseEvent::Type::Motion;
             } else {
-                throw std::runtime_error("Unexpected wxEvent type");
+                throw std::runtime_error("Unexpected qEvent type");
             }
         }
 
-        MouseEvent::Button InputEventRecorder::getButton(const QMouseEvent* wxEvent) {
-            if (wxEvent->button() == Qt::LeftButton) {
+        MouseEvent::Button InputEventRecorder::getButton(const QMouseEvent& qEvent) {
+            if (qEvent.button() == Qt::LeftButton) {
                 return MouseEvent::Button::Left;
-            } else if (wxEvent->button() == Qt::MiddleButton) {
+            } else if (qEvent.button() == Qt::MiddleButton) {
                 return MouseEvent::Button::Middle;
-            } else if (wxEvent->button() == Qt::RightButton) {
+            } else if (qEvent.button() == Qt::RightButton) {
                 return MouseEvent::Button::Right;
-            } else if (wxEvent->button() == Qt::XButton1) {
+            } else if (qEvent.button() == Qt::XButton1) {
                 return MouseEvent::Button::Aux1;
-            } else if (wxEvent->button() == Qt::XButton2) {
+            } else if (qEvent.button() == Qt::XButton2) {
                 return MouseEvent::Button::Aux2;
             } else {
                 return MouseEvent::Button::None;

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -172,8 +172,10 @@ namespace TrenchBroom {
             Type type;
             Button button;
             WheelAxis wheelAxis;
-            int posX;
-            int posY;
+            
+            /** Cursor position in Points, relative to top left of widget. */
+            float posX;
+            float posY;
             float scrollDistance;
         public:
             /**
@@ -186,7 +188,7 @@ namespace TrenchBroom {
              * @param posY the current Y position of the mouse pointer
              * @param scrollDistance the distance by which the mouse wheel was scrolled, in lines
              */
-            MouseEvent(Type type, Button button, WheelAxis wheelAxis, int posX, int posY, float scrollDistance);
+            MouseEvent(Type type, Button button, WheelAxis wheelAxis, float posX, float posY, float scrollDistance);
         public:
             /**
              * Collates this mouse event with the given mouse event. Only successive Motion, Drag and Scroll events are
@@ -297,11 +299,11 @@ namespace TrenchBroom {
             /**
              * The X position of the last mouse down event.
              */
-            int m_lastClickX;
+            float m_lastClickX;
             /**
              * The Y position of the last mouse down event.
              */
-            int m_lastClickY;
+            float m_lastClickY;
             /**
              * The time at which the last mouse down event was recorded.
              */
@@ -352,7 +354,7 @@ namespace TrenchBroom {
              * @param posY the Y position
              * @return true if the given position should start a drag and false otherwise
              */
-            bool isDrag(int posX, int posY) const;
+            bool isDrag(float posX, float posY) const;
 
             /**
              * Decodes the event type of the given key event.

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -325,18 +325,18 @@ namespace TrenchBroom {
              *
              * @param event the event to record
              */
-            void recordEvent(const QKeyEvent* event);
+            void recordEvent(const QKeyEvent& event);
 
             /**
              * Records the given mouse event.
              *
              * @param event the event to record
              */
-            void recordEvent(const QMouseEvent* event);
+            void recordEvent(const QMouseEvent& event);
 
-            static QPointF scrollLinesForEvent(const QWheelEvent* qtEvent);
+            static QPointF scrollLinesForEvent(const QWheelEvent& event);
 
-            void recordEvent(const QWheelEvent* event);
+            void recordEvent(const QWheelEvent& event);
 
             /**
              * Processes all recorded events using the given event processor.
@@ -357,26 +357,26 @@ namespace TrenchBroom {
             /**
              * Decodes the event type of the given key event.
              *
-             * @param wxEvent the event to decode
+             * @param event the event to decode
              * @return the event type
              */
-            static KeyEvent::Type getEventType(const QKeyEvent* wxEvent);
+            static KeyEvent::Type getEventType(const QKeyEvent& event);
 
             /**
              * Decodes the event type of the given mouse event.
              *
-             * @param wxEvent the event to decode
+             * @param event the event to decode
              * @return the event type
              */
-            static MouseEvent::Type getEventType(const QMouseEvent* wxEvent);
+            static MouseEvent::Type getEventType(const QMouseEvent& event);
 
             /**
              * Decodes the button of the given mouse event, if any.
              *
-             * @param wxEvent the event to decode
+             * @param event the event to decode
              * @return the mouse button
              */
-            static MouseEvent::Button getButton(const QMouseEvent* wxEvent);
+            static MouseEvent::Button getButton(const QMouseEvent& event);
         };
 
         /**

--- a/common/src/View/InputState.cpp
+++ b/common/src/View/InputState.cpp
@@ -33,25 +33,25 @@ namespace TrenchBroom {
         InputState::InputState() :
         m_modifierKeys(ModifierKeys::MKNone),
         m_mouseButtons(MouseButtons::MBNone),
-        m_mouseX(0),
-        m_mouseY(0),
-        m_mouseDX(0),
-        m_mouseDY(0),
+        m_mouseX(0.0f),
+        m_mouseY(0.0f),
+        m_mouseDX(0.0f),
+        m_mouseDY(0.0f),
         m_scrollX(0.0f),
         m_scrollY(0.0f),
         m_anyToolDragging(false) {
             const QPoint mouseState = QCursor::pos();
-            m_mouseX = mouseState.x();
-            m_mouseY = mouseState.y();
+            m_mouseX = static_cast<float>(mouseState.x());
+            m_mouseY = static_cast<float>(mouseState.y());
         }
 
-        InputState::InputState(const int mouseX, const int mouseY) :
+        InputState::InputState(const float mouseX, const float mouseY) :
         m_modifierKeys(ModifierKeys::MKNone),
         m_mouseButtons(MouseButtons::MBNone),
         m_mouseX(mouseX),
         m_mouseY(mouseY),
-        m_mouseDX(0),
-        m_mouseDY(0),
+        m_mouseDX(0.0f),
+        m_mouseDY(0.0f),
         m_scrollX(0.0f),
         m_scrollY(0.0f),
         m_anyToolDragging(false) {}
@@ -113,19 +113,19 @@ namespace TrenchBroom {
             return mouseButtons() == buttons;
         }
 
-        int InputState::mouseX() const {
+        float InputState::mouseX() const {
             return m_mouseX;
         }
 
-        int InputState::mouseY() const {
+        float InputState::mouseY() const {
             return m_mouseY;
         }
 
-        int InputState::mouseDX() const {
+        float InputState::mouseDX() const {
             return m_mouseDX;
         }
 
-        int InputState::mouseDY() const {
+        float InputState::mouseDY() const {
             return m_mouseDY;
         }
 
@@ -157,7 +157,7 @@ namespace TrenchBroom {
             m_mouseButtons = MouseButtons::MBNone;
         }
 
-        void InputState::mouseMove(const int mouseX, const int mouseY, const int mouseDX, const int mouseDY) {
+        void InputState::mouseMove(const float mouseX, const float mouseY, const float mouseDX, const float mouseDY) {
             m_mouseX = mouseX;
             m_mouseY = mouseY;
             m_mouseDX = mouseDX;

--- a/common/src/View/InputState.h
+++ b/common/src/View/InputState.h
@@ -56,10 +56,11 @@ namespace TrenchBroom {
         private:
             ModifierKeyState m_modifierKeys;
             MouseButtonState m_mouseButtons;
-            int m_mouseX;
-            int m_mouseY;
-            int m_mouseDX;
-            int m_mouseDY;
+            /** Mouse position in units of points, relative to top left of widget */
+            float m_mouseX;
+            float m_mouseY;
+            float m_mouseDX;
+            float m_mouseDY;
             float m_scrollX;
             float m_scrollY;
 
@@ -68,7 +69,7 @@ namespace TrenchBroom {
             Model::PickResult m_pickResult;
         public:
             InputState();
-            InputState(const int mouseX, const int mouseY);
+            InputState(const float mouseX, const float mouseY);
             virtual ~InputState();
 
             virtual ModifierKeyState modifierKeys() const;
@@ -84,10 +85,10 @@ namespace TrenchBroom {
              * Checks whether only the given buttons are down (and no others).
              */
             bool mouseButtonsPressed(const MouseButtonState buttons) const;
-            int mouseX() const;
-            int mouseY() const;
-            int mouseDX() const;
-            int mouseDY() const;
+            float mouseX() const;
+            float mouseY() const;
+            float mouseDX() const;
+            float mouseDY() const;
 
             /**
              * Number of "lines" to scroll horizontally.
@@ -103,7 +104,7 @@ namespace TrenchBroom {
             void mouseDown(const MouseButtonState button);
             void mouseUp(const MouseButtonState button);
             void clearMouseButtons();
-            void mouseMove(const int mouseX, const int mouseY, const int mouseDX, const int mouseDY);
+            void mouseMove(const float mouseX, const float mouseY, const float mouseDX, const float mouseDY);
             void scroll(const float scrollX, const float scrollY);
 
             bool anyToolDragging() const;

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             update();
         }
 
-        PickRequest MapView2D::doGetPickRequest(const int x, const int y) const {
+        PickRequest MapView2D::doGetPickRequest(const float x, const float y) const {
             return PickRequest(vm::ray3(m_camera->pickRay(x, y)), *m_camera);
         }
 

--- a/common/src/View/MapView2D.h
+++ b/common/src/View/MapView2D.h
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             void unbindObservers();
             void cameraDidChange(const Renderer::Camera* camera);
         private: // implement ToolBoxConnector interface
-            PickRequest doGetPickRequest(int x, int y) const override;
+            PickRequest doGetPickRequest(float x, float y) const override;
             Model::PickResult doPick(const vm::ray3& pickRay) const override;
         protected: // QOpenGLWidget overrides
             void initializeGL() override;

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -186,7 +186,7 @@ namespace TrenchBroom {
             m_flyModeHelper->resetKeys();
         }
 
-        PickRequest MapView3D::doGetPickRequest(const int x, const int y) const {
+        PickRequest MapView3D::doGetPickRequest(const float x, const float y) const {
             return PickRequest(vm::ray3(m_camera->pickRay(x, y)), *m_camera);
         }
 
@@ -211,7 +211,7 @@ namespace TrenchBroom {
             const auto clientCoords = mapFromGlobal(pos);
 
             if (QRect(0, 0, width(), height()).contains(clientCoords)) {
-                const auto pickRay = vm::ray3(m_camera->pickRay(clientCoords.x(), clientCoords.y()));
+                const auto pickRay = vm::ray3(m_camera->pickRay(static_cast<float>(clientCoords.x()), static_cast<float>(clientCoords.y())));
 
                 const auto& editorContext = document->editorContext();
                 auto pickResult = Model::PickResult::byDistance(editorContext);

--- a/common/src/View/MapView3D.h
+++ b/common/src/View/MapView3D.h
@@ -69,7 +69,7 @@ namespace TrenchBroom {
             void updateFlyMode();
             void resetFlyModeKeys();
         private: // implement ToolBoxConnector interface
-            PickRequest doGetPickRequest(int x, int y) const override;
+            PickRequest doGetPickRequest(float x, float y) const override;
             Model::PickResult doPick(const vm::ray3& pickRay) const override;
         private: // implement RenderView interface
             void doUpdateViewport(int x, int y, int width, int height) override;

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1127,7 +1127,7 @@ namespace TrenchBroom {
          * Forward drag and drop events from QWidget to ToolBoxConnector
          */
         void MapViewBase::dragEnterEvent(QDragEnterEvent* dragEnterEvent) {
-            dragEnter(dragEnterEvent->pos().x(), dragEnterEvent->pos().y(), dragEnterEvent->mimeData()->text().toStdString());
+            dragEnter(static_cast<float>(dragEnterEvent->posF().x()), static_cast<float>(dragEnterEvent->posF().y()), dragEnterEvent->mimeData()->text().toStdString());
             dragEnterEvent->acceptProposedAction();
         }
 
@@ -1136,12 +1136,12 @@ namespace TrenchBroom {
         }
 
         void MapViewBase::dragMoveEvent(QDragMoveEvent* dragMoveEvent) {
-            dragMove(dragMoveEvent->pos().x(), dragMoveEvent->pos().y(), dragMoveEvent->mimeData()->text().toStdString());
+            dragMove(static_cast<float>(dragMoveEvent->posF().x()), static_cast<float>(dragMoveEvent->posF().y()), dragMoveEvent->mimeData()->text().toStdString());
             dragMoveEvent->acceptProposedAction();
         }
 
         void MapViewBase::dropEvent(QDropEvent* dropEvent) {
-            dragDrop(dropEvent->pos().x(), dropEvent->pos().y(), dropEvent->mimeData()->text().toStdString());
+            dragDrop(static_cast<float>(dropEvent->posF().x()), static_cast<float>(dropEvent->posF().y()), dropEvent->mimeData()->text().toStdString());
             dropEvent->acceptProposedAction();
         }
 

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -121,37 +121,37 @@ namespace TrenchBroom {
         RenderView::~RenderView() = default;
 
         void RenderView::keyPressEvent(QKeyEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 
         void RenderView::keyReleaseEvent(QKeyEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 
         void RenderView::mouseDoubleClickEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 
         void RenderView::mouseMoveEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 
         void RenderView::mousePressEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 
         void RenderView::mouseReleaseEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 
         void RenderView::wheelEvent(QWheelEvent* event) {
-            m_eventRecorder.recordEvent(event);
+            m_eventRecorder.recordEvent(*event);
             update();
         }
 

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -130,23 +130,31 @@ namespace TrenchBroom {
             update();
         }
 
+        static auto mouseEventWithFullPrecisionLocalPos(const QWidget* widget, const QMouseEvent* event) {
+            // The localPos of a Qt mouse event is only in integer coordinates, but window pos
+            // and screen pos have full precision. We can't directly map the windowPos because
+            // mapTo takes QPoint, so we just map the origin and subtract that.
+            const auto localPos = event->windowPos() - QPointF(widget->mapTo(widget->window(), QPoint(0, 0)));
+            return QMouseEvent(event->type(), localPos, event->windowPos(), event->screenPos(), event->button(), event->buttons(), event->modifiers(), event->source());
+        }
+
         void RenderView::mouseDoubleClickEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(*event);
+            m_eventRecorder.recordEvent(mouseEventWithFullPrecisionLocalPos(this, event));
             update();
         }
 
         void RenderView::mouseMoveEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(*event);
+            m_eventRecorder.recordEvent(mouseEventWithFullPrecisionLocalPos(this, event));
             update();
         }
 
         void RenderView::mousePressEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(*event);
+            m_eventRecorder.recordEvent(mouseEventWithFullPrecisionLocalPos(this, event));
             update();
         }
 
         void RenderView::mouseReleaseEvent(QMouseEvent* event) {
-            m_eventRecorder.recordEvent(*event);
+            m_eventRecorder.recordEvent(mouseEventWithFullPrecisionLocalPos(this, event));
             update();
         }
 

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -34,8 +34,8 @@ namespace TrenchBroom {
         ToolBoxConnector::ToolBoxConnector() :
         m_toolBox(nullptr),
         m_toolChain(new ToolChain()),
-        m_lastMouseX(0),
-        m_lastMouseY(0),
+        m_lastMouseX(0.0f),
+        m_lastMouseY(0.0f),
         m_ignoreNextDrag(false) {}
 
         ToolBoxConnector::~ToolBoxConnector() {
@@ -68,7 +68,7 @@ namespace TrenchBroom {
             m_toolChain->append(tool);
         }
 
-        bool ToolBoxConnector::dragEnter(const int x, const int y, const std::string& text) {
+        bool ToolBoxConnector::dragEnter(const float x, const float y, const std::string& text) {
             ensure(m_toolBox != nullptr, "toolBox is null");
 
             mouseMoved(x, y);
@@ -77,7 +77,7 @@ namespace TrenchBroom {
             return m_toolBox->dragEnter(m_toolChain, m_inputState, text);
         }
 
-        bool ToolBoxConnector::dragMove(const int x, const int y, const std::string& text) {
+        bool ToolBoxConnector::dragMove(const float x, const float y, const std::string& text) {
             ensure(m_toolBox != nullptr, "toolBox is null");
 
             mouseMoved(x, y);
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             m_toolBox->dragLeave(m_toolChain, m_inputState);
         }
 
-        bool ToolBoxConnector::dragDrop(const int /* x */, const int /* y */, const std::string& text) {
+        bool ToolBoxConnector::dragDrop(const float /* x */, const float /* y */, const std::string& text) {
             ensure(m_toolBox != nullptr, "toolBox is null");
 
             updatePickResult();
@@ -316,7 +316,7 @@ namespace TrenchBroom {
             }
         }
 
-        void ToolBoxConnector::mouseMoved(int x, int y) {
+        void ToolBoxConnector::mouseMoved(const float x, const float y) {
             const auto dx = x - m_lastMouseX;
             const auto dy = y - m_lastMouseY;
             m_inputState.mouseMove(x, y, dx, dy);

--- a/common/src/View/ToolBoxConnector.h
+++ b/common/src/View/ToolBoxConnector.h
@@ -49,8 +49,8 @@ namespace TrenchBroom {
 
             InputState m_inputState;
 
-            int m_lastMouseX;
-            int m_lastMouseY;
+            float m_lastMouseX;
+            float m_lastMouseY;
             bool m_ignoreNextDrag;
         public:
             ToolBoxConnector();
@@ -65,10 +65,10 @@ namespace TrenchBroom {
             void setToolBox(ToolBox& toolBox);
             void addTool(ToolController* tool);
         public: // drag and drop
-            bool dragEnter(int x, int y, const std::string& text);
-            bool dragMove(int x, int y, const std::string& text);
+            bool dragEnter(float x, float y, const std::string& text);
+            bool dragMove(float x, float y, const std::string& text);
             void dragLeave();
-            bool dragDrop(int x, int y, const std::string& text);
+            bool dragDrop(float x, float y, const std::string& text);
         public: // cancel
             bool cancel();
         protected: // rendering
@@ -98,11 +98,11 @@ namespace TrenchBroom {
             void processDragEnd(const MouseEvent& event);
 
             MouseButtonState mouseButton(const MouseEvent& event);
-            void mouseMoved(int x, int y);
+            void mouseMoved(float x, float y);
         public:
             bool cancelDrag();
         private:
-            virtual PickRequest doGetPickRequest(int x, int y) const = 0;
+            virtual PickRequest doGetPickRequest(float x, float y) const = 0;
             virtual Model::PickResult doPick(const vm::ray3& pickRay) const = 0;
             virtual void doShowPopupMenu();
 

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -345,7 +345,7 @@ namespace TrenchBroom {
             ToolBoxConnector::processEvent(event);
         }
 
-        PickRequest UVView::doGetPickRequest(const int x, const int y) const {
+        PickRequest UVView::doGetPickRequest(const float x, const float y) const {
             return PickRequest(vm::ray3(m_camera.pickRay(x, y)), m_camera);
         }
 

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -112,7 +112,7 @@ namespace TrenchBroom {
             void processEvent(const MouseEvent& event) override;
             void processEvent(const CancelEvent& event) override;
         private:
-            PickRequest doGetPickRequest(int x, int y) const override;
+            PickRequest doGetPickRequest(float x, float y) const override;
             Model::PickResult doPick(const vm::ray3& pickRay) const override;
         };
     }

--- a/common/test/src/View/ClipToolControllerTest.cpp
+++ b/common/test/src/View/ClipToolControllerTest.cpp
@@ -41,7 +41,7 @@ namespace TrenchBroom {
 
         static void updatePickState(InputState& inputState, const Renderer::Camera& camera, const MapDocument& document) {
             Model::PickResult pickResult = Model::PickResult::byDistance(document.editorContext());
-            const PickRequest pickRequest(vm::ray3(camera.pickRay(inputState.mouseX(), inputState.mouseY())), camera);
+            const PickRequest pickRequest(vm::ray3(camera.pickRay(static_cast<float>(inputState.mouseX()), static_cast<float>(inputState.mouseY()))), camera);
 
             document.pick(pickRequest.pickRay(), pickResult);
 
@@ -84,19 +84,19 @@ namespace TrenchBroom {
             const auto clipPoint1 = vm::vec3(-16, -16, 52);
             const auto clipPoint2 = vm::vec3( 20, -16, 52);
 
-            auto clipPoint1ScreenSpace = vm::vec2i(vm::round(camera.project(vm::vec3f(clipPoint1))));
-            auto clipPoint2ScreenSpace = vm::vec2i(vm::round(camera.project(vm::vec3f(clipPoint2))));
+            auto clipPoint1ScreenSpace = vm::vec2f(camera.project(vm::vec3f(clipPoint1)));
+            auto clipPoint2ScreenSpace = vm::vec2f(camera.project(vm::vec3f(clipPoint2)));
 
             // Transform the points so (0, 0) is in the upper left
-            clipPoint1ScreenSpace = vm::vec2i(clipPoint1ScreenSpace.x(), viewport.height - clipPoint1ScreenSpace.y());
-            clipPoint2ScreenSpace = vm::vec2i(clipPoint2ScreenSpace.x(), viewport.height - clipPoint2ScreenSpace.y());
+            clipPoint1ScreenSpace = vm::vec2f(clipPoint1ScreenSpace.x(), static_cast<float>(viewport.height) - clipPoint1ScreenSpace.y());
+            clipPoint2ScreenSpace = vm::vec2f(clipPoint2ScreenSpace.x(), static_cast<float>(viewport.height) - clipPoint2ScreenSpace.y());
 
             CHECK_FALSE(tool.canClip());
             CHECK(tool.canAddPoint( clipPoint1));
 
             // HACK: bias the points towards the center of the screen a bit
             // There's no way around this unless the clip tool allowed the mouse to be slightly outside of the brush
-            InputState inputState(clipPoint1ScreenSpace.x() + 2, clipPoint1ScreenSpace.y());
+            InputState inputState(clipPoint1ScreenSpace.x() + 2.0f, clipPoint1ScreenSpace.y());
             updatePickState(inputState, camera, *document);
             REQUIRE(inputState.pickResult().size() == 1u);
 
@@ -108,7 +108,7 @@ namespace TrenchBroom {
             CHECK(tool.canAddPoint(clipPoint2));
 
             // HACK: bias the points towards the center of the screen a bit
-            inputState.mouseMove(clipPoint2ScreenSpace.x() - 2, clipPoint2ScreenSpace.y(), 0, 0);
+            inputState.mouseMove(clipPoint2ScreenSpace.x() - 2.0f, clipPoint2ScreenSpace.y(), 0.0f, 0.0f);
             updatePickState(inputState, camera, *document);
             REQUIRE(inputState.pickResult().size() == 1u);
 

--- a/common/test/src/View/InputEventTest.cpp
+++ b/common/test/src/View/InputEventTest.cpp
@@ -189,11 +189,9 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordKeyEvents", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qKeyPress = QKeyEvent(QEvent::KeyPress, 0, 0, 0, 0);
-            const auto qKeyRelease = QKeyEvent(QEvent::KeyRelease, 0, 0, 0, 0);
 
-            r.recordEvent(&qKeyPress);
-            r.recordEvent(&qKeyRelease);
+            r.recordEvent(QKeyEvent(QEvent::KeyPress, 0, 0, 0, 0));
+            r.recordEvent(QKeyEvent(QEvent::KeyRelease, 0, 0, 0, 0));
             
             checkEventQueue(r,
                 KeyEvent(KeyEvent::Type::Down),
@@ -202,11 +200,9 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordLeftClick", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,  MouseEvent::Button::Left, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -216,15 +212,11 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordLeftDoubleClick", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease1 = QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseDoubleClick = QMouseEvent(QEvent::MouseButtonDblClick, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease2 = QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseRelease1);
-            r.recordEvent(&qMouseDoubleClick);
-            r.recordEvent(&qMouseRelease2);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonDblClick, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
 
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,        MouseEvent::Button::Left, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -237,11 +229,9 @@ namespace TrenchBroom {
 
         TEST_CASE("InputEventRecorderTest.recordCtrlLeftClick", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, Qt::MetaModifier);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, Qt::MetaModifier));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,  MouseEvent::Button::Right, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -251,11 +241,9 @@ namespace TrenchBroom {
 
         TEST_CASE("InputEventRecorderTest.recordRightClick", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::RightButton, Qt::RightButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::RightButton, Qt::RightButton, 0);
 
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::RightButton, Qt::RightButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 2.0f, 5.0f }, {}, {}, Qt::RightButton, Qt::RightButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,  MouseEvent::Button::Right, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -265,12 +253,10 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordMotionWithCollation", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMouseMotion1 = QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::NoButton, Qt::NoButton, 0);
-            const auto qMouseMotion2 = QMouseEvent(QEvent::MouseMove, { 12.0f, 8.0f }, {}, {}, Qt::NoButton, Qt::NoButton, 0);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qMouseMotion1);
-            r.recordEvent(&qMouseMotion2);
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::NoButton, Qt::NoButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 12.0f, 8.0f }, {}, {}, Qt::NoButton, Qt::NoButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Motion, MouseEvent::Button::None, MouseEvent::WheelAxis::None, 12, 8, 0.0f));
@@ -282,13 +268,13 @@ namespace TrenchBroom {
             const auto qWheel2 = makeWheelEvent({ 3, 0 });
 
             const float expectedScrollLines = \
-                static_cast<float>((InputEventRecorder::scrollLinesForEvent(&qWheel1) +
-                                    InputEventRecorder::scrollLinesForEvent(&qWheel2)).x());
-            CHECK(expectedScrollLines > 0.0f);
+                static_cast<float>((InputEventRecorder::scrollLinesForEvent(qWheel1) +
+                                    InputEventRecorder::scrollLinesForEvent(qWheel2)).x());
+            REQUIRE(expectedScrollLines > 0.0f);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qWheel1);
-            r.recordEvent(&qWheel2);
+            r.recordEvent(qWheel1);
+            r.recordEvent(qWheel2);
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Scroll, MouseEvent::Button::None, MouseEvent::WheelAxis::Horizontal, 0, 0, expectedScrollLines));
@@ -300,13 +286,13 @@ namespace TrenchBroom {
             const auto qWheel2 = makeWheelEvent({ 0, 4 });
 
             const float expectedScrollLines = \
-                static_cast<float>((InputEventRecorder::scrollLinesForEvent(&qWheel1) +
-                                    InputEventRecorder::scrollLinesForEvent(&qWheel2)).y());
-            CHECK(expectedScrollLines > 0.0f);
+                static_cast<float>((InputEventRecorder::scrollLinesForEvent(qWheel1) +
+                                    InputEventRecorder::scrollLinesForEvent(qWheel2)).y());
+            REQUIRE(expectedScrollLines > 0.0f);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qWheel1);
-            r.recordEvent(&qWheel2);
+            r.recordEvent(qWheel1);
+            r.recordEvent(qWheel2);
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Scroll, MouseEvent::Button::None, MouseEvent::WheelAxis::Vertical, 0, 0, expectedScrollLines));
@@ -317,17 +303,17 @@ namespace TrenchBroom {
             const auto qWheel1 = makeWheelEvent({ 1, 3 });
             const auto qWheel2 = makeWheelEvent({ 3, 0 });
 
-            const QPointF expectedScrollLines1 = InputEventRecorder::scrollLinesForEvent(&qWheel1);
-            CHECK(expectedScrollLines1.x() > 0.0f);
-            CHECK(expectedScrollLines1.y() > 0.0f);
+            const QPointF expectedScrollLines1 = InputEventRecorder::scrollLinesForEvent(qWheel1);
+            REQUIRE(expectedScrollLines1.x() > 0.0f);
+            REQUIRE(expectedScrollLines1.y() > 0.0f);
 
-            const QPointF expectedScrollLines2 = InputEventRecorder::scrollLinesForEvent(&qWheel2);
-            CHECK(expectedScrollLines2.x() > 0.0f);
-            CHECK(0.0f == expectedScrollLines2.y());
+            const QPointF expectedScrollLines2 = InputEventRecorder::scrollLinesForEvent(qWheel2);
+            REQUIRE(expectedScrollLines2.x() > 0.0f);
+            REQUIRE(0.0f == expectedScrollLines2.y());
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qWheel1);
-            r.recordEvent(&qWheel2);
+            r.recordEvent(qWheel1);
+            r.recordEvent(qWheel2);
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Scroll, MouseEvent::Button::None, MouseEvent::WheelAxis::Horizontal, 0, 0, static_cast<float>(expectedScrollLines1.x())),
@@ -337,14 +323,11 @@ namespace TrenchBroom {
 
         TEST_CASE("InputEventRecorderTest.recordLeftClickWithQuickSmallMotion", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseMotion = QMouseEvent(QEvent::MouseMove, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseMotion);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,   MouseEvent::Button::Left, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -355,15 +338,12 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordLeftClickWithSlowSmallMotion", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseMotion = QMouseEvent(QEvent::MouseMove, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseMotion);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             std::this_thread::sleep_for(200ms);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 4.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,   MouseEvent::Button::Left, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -374,14 +354,11 @@ namespace TrenchBroom {
 
         TEST_CASE("InputEventRecorderTest.recordLeftClickWithAccidentalDrag", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseMotion = QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseMotion);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,      MouseEvent::Button::Left, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -393,15 +370,12 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordLeftDrag", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseMotion = QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseMotion);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             std::this_thread::sleep_for(200ms);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,      MouseEvent::Button::Left, MouseEvent::WheelAxis::None, 2, 5, 0.0f),
@@ -413,17 +387,13 @@ namespace TrenchBroom {
         
         TEST_CASE("InputEventRecorderTest.recordLeftDragWithCollation", "[InputEventRecorderTest]") {
             InputEventRecorder r;
-            const auto qMousePress = QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseMotion1 = QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseMotion2 = QMouseEvent(QEvent::MouseMove, { 12.0f, 8.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
-            const auto qMouseRelease = QMouseEvent(QEvent::MouseButtonRelease, { 12.0f, 8.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0);
 
             using namespace std::chrono_literals;
-            r.recordEvent(&qMousePress);
-            r.recordEvent(&qMouseMotion1);
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonPress, { 2.0f, 5.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 6.0f, 3.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             std::this_thread::sleep_for(200ms);
-            r.recordEvent(&qMouseMotion2);
-            r.recordEvent(&qMouseRelease);
+            r.recordEvent(QMouseEvent(QEvent::MouseMove, { 12.0f, 8.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
+            r.recordEvent(QMouseEvent(QEvent::MouseButtonRelease, { 12.0f, 8.0f }, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
             
             checkEventQueue(r,
                 MouseEvent(MouseEvent::Type::Down,      MouseEvent::Button::Left, MouseEvent::WheelAxis::None,  2, 5, 0.0f),


### PR DESCRIPTION
Closes #3561.

This improves precision on some platforms, and makes mouse input feel
less jagged depending on the input device and preferences.