### PR TITLE
3813: Fix .obj export being clobbered by .mtl file

### DIFF
--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -218,7 +218,7 @@ namespace TrenchBroom {
                     }
 
                     const auto mtlPath = path.replaceExtension("mtl");
-                    std::ofstream mtlFile = openPathAsOutputStream(path);
+                    std::ofstream mtlFile = openPathAsOutputStream(mtlPath);
                     if (!mtlFile) {
                         throw FileSystemException("Cannot open file: " + mtlPath.asString());
                     }


### PR DESCRIPTION
Fixes #3813

With the fix, I can now export DM3.map (from the quake map source) and load the result in blender again (same as in 2021.1).