### PR TITLE
3701: Expand inspector panels by default

### DIFF
--- a/common/src/View/CollapsibleTitledPanel.cpp
+++ b/common/src/View/CollapsibleTitledPanel.cpp
@@ -95,6 +95,26 @@ namespace TrenchBroom {
             updateExpanded();
         }
 
+        QByteArray CollapsibleTitledPanel::saveState() const {
+            auto result = QByteArray();
+            auto stream = QDataStream(&result, QIODevice::WriteOnly);
+            stream << m_expanded;
+            return result;
+        }
+
+        bool CollapsibleTitledPanel::restoreState(const QByteArray& state) {
+            auto stream = QDataStream(state);
+            bool expanded;
+            stream >> expanded;
+
+            if (stream.status() == QDataStream::Ok) {
+                setExpanded(expanded);
+                return true;
+            }
+
+            return false;
+        }
+
         void CollapsibleTitledPanel::updateExpanded() {
             if (m_expanded) {
                 m_divider->show();

--- a/common/src/View/CollapsibleTitledPanel.h
+++ b/common/src/View/CollapsibleTitledPanel.h
@@ -59,6 +59,9 @@ namespace TrenchBroom {
             void collapse();
             bool expanded() const;
             void setExpanded(bool expanded);
+
+            QByteArray saveState() const;
+            bool restoreState(const QByteArray& state);
         private:
             void updateExpanded();
         };

--- a/common/src/View/EntityInspector.cpp
+++ b/common/src/View/EntityInspector.cpp
@@ -92,7 +92,7 @@ namespace TrenchBroom {
         }
 
         CollapsibleTitledPanel* EntityInspector::createEntityDefinitionFileChooser(QWidget* parent, std::weak_ptr<MapDocument> document) {
-            auto* panel = new CollapsibleTitledPanel(tr("Entity Definitions"), false, parent);
+            auto* panel = new CollapsibleTitledPanel(tr("Entity Definitions"), true, parent);
             panel->setObjectName("EntityInspector_EntityDefinitionFileChooser");
 
             auto* entityDefinitionFileChooser = new EntityDefinitionFileChooser(document);

--- a/common/src/View/EntityInspector.cpp
+++ b/common/src/View/EntityInspector.cpp
@@ -44,6 +44,7 @@ namespace TrenchBroom {
 
         EntityInspector::~EntityInspector() {
             saveWindowState(m_splitter);
+            saveWindowState(m_entityDefinitionFileChooser);
         }
 
         void EntityInspector::createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager) {
@@ -60,12 +61,14 @@ namespace TrenchBroom {
             m_attributeEditor->setMinimumSize(100, 150);
             m_entityBrowser->setMinimumSize(100, 150);
 
+            m_entityDefinitionFileChooser = createEntityDefinitionFileChooser(this, document);
+
             auto* outerSizer = new QVBoxLayout();
             outerSizer->setContentsMargins(0, 0, 0, 0);
             outerSizer->setSpacing(0);
             outerSizer->addWidget(m_splitter, 1);
             outerSizer->addWidget(new BorderLine(BorderLine::Direction::Horizontal), 0);
-            outerSizer->addWidget(createEntityDefinitionFileChooser(this, document), 0);
+            outerSizer->addWidget(m_entityDefinitionFileChooser, 0);
             setLayout(outerSizer);
 
             restoreWindowState(m_splitter);
@@ -88,14 +91,18 @@ namespace TrenchBroom {
             return panel;
         }
 
-        QWidget* EntityInspector::createEntityDefinitionFileChooser(QWidget* parent, std::weak_ptr<MapDocument> document) {
-            CollapsibleTitledPanel* panel = new CollapsibleTitledPanel(tr("Entity Definitions"), false, parent);
-            m_entityDefinitionFileChooser = new EntityDefinitionFileChooser(document);
+        CollapsibleTitledPanel* EntityInspector::createEntityDefinitionFileChooser(QWidget* parent, std::weak_ptr<MapDocument> document) {
+            auto* panel = new CollapsibleTitledPanel(tr("Entity Definitions"), false, parent);
+            panel->setObjectName("EntityInspector_EntityDefinitionFileChooser");
+
+            auto* entityDefinitionFileChooser = new EntityDefinitionFileChooser(document);
 
             auto* sizer = new QVBoxLayout();
             sizer->setContentsMargins(0, 0, 0, 0);
-            sizer->addWidget(m_entityDefinitionFileChooser, 1);
+            sizer->addWidget(entityDefinitionFileChooser, 1);
             panel->getPanel()->setLayout(sizer);
+
+            restoreWindowState(panel);
 
             return panel;
         }

--- a/common/src/View/EntityInspector.h
+++ b/common/src/View/EntityInspector.h
@@ -27,8 +27,8 @@ class QSplitter;
 
 namespace TrenchBroom {
     namespace View {
+        class CollapsibleTitledPanel;
         class EntityBrowser;
-        class EntityDefinitionFileChooser;
         class EntityPropertyEditor;
         class GLContextManager;
         class MapDocument;
@@ -39,7 +39,7 @@ namespace TrenchBroom {
             QSplitter* m_splitter;
             EntityPropertyEditor* m_attributeEditor;
             EntityBrowser* m_entityBrowser;
-            EntityDefinitionFileChooser* m_entityDefinitionFileChooser;
+            CollapsibleTitledPanel* m_entityDefinitionFileChooser;
         public:
             EntityInspector(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
             ~EntityInspector() override;
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             void createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
             QWidget* createAttributeEditor(QWidget* parent, std::weak_ptr<MapDocument> document);
             QWidget* createEntityBrowser(QWidget* parent, std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
-            QWidget* createEntityDefinitionFileChooser(QWidget* parent, std::weak_ptr<MapDocument> document);
+            CollapsibleTitledPanel* createEntityDefinitionFileChooser(QWidget* parent, std::weak_ptr<MapDocument> document);
         };
     }
 }

--- a/common/src/View/FaceInspector.cpp
+++ b/common/src/View/FaceInspector.cpp
@@ -112,7 +112,7 @@ namespace TrenchBroom {
         }
 
         CollapsibleTitledPanel* FaceInspector::createTextureCollectionEditor(QWidget* parent, std::weak_ptr<MapDocument> document) {
-            auto* panel = new CollapsibleTitledPanel(tr("Texture Collections"), false, parent);
+            auto* panel = new CollapsibleTitledPanel(tr("Texture Collections"), true, parent);
             panel->setObjectName("FaceInspector_TextureCollections");
 
             auto* collectionEditor = new TextureCollectionEditor(std::move(document));

--- a/common/src/View/FaceInspector.cpp
+++ b/common/src/View/FaceInspector.cpp
@@ -48,12 +48,14 @@ namespace TrenchBroom {
         m_document(document),
         m_splitter(nullptr),
         m_faceAttribsEditor(nullptr),
-        m_textureBrowser(nullptr) {
+        m_textureBrowser(nullptr),
+        m_textureCollectionsEditor(nullptr) {
             createGui(document, contextManager);
         }
 
         FaceInspector::~FaceInspector() {
             saveWindowState(m_splitter);
+            saveWindowState(m_textureCollectionsEditor);
         }
 
         bool FaceInspector::cancelMouseDrag() {
@@ -76,12 +78,14 @@ namespace TrenchBroom {
             m_splitter->setStretchFactor(0, 0);
             m_splitter->setStretchFactor(1, 1);
 
+            m_textureCollectionsEditor = createTextureCollectionEditor(this, document);
+
             auto* layout = new QVBoxLayout();
             layout->setContentsMargins(0, 0, 0, 0);
             layout->setSpacing(0);
             layout->addWidget(m_splitter, 1);
             layout->addWidget(new BorderLine(BorderLine::Direction::Horizontal));
-            layout->addWidget(createTextureCollectionEditor(this, document));
+            layout->addWidget(m_textureCollectionsEditor);
             setLayout(layout);
 
             connect(m_textureBrowser, &TextureBrowser::textureSelected, this, &FaceInspector::textureSelected);
@@ -107,14 +111,18 @@ namespace TrenchBroom {
             return panel;
         }
 
-        QWidget* FaceInspector::createTextureCollectionEditor(QWidget* parent, std::weak_ptr<MapDocument> document) {
+        CollapsibleTitledPanel* FaceInspector::createTextureCollectionEditor(QWidget* parent, std::weak_ptr<MapDocument> document) {
             auto* panel = new CollapsibleTitledPanel(tr("Texture Collections"), false, parent);
+            panel->setObjectName("FaceInspector_TextureCollections");
+
             auto* collectionEditor = new TextureCollectionEditor(std::move(document));
 
             auto* layout = new QVBoxLayout();
             layout->setContentsMargins(0, 0, 0, 0);
             layout->addWidget(collectionEditor, 1);
             panel->getPanel()->setLayout(layout);
+
+            restoreWindowState(panel);
 
             return panel;
         }

--- a/common/src/View/FaceInspector.h
+++ b/common/src/View/FaceInspector.h
@@ -32,6 +32,7 @@ namespace TrenchBroom {
     }
 
     namespace View {
+        class CollapsibleTitledPanel;
         class FaceAttribsEditor;
         class GLContextManager;
         class MapDocument;
@@ -44,6 +45,7 @@ namespace TrenchBroom {
             QSplitter* m_splitter;
             FaceAttribsEditor* m_faceAttribsEditor;
             TextureBrowser* m_textureBrowser;
+            CollapsibleTitledPanel* m_textureCollectionsEditor;
         public:
             FaceInspector(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
             ~FaceInspector() override;
@@ -54,7 +56,7 @@ namespace TrenchBroom {
             void createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
             QWidget* createFaceAttribsEditor(QWidget* parent, std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
             QWidget* createTextureBrowser(QWidget* parent, std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
-            QWidget* createTextureCollectionEditor(QWidget* parent, std::weak_ptr<MapDocument> document);
+            CollapsibleTitledPanel* createTextureCollectionEditor(QWidget* parent, std::weak_ptr<MapDocument> document);
 
             void textureSelected(const Assets::Texture* texture);
         };

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -160,12 +160,20 @@ namespace TrenchBroom {
             m_softBoundsFromGameMaxLabel = new QLabel();
             auto* softBoundsFromGameLabel = new ClickableLabel(tr("Use game default"));
 
+            auto* minCaptionLabel = new QLabel(tr("Min:"));
+            auto* maxCaptionLabel = new QLabel(tr("Max:"));
+
+            makeInfo(minCaptionLabel);
+            makeInfo(maxCaptionLabel);
+            makeInfo(m_softBoundsFromGameMinLabel);
+            makeInfo(m_softBoundsFromGameMaxLabel);
+
             auto* softBoundsFromGameValueLayout = new QHBoxLayout();
             softBoundsFromGameValueLayout->setContentsMargins(0, 0, 0, 0);
             softBoundsFromGameValueLayout->setSpacing(LayoutConstants::MediumHMargin);
-            softBoundsFromGameValueLayout->addWidget(new QLabel(tr("Min:")));
+            softBoundsFromGameValueLayout->addWidget(minCaptionLabel);
             softBoundsFromGameValueLayout->addWidget(m_softBoundsFromGameMinLabel);
-            softBoundsFromGameValueLayout->addWidget(new QLabel(tr("Max:")));
+            softBoundsFromGameValueLayout->addWidget(maxCaptionLabel);
             softBoundsFromGameValueLayout->addWidget(m_softBoundsFromGameMaxLabel);
             softBoundsFromGameValueLayout->addStretch(1);
             

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
 
             sizer->addWidget(createLayerEditor(document), 1);
             sizer->addWidget(new BorderLine(BorderLine::Direction::Horizontal), 0);
-            sizer->addWidget(createMapProperties(document), 0);
+            sizer->addWidget(createMapPropertiesEditor(document), 0);
             sizer->addWidget(new BorderLine(BorderLine::Direction::Horizontal), 0);
             sizer->addWidget(createModEditor(document), 0);
             setLayout(sizer);
@@ -78,7 +78,7 @@ namespace TrenchBroom {
             return titledPanel;
         }
 
-        QWidget* MapInspector::createMapProperties(std::weak_ptr<MapDocument> document) {
+        QWidget* MapInspector::createMapPropertiesEditor(std::weak_ptr<MapDocument> document) {
             CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Map Properties"), false);
             auto* editor = new MapPropertiesEditor(document);
 

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -49,20 +49,30 @@ namespace TrenchBroom {
         // MapInspector
 
         MapInspector::MapInspector(std::weak_ptr<MapDocument> document, QWidget* parent) :
-        TabBookPage(parent) {
+        TabBookPage(parent),
+        m_mapPropertiesEditor(nullptr),
+        m_modEditor(nullptr) {
             createGui(document);
         }
 
+        MapInspector::~MapInspector() {
+            saveWindowState(m_mapPropertiesEditor);
+            saveWindowState(m_modEditor);
+        }
+
         void MapInspector::createGui(std::weak_ptr<MapDocument> document) {
+            m_mapPropertiesEditor = createMapPropertiesEditor(document);
+            m_modEditor = createModEditor(document);
+
             auto* sizer = new QVBoxLayout();
             sizer->setContentsMargins(0, 0, 0, 0);
             sizer->setSpacing(0);
 
             sizer->addWidget(createLayerEditor(document), 1);
             sizer->addWidget(new BorderLine(BorderLine::Direction::Horizontal), 0);
-            sizer->addWidget(createMapPropertiesEditor(document), 0);
+            sizer->addWidget(m_mapPropertiesEditor, 0);
             sizer->addWidget(new BorderLine(BorderLine::Direction::Horizontal), 0);
-            sizer->addWidget(createModEditor(document), 0);
+            sizer->addWidget(m_modEditor, 0);
             setLayout(sizer);
         }
 
@@ -78,8 +88,10 @@ namespace TrenchBroom {
             return titledPanel;
         }
 
-        QWidget* MapInspector::createMapPropertiesEditor(std::weak_ptr<MapDocument> document) {
+        CollapsibleTitledPanel* MapInspector::createMapPropertiesEditor(std::weak_ptr<MapDocument> document) {
             CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Map Properties"), false);
+            titledPanel->setObjectName("MapInspector_MapPropertiesPanel");
+
             auto* editor = new MapPropertiesEditor(document);
 
             auto* sizer = new QVBoxLayout();
@@ -87,17 +99,23 @@ namespace TrenchBroom {
             sizer->addWidget(editor, 1);
             titledPanel->getPanel()->setLayout(sizer);
 
+            restoreWindowState(titledPanel);
+
             return titledPanel;
         }
 
-        QWidget* MapInspector::createModEditor(std::weak_ptr<MapDocument> document) {
+        CollapsibleTitledPanel* MapInspector::createModEditor(std::weak_ptr<MapDocument> document) {
             CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Mods"), false);
+            titledPanel->setObjectName("MapInspector_ModsPanel");
+
             ModEditor* modEditor = new ModEditor(document);
 
             auto* sizer = new QVBoxLayout();
             sizer->setContentsMargins(0, 0, 0, 0);
             sizer->addWidget(modEditor, 1);
             titledPanel->getPanel()->setLayout(sizer);
+
+            restoreWindowState(titledPanel);
 
             return titledPanel;
         }

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -89,7 +89,7 @@ namespace TrenchBroom {
         }
 
         CollapsibleTitledPanel* MapInspector::createMapPropertiesEditor(std::weak_ptr<MapDocument> document) {
-            CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Map Properties"), false);
+            CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Map Properties"));
             titledPanel->setObjectName("MapInspector_MapPropertiesPanel");
 
             auto* editor = new MapPropertiesEditor(document);
@@ -105,7 +105,7 @@ namespace TrenchBroom {
         }
 
         CollapsibleTitledPanel* MapInspector::createModEditor(std::weak_ptr<MapDocument> document) {
-            CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Mods"), false);
+            CollapsibleTitledPanel* titledPanel = new CollapsibleTitledPanel(tr("Mods"));
             titledPanel->setObjectName("MapInspector_ModsPanel");
 
             ModEditor* modEditor = new ModEditor(document);

--- a/common/src/View/MapInspector.h
+++ b/common/src/View/MapInspector.h
@@ -38,17 +38,22 @@ namespace TrenchBroom {
     }
 
     namespace View {
+        class CollapsibleTitledPanel;
         class MapDocument;
 
         class MapInspector : public TabBookPage {
             Q_OBJECT
+        private:
+            CollapsibleTitledPanel* m_mapPropertiesEditor;
+            CollapsibleTitledPanel* m_modEditor;
         public:
             explicit MapInspector(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
+            ~MapInspector();
         private:
             void createGui(std::weak_ptr<MapDocument> document);
             QWidget* createLayerEditor(std::weak_ptr<MapDocument> document);
-            QWidget* createMapPropertiesEditor(std::weak_ptr<MapDocument> document);
-            QWidget* createModEditor(std::weak_ptr<MapDocument> document);
+            CollapsibleTitledPanel* createMapPropertiesEditor(std::weak_ptr<MapDocument> document);
+            CollapsibleTitledPanel* createModEditor(std::weak_ptr<MapDocument> document);
         };
 
         /**

--- a/common/src/View/MapInspector.h
+++ b/common/src/View/MapInspector.h
@@ -47,7 +47,7 @@ namespace TrenchBroom {
         private:
             void createGui(std::weak_ptr<MapDocument> document);
             QWidget* createLayerEditor(std::weak_ptr<MapDocument> document);
-            QWidget* createMapProperties(std::weak_ptr<MapDocument> document);
+            QWidget* createMapPropertiesEditor(std::weak_ptr<MapDocument> document);
             QWidget* createModEditor(std::weak_ptr<MapDocument> document);
         };
 


### PR DESCRIPTION
Closes #3701

To make the inspector panels such as the map properties or the texture collections easier to discover, we want them to be expanded by default. Once discovered, they should retain their state, so we add support for saving the window state to `CollapsibleTitledPanel`.