### PR TITLE
3644: Fix error when adding a point to a polygon fails

### DIFF
--- a/common/src/Model/Polyhedron_ConvexHull.h
+++ b/common/src/Model/Polyhedron_ConvexHull.h
@@ -805,6 +805,28 @@ namespace TrenchBroom {
                     // If the vertex has only three incident edges, then it will be removed when the faces are merged.
                     const bool hasThreeIncidentEdges = leaving == leaving->nextIncident()->nextIncident()->nextIncident();
 
+                    if (hasThreeIncidentEdges && m_faces.size() == 4u) {
+                        // Merging any faces will fail because it will turn this polyhedron into a polygon.
+                        // We treat this case by removing all incident faces and edges, and the given vertex.
+
+                        // Build a seam consisting of the edges of the remaining polygon.
+                        auto seam = Seam{};
+                        auto* remainingFace = leaving->next()->twin()->face();
+                        auto& boundary = remainingFace->boundary();
+
+                        // The seam must be CCW, so we have to iterate in reverse order in this case.
+                        for (auto it = boundary.rbegin(), end = boundary.rend(); it != end; ++it) {
+                            auto* halfEdge = *it;
+                            auto* seamEdge = halfEdge->edge();
+                            seamEdge->makeFirstEdge(halfEdge);
+                            seam.push_back(seamEdge);
+                        }
+
+                        // Split this polyhedron.
+                        split(seam);
+                        return nullptr;
+                    }
+
                     // Choose the face to retain. We prefer the face that produces minimal error, i.e. the face such
                     // such that the maximum distance of the other face's vertices to the face plane is minimal.
                     if (firstFace->maximumVertexDistance(secondFace->plane()) <

--- a/common/test/src/Model/PolyhedronTest.cpp
+++ b/common/test/src/Model/PolyhedronTest.cpp
@@ -1978,5 +1978,22 @@ TEST_CASE("PolyhedronTest.testWeaveSimpleCap", "[PolyhedronTest]") {
                 vm::vec3d(+2.0, +2.0, 0.0),
             }, cube));
         }
+
+        TEST_CASE("PolyhedronTest.addVertexToPolygonAndAllFacesCoplanar", "[PolyhedronTest]") {
+            auto p = Polyhedron3d{
+                vm::vec3{-64.0, 64.0, -16.0},
+                vm::vec3{64.0, 64.0, -16.0},
+                vm::vec3{22288.0, 18208.0, 16.0},
+                vm::vec3{22288.0, 18336.0, 16.0}, // does not get added due to all incident faces being coplanar
+                vm::vec3{22416.0, 18336.0, 16.0},
+            };
+
+            CHECK(p.hasAllVertices({
+                vm::vec3{-64.0, 64.0, -16.0},
+                vm::vec3{64.0, 64.0, -16.0},
+                vm::vec3{22288.0, 18208.0, 16.0},
+                vm::vec3{22416.0, 18336.0, 16.0},
+            }, 0.0));
+        }
     }
 }


### PR DESCRIPTION
Closes #3644

Adding a point to a polygon can fail if all incident faces of the newly
added vertex are coplanar. In this case, the point cannot be added and
the polyhedron remains a polygon.