### PR TITLE
3725: Use vertex position matching to set face attributes after CSG merge

### DIFF
--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -88,6 +88,7 @@ namespace TrenchBroom {
             bool fullySpecified() const;
         public: // clone face attributes from matching faces of other brushes
             void cloneFaceAttributesFrom(const Brush& brush);
+            void cloneFaceAttributesFrom(const std::vector<const Brush*>& brushes);
             void cloneInvertedFaceAttributesFrom(const Brush& brush);
         public: // clipping
             kdl::result<void, BrushError> clip(const vm::bbox3& worldBounds, BrushFace face);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2003,9 +2003,7 @@ namespace TrenchBroom {
             const Model::BrushBuilder builder(m_world->mapFormat(), m_worldBounds, m_game->defaultFaceAttribs());
             return builder.createBrush(polyhedron, currentTextureName())
                 .and_then([&](Model::Brush&& b) {
-                    for (const Model::BrushNode* selectedBrushNode : selectedNodes().brushes()) {
-                        b.cloneFaceAttributesFrom(selectedBrushNode->brush());
-                    }
+                    b.cloneFaceAttributesFrom(kdl::vec_transform(selectedNodes().brushes(), [](const auto* brushNode) { return &brushNode->brush(); }));
 
                     // The nodelist is either empty or contains only brushes.
                     const auto toRemove = selectedNodes().nodes();


### PR DESCRIPTION
Closes #3725

This change introduces a new method of setting face attributes after performing
a CSG convex merge operation. For each newly created face, we find the best
matching face of the source brushes. A face of a source brush receives a match
score based on the number of vertices it shares with the newly created face.
Ties are broken using the face normals.