### PR TITLE
3761: cloneAndTransformChildren: unset selection when cloning brush

### DIFF
--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -22,6 +22,7 @@
 #include "Ensure.h"
 #include "FloatType.h"
 #include "Model/Brush.h"
+#include "Model/BrushFace.h"
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
 #include "Model/EntityNode.h"
@@ -64,6 +65,12 @@ namespace TrenchBroom {
                     },
                     [&](const BrushNode* brushNode) -> VisitResult {
                         auto brush = brushNode->brush();
+                        // clear selection on clone
+                        for (auto& face : brush.faces()) {
+                            if (face.selected()) {
+                                face.deselect();
+                            }
+                        }
                         return brush.transform(worldBounds, transformation, true)
                             .and_then([&]() -> kdl::result<std::unique_ptr<Node>, BrushError> {
                                 return std::make_unique<BrushNode>(std::move(brush));


### PR DESCRIPTION
Fixes #3761

This fixes the steps to reproduce I posted at https://github.com/TrenchBroom/TrenchBroom/issues/3761#issuecomment-792493956

This was just the first thing that I thought of, and it works, not sure if it's the proper fix? But it kind of makes sense; usually when cloning a Brush we want to keep the selection state, but in this case we don't.