### PR TITLE
3746: make Revert command less prone to accidental activation

### DIFF
--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -834,7 +834,7 @@ namespace TrenchBroom {
                 },
                 [](ActionExecutionContext& context) { return context.hasDocument(); }));
             fileMenu.addSeparator();
-            fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Revert"), QObject::tr("Revert"), 0,
+            fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Revert"), QObject::tr("Revert Document"), 0,
                 [](ActionExecutionContext& context) {
                     context.frame()->revertDocument();
                 },

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -767,12 +767,6 @@ namespace TrenchBroom {
                     context.frame()->saveDocumentAs();
                 },
                 [](ActionExecutionContext& context) { return context.hasDocument(); }));
-            fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Revert"), QObject::tr("Revert"), 0,
-                [](ActionExecutionContext& context) {
-                    context.frame()->revertDocument();
-                },
-                [](ActionExecutionContext& context) { return context.hasDocument(); },
-                IO::Path(), QObject::tr("Discards any unsaved changes and reloads the map file.")));
 
             auto& exportMenu = fileMenu.addMenu("Export");
             exportMenu.addItem(createMenuAction(IO::Path("Menu/File/Export/Wavefront OBJ..."), QObject::tr("Wavefront OBJ..."), 0,
@@ -840,6 +834,12 @@ namespace TrenchBroom {
                 },
                 [](ActionExecutionContext& context) { return context.hasDocument(); }));
             fileMenu.addSeparator();
+            fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Revert"), QObject::tr("Revert"), 0,
+                [](ActionExecutionContext& context) {
+                    context.frame()->revertDocument();
+                },
+                [](ActionExecutionContext& context) { return context.hasDocument(); },
+                IO::Path(), QObject::tr("Discards any unsaved changes and reloads the map file.")));
             fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Close"), QObject::tr("Close Document"), QKeySequence::Close,
                 [](ActionExecutionContext& context) {
                     context.frame()->closeDocument();

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -933,7 +933,8 @@ namespace TrenchBroom {
             messageBox.setInformativeText(tr("This will discard all unsaved changes and reload the document from disk."));
 
             auto* revertButton = messageBox.addButton(tr("Revert"), QMessageBox::DestructiveRole);
-            messageBox.addButton(QMessageBox::Cancel);
+            auto* cancelButton = messageBox.addButton(QMessageBox::Cancel);
+            messageBox.setDefaultButton(cancelButton);
 
             messageBox.exec();
 


### PR DESCRIPTION
1. Move the menu item down:

   ![menu](https://user-images.githubusercontent.com/239161/109260633-bab5d300-77bb-11eb-913b-9c344dc09e69.PNG)

2. Make "Cancel" the default button. Pressing Space or Enter (or Escape) all dismiss the dialog. You can accept the revert with Tab then Space, though.
    
    ![default button](https://user-images.githubusercontent.com/239161/109260690-d620de00-77bb-11eb-8a4c-21f6d9c22383.PNG)

Fixes #3746