### PR TITLE
3361: Improve support for quoted texture names in map files

### DIFF
--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -32,6 +32,7 @@
 
 #include <kdl/overload.h>
 #include <kdl/parallel.h>
+#include <kdl/string_format.h>
 #include <kdl/vector_utils.h>
 
 #include <fmt/format.h>
@@ -70,11 +71,19 @@ namespace TrenchBroom {
                                points[2].z());
             }
 
+            static bool shouldQuoteTextureName(const std::string& textureName) {
+                return textureName.empty() || textureName.find_first_of("\"\\ \t") != std::string::npos;
+            }
+
+            static std::string quoteTextureName(const std::string& textureName) {
+                return "\"" + kdl::str_escape(textureName, "\"") + "\"";
+            }
+
             void writeTextureInfo(std::ostream& stream, const Model::BrushFace& face) const {
                 const std::string& textureName = face.attributes().textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face.attributes().textureName();
 
                 fmt::format_to(std::ostreambuf_iterator<char>(stream), " {} {} {} {} {} {}",
-                               textureName,
+                               shouldQuoteTextureName(textureName) ? quoteTextureName(textureName) : textureName,
                                face.attributes().xOffset(),
                                face.attributes().yOffset(),
                                face.attributes().rotation(),

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -583,8 +583,9 @@ namespace TrenchBroom {
             return std::make_tuple(p1, p2, p3);
         }
 
-        std::string_view StandardMapParser::parseTextureName(ParserStatus& /* status */) {
-            return m_tokenizer.readAnyString(QuakeMapTokenizer::Whitespace());
+        std::string StandardMapParser::parseTextureName(ParserStatus& /* status */) {
+            const auto [textureName, wasQuoted] = m_tokenizer.readAnyString(QuakeMapTokenizer::Whitespace());
+            return wasQuoted ? kdl::str_unescape(textureName, "\"\\") : std::string(textureName);
         }
 
         std::tuple<vm::vec3, float, vm::vec3, float> StandardMapParser::parseValveTextureAxes(ParserStatus& /* status */) {

--- a/common/src/IO/StandardMapParser.h
+++ b/common/src/IO/StandardMapParser.h
@@ -115,7 +115,7 @@ namespace TrenchBroom {
             void parsePatch(ParserStatus& status, size_t startLine);
 
             std::tuple<vm::vec3, vm::vec3, vm::vec3> parseFacePoints(ParserStatus& status);
-            std::string_view parseTextureName(ParserStatus& status);
+            std::string parseTextureName(ParserStatus& status);
             std::tuple<vm::vec3, float, vm::vec3, float> parseValveTextureAxes(ParserStatus& status);
             std::tuple<vm::vec3, vm::vec3> parsePrimitiveTextureAxes(ParserStatus& status);
 

--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -27,6 +27,7 @@
 #include <kdl/string_format.h>
 
 #include <cassert>
+#include <tuple>
 #include <string>
 #include <string_view>
 
@@ -262,13 +263,21 @@ namespace TrenchBroom {
                 return std::string_view(startPos, static_cast<size_t>(endPos - startPos));
             }
 
-            std::string_view readAnyString(std::string_view delims) {
+            std::tuple<std::string_view, bool> readAnyString(std::string_view delims) {
                 while (isWhitespace(curChar())) {
                     advance();
                 }
+
+                if (curChar() == '"') {
+                    advance();
+                    const char* startPos = curPos();
+                    const char* endPos = readQuotedString();
+                    return {std::string_view(startPos, static_cast<size_t>(endPos - startPos)), true};
+                }
+
                 const char* startPos = curPos();
-                const char* endPos = (curChar() == '"' ? readQuotedString() : readUntil(delims));
-                return std::string_view(startPos, static_cast<size_t>(endPos - startPos));
+                const char* endPos = readUntil(delims);
+                return {std::string_view(startPos, static_cast<size_t>(endPos - startPos)), false};
             }
 
             std::string unescapeString(std::string_view str) const {


### PR DESCRIPTION
Closes #3361.

This PR fixes and improves support for reading quoted texture names, and adds support for quoting texture names if necessary when writing map files.