### PR TITLE
3023: give Github Actions PR and master branch builds descriptive version names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,15 @@ jobs:
             tb-arch: x64
           - os: windows-2019
             tb-arch: Win32
-
+    env:
+      # Record pull request head commit SHA
+      TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       # See: https://github.com/actions/checkout
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-
-      - name: Record pull request head commit SHA
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          echo "TB_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: Test pull request head commit SHA
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,6 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Test pull request head commit SHA
-        run: |
-          echo "TB_PULL_REQUEST_HEAD_SHA=${TB_PULL_REQUEST_HEAD_SHA}"
-          echo "GITHUB_SHA=${GITHUB_SHA}"
-
       # Dependencies
 
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             tb-arch: Win32
     env:
       # Record pull request head commit SHA
-      TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pulll_request.head.sha }}
     steps:
       # See: https://github.com/actions/checkout
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             tb-arch: Win32
     env:
       # Record pull request head commit SHA
-      TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pulll_request.head.sha }}
+      TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       # See: https://github.com/actions/checkout
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,16 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Record pull request head commit SHA
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "TB_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+
+      - name: Test pull request head commit SHA
+        run: |
+          echo "TB_PULL_REQUEST_HEAD_SHA=${TB_PULL_REQUEST_HEAD_SHA}"
+          echo "GITHUB_SHA=${GITHUB_SHA}"
+
       # Dependencies
 
       - name: Install Linux dependencies

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -178,7 +178,6 @@ macro(GET_GIT_DESCRIBE GIT SOURCE_DIR GIT_DESCRIBE)
     if(${GIT_DESCRIBE})
         message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from git describe")
     endif()
-    set(${GIT_DESCRIBE} "")
 
     if(NOT ${GIT_DESCRIBE})
         # On GitHub Actions, "git describe" will fail due to it being a shallow clone (for PR and branch builds).

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -159,16 +159,15 @@ macro(ADD_TARGET_PROPERTY TARGET PROPERTY VALUE)
 endmacro(ADD_TARGET_PROPERTY)
 
 macro(GET_APP_VERSION GIT_DESCRIBE VERSION_YEAR VERSION_NUMBER)
-    if(NOT ${GIT_DESCRIBE})
-        set(${GIT_DESCRIBE} "v0000.0")
-    endif()
     STRING(REGEX MATCH "v([0-9][0-9][0-9][0-9])[.]([0-9]+)" GIT_DESCRIBE_MATCH "${${GIT_DESCRIBE}}")
 
     if(GIT_DESCRIBE_MATCH)
         set(${VERSION_YEAR} ${CMAKE_MATCH_1})
         set(${VERSION_NUMBER} ${CMAKE_MATCH_2})
     else()
-        message(FATAL_ERROR "Couldn't parse version from git describe output '${${GIT_DESCRIBE}}'")
+        # GIT_DESCRIBE is not a release tag following the "v0000.0" format.
+        set(${VERSION_YEAR} "0")
+        set(${VERSION_NUMBER} "0")
     endif()
 endmacro(GET_APP_VERSION)
 
