### PR TITLE
3757: Update linked group nodes after setting properties to unprotected

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -96,6 +96,7 @@
 #include "View/SetCurrentLayerCommand.h"
 #include "View/SetVisibilityCommand.h"
 #include "View/SwapNodeContentsCommand.h"
+#include "View/UpdateLinkedGroupsHelper.h"
 #include "View/ViewEffectsService.h"
 
 #include <kdl/collection_utils.h>
@@ -2339,8 +2340,7 @@ namespace TrenchBroom {
                 nodesToUpdate.emplace_back(entityNode, std::move(entity));
             }
 
-            // The linked groups are not affected!
-            return swapNodeContents("Set Protected Property", nodesToUpdate, {});
+            return swapNodeContents("Set Protected Property", nodesToUpdate, findContainingLinkedGroupsToUpdate(*m_world, entityNodes));
         }
 
         bool MapDocument::clearProtectedProperties() {
@@ -2376,13 +2376,17 @@ namespace TrenchBroom {
                 nodesToUpdate.emplace_back(entityNode, std::move(entity));
             }
 
-            // The linked groups are not affected!
-            return swapNodeContents("Clear Protected Properties", nodesToUpdate, {});
+            return swapNodeContents("Clear Protected Properties", nodesToUpdate, findContainingLinkedGroupsToUpdate(*m_world, entityNodes));
         }
 
         bool MapDocument::canClearProtectedProperties() const {
             const auto entityNodes = allSelectedEntityNodes();
-            return !entityNodes.empty() && (entityNodes.size() > 1u || entityNodes.front() != m_world.get());
+            if (entityNodes.empty() || (entityNodes.size() == 1u && entityNodes.front() == m_world.get())) {
+                return false;
+            }
+
+            const auto linkedGroupsToUpdate = findContainingLinkedGroupsToUpdate(*m_world, entityNodes);
+            return checkLinkedGroupsToUpdate(kdl::vec_transform(linkedGroupsToUpdate, [](const auto& p) { return p.first; }));
         }
 
         bool MapDocument::resizeBrushes(const std::vector<vm::polygon3>& faces, const vm::vec3& delta) {

--- a/common/test/src/View/SetEntityPropertiesTest.cpp
+++ b/common/test/src/View/SetEntityPropertiesTest.cpp
@@ -130,8 +130,9 @@ namespace TrenchBroom {
             // both entities have the same value initially
             auto* linkedEntityNode = dynamic_cast<Model::EntityNode*>(linkedGroupNode->children().front());
             REQUIRE(linkedEntityNode);
-            REQUIRE(linkedEntityNode->entity().property("some_key") != nullptr);
-            REQUIRE(*linkedEntityNode->entity().property("some_key") == "some_value");
+            REQUIRE_THAT(linkedEntityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                {"some_key", "some_value"}
+            }));
 
             document->deselectAll();
             document->select(linkedEntityNode);
@@ -139,22 +140,27 @@ namespace TrenchBroom {
             // set the property to protected in the linked entity and change its value
             document->setProtectedProperty("some_key", true);
             document->setProperty("some_key", "another_value");
-            REQUIRE(linkedEntityNode->entity().property("some_key") != nullptr);
-            REQUIRE(*linkedEntityNode->entity().property("some_key") == "another_value");
+            REQUIRE_THAT(linkedEntityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                {"some_key", "another_value"}
+            }));
 
             // the value in the original entity remains unchanged
             entityNode = dynamic_cast<Model::EntityNode*>(groupNode->children().front());
-            REQUIRE(entityNode->entity().property("some_key") != nullptr);
-            REQUIRE(*entityNode->entity().property("some_key") == "some_value");
+            REQUIRE_THAT(entityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                {"some_key", "some_value"}
+            }));
 
             SECTION("When there is an unprotected property in the corresponding entity") {
                 // set the property to unprotected, now the original value should be restored
                 document->setProtectedProperty("some_key", false);
-                CHECK(linkedEntityNode->entity().property("some_key") != nullptr);
-                CHECK(*linkedEntityNode->entity().property("some_key") == "some_value");
 
-                CHECK(entityNode->entity().property("some_key") != nullptr);
-                CHECK(*entityNode->entity().property("some_key") == "some_value");
+                entityNode = dynamic_cast<Model::EntityNode*>(groupNode->children().front());
+                CHECK_THAT(linkedEntityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                    {"some_key", "some_value"}
+                }));
+                CHECK_THAT(entityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                    {"some_key", "some_value"}
+                }));
             }
 
             SECTION("When no corresponding entity with an unprotected property can be found") {
@@ -162,27 +168,39 @@ namespace TrenchBroom {
                 document->deselectAll();
                 document->select(entityNode);
                 document->setProtectedProperty("some_key", true);
-                REQUIRE(entityNode->entity().property("some_key") != nullptr);
-                REQUIRE(*entityNode->entity().property("some_key") == "some_value");
-                REQUIRE(linkedEntityNode->entity().property("some_key") != nullptr);
-                REQUIRE(*linkedEntityNode->entity().property("some_key") == "another_value");
+
+                linkedEntityNode = dynamic_cast<Model::EntityNode*>(linkedGroupNode->children().front());
+                REQUIRE_THAT(entityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                    {"some_key", "some_value"}
+                }));
+                REQUIRE_THAT(linkedEntityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                    {"some_key", "another_value"}
+                }));
 
                 document->deselectAll();
                 document->select(linkedEntityNode);
                 document->setProtectedProperty("some_key", false);
-                CHECK(linkedEntityNode->entity().property("some_key") != nullptr);
-                CHECK(*linkedEntityNode->entity().property("some_key") == "another_value");
-                CHECK(entityNode->entity().property("some_key") != nullptr);
-                CHECK(*entityNode->entity().property("some_key") == "some_value");
+
+                entityNode = dynamic_cast<Model::EntityNode*>(groupNode->children().front());
+                CHECK_THAT(entityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                    {"some_key", "some_value"}
+                }));
+                CHECK_THAT(linkedEntityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                    {"some_key", "another_value"}
+                }));
 
                 SECTION("Setting the property to unprotected in the original entity will fetch the new value now") {
                     document->deselectAll();
                     document->select(entityNode);
                     document->setProtectedProperty("some_key", false);
-                    CHECK(linkedEntityNode->entity().property("some_key") != nullptr);
-                    CHECK(*linkedEntityNode->entity().property("some_key") == "another_value");
-                    CHECK(entityNode->entity().property("some_key") != nullptr);
-                    CHECK(*entityNode->entity().property("some_key") == "another_value");
+
+                    linkedEntityNode = dynamic_cast<Model::EntityNode*>(linkedGroupNode->children().front());
+                    CHECK_THAT(entityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                        {"some_key", "another_value"}
+                    }));
+                    CHECK_THAT(linkedEntityNode->entity().properties(), Catch::UnorderedEquals(std::vector<Model::EntityProperty>{
+                        {"some_key", "another_value"}
+                    }));
                 }
             }
         }


### PR DESCRIPTION
Closes #3757

After setting some properties to unprotected, we need to update linked
nodes because in some situations, setting a property to unprotected can
lead to it being replicated into the corresponding entities in linked
groups. Suppose we have two linked groups, each containing an entity.
One of the entities has some protected property that the other doesn't.
In this case, when the protected property is set to unprotected, it must
be replicated into the corresponding entity.