### PR TITLE
3443: Clone face attributes from subtrahends after CSG subtract

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -911,6 +911,7 @@ namespace TrenchBroom {
             }).and_then([&](Brush&& brush) {
                 brush.cloneFaceAttributesFrom(*this);
                 for (const auto* subtrahend : subtrahends) {
+                    brush.cloneFaceAttributesFrom(*subtrahend);
                     brush.cloneInvertedFaceAttributesFrom(*subtrahend);
                 }
                 return std::move(brush);

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -834,16 +834,12 @@ namespace TrenchBroom {
         kdl::result<std::vector<Brush>, BrushError> Brush::subtract(const MapFormat mapFormat, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<const Brush*>& subtrahends) const {
             auto result = std::vector<BrushGeometry>{*m_geometry};
 
-            for (auto* subtrahend : subtrahends) {
-                auto nextResults = std::vector<BrushGeometry>();
+            for (const auto* subtrahend : subtrahends) {
+                auto nextResults = std::vector<BrushGeometry>{};
 
                 for (const BrushGeometry& fragment : result) {
                     auto subFragments = fragment.subtract(*subtrahend->m_geometry);
-
-                    nextResults.reserve(nextResults.size() + subFragments.size());
-                    for (auto& subFragment : subFragments) {
-                        nextResults.push_back(std::move(subFragment));
-                    }
+                    nextResults = kdl::vec_concat(std::move(nextResults), std::move(subFragments));
                 }
 
                 result = std::move(nextResults);

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -3132,8 +3132,8 @@ namespace TrenchBroom {
             CHECK(top->findFace(vm::plane3(0.0, vm::vec3::neg_z())));
 
             // top brush textures
-            CHECK(top->face(*top->findFace(vm::vec3::pos_x())).attributes().textureName() == defaultTexture);
-            CHECK(top->face(*top->findFace(vm::vec3::neg_x())).attributes().textureName() == defaultTexture);
+            CHECK(top->face(*top->findFace(vm::vec3::pos_x())).attributes().textureName() == subtrahendTexture);
+            CHECK(top->face(*top->findFace(vm::vec3::neg_x())).attributes().textureName() == subtrahendTexture);
             CHECK(top->face(*top->findFace(vm::vec3::pos_y())).attributes().textureName() == minuendTexture);
             CHECK(top->face(*top->findFace(vm::vec3::neg_y())).attributes().textureName() == minuendTexture);
             CHECK(top->face(*top->findFace(vm::vec3::pos_z())).attributes().textureName() == minuendTexture);


### PR DESCRIPTION
Closes #3443.

This was mostly an oversight and it's easy to fix so that CSG subtract will clone face attributes for all newly created faces.