### PR TITLE
3722: Use unique directory for TestEnvironment

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -452,6 +452,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Preferences.cpp
         ${COMMON_SOURCE_DIR}/TrenchBroomApp.cpp
         ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.cpp
+        ${COMMON_SOURCE_DIR}/Uuid.cpp
 )
 
 set(COMMON_HEADER
@@ -954,6 +955,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/RecoverableExceptions.h
         ${COMMON_SOURCE_DIR}/TrenchBroomApp.h
         ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.h
+        ${COMMON_SOURCE_DIR}/Uuid.h
 )
 
 add_library(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})

--- a/common/src/Uuid.cpp
+++ b/common/src/Uuid.cpp
@@ -1,0 +1,28 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Uuid.h"
+
+#include <QUuid>
+
+namespace TrenchBroom {
+    std::string generateUuid() {
+        return QUuid::createUuid().toString().toStdString();
+    }
+}

--- a/common/src/Uuid.h
+++ b/common/src/Uuid.h
@@ -1,0 +1,26 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace TrenchBroom {
+    std::string generateUuid();
+}

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -20,6 +20,7 @@
 #include "TestEnvironment.h"
 
 #include "Macros.h"
+#include "Uuid.h"
 #include "IO/PathQt.h"
 
 #include <string>
@@ -34,7 +35,7 @@
 namespace TrenchBroom {
     namespace IO {
         TestEnvironment::TestEnvironment(const std::string& dir) :
-            m_dir(IO::pathFromQString(QDir::current().path()) + Path(dir)) {
+            m_dir(pathFromQString(QDir::current().path()) + Path(generateUuid()) + Path(dir)) {
             createTestEnvironment();
         }
 


### PR DESCRIPTION
Closes #3722.

Tests that use the file system all rely on TestEnvironment and therefore
depend on the state of the file system. To isolate these tests from each
other, we create a unique directory for each test environment using a
UUID. This allows these tests to be executed in parallel.