### PR TITLE
3766: Swap add property buttons

### DIFF
--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -222,11 +222,6 @@ namespace TrenchBroom {
                 addProperty(false);
             });
 
-            m_addPropertyButton = createBitmapButton("Add.svg", tr("Add a new property (%1)").arg(EntityPropertyTable::insertRowShortcutString()), this);
-            connect(m_addPropertyButton, &QAbstractButton::clicked, this, [=](const bool /* checked */){
-                addProperty(false);
-            });
-
             m_addProtectedPropertyButton = createBitmapButton("AddProtected.svg", tr("Add a new protected property"), this);
             connect(m_addProtectedPropertyButton, &QAbstractButton::clicked, this, [=](const bool /* checked */){
                 addProperty(true);

--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -281,8 +281,8 @@ namespace TrenchBroom {
             // Shortcuts
 
             auto* toolBar = createMiniToolBarLayout(
-                m_addProtectedPropertyButton,
                 m_addPropertyButton,
+                m_addProtectedPropertyButton,
                 m_removePropertiesButton,
                 LayoutConstants::WideHMargin,
                 m_showDefaultPropertiesCheckBox);


### PR DESCRIPTION
Closes #3766.

This PR simply swaps the regular button to add an entity property and the new button to add a protected entity property.