### PR TITLE
3688: Ignore unselected nodes when updating vertex handle manager

### DIFF
--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -468,13 +468,15 @@ namespace TrenchBroom {
 
             void nodesWillChange(const std::vector<Model::Node*>& nodes) {
                 if (m_ignoreChangeNotifications == 0u) {
-                    removeHandles(nodes);
+                    const auto selectedNodes = kdl::vec_filter(nodes, [](const auto* node) { return node->selected(); });
+                    removeHandles(selectedNodes);
                 }
             }
 
             void nodesDidChange(const std::vector<Model::Node*>& nodes) {
                 if (m_ignoreChangeNotifications == 0u) {
-                    addHandles(nodes);
+                    const auto selectedNodes = kdl::vec_filter(nodes, [](const auto* node) { return node->selected(); });
+                    addHandles(selectedNodes);
                 }
             }
         protected:


### PR DESCRIPTION
Closes #3688.

This fixes the problem, but I wonder if we shouldn't disable this particular interaction while in vertex mode.