### PR TITLE
3775: Correctly set Entity::pointEntity when removing last child node

### DIFF
--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -130,7 +130,7 @@ namespace TrenchBroom {
         }
 
         void EntityNode::doChildWasRemoved(Node* /* node */) {
-            m_entity.setPointEntity(hasChildren());
+            m_entity.setPointEntity(!hasChildren());
             nodePhysicalBoundsDidChange();
         }
 

--- a/common/test/src/Model/EntityNodeTest.cpp
+++ b/common/test/src/Model/EntityNodeTest.cpp
@@ -94,6 +94,26 @@ namespace TrenchBroom {
             CHECK(entityNode.canRemoveChild(&brushNode));
             CHECK(entityNode.canRemoveChild(&patchNode));
         }
+
+        TEST_CASE("EntityNodeTest.setPointEntity") {
+            constexpr auto worldBounds = vm::bbox3d{8192.0};
+            constexpr auto mapFormat = MapFormat::Quake3;
+
+            auto entityNode = EntityNode{Entity{}};
+            auto brushNode1 = BrushNode{BrushBuilder{mapFormat, worldBounds}.createCube(64.0, "texture").value()};
+            auto brushNode2 = BrushNode{BrushBuilder{mapFormat, worldBounds}.createCube(64.0, "texture").value()};
+
+            REQUIRE(entityNode.entity().pointEntity());
+            entityNode.addChild(&brushNode1);
+            CHECK_FALSE(entityNode.entity().pointEntity());
+            entityNode.addChild(&brushNode2);
+            CHECK_FALSE(entityNode.entity().pointEntity());
+
+            entityNode.removeChild(&brushNode1);
+            CHECK_FALSE(entityNode.entity().pointEntity());
+            entityNode.removeChild(&brushNode2);
+            CHECK(entityNode.entity().pointEntity());
+        }
         
         TEST_CASE("EntityNodeTest.area") {
             auto definition = Assets::PointEntityDefinition("some_name", Color(), vm::bbox3(vm::vec3::zero(), vm::vec3(1.0, 2.0, 3.0)), "", {}, {});


### PR DESCRIPTION
Closes #3775.

This was just a typo, but a bad one. When Entity::pointEntity is not set correctly, transforming a brush entity can add an origin property.