### PR TITLE
3725: transfer attributes after csg merge

### DIFF
--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -88,6 +88,7 @@ namespace TrenchBroom {
             bool fullySpecified() const;
         public: // clone face attributes from matching faces of other brushes
             void cloneFaceAttributesFrom(const Brush& brush);
+            void cloneFaceAttributesFrom(const std::vector<const Brush*>& brushes);
             void cloneInvertedFaceAttributesFrom(const Brush& brush);
         public: // clipping
             kdl::result<void, BrushError> clip(const vm::bbox3& worldBounds, BrushFace face);

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -322,6 +322,19 @@ namespace TrenchBroom {
             return sum / 2.0;
         }
 
+        bool BrushFace::coplanarWith(const vm::plane3d& plane) const {
+            // Test if the face's center lies on the reference plane within an epsilon.
+            if (!vm::is_zero(plane.point_distance(center()), vm::constants<FloatType>::almost_zero() * 10.0)) {
+                return false;
+            }
+
+            // Test if the normals are colinear by checking their enclosed angle.
+            if (1.0 - vm::dot(boundary().normal, plane.normal) >= vm::constants<FloatType>::colinear_epsilon()) {
+                return false;
+            }
+            return true;
+        }
+
         const BrushFaceAttributes& BrushFace::attributes() const {
             return m_attributes;
         }

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -307,6 +307,21 @@ namespace TrenchBroom {
             return vm::abs((c1 - c2) / 2.0);
         }
 
+        FloatType BrushFace::area() const {
+            FloatType sum = 0.0;
+            const std::vector<vm::vec3> v = vertexPositions();
+            for (size_t i = 2; i < v.size(); ++i) {
+                const vm::vec3& a = v[0];
+                const vm::vec3& b = v[i - 1];
+                const vm::vec3& c = v[i];
+
+                const FloatType doubleTriangleArea = vm::length(vm::cross(b - a, c - a));
+
+                sum += doubleTriangleArea;
+            }
+            return sum / 2.0;
+        }
+
         const BrushFaceAttributes& BrushFace::attributes() const {
             return m_attributes;
         }

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -281,7 +281,7 @@ namespace TrenchBroom {
             return fromPlane * bounds.center();
         }
 
-        FloatType BrushFace::area(const vm::axis::type axis) const {
+        FloatType BrushFace::projectedArea(const vm::axis::type axis) const {
             FloatType c1 = 0.0;
             FloatType c2 = 0.0;
             switch (axis) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -154,6 +154,7 @@ namespace TrenchBroom {
             vm::vec3 center() const;
             vm::vec3 boundsCenter() const;
             FloatType area(vm::axis::type axis) const;
+            FloatType area() const;
 
             const BrushFaceAttributes& attributes() const;
             void setAttributes(const BrushFaceAttributes& attributes);

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -155,6 +155,7 @@ namespace TrenchBroom {
             vm::vec3 boundsCenter() const;
             FloatType projectedArea(vm::axis::type axis) const;
             FloatType area() const;
+            bool coplanarWith(const vm::plane3d& plane) const;
 
             const BrushFaceAttributes& attributes() const;
             void setAttributes(const BrushFaceAttributes& attributes);

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -153,7 +153,7 @@ namespace TrenchBroom {
             const vm::vec3& normal() const;
             vm::vec3 center() const;
             vm::vec3 boundsCenter() const;
-            FloatType area(vm::axis::type axis) const;
+            FloatType projectedArea(vm::axis::type axis) const;
             FloatType area() const;
 
             const BrushFaceAttributes& attributes() const;

--- a/common/src/Model/CompareHits.cpp
+++ b/common/src/Model/CompareHits.cpp
@@ -81,9 +81,9 @@ namespace TrenchBroom {
 
         FloatType CompareHitsBySize::getSize(const Hit& hit) const {
             if (const auto faceHandle = Model::hitToFaceHandle(hit)) {
-                return faceHandle->face().area(m_axis);
+                return faceHandle->face().projectedArea(m_axis);
             } else if (const EntityNode* entity = hitToEntity(hit)) {
-                return entity->area(m_axis);
+                return entity->projectedArea(m_axis);
             } else {
                 return 0.0;
             }

--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
         EntityNode::EntityNode(std::initializer_list<EntityProperty> properties) :
         EntityNode(Entity(std::move(properties))) {}
 
-        FloatType EntityNode::area(vm::axis::type axis) const {
+        FloatType EntityNode::projectedArea(vm::axis::type axis) const {
             const vm::vec3 size = physicalBounds().size();
             switch (axis) {
                 case vm::axis::x:

--- a/common/src/Model/EntityNode.h
+++ b/common/src/Model/EntityNode.h
@@ -59,7 +59,7 @@ namespace TrenchBroom {
             explicit EntityNode(Entity entity);
             explicit EntityNode(std::initializer_list<EntityProperty> properties);
 
-            FloatType area(vm::axis::type axis) const;
+            FloatType projectedArea(vm::axis::type axis) const;
         public: // entity model
             const vm::bbox3& modelBounds() const;
             void setModelFrame(const Assets::EntityModelFrame* modelFrame);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2046,9 +2046,7 @@ namespace TrenchBroom {
             const Model::BrushBuilder builder(m_world->mapFormat(), m_worldBounds, m_game->defaultFaceAttribs());
             return builder.createBrush(polyhedron, currentTextureName())
                 .and_then([&](Model::Brush&& b) {
-                    for (const Model::BrushNode* selectedBrushNode : selectedNodes().brushes()) {
-                        b.cloneFaceAttributesFrom(selectedBrushNode->brush());
-                    }
+                    b.cloneFaceAttributesFrom(kdl::vec_transform(selectedNodes().brushes(), [](const auto* brushNode) { return &brushNode->brush(); }));
 
                     // The nodelist is either empty or contains only brushes.
                     const auto toRemove = selectedNodes().nodes();

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -239,13 +239,7 @@ namespace TrenchBroom {
                                 continue;
                             }
 
-                            // Test if the face's center lies on the reference plane within an epsilon.
-                            if (!vm::is_zero(referenceFace.boundary().point_distance(face.center()), vm::constants<FloatType>::almost_zero() * 10.0)) {
-                                continue;
-                            }
-                            
-                            // Test if the normals are colinear by checking their enclosed angle.
-                            if (1.0 - vm::dot(face.boundary().normal, referenceFace.boundary().normal) >= vm::constants<FloatType>::colinear_epsilon()) {
+                            if (!face.coplanarWith(referenceFace.boundary())) {
                                 continue;
                             }
 

--- a/common/test/src/Model/EntityNodeTest.cpp
+++ b/common/test/src/Model/EntityNodeTest.cpp
@@ -47,9 +47,9 @@ namespace TrenchBroom {
             auto entityNode = EntityNode{};
             entityNode.setDefinition(&definition);
 
-            CHECK(entityNode.area(vm::axis::x) == 6.0);
-            CHECK(entityNode.area(vm::axis::y) == 3.0);
-            CHECK(entityNode.area(vm::axis::z) == 2.0);
+            CHECK(entityNode.projectedArea(vm::axis::x) == 6.0);
+            CHECK(entityNode.projectedArea(vm::axis::y) == 3.0);
+            CHECK(entityNode.projectedArea(vm::axis::z) == 2.0);
         }
 
         static const std::string TestClassname = "something";


### PR DESCRIPTION
Fixes #3725

I've reworked https://github.com/TrenchBroom/TrenchBroom/pull/3745 with a new heuristic and bug fixes:

- If the output face has any coplanar faces in the source brushes, use the largest area one.
- Otherwise take the face from the source brushes whose center point is closest to the output face plane.