### PR TITLE
3774: Close compile dialog when creating or opening a document

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -790,7 +790,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::newDocument(std::shared_ptr<Model::Game> game, const Model::MapFormat mapFormat) {
-            if (!confirmOrDiscardChanges()) {
+            if (!confirmOrDiscardChanges() || !closeCompileDialog()) {
                 return false;
             }
             m_document->newDocument(mapFormat, MapDocument::DefaultWorldBounds, game);
@@ -798,7 +798,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::openDocument(std::shared_ptr<Model::Game> game, const Model::MapFormat mapFormat, const IO::Path& path) {
-            if (!confirmOrDiscardChanges()) {
+            if (!confirmOrDiscardChanges() || !closeCompileDialog()) {
                 return false;
             }
             const auto startTime = std::chrono::high_resolution_clock::now();

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1679,6 +1679,19 @@ namespace TrenchBroom {
             showModelessDialog(m_compilationDialog);
         }
 
+        bool MapFrame::closeCompileDialog() {
+            if (!m_compilationDialog) {
+                return true;
+            }
+
+            if (m_compilationDialog->close()) {
+                m_compilationDialog = nullptr;
+                return true;
+            }
+
+            return false;
+        }
+
         void MapFrame::showLaunchEngineDialog() {
             LaunchGameEngineDialog dialog(m_document, this);
             dialog.exec();
@@ -1833,7 +1846,7 @@ namespace TrenchBroom {
         }
 
         void MapFrame::closeEvent(QCloseEvent* event) {
-            if (m_compilationDialog != nullptr && !m_compilationDialog->close()) {
+            if (!closeCompileDialog()) {
                 event->ignore();
             } else {
                 ensure(m_frameManager != nullptr, "frameManager is null");

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -346,6 +346,7 @@ namespace TrenchBroom {
             bool currentViewMaximized();
 
             void showCompileDialog();
+            bool closeCompileDialog();
 
             void showLaunchEngineDialog();
 


### PR DESCRIPTION
Closes #3774.

@ericwa could you please give this a brief testing in Windows? I currently don't have access to a Windows machine where TB runs.