@@ -176,6 +175,26 @@ macro(GET_GIT_DESCRIBE GIT SOURCE_DIR GIT_DESCRIBE)
     # When building tags, GitHub Actions checks them out as lightweight tags even if the original tag was annotated.
     # Pass --tags to enable git describe to match non-annotated tags.
     execute_process(COMMAND ${GIT} describe --dirty --tags WORKING_DIRECTORY ${SOURCE_DIR} OUTPUT_VARIABLE ${GIT_DESCRIBE} OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(${GIT_DESCRIBE})
+        message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from git describe")
+    endif()
+
+    if(NOT ${GIT_DESCRIBE})
+        # On GitHub Actions, "git describe" will fail due to it being a shallow clone (for PR and branch builds).
+        # In this case, use GITHUB_SHA and GITHUB_REF to construct a descriptive version string.
+        # See: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+        if((DEFINED ENV{GITHUB_SHA}) AND (DEFINED ENV{GITHUB_REF}))
+            set(${GIT_DESCRIBE} "$ENV{GITHUB_REF}@$ENV{GITHUB_SHA}")
+            # Replace / with _ because we need GIT_DESCRIBE to be valid to put in a filename for the final package
+            string(REPLACE "/" "_" ${GIT_DESCRIBE} ${${GIT_DESCRIBE}})
+            message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from environment variables GITHUB_SHA and GITHUB_REF")
+        endif()
+    endif()
+
+    if(NOT ${GIT_DESCRIBE})
+        set(${GIT_DESCRIBE} "unknown")
+        message(WARNING "Unable to determine version description; using \"${${GIT_DESCRIBE}}\"")
+    endif()
 endmacro(GET_GIT_DESCRIBE)
 
 macro(GET_BUILD_PLATFORM PLATFORM_NAME)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -178,13 +178,14 @@ macro(GET_GIT_DESCRIBE GIT SOURCE_DIR GIT_DESCRIBE)
     if(${GIT_DESCRIBE})
         message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from git describe")
     endif()
+    set(${GIT_DESCRIBE} "")
 
     if(NOT ${GIT_DESCRIBE})
         # On GitHub Actions, "git describe" will fail due to it being a shallow clone (for PR and branch builds).
         # In this case, use GITHUB_SHA and GITHUB_REF to construct a descriptive version string.
         # See: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
         if((DEFINED ENV{GITHUB_SHA}) AND (DEFINED ENV{GITHUB_REF}))
-            set(${GIT_DESCRIBE} "$ENV{GITHUB_REF}@$ENV{GITHUB_SHA}")
+            set(${GIT_DESCRIBE} "$ENV{GITHUB_REF}-$ENV{GITHUB_SHA}")
             # Replace / with _ because we need GIT_DESCRIBE to be valid to put in a filename for the final package
             string(REPLACE "/" "_" ${GIT_DESCRIBE} ${${GIT_DESCRIBE}})
             message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from environment variables GITHUB_SHA and GITHUB_REF")

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -184,7 +184,7 @@ macro(GET_GIT_DESCRIBE GIT SOURCE_DIR GIT_DESCRIBE)
         # In this case, use GITHUB_SHA and GITHUB_REF to construct a descriptive version string.
         # See: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
         if((DEFINED ENV{GITHUB_SHA}) AND (DEFINED ENV{GITHUB_REF}))
-            set(${GIT_DESCRIBE} "$ENV{GITHUB_REF}-$ENV{GITHUB_SHA}")
+            set(${GIT_DESCRIBE} "unstable-$ENV{GITHUB_REF}-$ENV{GITHUB_SHA}")
             # Replace / with _ because we need GIT_DESCRIBE to be valid to put in a filename for the final package
             string(REPLACE "/" "_" ${GIT_DESCRIBE} ${${GIT_DESCRIBE}})
             message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from environment variables GITHUB_SHA and GITHUB_REF")

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -187,7 +187,7 @@ macro(GET_GIT_DESCRIBE GIT SOURCE_DIR GIT_DESCRIBE)
     # and GITHUB_REF to construct a descriptive version string.
     # See: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
     if(NOT ${GIT_DESCRIBE})
-        if((DEFINED ENV{GITHUB_SHA}) AND (DEFINED ENV{TB_PULL_REQUEST_HEAD_SHA}))
+        if((NOT ("$ENV{GITHUB_SHA}" STREQUAL "")) AND (NOT ("$ENV{TB_PULL_REQUEST_HEAD_SHA}" STREQUAL "")))
             set(${GIT_DESCRIBE} "unstable-$ENV{GITHUB_REF}-$ENV{TB_PULL_REQUEST_HEAD_SHA}")
             # Replace / with _ because we need GIT_DESCRIBE to be valid to put in a filename for the final package
             string(REPLACE "/" "_" ${GIT_DESCRIBE} ${${GIT_DESCRIBE}})
@@ -196,7 +196,7 @@ macro(GET_GIT_DESCRIBE GIT SOURCE_DIR GIT_DESCRIBE)
     endif()
 
     if(NOT ${GIT_DESCRIBE})
-        if((DEFINED ENV{GITHUB_SHA}) AND (DEFINED ENV{GITHUB_REF}))
+        if((NOT ("$ENV{GITHUB_SHA}" STREQUAL "")) AND (NOT ("$ENV{GITHUB_REF}" STREQUAL "")))
             set(${GIT_DESCRIBE} "unstable-$ENV{GITHUB_REF}-$ENV{GITHUB_SHA}")
             string(REPLACE "/" "_" ${GIT_DESCRIBE} ${${GIT_DESCRIBE}})
             message(STATUS "Using version description \"${${GIT_DESCRIBE}}\" from environment variables GITHUB_SHA and GITHUB_REF")

--- a/common/src/View/AppInfoPanel.cpp
+++ b/common/src/View/AppInfoPanel.cpp
@@ -57,6 +57,8 @@ namespace TrenchBroom {
             makeInfo(version);
             makeInfo(build);
             makeInfo(qtVersion);
+            build->setWordWrap(true);
+            build->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
             const auto tooltip = tr("Click to copy to clipboard");
             version->setToolTip(tooltip);


### PR DESCRIPTION
Adjust GET_GIT_DESCRIBE macro behaviour:

- If "git describe" fails (e.g. because it's a shallow clone, from GitHub Actions building a PR or a commit on `master`), try to use GITHUB_SHA and GITHUB_REF to construct a replacement version string (see: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables )
- The version string is `{GITHUB_REF}-{GITHUB_SHA}`, with forward slashes replaced with underscores (so the package filename will be valid)
- Behavior should be unchanged for building release tags

Also make it non-fatal if the version description isn't in the v0000.0 format (it won't be for the GitHub Actions master branch / PR cases).

--- 

The Windows build for this PR gets the following package name: 

- `TrenchBroom-Win64-refs_pull_3771_merge-8cee1ee2739547ad2cf21214ff4f3ab1078470b8-Release.7z` 

and the following welcome screen:

![Capture](https://user-images.githubusercontent.com/239161/110064346-281cb300-7d2a-11eb-90b0-2b2c1b4329ba.PNG)

Limitations to note:

- the commit displayed for PR's is the temporary merge commit the GitHub actions makes. I'm not sure if this is possible to trace back to the commit on the PR branch. e.g. the screenshot was taken from the 3rd commit on this branch, 397cc94 . With more work we can probably get the SHA of the commit on the PR branch, but this is probably good enough for now
- The version number is 0.0 for these builds. Since we're working with shallow clones on GitHub Actions, we don't know the most recent tag. This I don't see as a huge problem (it will have the correct version for tagged release builds), although if we care we can switch to non-shallow clones for CI (wasting bandwidth / time though).

Fixes #3023