### PR TITLE
3789: EntityPropertyGrid: use symbolic column indices, fix some wrong ones

### DIFF
--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -110,7 +110,7 @@ namespace TrenchBroom {
             ensure(row != -1, "row should have been inserted");
 
             // Select the newly inserted property key
-            const QModelIndex mi = m_proxyModel->mapFromSource(m_model->index(row, 1));
+            const QModelIndex mi = m_proxyModel->mapFromSource(m_model->index(row, EntityPropertyModel::ColumnKey));
 
             m_table->clearSelection();
             m_table->setCurrentIndex(mi);
@@ -203,7 +203,7 @@ namespace TrenchBroom {
 
             m_proxyModel = new EntitySortFilterProxyModel(this);
             m_proxyModel->setSourceModel(m_model);
-            m_proxyModel->sort(0);
+            m_proxyModel->sort(0); // NOTE: must be column 0, because EntitySortFilterProxyModel::lessThan ignores the column part of the QModelIndex
             m_table->setModel(m_proxyModel);
 
             m_table->setItemDelegate(new EntityPropertyItemDelegate(m_table, m_model, m_proxyModel, m_table));
@@ -211,9 +211,9 @@ namespace TrenchBroom {
             autoResizeRows(m_table);
 
             m_table->verticalHeader()->setVisible(false);
-            m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-            m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
-            m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+            m_table->horizontalHeader()->setSectionResizeMode(EntityPropertyModel::ColumnProtected, QHeaderView::ResizeToContents);
+            m_table->horizontalHeader()->setSectionResizeMode(EntityPropertyModel::ColumnKey, QHeaderView::ResizeToContents);
+            m_table->horizontalHeader()->setSectionResizeMode(EntityPropertyModel::ColumnValue, QHeaderView::Stretch);
             m_table->horizontalHeader()->setSectionsClickable(false);
             m_table->setSelectionBehavior(QAbstractItemView::SelectItems);
 
@@ -354,7 +354,7 @@ namespace TrenchBroom {
                 ensureSelectionVisible();
 
                 const auto shouldShowProtectedProperties = m_model->shouldShowProtectedProperties();
-                m_table->setColumnHidden(0, !shouldShowProtectedProperties);
+                m_table->setColumnHidden(EntityPropertyModel::ColumnProtected, !shouldShowProtectedProperties);
                 m_addProtectedPropertyButton->setHidden(!shouldShowProtectedProperties);
             });
             updateControlsEnabled();

--- a/common/src/View/EntityPropertyModel.h
+++ b/common/src/View/EntityPropertyModel.h
@@ -118,6 +118,11 @@ namespace TrenchBroom {
          */
         class EntityPropertyModel : public QAbstractTableModel {
             Q_OBJECT
+        public:
+            static const int ColumnProtected = 0;
+            static const int ColumnKey = 1;
+            static const int ColumnValue = 2;
+            static const int NumColumns = 3;
         private:
             std::vector<PropertyRow> m_rows;
             bool m_showDefaultRows;


### PR DESCRIPTION
Fixes #3789

Aside from the `getCompletions` being wrong, these were also wrong: `const QModelIndex bottomRight = index(static_cast<int>(*oldIndex), 1);` (might have caused the "value" column to not be updated under some circumstances).