### PR TITLE
3762: Fix ungrouping several members of a link set

### DIFF
--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -376,6 +376,9 @@ namespace TrenchBroom {
             void selectLinkedGroups();
             bool canSelectLinkedGroups() const;
 
+            void linkGroups(const std::vector<Model::GroupNode*>& groupNodes);
+            void unlinkGroups(const std::vector<Model::GroupNode*>& groupNodes);
+
             /**
              * Unlinks the selected linked groups.
              *


### PR DESCRIPTION
Closes #3762

The code that separates linked groups did not handle cases where
multiple members of a link set are separated and not relinked again,
which lead to groups getting deleted when ungrouped. This commit
contains a fix for MapDocument::separateLinkedGroups that also repairs
this bug.