### PR TITLE
3785: exit early in performReplaceChildren() if given empty vector

### DIFF
--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -262,6 +262,10 @@ namespace TrenchBroom {
         }
 
         std::vector<std::pair<Model::Node*, std::vector<std::unique_ptr<Model::Node>>>> MapDocumentCommandFacade::performReplaceChildren(std::vector<std::pair<Model::Node*, std::vector<std::unique_ptr<Model::Node>>>> nodes) {
+            if (nodes.empty()) {
+                return {};
+            }
+
             const std::vector<Model::Node*> parents = collectParents(nodes);
             Notifier<const std::vector<Model::Node*>&>::NotifyBeforeAndAfter notifyParents(nodesWillChangeNotifier, nodesDidChangeNotifier, parents);
 


### PR DESCRIPTION
UpdateLinkedGroupsHelper calls this with an empty vector of nodes to
replace. Adding the early exit fixes a performance bottleneck with
dragging 1 brush on a large map with no linked groups.

Fixes #3785