### PR TITLE
3800: optimize layer list UI updates

### DIFF
--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -182,8 +182,6 @@ namespace TrenchBroom {
         }
 
         void ControlListBox::reload() {
-            DisableWindowUpdates disableUpdates(this);
-
             // WARNING: At this point, the ControlListBoxItemRenderer's might
             // contain dangling pointers to model objects (if
             // MapDocument::clearWorld world is called, e.g. when opening a new map).
@@ -211,7 +209,6 @@ namespace TrenchBroom {
         }
 
         void ControlListBox::updateItems() {
-            DisableWindowUpdates disableUpdates(this);
             for (int i = 0; i < m_listWidget->count(); ++i) {
                 auto* renderer = this->renderer(i);
                 renderer->updateItem();

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -209,14 +209,14 @@ namespace TrenchBroom {
         }
 
         void LayerListBox::nodesDidChange(const std::vector<Model::Node*>& nodes) {
-            for (const auto* node : nodes) {
-                if (dynamic_cast<const Model::LayerNode*>(node) != nullptr) {
-                    // A layer was added or removed or modified, so we need to clear and repopulate the list
-                    auto* previouslySelectedLayer = selectedLayer();
-                    reload();
-                    setSelectedLayer(previouslySelectedLayer);
-                    return;
-                }
+            const auto documentLayers = kdl::mem_lock(m_document)->world()->allLayersUserSorted();
+
+            if (layers() != documentLayers) {
+                // A layer was added or removed or modified, so we need to clear and repopulate the list
+                auto* previouslySelectedLayer = selectedLayer();
+                reload();
+                setSelectedLayer(previouslySelectedLayer);
+                return;
             }
             updateItems();
         }
@@ -274,6 +274,17 @@ namespace TrenchBroom {
             } else {
                 return widget->layer();
             }
+        }
+
+        std::vector<Model::LayerNode*> LayerListBox::layers() const {
+            const int rowCount = count();
+
+            std::vector<Model::LayerNode*> result;
+            result.reserve(static_cast<size_t>(rowCount));
+            for (int i = 0; i < rowCount; ++i) {
+                result.push_back(layerForRow(i));
+            }
+            return result;
         }
     }
 }

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -208,7 +208,7 @@ namespace TrenchBroom {
             reload();
         }
 
-        void LayerListBox::nodesDidChange(const std::vector<Model::Node*>& nodes) {
+        void LayerListBox::nodesDidChange(const std::vector<Model::Node*>&) {
             const auto documentLayers = kdl::mem_lock(m_document)->world()->allLayersUserSorted();
 
             if (layers() != documentLayers) {

--- a/common/src/View/LayerListBox.h
+++ b/common/src/View/LayerListBox.h
@@ -93,6 +93,8 @@ namespace TrenchBroom {
 
             const LayerListBoxWidget* widgetAtRow(int row) const;
             Model::LayerNode* layerForRow(int row) const;
+
+            std::vector<Model::LayerNode*> layers() const;
         signals:
             void layerSelected(Model::LayerNode* layer);
             void layerSetCurrent(Model::LayerNode* layer);


### PR DESCRIPTION
Addresses the biggest slowdown noticed in #3800 ... IMO we can leave that open because we might want to still do a better underlying fix.

Here are some benchmarks:

- The test conditions are: resize-perf.map posted in #3800 , resizing the brush in the .gif there.

- current master ( 523e5e55dc52c799bb5e7b4d48e333da0e673543 ): win64 build from CI
  - Average FPS: 23-27
- this PR (TrenchBroom-Win64-unstable-refs_pull_3807_merge-beb4214fb588aefe4e6a797b3de06510fc1627ed-Release)
  - Average FPS: 164