### PR TITLE
3734: opt into fractional dpi scaling, so Windows at 150% works

### DIFF
--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -49,6 +49,10 @@ int main(int argc, char *argv[])
     // Set up Hi DPI scaling
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    // Enables non-integer scaling (e.g. 150% scaling on Windows)
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
 
     // Workaround bug in Qt's Ctrl+Click = RMB emulation (a macOS feature.)
     // In Qt 5.13.0 / macOS 10.14.6, Ctrl+trackpad click+Drag produces no mouse events at all, but


### PR DESCRIPTION
Fixes #3734

Screenshot of Windows set to 150% with this PR. Without the PR everything is too large.
<img width="1040" alt="Capture" src="https://user-images.githubusercontent.com/239161/107871011-05019080-6e5b-11eb-9cec-3afd321ba483.PNG">
