### PR TITLE
3767: Restore context menu entry for "Separate Linked Groups"

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1001,11 +1001,10 @@ namespace TrenchBroom {
 
             QMenu menu;
             const auto addMainMenuAction = [&](const auto& path) -> QAction* {
-                if (auto* groupAction = mapFrame->findAction(path)) {
-                    menu.addAction(groupAction);
-                    return groupAction;
-                }
-                return nullptr;
+                auto* groupAction = mapFrame->findAction(path);
+                assert(groupAction != nullptr);
+                menu.addAction(groupAction);
+                return groupAction;
             };
 
             addMainMenuAction(IO::Path("Menu/Edit/Group"));
@@ -1037,7 +1036,7 @@ namespace TrenchBroom {
 
             addMainMenuAction(IO::Path("Menu/Edit/Create Linked Duplicate"));
             addMainMenuAction(IO::Path("Menu/Edit/Select Linked Groups"));
-            addMainMenuAction(IO::Path("Menu/Edit/Unlink Groups"));
+            addMainMenuAction(IO::Path("Menu/Edit/Separate Linked Groups"));
             menu.addSeparator();
 
             // Layer operations


### PR DESCRIPTION
Closes #3767

This context menu entry did not show up because the code that builds the menu
was using an outdated menu entry path.