### PR TITLE
3716: Quake 3 compilation tools, including tooltips

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1156,7 +1156,9 @@ Additionally, you can configure the game engines for the selected game by clicki
 
 In this dialog, you can add a game engine profile by clicking on the '+' button below the profile list on the left, and you can delete the selected profile by clicking on the '-' button. To the right of the list, you can edit the details of the selected game engine profile, specifically its name and path. Similar to the game path, if you edit the engine path manually, you have to apply the changes by pressing #key(Return) while in the path text box. Click [here](#launching_game_engines) to find out how to launch game engines from within TrenchBroom.
 
-For some game configurations (such as for Quake, shown above) you can also optionally enter paths for a set of compilation tools. If you do, then the name shown to the left of the path can be used as a variable in your [compilation profiles](#compiling_maps) for this game. Wherever that variable occurs, the path specified here will be used. For example if your path to the `qbsp` tool is `C:\mapping\ericw-tools-v0.18.1-win64\bin\qbsp.exe`, and you set that path here... then in your compilation profiles you can enter `${qbsp}` wherever you need to refer to that whole qbsp.exe path.
+For some game configurations (such as for Quake, shown above) you can also optionally enter paths for a set of compilation tools. If it's not clear what you should be specifying a path to here, then hovering over the path entry box may give you a tooltip with additional info about that compilation tool.
+
+If you do enter a path here, then the name shown to the left of the path can be used as a variable in your [compilation profiles](#compiling_maps) for this game. Wherever that variable occurs, the path specified here will be used. For example if your path to the `qbsp` tool is `C:\mapping\ericw-tools-v0.18.1-win64\bin\qbsp.exe`, and you set that path here... then in your compilation profiles you can enter `${qbsp}` wherever you need to refer to that whole qbsp.exe path.
 
 The benefits of specifying your tool paths here (if the game configuration allows) are:
 
@@ -2229,9 +2231,9 @@ The game configuration is an [expression language](#expression_language) map wit
             ]
         },
         "compilationTools": [
-            { "name": "qbsp" },
+            { "name": "bsp" },
             { "name": "vis" },
-            { "name": "light" }
+            { "name": "rad" }
         ]
     }
 
@@ -2515,12 +2517,11 @@ The `color` value must be a string of the form "R G B" or "R G B A". R G B and A
 
 The optional `compilationTools` list identifies tool names that will appear in the [game configuration dialog](#game_configuration), allowing the user to associate these names with paths to tool executables. Such a name can be used as a variable in this game's [compilation profiles](#compiling_maps) to represent the associated path.
 
-Each element in the list is just an object with a `name` key. An example from the Quake game configuration that defines three compilation tools:
+Each element in the list is an object that must have a `name` key and may optionally have a `description` key (used for tooltips). An example from the Quake 3 game configuration that defines two tools:
 
     "compilationTools": [
-        { "name": "qbsp"},
-        { "name": "vis"},
-        { "name": "light"}
+        { "name": "q3map2", "description": "Path to your q3map2 executable, which performs the main bsp/vis/light compilation phases" },
+        { "name": "bspc", "description": "Path to your bspc or mbspc executable, which creates .aas files for bot support" }
     ]
 
 # Getting Involved

--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -122,5 +122,9 @@
             } // 134,217,728
         ]
     },
-    "softMapBounds":"-65536 -65536 -65536 65536 65536 65536"
+    "softMapBounds":"-65536 -65536 -65536 65536 65536 65536",
+    "compilationTools": [
+        { "name": "q3map2", "description": "Path to your q3map2 executable, which performs the main bsp/vis/light compilation phases" },
+        { "name": "bspc", "description": "Path to your bspc or mbspc executable, which creates .aas files for bot support" }
+    ]
 }

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -497,12 +497,16 @@ namespace TrenchBroom {
                         value[i],
                         "["
                         "{'name': 'String'},"
-                        "{}"
+                        "{'description': 'String'}"
                         "]");
 
                 const std::string name = value[i]["name"].stringValue();
-
-                result.push_back(Model::CompilationTool{name});
+                if (!value[i]["description"].null()) {
+                    const std::string desc = value[i]["description"].stringValue();
+                    result.push_back(Model::CompilationTool{name, desc});
+                } else {
+                    result.push_back(Model::CompilationTool{name, std::nullopt});
+                }
             }
 
             return result;

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -225,7 +225,8 @@ namespace TrenchBroom {
         }
 
         bool operator==(const CompilationTool& lhs, const CompilationTool& rhs) {
-            return lhs.name == rhs.name;
+            return lhs.name == rhs.name && 
+                   lhs.description == rhs.description;
         }
 
         bool operator!=(const CompilationTool& lhs, const CompilationTool& rhs) {

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -159,6 +159,7 @@ namespace TrenchBroom {
 
         struct CompilationTool {
             std::string name;
+            std::optional<std::string> description;
         };
 
         bool operator==(const CompilationTool& lhs, const CompilationTool& rhs);

--- a/common/src/View/GamesPreferencePane.cpp
+++ b/common/src/View/GamesPreferencePane.cpp
@@ -176,7 +176,7 @@ namespace TrenchBroom {
                 auto* edit = new QLineEdit();
                 edit->setText(IO::pathAsQString(gameFactory.compilationToolPath(m_gameName, toolName)));
                 if (tool.description) {
-                    edit->setToolTip(tool.description->c_str());
+                    edit->setToolTip(QString::fromStdString(*tool.description));
                 }
                 connect(edit, &QLineEdit::editingFinished, this, [=](){
                     Model::GameFactory::instance().setCompilationToolPath(m_gameName, toolName, IO::pathFromQString(edit->text()));

--- a/common/src/View/GamesPreferencePane.cpp
+++ b/common/src/View/GamesPreferencePane.cpp
@@ -175,6 +175,9 @@ namespace TrenchBroom {
                 const std::string toolName = tool.name;
                 auto* edit = new QLineEdit();
                 edit->setText(IO::pathAsQString(gameFactory.compilationToolPath(m_gameName, toolName)));
+                if (tool.description) {
+                    edit->setToolTip(tool.description->c_str());
+                }
                 connect(edit, &QLineEdit::editingFinished, this, [=](){
                     Model::GameFactory::instance().setCompilationToolPath(m_gameName, toolName, IO::pathFromQString(edit->text()));
                 });


### PR DESCRIPTION
Closes #3716.

Although other game configs could undoubtedly use compilation tools, and the current Quake config (which has tools) might benefit from tooltips... I only modified the Quake 3 config in this change.

I also adjusted the tool names in the example game config in the manual slightly, since it is supposed to be something resembling Quake 2 (even though the real Q2 config doesn't have compilation tools yet).