### PR TITLE
Correctly render pointfiles with duplicate vertices

### DIFF
--- a/common/src/Model/PointFile.cpp
+++ b/common/src/Model/PointFile.cpp
@@ -99,8 +99,13 @@ namespace TrenchBroom {
                 vm::vec3f lastPoint = points.back();
 
                 if (!stream.eof()) {
-                    std::getline(stream, line);
-                    vm::vec3f curPoint = vm::parse<float, 3>(line).value_or(vm::vec3f::zero());
+                    vm::vec3f curPoint;
+                    bool secondPointExists = false;
+                    while (!stream.eof() && !secondPointExists){
+                        std::getline(stream, line);
+                        curPoint = vm::parse<float, 3>(line).value_or(vm::vec3f::zero());
+                        secondPointExists = curPoint != lastPoint;
+                    }
                     vm::vec3f refDir = normalize(curPoint - lastPoint);
 
                     while (!stream.eof()) {
@@ -114,8 +119,8 @@ namespace TrenchBroom {
                             refDir = dir;
                         }
                     }
-
-                    points.push_back(curPoint);
+                    if (secondPointExists)
+                        points.push_back(curPoint);
                 }
             }
 


### PR DESCRIPTION
If the first two vertices of a pointfile are identical (as some compilers output), the current implementation will only show the first vertex and disregard the whole rest of the file.
This is because the program attempts to normalize the (null) vector connecting the first two vertices and generates a NaN, which then results in no further vertices being picked up.
This pull request explicitly guards against this by cycling until a genuinely different vertex is found.