### PR TITLE
3732: Run tests with sandboxed preferences

### DIFF
--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -17,11 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "PreferenceManager.h"
+#include "TrenchBroomApp.h"
 #include "Model/GameFactory.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentCommandFacade.h"
 #include "View/MapFrame.h"
-#include "TrenchBroomApp.h"
 
 #include <QApplication>
 #include <QSurfaceFormat>
@@ -65,7 +66,9 @@ int main(int argc, char *argv[])
     // actually work with TB.)
     qputenv("QT_OPENGL_BUGLIST", ":/opengl_buglist.json");
 
+    TrenchBroom::PreferenceManager::createInstance<TrenchBroom::AppPreferenceManager>();
     TrenchBroom::View::TrenchBroomApp app(argc, argv);
+
     app.parseCommandLineAndShowFrame();
     return app.exec();
 }

--- a/common/benchmark/src/Main.cpp
+++ b/common/benchmark/src/Main.cpp
@@ -18,5 +18,5 @@
  */
 
 // Hack to reuse the same main() function as the test suite
+#include "../../test/src/TestPreferenceManager.cpp"
 #include "../../test/src/RunAllTests.cpp"
-

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -103,6 +103,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/RunAllTests.cpp"
         "${COMMON_TEST_SOURCE_DIR}/StackWalkerTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/TestLogger.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/TestPreferenceManager.cpp"
         "${COMMON_TEST_SOURCE_DIR}/TestUtils.cpp"
         "${COMMON_TEST_SOURCE_DIR}/TestUtils.h"
 )

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -35,7 +35,8 @@
 namespace TrenchBroom {
     namespace IO {
         TestEnvironment::TestEnvironment(const std::string& dir) :
-            m_dir(pathFromQString(QDir::current().path()) + Path(generateUuid()) + Path(dir)) {
+            m_sandboxPath(pathFromQString(QDir::current().path()) + Path(generateUuid())),
+            m_dir(m_sandboxPath + Path(dir)) {
             createTestEnvironment();
         }
 
@@ -78,7 +79,7 @@ namespace TrenchBroom {
         }
 
         bool TestEnvironment::deleteTestEnvironment() {
-            return deleteDirectoryAbsolute(m_dir);
+            return deleteDirectoryAbsolute(m_sandboxPath);
         }
 
         bool TestEnvironment::directoryExists(const Path& path) const {

--- a/common/test/src/IO/TestEnvironment.h
+++ b/common/test/src/IO/TestEnvironment.h
@@ -27,6 +27,7 @@ namespace TrenchBroom {
     namespace IO {
         class TestEnvironment {
         private:
+            Path m_sandboxPath;
             Path m_dir;
         public:
             explicit TestEnvironment(const std::string& dir);

--- a/common/test/src/RunAllTests.cpp
+++ b/common/test/src/RunAllTests.cpp
@@ -31,15 +31,6 @@ int main(int argc, char **argv) {
     TrenchBroom::PreferenceManager::createInstance<TrenchBroom::TestPreferenceManager>();
     TrenchBroom::View::TrenchBroomApp app(argc, argv);
 
-/*
-    // use an empty file config so that we always use the default preferences
-    // this must happen exactly between creating the app instance and initializing it
-    // so that the app itself will not try to access the config file before we reset it here
-    const auto configFileName = "TrenchBroom-Test.ini";
-    const auto configFilePath = wxFileConfig::GetLocalFile(configFileName);
-    wxRemove(configFilePath.GetPath());
-    wxConfig::Set(new wxFileConfig(wxEmptyString, wxEmptyString, configFileName));
-*/
     TrenchBroom::View::setCrashReportGUIEnbled(false);
 
     ensure(qApp == &app, "invalid app instance");

--- a/common/test/src/RunAllTests.cpp
+++ b/common/test/src/RunAllTests.cpp
@@ -20,7 +20,7 @@
 #define CATCH_CONFIG_RUNNER
 
 #include "Ensure.h"
-#include "PreferenceManager.h"
+#include "TestPreferenceManager.h"
 #include "TrenchBroomApp.h"
 
 #include <clocale>
@@ -28,7 +28,7 @@
 #include "Catch2.h"
 
 int main(int argc, char **argv) {
-    TrenchBroom::PreferenceManager::createInstance<TrenchBroom::AppPreferenceManager>();
+    TrenchBroom::PreferenceManager::createInstance<TrenchBroom::TestPreferenceManager>();
     TrenchBroom::View::TrenchBroomApp app(argc, argv);
 
 /*

--- a/common/test/src/RunAllTests.cpp
+++ b/common/test/src/RunAllTests.cpp
@@ -19,14 +19,16 @@
 
 #define CATCH_CONFIG_RUNNER
 
-#include "TrenchBroomApp.h"
 #include "Ensure.h"
+#include "PreferenceManager.h"
+#include "TrenchBroomApp.h"
 
 #include <clocale>
 
 #include "Catch2.h"
 
 int main(int argc, char **argv) {
+    TrenchBroom::PreferenceManager::createInstance<TrenchBroom::AppPreferenceManager>();
     TrenchBroom::View::TrenchBroomApp app(argc, argv);
 
 /*

--- a/common/test/src/TestPreferenceManager.cpp
+++ b/common/test/src/TestPreferenceManager.cpp
@@ -1,0 +1,36 @@
+/*
+ Copyright (C) 2021 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestPreferenceManager.h"
+
+namespace TrenchBroom {
+    void TestPreferenceManager::initialize() {}
+
+    bool TestPreferenceManager::saveInstantly() const { return false; }
+    
+    void TestPreferenceManager::saveChanges() {}
+    
+    void TestPreferenceManager::discardChanges() {}
+
+    void TestPreferenceManager::validatePreference(PreferenceBase& preference) {
+        preference.setValid(true);
+    }
+
+    void TestPreferenceManager::savePreference(PreferenceBase&) {}
+}

--- a/common/test/src/TestPreferenceManager.h
+++ b/common/test/src/TestPreferenceManager.h
@@ -1,0 +1,38 @@
+/*
+ Copyright (C) 2021 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "PreferenceManager.h"
+
+namespace TrenchBroom {
+    class TestPreferenceManager : public PreferenceManager {
+    public:
+        TestPreferenceManager() = default;
+
+        void initialize() override;
+
+        bool saveInstantly() const override;
+        void saveChanges() override;
+        void discardChanges() override;
+    private:
+        void validatePreference(PreferenceBase&) override;
+        void savePreference(PreferenceBase&) override;
+    };
+}

--- a/dump-shortcuts/src/Main.cpp
+++ b/dump-shortcuts/src/Main.cpp
@@ -20,8 +20,9 @@
 #include "View/Actions.h"
 
 #include "KeyStrings.h"
-#include "IO/Path.h"
+#include "PreferenceManager.h"
 #include "Preferences.h"
+#include "IO/Path.h"
 
 #include <QApplication>
 #include <QFileInfo>
@@ -200,6 +201,8 @@ int main(int argc, char *argv[]) {
 
     QTextStream out(&file);
     out.setCodec("UTF-8");
+
+    TrenchBroom::PreferenceManager::createInstance<TrenchBroom::AppPreferenceManager>();
 
     // QKeySequence requires that an application instance is created!
     QApplication app(argc, argv);


### PR DESCRIPTION
Closes #3732.

This PR introduces a refactoring of `PreferenceManager` that allows us to create a `TestPreferenceManager`, which doesn't access user preferences and is read only. This also speeds up test runs because it doesn't trigger any preference migrations or instantiates actions.