### PR TITLE
3761: Deselect brush faces when creating a new brush node

### DIFF
--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -66,7 +66,7 @@ namespace TrenchBroom {
         BrushNode::BrushNode(Brush brush) :
         m_brushRendererBrushCache(std::make_unique<Renderer::BrushRendererBrushCache>()),
         m_brush(std::move(brush)) {
-            updateSelectedFaceCount();
+            clearSelectedFaces();
         }
 
         BrushNode::~BrushNode() = default;
@@ -130,6 +130,15 @@ namespace TrenchBroom {
             
             invalidateIssues();
             invalidateVertexCache();
+        }
+
+        void BrushNode::clearSelectedFaces() {
+            for (BrushFace& face : m_brush.faces()) {
+                if (face.selected()) {
+                    face.deselect();
+                }
+            }
+            m_selectedFaceCount = 0u;
         }
 
         void BrushNode::updateSelectedFaceCount() {

--- a/common/src/Model/BrushNode.h
+++ b/common/src/Model/BrushNode.h
@@ -83,6 +83,7 @@ namespace TrenchBroom {
             
             void setFaceTexture(size_t faceIndex, Assets::Texture* texture);
         private:
+            void clearSelectedFaces();
             void updateSelectedFaceCount();
         private: // implement Node interface
             const std::string& doGetName() const override;

--- a/common/test/src/Model/BrushNodeTest.cpp
+++ b/common/test/src/Model/BrushNodeTest.cpp
@@ -274,7 +274,7 @@ namespace TrenchBroom {
                 CHECK(!brush.hasSelectedFaces());
             }
             
-            SECTION("Passing a brush with selected faces to constructor correctly updates the node's face selection count") {
+            SECTION("Passing a brush with selected faces to constructor clears the brushes face selection") {
                 REQUIRE(!brush.hasSelectedFaces());
                 
                 Brush copy = brush.brush();
@@ -282,12 +282,6 @@ namespace TrenchBroom {
                 copy.face(1u).select();
                 
                 BrushNode another(std::move(copy));
-                CHECK(another.hasSelectedFaces());
-
-                another.deselectFace(0u);
-                CHECK(another.hasSelectedFaces());
-                
-                another.deselectFace(1u);
                 CHECK(!another.hasSelectedFaces());
             }
 
@@ -308,7 +302,7 @@ namespace TrenchBroom {
                 CHECK(!brush.hasSelectedFaces());
             }
             
-            SECTION("Cloning a brush node returns a clone with correct face selection count") {
+            SECTION("Cloning a brush node with selected faces returns a clone with no selected faces") {
                 REQUIRE(!brush.hasSelectedFaces());
                 
                 brush.selectFace(0u);
@@ -316,10 +310,6 @@ namespace TrenchBroom {
                 REQUIRE(brush.hasSelectedFaces());
 
                 auto clone = std::unique_ptr<BrushNode>(brush.clone(worldBounds));
-                CHECK(clone->hasSelectedFaces());
-                
-                clone->deselectFace(0u);
-                clone->deselectFace(1u);
                 CHECK(!clone->hasSelectedFaces());
             }
         }


### PR DESCRIPTION
Closes #3761

When a new brush node is created, we need to deselect the faces of the brush passed into the constructor to avoid consistency errors. Likewise, when a brush is cloned, the clone should not have any selected faces.

I have decided not to add an enum to the `BrushNode` constructor or `BrushNode::setBrush`. I checked all call sites and it turns out that we always want to reset the face selection when creating / cloning a brush node, and we always want to retain the face selection when calling `BrushNode::setBrush`, so I suppose this error naturally doesn't happen after all. The bug was that we didn't reset the face selection in the constructor, which we now do.