### PR TITLE
3784: lock textures when transforming brushes in linked group

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1983,8 +1983,8 @@ namespace TrenchBroom {
                         nodesToUpdate.emplace_back(entityNode, entity);
                     },
                     [&](Model::BrushNode* brushNode) {
-                        const bool inLinkedGroup = (Model::findContainingLinkedGroup(*brushNode) != nullptr);
-                        const bool lockTextures = inLinkedGroup || pref(Preferences::TextureLock);
+                        const bool lockTextures = pref(Preferences::TextureLock)
+                            || (Model::findContainingLinkedGroup(*brushNode) != nullptr);
 
                         auto brush = brushNode->brush();
                         brush.transform(m_worldBounds, transformation, lockTextures)

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -20,6 +20,8 @@
 #include "MapDocumentTest.h"
 
 #include "Exceptions.h"
+#include "Preferences.h"
+#include "PreferenceManager.h"
 #include "Assets/EntityDefinition.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
@@ -1209,6 +1211,47 @@ namespace TrenchBroom {
             CHECK(document->selectedNodes().groups().at(0)->name() == groupName);
             CHECK(document->translateObjects(delta));
             CHECK(document->selectionBounds() == box.translate(delta));
+        }
+
+        // https://github.com/TrenchBroom/TrenchBroom/issues/3784
+        TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.translateLinkedGroup") {
+            // delete default brush
+            document->selectAllNodes();
+            document->deleteObjects();
+
+            const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
+            const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
+
+            auto* brushNode1 = new Model::BrushNode(builder.createCuboid(box, "texture").value());
+            addNode(*document, document->parentForNodes(), brushNode1);
+            document->select(brushNode1);
+
+            auto* group = document->groupSelection("testGroup");
+            document->select(group);
+
+            auto* linkedGroup = document->createLinkedDuplicate();
+            document->deselectAll();
+            document->select(linkedGroup);
+            REQUIRE_THAT(document->selectedNodes().nodes(), Catch::UnorderedEquals(std::vector<Model::Node*>{linkedGroup}));
+
+            auto* linkedBrushNode = dynamic_cast<Model::BrushNode*>(linkedGroup->children().at(0));
+            REQUIRE(linkedBrushNode != nullptr);
+
+            setPref(Preferences::TextureLock, false);
+
+            const auto delta = vm::vec3(0.125, 0, 0);
+            REQUIRE(document->translateObjects(delta));
+
+            auto getTexCoords = [](Model::BrushNode* brushNode, const vm::vec3& normal) -> std::vector<vm::vec2f> {
+                const Model::BrushFace& face = brushNode->brush().face(*brushNode->brush().findFace(normal));
+                return kdl::vec_transform(face.vertexPositions(), [&](auto x) { return face.textureCoords(x); });
+            };
+
+            // Brushes in linked groups should have texture lock forced on
+            CHECK(UVListsEqual(getTexCoords(brushNode1, vm::vec3::pos_z()),
+                               getTexCoords(linkedBrushNode, vm::vec3::pos_z())));
+
+            PreferenceManager::instance().resetToDefault(Preferences::TextureLock);
         }
 
         // https://github.com/TrenchBroom/TrenchBroom/issues/3117


### PR DESCRIPTION
Fixes #3784