### PR TITLE
CMake cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,7 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 
 # Find Qt and OpenGL
 find_package(OpenGL REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Svg REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Svg REQUIRED)
 # Qt will warn about API's that were deprecated after 5.9.5.
 # Since we're not raising our minimum Qt version, and can't use the replacement
 # API's, disable these warnings.

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -47,7 +47,7 @@ if(APPLE)
         set(GAME_FILE "${APP_RESOURCE_DIR}/games/${GAME_FILE}")
 
         set(APP_SOURCE ${APP_SOURCE} ${GAME_FILE})
-        set_source_files_properties(${GAME_FILE} PROPERTIES  MACOSX_PACKAGE_LOCATION Resources/games/${GAME_FILE_DIR})
+        set_source_files_properties(${GAME_FILE} PROPERTIES  MACOSX_PACKAGE_LOCATION Resources/games/${GAME_FILE_DIR} HEADER_FILE_ONLY ON)
     endforeach()
 
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -60,7 +60,7 @@ if(APPLE)
             set(GAME_FILE "${APP_RESOURCE_DIR}/games-testing/${GAME_FILE}")
 
             set(APP_SOURCE ${APP_SOURCE} ${GAME_FILE})
-            set_source_files_properties(${GAME_FILE} PROPERTIES  MACOSX_PACKAGE_LOCATION Resources/games/${GAME_FILE_DIR})
+            set_source_files_properties(${GAME_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/games/${GAME_FILE_DIR} HEADER_FILE_ONLY ON)
         endforeach()
     endif()
 


### PR DESCRIPTION
These are just two small changes I made while trying to get rid of linker warnings. The first warning I fixed was about my Qt version being built for a later macOS version that what we are linking for. This one has to do with my installation, but while working on it I changed how we find Qt5 to use components. The end result is identical, it's just one less line.

The other change relates to .obj files in our game configs. On macOS, these files must be added as source files in order to set their macOS bundle location. The linker would try to link these .obj files and would fail because they are not binary images, but wavefront files. Setting these files to have the `HEADER_FILE_ONLY` property tells the linker to ignore them.