### PR TITLE
3548: Correctly check source and target drag face handles

### DIFF
--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -183,7 +183,7 @@ namespace TrenchBroom {
                 return true;
             }
 
-            if (!m_dragTargetFaceHandle && !m_dragTargetFaceHandle) {
+            if (!m_dragSourceFaceHandle && !m_dragTargetFaceHandle) {
                 // Start drag
                 m_dragSourceFaceHandle = m_dragInitialSelectedFaceHandle;
                 m_dragTargetFaceHandle = faceHandle;


### PR DESCRIPTION
Closes #3548.

This was an error introduced during a refactoring.