### PR TITLE
3781: Refactor tool controllers

### DIFF
--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -31,7 +31,7 @@
 namespace TrenchBroom {
     namespace View {
         CameraTool2D::CameraTool2D(Renderer::OrthographicCamera& camera) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_camera{camera} {}
 
@@ -58,7 +58,7 @@ namespace TrenchBroom {
             camera.moveBy(-delta);
         }
 
-        void CameraTool2D::doMouseScroll(const InputState& inputState) {
+        void CameraTool2D::mouseScroll(const InputState& inputState) {
             if (shouldZoom(inputState)) {
                 if (inputState.scrollY() != 0.0f) {
                     const float speed = pref(Preferences::CameraMouseWheelInvert) ? -1.0f : 1.0f;
@@ -143,7 +143,7 @@ namespace TrenchBroom {
             return nullptr;
         }
 
-        bool CameraTool2D::doCancel() {
+        bool CameraTool2D::cancel() {
             return false;
         }
     }

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -35,12 +35,12 @@ namespace TrenchBroom {
         Tool{true},
         m_camera{camera} {}
 
-        Tool* CameraTool2D::tool() {
-            return this;
+        Tool& CameraTool2D::tool() {
+            return *this;
         }
 
-        const Tool* CameraTool2D::tool() const {
-            return this;
+        const Tool& CameraTool2D::tool() const {
+            return *this;
         }
 
         static bool shouldZoom(const InputState& inputState) {

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -35,11 +35,11 @@ namespace TrenchBroom {
         Tool{true},
         m_camera{camera} {}
 
-        Tool* CameraTool2D::doGetTool() {
+        Tool* CameraTool2D::tool() {
             return this;
         }
 
-        const Tool* CameraTool2D::doGetTool() const {
+        const Tool* CameraTool2D::tool() const {
             return this;
         }
 

--- a/common/src/View/CameraTool2D.h
+++ b/common/src/View/CameraTool2D.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
     namespace View {
         class DragTracker;
 
-        class CameraTool2D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
+        class CameraTool2D : public ToolController, public Tool {
         private:
             Renderer::OrthographicCamera& m_camera;
             vm::vec2f m_lastMousePos;
@@ -43,11 +43,11 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doMouseScroll(const InputState& inputState) override;
+            void mouseScroll(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/CameraTool2D.h
+++ b/common/src/View/CameraTool2D.h
@@ -40,8 +40,8 @@ namespace TrenchBroom {
         public:
             explicit CameraTool2D(Renderer::OrthographicCamera& camera);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void mouseScroll(const InputState& inputState) override;
 

--- a/common/src/View/CameraTool2D.h
+++ b/common/src/View/CameraTool2D.h
@@ -40,8 +40,8 @@ namespace TrenchBroom {
         public:
             explicit CameraTool2D(Renderer::OrthographicCamera& camera);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void mouseScroll(const InputState& inputState) override;
 

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -115,11 +115,11 @@ namespace TrenchBroom {
         Tool{true},
         m_camera{camera} {}
 
-        Tool* CameraTool3D::doGetTool() {
+        Tool* CameraTool3D::tool() {
             return this;
         }
 
-        const Tool* CameraTool3D::doGetTool() const {
+        const Tool* CameraTool3D::tool() const {
             return this;
         }
 

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -111,7 +111,7 @@ namespace TrenchBroom {
         }
 
         CameraTool3D::CameraTool3D(Renderer::PerspectiveCamera& camera) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_camera{camera} {}
 
@@ -123,7 +123,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        void CameraTool3D::doMouseScroll(const InputState& inputState) {
+        void CameraTool3D::mouseScroll(const InputState& inputState) {
             const float factor = pref(Preferences::CameraMouseWheelInvert) ? -1.0f : 1.0f;
             const bool zoom = inputState.modifierKeysPressed(ModifierKeys::MKShift);
             const float scrollDist = inputState.scrollY();
@@ -140,7 +140,7 @@ namespace TrenchBroom {
             }
         }
 
-        void CameraTool3D::doMouseUp(const InputState& inputState) {
+        void CameraTool3D::mouseUp(const InputState& inputState) {
             if (inputState.mouseButtonsPressed(MouseButtons::MBRight)) {
                 auto& prefs = PreferenceManager::instance();
                 if (!prefs.saveInstantly()) {
@@ -261,7 +261,7 @@ namespace TrenchBroom {
             return nullptr;
         }
 
-        bool CameraTool3D::doCancel() {
+        bool CameraTool3D::cancel() {
             return false;
         }
     }

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -115,12 +115,12 @@ namespace TrenchBroom {
         Tool{true},
         m_camera{camera} {}
 
-        Tool* CameraTool3D::tool() {
-            return this;
+        Tool& CameraTool3D::tool() {
+            return *this;
         }
 
-        const Tool* CameraTool3D::tool() const {
-            return this;
+        const Tool& CameraTool3D::tool() const {
+            return *this;
         }
 
         void CameraTool3D::mouseScroll(const InputState& inputState) {

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         public:
             CameraTool3D(Renderer::PerspectiveCamera& camera);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void mouseScroll(const InputState& inputState) override;
             void mouseUp(const InputState& inputState) override;

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -35,7 +35,7 @@ namespace TrenchBroom {
     namespace View {
         class DragTracker;
 
-        class CameraTool3D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
+        class CameraTool3D : public ToolController, public Tool {
         private:
             Renderer::PerspectiveCamera& m_camera;
         public:
@@ -44,12 +44,12 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doMouseScroll(const InputState& inputState) override;
-            void doMouseUp(const InputState& inputState) override;
+            void mouseScroll(const InputState& inputState) override;
+            void mouseUp(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         public:
             CameraTool3D(Renderer::PerspectiveCamera& camera);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void mouseScroll(const InputState& inputState) override;
             void mouseUp(const InputState& inputState) override;

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -292,11 +292,11 @@ namespace TrenchBroom {
                 explicit AddClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
             private:
-                Tool* doGetTool() override {
+                Tool* tool() override {
                     return m_delegate->tool();
                 }
 
-                const Tool* doGetTool() const override {
+                const Tool* tool() const override {
                     return m_delegate->tool();
                 }
 
@@ -375,11 +375,11 @@ namespace TrenchBroom {
                 explicit MoveClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
             private:
-                Tool* doGetTool() override {
+                Tool* tool() override {
                     return m_delegate->tool();
                 }
 
-                const Tool* doGetTool() const override {
+                const Tool* tool() const override {
                     return m_delegate->tool();
                 }
 
@@ -410,11 +410,11 @@ namespace TrenchBroom {
 
         ClipToolControllerBase::~ClipToolControllerBase() = default;
 
-        Tool* ClipToolControllerBase::doGetTool() {
+        Tool* ClipToolControllerBase::tool() {
             return m_tool;
         }
 
-        const Tool* ClipToolControllerBase::doGetTool() const {
+        const Tool* ClipToolControllerBase::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -418,23 +418,23 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        void ClipToolControllerBase::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void ClipToolControllerBase::pick(const InputState& inputState, Model::PickResult& pickResult) {
             m_tool->pick(inputState.pickRay(), inputState.camera(), pickResult);
         }
 
-        void ClipToolControllerBase::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
+        void ClipToolControllerBase::setRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             if (m_tool->hasBrushes()) {
                 renderContext.setHideSelection();
                 renderContext.setForceHideSelectionGuide();
             }
         }
 
-        void ClipToolControllerBase::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ClipToolControllerBase::render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             m_tool->render(renderContext, renderBatch, inputState.pickResult());
-            ToolControllerGroup::doRender(inputState, renderContext, renderBatch);
+            ToolControllerGroup::render(inputState, renderContext, renderBatch);
         }
 
-        bool ClipToolControllerBase::doCancel() {
+        bool ClipToolControllerBase::cancel() {
             if (m_tool->removeLastPoint()) {
                 if (!m_tool->hasPoints()) {
                     m_tool->reset();

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -60,8 +60,8 @@ namespace TrenchBroom {
 
                 virtual ~PartDelegateBase() = default;
 
-                ClipTool* tool() const {
-                    return m_tool;
+                ClipTool& tool() const {
+                    return *m_tool;
                 }
 
                 std::optional<std::tuple<vm::vec3, vm::vec3>> addClipPoint(const InputState& inputState) {
@@ -260,12 +260,12 @@ namespace TrenchBroom {
                 DragStatus drag(const InputState& inputState, const DragState&, const vm::vec3& proposedHandlePosition) override {
                     if (!m_secondPointSet) {
                         if (m_delegate.addClipPoint(inputState)) {
-                            m_delegate.tool()->beginDragLastPoint();
+                            m_delegate.tool().beginDragLastPoint();
                             m_secondPointSet = true;
                             return DragStatus::Continue;
                         }
                     } else {
-                        if (m_delegate.tool()->dragPoint(proposedHandlePosition, m_delegate.getHelpVectors(inputState, proposedHandlePosition))) {
+                        if (m_delegate.tool().dragPoint(proposedHandlePosition, m_delegate.getHelpVectors(inputState, proposedHandlePosition))) {
                             return DragStatus::Continue;
                         }
                     }
@@ -274,16 +274,16 @@ namespace TrenchBroom {
 
                 void end(const InputState&, const DragState&) override {
                     if (m_secondPointSet) {
-                        m_delegate.tool()->endDragPoint();
+                        m_delegate.tool().endDragPoint();
                     }
                 }
 
                 void cancel(const DragState&) override {
                     if (m_secondPointSet) {
-                        m_delegate.tool()->cancelDragPoint();
-                        m_delegate.tool()->removeLastPoint();
+                        m_delegate.tool().cancelDragPoint();
+                        m_delegate.tool().removeLastPoint();
                     }
-                    m_delegate.tool()->removeLastPoint();
+                    m_delegate.tool().removeLastPoint();
                 }
             };
 
@@ -292,11 +292,11 @@ namespace TrenchBroom {
                 explicit AddClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
             private:
-                Tool* tool() override {
+                Tool& tool() override {
                     return m_delegate->tool();
                 }
 
-                const Tool* tool() const override {
+                const Tool& tool() const override {
                     return m_delegate->tool();
                 }
 
@@ -354,7 +354,7 @@ namespace TrenchBroom {
                 }
 
                 DragStatus drag(const InputState& inputState, const DragState&, const vm::vec3& proposedHandlePosition) override {
-                    if (m_delegate.tool()->dragPoint(proposedHandlePosition, m_delegate.getHelpVectors(inputState, proposedHandlePosition))) {
+                    if (m_delegate.tool().dragPoint(proposedHandlePosition, m_delegate.getHelpVectors(inputState, proposedHandlePosition))) {
                         return DragStatus::Continue;
                     } else {
                         return DragStatus::Deny;
@@ -362,11 +362,11 @@ namespace TrenchBroom {
                 }
 
                 void end(const InputState&, const DragState&) override {
-                    m_delegate.tool()->endDragPoint();
+                    m_delegate.tool().endDragPoint();
                 }
 
                 void cancel(const DragState&) override {
-                    m_delegate.tool()->cancelDragPoint();
+                    m_delegate.tool().cancelDragPoint();
                 }
             };
 
@@ -375,11 +375,11 @@ namespace TrenchBroom {
                 explicit MoveClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
             private:
-                Tool* tool() override {
+                Tool& tool() override {
                     return m_delegate->tool();
                 }
 
-                const Tool* tool() const override {
+                const Tool& tool() const override {
                     return m_delegate->tool();
                 }
 
@@ -390,7 +390,7 @@ namespace TrenchBroom {
                         return nullptr;
                     }
 
-                    const auto initialHandlePositionAndOffset = m_delegate->tool()->beginDragPoint(inputState.pickResult());
+                    const auto initialHandlePositionAndOffset = m_delegate->tool().beginDragPoint(inputState.pickResult());
                     if (!initialHandlePositionAndOffset) {
                         return nullptr;
                     }
@@ -410,12 +410,12 @@ namespace TrenchBroom {
 
         ClipToolControllerBase::~ClipToolControllerBase() = default;
 
-        Tool* ClipToolControllerBase::tool() {
-            return m_tool;
+        Tool& ClipToolControllerBase::tool() {
+            return *m_tool;
         }
 
-        const Tool* ClipToolControllerBase::tool() const {
-            return m_tool;
+        const Tool& ClipToolControllerBase::tool() const {
+            return *m_tool;
         }
 
         void ClipToolControllerBase::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -287,7 +287,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class AddClipPointPart : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, protected PartBase {
+            class AddClipPointPart : public ToolController, protected PartBase {
             public:
                 explicit AddClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
@@ -300,7 +300,7 @@ namespace TrenchBroom {
                     return m_delegate->tool();
                 }
 
-                bool doMouseClick(const InputState& inputState) override {
+                bool mouseClick(const InputState& inputState) override {
                     if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft) ||
                         !inputState.modifierKeysPressed(ModifierKeys::MKNone)) {
                         return false;
@@ -309,7 +309,7 @@ namespace TrenchBroom {
                     return m_delegate->addClipPoint(inputState) != std::nullopt;
                 }
 
-                bool doMouseDoubleClick(const InputState& inputState) override {
+                bool mouseDoubleClick(const InputState& inputState) override {
                     if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft) ||
                         !inputState.modifierKeysPressed(ModifierKeys::MKNone)) {
                         return false;
@@ -333,11 +333,11 @@ namespace TrenchBroom {
                     return createHandleDragTracker(AddClipPointDragDelegate{*m_delegate}, inputState, initialHandlePosition, handleOffset);
                 }
 
-                void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
+                void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
                     m_delegate->renderFeedback(inputState, renderContext, renderBatch);
                 }
 
-                bool doCancel() override {
+                bool cancel() override {
                     return false;
                 }
             };
@@ -370,7 +370,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class MoveClipPointPart : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy>, protected PartBase {
+            class MoveClipPointPart : public ToolController, protected PartBase {
             public:
                 explicit MoveClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
@@ -399,7 +399,7 @@ namespace TrenchBroom {
                     return createHandleDragTracker(MoveClipPointDragDelegate{*m_delegate}, inputState, initialHandlePosition, handleOffset);
                 }
 
-                bool doCancel() override {
+                bool cancel() override {
                     return false;
                 }
             };

--- a/common/src/View/ClipToolController.h
+++ b/common/src/View/ClipToolController.h
@@ -49,8 +49,8 @@ namespace TrenchBroom {
             explicit ClipToolControllerBase(ClipTool* tool);
             virtual ~ClipToolControllerBase() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/ClipToolController.h
+++ b/common/src/View/ClipToolController.h
@@ -49,8 +49,8 @@ namespace TrenchBroom {
             explicit ClipToolControllerBase(ClipTool* tool);
             virtual ~ClipToolControllerBase() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/ClipToolController.h
+++ b/common/src/View/ClipToolController.h
@@ -44,9 +44,9 @@ namespace TrenchBroom {
 
         class ClipToolControllerBase : public ToolControllerGroup {
         protected:
-            ClipTool* m_tool;
+            ClipTool& m_tool;
         protected:
-            explicit ClipToolControllerBase(ClipTool* tool);
+            explicit ClipToolControllerBase(ClipTool& tool);
             virtual ~ClipToolControllerBase() override;
         private:
             Tool& tool() override;
@@ -62,12 +62,12 @@ namespace TrenchBroom {
 
         class ClipToolController2D : public ClipToolControllerBase {
         public:
-            explicit ClipToolController2D(ClipTool* tool);
+            explicit ClipToolController2D(ClipTool& tool);
         };
 
         class ClipToolController3D : public ClipToolControllerBase {
         public:
-            explicit ClipToolController3D(ClipTool* tool);
+            explicit ClipToolController3D(ClipTool& tool);
         };
     }
 }

--- a/common/src/View/ClipToolController.h
+++ b/common/src/View/ClipToolController.h
@@ -52,12 +52,12 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-            void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
 
         class ClipToolController2D : public ClipToolControllerBase {

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -130,8 +130,8 @@ namespace TrenchBroom {
                 explicit DrawFacePart(CreateComplexBrushTool* tool) :
                 Part{tool} {}
             private:
-                Tool* doGetTool() override { return m_tool; }
-                const Tool* doGetTool() const override { return m_tool; }
+                Tool* tool() override { return m_tool; }
+                const Tool* tool() const override { return m_tool; }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
                     using namespace Model::HitFilters;
@@ -204,8 +204,8 @@ namespace TrenchBroom {
                 DuplicateFacePart(CreateComplexBrushTool* tool) :
                 Part{tool} {}
             private:
-                Tool* doGetTool() override { return m_tool; }
-                const Tool* doGetTool() const override { return m_tool; }
+                Tool* tool() override { return m_tool; }
+                const Tool* tool() const override { return m_tool; }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
                     using namespace Model::HitFilters;
@@ -240,11 +240,11 @@ namespace TrenchBroom {
             addController(std::make_unique<DuplicateFacePart>(m_tool));
         }
 
-        Tool* CreateComplexBrushToolController3D::doGetTool() {
+        Tool* CreateComplexBrushToolController3D::tool() {
             return m_tool;
         }
 
-        const Tool* CreateComplexBrushToolController3D::doGetTool() const {
+        const Tool* CreateComplexBrushToolController3D::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -130,8 +130,8 @@ namespace TrenchBroom {
                 explicit DrawFacePart(CreateComplexBrushTool* tool) :
                 Part{tool} {}
             private:
-                Tool* tool() override { return m_tool; }
-                const Tool* tool() const override { return m_tool; }
+                Tool& tool() override { return *m_tool; }
+                const Tool& tool() const override { return *m_tool; }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
                     using namespace Model::HitFilters;
@@ -204,8 +204,8 @@ namespace TrenchBroom {
                 DuplicateFacePart(CreateComplexBrushTool* tool) :
                 Part{tool} {}
             private:
-                Tool* tool() override { return m_tool; }
-                const Tool* tool() const override { return m_tool; }
+                Tool& tool() override { return *m_tool; }
+                const Tool& tool() const override { return *m_tool; }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
                     using namespace Model::HitFilters;
@@ -240,12 +240,12 @@ namespace TrenchBroom {
             addController(std::make_unique<DuplicateFacePart>(m_tool));
         }
 
-        Tool* CreateComplexBrushToolController3D::tool() {
-            return m_tool;
+        Tool& CreateComplexBrushToolController3D::tool() {
+            return *m_tool;
         }
 
-        const Tool* CreateComplexBrushToolController3D::tool() const {
-            return m_tool;
+        const Tool& CreateComplexBrushToolController3D::tool() const {
+            return *m_tool;
         }
 
         bool CreateComplexBrushToolController3D::mouseClick(const InputState& inputState) {

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -122,7 +122,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class DrawFacePart : public Part, public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
+            class DrawFacePart : public Part, public ToolController {
             private:
                 vm::plane3 m_plane;
                 vm::vec3 m_initialPoint;
@@ -152,7 +152,7 @@ namespace TrenchBroom {
                     return createHandleDragTracker(DrawFaceDragDelegate{*m_tool, plane}, inputState, initialHandlePosition, handleOffset);
                 }
 
-                bool doCancel() override { return false; }
+                bool cancel() override { return false; }
             };
 
             class DuplicateFaceDragDelegate : public HandleDragTrackerDelegate {
@@ -197,7 +197,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class DuplicateFacePart : public Part, public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
+            class DuplicateFacePart : public Part, public ToolController {
             private:
                 vm::vec3 m_dragDir;
             public:
@@ -229,7 +229,7 @@ namespace TrenchBroom {
 
                     return createHandleDragTracker(DuplicateFaceDragDelegate{*m_tool, normal}, inputState, initialHandlePosition, handleOffset);
                 }
-                bool doCancel() override { return false; }
+                bool cancel() override { return false; }
             };
         }
 

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -248,7 +248,7 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        bool CreateComplexBrushToolController3D::doMouseClick(const InputState& inputState) {
+        bool CreateComplexBrushToolController3D::mouseClick(const InputState& inputState) {
             if (!inputState.mouseButtonsDown(MouseButtons::MBLeft)) {
                 return false;
             }
@@ -272,7 +272,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool CreateComplexBrushToolController3D::doMouseDoubleClick(const InputState& inputState) {
+        bool CreateComplexBrushToolController3D::mouseDoubleClick(const InputState& inputState) {
             if (!inputState.mouseButtonsDown(MouseButtons::MBLeft)) {
                 return false;
             }
@@ -304,7 +304,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void CreateComplexBrushToolController3D::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void CreateComplexBrushToolController3D::render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             m_tool->render(renderContext, renderBatch);
 
             const Model::Polyhedron3& polyhedron = m_tool->polyhedron();
@@ -338,7 +338,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool CreateComplexBrushToolController3D::doCancel() {
+        bool CreateComplexBrushToolController3D::cancel() {
             const Model::Polyhedron3& polyhedron = m_tool->polyhedron();
             if (polyhedron.empty()) {
                 return false;

--- a/common/src/View/CreateComplexBrushToolController3D.h
+++ b/common/src/View/CreateComplexBrushToolController3D.h
@@ -27,9 +27,9 @@ namespace TrenchBroom {
 
         class CreateComplexBrushToolController3D : public ToolControllerGroup {
         private:
-            CreateComplexBrushTool* m_tool;
+            CreateComplexBrushTool& m_tool;
         public:
-            explicit CreateComplexBrushToolController3D(CreateComplexBrushTool* tool);
+            explicit CreateComplexBrushToolController3D(CreateComplexBrushTool& tool);
         private:
             Tool& tool() override;
             const Tool& tool() const override;

--- a/common/src/View/CreateComplexBrushToolController3D.h
+++ b/common/src/View/CreateComplexBrushToolController3D.h
@@ -31,8 +31,8 @@ namespace TrenchBroom {
         public:
             explicit CreateComplexBrushToolController3D(CreateComplexBrushTool* tool);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             bool mouseClick(const InputState& inputState) override;
             bool mouseDoubleClick(const InputState& inputState) override;

--- a/common/src/View/CreateComplexBrushToolController3D.h
+++ b/common/src/View/CreateComplexBrushToolController3D.h
@@ -34,14 +34,14 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            bool doMouseClick(const InputState& inputState) override;
-            bool doMouseDoubleClick(const InputState& inputState) override;
+            bool mouseClick(const InputState& inputState) override;
+            bool mouseDoubleClick(const InputState& inputState) override;
 
             bool doShouldHandleMouseDrag(const InputState& inputState) const override;
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/CreateComplexBrushToolController3D.h
+++ b/common/src/View/CreateComplexBrushToolController3D.h
@@ -31,8 +31,8 @@ namespace TrenchBroom {
         public:
             explicit CreateComplexBrushToolController3D(CreateComplexBrushTool* tool);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             bool mouseClick(const InputState& inputState) override;
             bool mouseDoubleClick(const InputState& inputState) override;

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -39,11 +39,11 @@ namespace TrenchBroom {
 
         CreateEntityToolController::~CreateEntityToolController() = default;
 
-        Tool* CreateEntityToolController::doGetTool() {
+        Tool* CreateEntityToolController::tool() {
             return m_tool;
         }
 
-        const Tool* CreateEntityToolController::doGetTool() const {
+        const Tool* CreateEntityToolController::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -19,7 +19,6 @@
 
 #include "CreateEntityToolController.h"
 
-#include "Ensure.h"
 #include "View/CreateEntityTool.h"
 #include "View/DropTracker.h"
 #include "View/InputState.h"
@@ -32,19 +31,17 @@
 
 namespace TrenchBroom {
     namespace View {
-        CreateEntityToolController::CreateEntityToolController(CreateEntityTool* tool) :
-        m_tool(tool) {
-            ensure(m_tool != nullptr, "tool is null");
-        }
+        CreateEntityToolController::CreateEntityToolController(CreateEntityTool& tool) :
+        m_tool(tool) {}
 
         CreateEntityToolController::~CreateEntityToolController() = default;
 
         Tool& CreateEntityToolController::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& CreateEntityToolController::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         std::unique_ptr<DropTracker> CreateEntityToolController::acceptDrop(const InputState& inputState, const std::string& payload) {
@@ -53,7 +50,7 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            if (!m_tool->createEntity(parts[1])) {
+            if (!m_tool.createEntity(parts[1])) {
                 return nullptr;
             }
 
@@ -93,18 +90,18 @@ namespace TrenchBroom {
             };
         }
 
-        CreateEntityToolController2D::CreateEntityToolController2D(CreateEntityTool* tool) :
+        CreateEntityToolController2D::CreateEntityToolController2D(CreateEntityTool& tool) :
         CreateEntityToolController(tool) {}
 
         std::unique_ptr<DropTracker> CreateEntityToolController2D::createDropTracker(const InputState& inputState) const {
-            return std::make_unique<CreateEntityDropTracker>(inputState, *m_tool, [](const auto& is, auto& t) { t.updateEntityPosition2D(is.pickRay()); });
+            return std::make_unique<CreateEntityDropTracker>(inputState, m_tool, [](const auto& is, auto& t) { t.updateEntityPosition2D(is.pickRay()); });
         }
 
-        CreateEntityToolController3D::CreateEntityToolController3D(CreateEntityTool* tool) :
+        CreateEntityToolController3D::CreateEntityToolController3D(CreateEntityTool& tool) :
         CreateEntityToolController(tool) {}
 
         std::unique_ptr<DropTracker> CreateEntityToolController3D::createDropTracker(const InputState& inputState) const {
-            return std::make_unique<CreateEntityDropTracker>(inputState, *m_tool, [](const auto& is, auto& t) { t.updateEntityPosition3D(is.pickRay(), is.pickResult()); });
+            return std::make_unique<CreateEntityDropTracker>(inputState, m_tool, [](const auto& is, auto& t) { t.updateEntityPosition3D(is.pickRay(), is.pickResult()); });
         }
     }
 }

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -39,12 +39,12 @@ namespace TrenchBroom {
 
         CreateEntityToolController::~CreateEntityToolController() = default;
 
-        Tool* CreateEntityToolController::tool() {
-            return m_tool;
+        Tool& CreateEntityToolController::tool() {
+            return *m_tool;
         }
 
-        const Tool* CreateEntityToolController::tool() const {
-            return m_tool;
+        const Tool& CreateEntityToolController::tool() const {
+            return *m_tool;
         }
 
         std::unique_ptr<DropTracker> CreateEntityToolController::acceptDrop(const InputState& inputState, const std::string& payload) {

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
             return createDropTracker(inputState);
         }
 
-        bool CreateEntityToolController::doCancel() {
+        bool CreateEntityToolController::cancel() {
             return false;
         }
 

--- a/common/src/View/CreateEntityToolController.h
+++ b/common/src/View/CreateEntityToolController.h
@@ -29,9 +29,9 @@ namespace TrenchBroom {
 
         class CreateEntityToolController : public ToolController {
         protected:
-            CreateEntityTool* m_tool;
+            CreateEntityTool& m_tool;
         protected:
-            CreateEntityToolController(CreateEntityTool* tool);
+            CreateEntityToolController(CreateEntityTool& tool);
         public:
             virtual ~CreateEntityToolController() override;
         private:
@@ -47,14 +47,14 @@ namespace TrenchBroom {
 
         class CreateEntityToolController2D : public CreateEntityToolController {
         public:
-            CreateEntityToolController2D(CreateEntityTool* tool);
+            CreateEntityToolController2D(CreateEntityTool& tool);
         private:
             std::unique_ptr<DropTracker> createDropTracker(const InputState& inputState) const override;
         };
 
         class CreateEntityToolController3D : public CreateEntityToolController {
         public:
-            CreateEntityToolController3D(CreateEntityTool* tool);
+            CreateEntityToolController3D(CreateEntityTool& tool);
         private:
             std::unique_ptr<DropTracker> createDropTracker(const InputState& inputState) const override;
         };

--- a/common/src/View/CreateEntityToolController.h
+++ b/common/src/View/CreateEntityToolController.h
@@ -35,8 +35,8 @@ namespace TrenchBroom {
         public:
             virtual ~CreateEntityToolController() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload) override;
 

--- a/common/src/View/CreateEntityToolController.h
+++ b/common/src/View/CreateEntityToolController.h
@@ -27,7 +27,7 @@ namespace TrenchBroom {
     namespace View {
         class CreateEntityTool;
 
-        class CreateEntityToolController : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
+        class CreateEntityToolController : public ToolController {
         protected:
             CreateEntityTool* m_tool;
         protected:
@@ -40,7 +40,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         private:
             virtual std::unique_ptr<DropTracker> createDropTracker(const InputState& inputState) const = 0;
         };

--- a/common/src/View/CreateEntityToolController.h
+++ b/common/src/View/CreateEntityToolController.h
@@ -35,8 +35,8 @@ namespace TrenchBroom {
         public:
             virtual ~CreateEntityToolController() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload) override;
 

--- a/common/src/View/CreateSimpleBrushToolController2D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController2D.cpp
@@ -42,12 +42,12 @@ namespace TrenchBroom {
             ensure(m_tool != nullptr, "tool is null");
         }
 
-        Tool* CreateSimpleBrushToolController2D::tool() {
-            return m_tool;
+        Tool& CreateSimpleBrushToolController2D::tool() {
+            return *m_tool;
         }
 
-        const Tool* CreateSimpleBrushToolController2D::tool() const {
-            return m_tool;
+        const Tool& CreateSimpleBrushToolController2D::tool() const {
+            return *m_tool;
         }
 
         namespace {

--- a/common/src/View/CreateSimpleBrushToolController2D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController2D.cpp
@@ -19,7 +19,6 @@
 
 #include "CreateSimpleBrushToolController2D.h"
 
-#include "Ensure.h"
 #include "Renderer/Camera.h"
 #include "View/CreateSimpleBrushTool.h"
 #include "View/Grid.h"
@@ -36,18 +35,16 @@
 
 namespace TrenchBroom {
     namespace View {
-        CreateSimpleBrushToolController2D::CreateSimpleBrushToolController2D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document) :
+        CreateSimpleBrushToolController2D::CreateSimpleBrushToolController2D(CreateSimpleBrushTool& tool, std::weak_ptr<MapDocument> document) :
         m_tool{tool},
-        m_document{document} {
-            ensure(m_tool != nullptr, "tool is null");
-        }
+        m_document{document} {}
 
         Tool& CreateSimpleBrushToolController2D::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& CreateSimpleBrushToolController2D::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         namespace {
@@ -151,7 +148,7 @@ namespace TrenchBroom {
             }
 
             const auto initialHandlePosition = vm::point_at_distance(inputState.pickRay(), distance);
-            return createHandleDragTracker(CreateSimpleBrushDragDelegate{*m_tool, document->worldBounds(), document->referenceBounds()}, inputState, initialHandlePosition, vm::vec3::zero());
+            return createHandleDragTracker(CreateSimpleBrushDragDelegate{m_tool, document->worldBounds(), document->referenceBounds()}, inputState, initialHandlePosition, vm::vec3::zero());
         }
 
         bool CreateSimpleBrushToolController2D::cancel() {

--- a/common/src/View/CreateSimpleBrushToolController2D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController2D.cpp
@@ -42,11 +42,11 @@ namespace TrenchBroom {
             ensure(m_tool != nullptr, "tool is null");
         }
 
-        Tool* CreateSimpleBrushToolController2D::doGetTool() {
+        Tool* CreateSimpleBrushToolController2D::tool() {
             return m_tool;
         }
 
-        const Tool* CreateSimpleBrushToolController2D::doGetTool() const {
+        const Tool* CreateSimpleBrushToolController2D::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/CreateSimpleBrushToolController2D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController2D.cpp
@@ -154,7 +154,7 @@ namespace TrenchBroom {
             return createHandleDragTracker(CreateSimpleBrushDragDelegate{*m_tool, document->worldBounds(), document->referenceBounds()}, inputState, initialHandlePosition, vm::vec3::zero());
         }
 
-        bool CreateSimpleBrushToolController2D::doCancel() {
+        bool CreateSimpleBrushToolController2D::cancel() {
             return false;
         }
     }

--- a/common/src/View/CreateSimpleBrushToolController2D.h
+++ b/common/src/View/CreateSimpleBrushToolController2D.h
@@ -40,8 +40,8 @@ namespace TrenchBroom {
         public:
             CreateSimpleBrushToolController2D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/CreateSimpleBrushToolController2D.h
+++ b/common/src/View/CreateSimpleBrushToolController2D.h
@@ -40,8 +40,8 @@ namespace TrenchBroom {
         public:
             CreateSimpleBrushToolController2D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/CreateSimpleBrushToolController2D.h
+++ b/common/src/View/CreateSimpleBrushToolController2D.h
@@ -35,10 +35,10 @@ namespace TrenchBroom {
 
         class CreateSimpleBrushToolController2D : public ToolController {
         private:
-            CreateSimpleBrushTool* m_tool;
+            CreateSimpleBrushTool& m_tool;
             std::weak_ptr<MapDocument> m_document;
         public:
-            CreateSimpleBrushToolController2D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document);
+            CreateSimpleBrushToolController2D(CreateSimpleBrushTool& tool, std::weak_ptr<MapDocument> document);
         private:
             Tool& tool() override;
             const Tool& tool() const override;

--- a/common/src/View/CreateSimpleBrushToolController2D.h
+++ b/common/src/View/CreateSimpleBrushToolController2D.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class DragTracker;
         class MapDocument;
 
-        class CreateSimpleBrushToolController2D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
+        class CreateSimpleBrushToolController2D : public ToolController {
         private:
             CreateSimpleBrushTool* m_tool;
             std::weak_ptr<MapDocument> m_document;
@@ -45,7 +45,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/CreateSimpleBrushToolController3D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController3D.cpp
@@ -50,11 +50,11 @@ namespace TrenchBroom {
             ensure(tool != nullptr, "tool is null");
         }
 
-        Tool* CreateSimpleBrushToolController3D::doGetTool() {
+        Tool* CreateSimpleBrushToolController3D::tool() {
             return m_tool;
         }
 
-        const Tool* CreateSimpleBrushToolController3D::doGetTool() const {
+        const Tool* CreateSimpleBrushToolController3D::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/CreateSimpleBrushToolController3D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController3D.cpp
@@ -50,12 +50,12 @@ namespace TrenchBroom {
             ensure(tool != nullptr, "tool is null");
         }
 
-        Tool* CreateSimpleBrushToolController3D::tool() {
-            return m_tool;
+        Tool& CreateSimpleBrushToolController3D::tool() {
+            return *m_tool;
         }
 
-        const Tool* CreateSimpleBrushToolController3D::tool() const {
-            return m_tool;
+        const Tool& CreateSimpleBrushToolController3D::tool() const {
+            return *m_tool;
         }
 
         namespace {

--- a/common/src/View/CreateSimpleBrushToolController3D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController3D.cpp
@@ -185,7 +185,7 @@ namespace TrenchBroom {
             return createHandleDragTracker(CreateSimpleBrushDragDelegate{*m_tool, document->worldBounds()}, inputState, initialHandlePosition, vm::vec3::zero());
         }
 
-        bool CreateSimpleBrushToolController3D::doCancel() {
+        bool CreateSimpleBrushToolController3D::cancel() {
             return false;
         }
     }

--- a/common/src/View/CreateSimpleBrushToolController3D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController3D.cpp
@@ -44,18 +44,16 @@
 
 namespace TrenchBroom {
     namespace View {
-        CreateSimpleBrushToolController3D::CreateSimpleBrushToolController3D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document) :
+        CreateSimpleBrushToolController3D::CreateSimpleBrushToolController3D(CreateSimpleBrushTool& tool, std::weak_ptr<MapDocument> document) :
         m_tool{tool},
-        m_document{document} {
-            ensure(tool != nullptr, "tool is null");
-        }
+        m_document{document} {}
 
         Tool& CreateSimpleBrushToolController3D::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& CreateSimpleBrushToolController3D::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         namespace {
@@ -182,7 +180,7 @@ namespace TrenchBroom {
             const auto& hit = inputState.pickResult().first(type(Model::BrushNode::BrushHitType));
             const auto initialHandlePosition = hit.isMatch() ? hit.hitPoint() : inputState.defaultPointUnderMouse();
 
-            return createHandleDragTracker(CreateSimpleBrushDragDelegate{*m_tool, document->worldBounds()}, inputState, initialHandlePosition, vm::vec3::zero());
+            return createHandleDragTracker(CreateSimpleBrushDragDelegate{m_tool, document->worldBounds()}, inputState, initialHandlePosition, vm::vec3::zero());
         }
 
         bool CreateSimpleBrushToolController3D::cancel() {

--- a/common/src/View/CreateSimpleBrushToolController3D.h
+++ b/common/src/View/CreateSimpleBrushToolController3D.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         class DragTracker;
         class MapDocument;
 
-        class CreateSimpleBrushToolController3D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
+        class CreateSimpleBrushToolController3D : public ToolController {
         private:
             CreateSimpleBrushTool* m_tool;
             std::weak_ptr<MapDocument> m_document;
@@ -46,7 +46,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/CreateSimpleBrushToolController3D.h
+++ b/common/src/View/CreateSimpleBrushToolController3D.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         public:
             CreateSimpleBrushToolController3D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/CreateSimpleBrushToolController3D.h
+++ b/common/src/View/CreateSimpleBrushToolController3D.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         public:
             CreateSimpleBrushToolController3D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/CreateSimpleBrushToolController3D.h
+++ b/common/src/View/CreateSimpleBrushToolController3D.h
@@ -34,12 +34,12 @@ namespace TrenchBroom {
 
         class CreateSimpleBrushToolController3D : public ToolController {
         private:
-            CreateSimpleBrushTool* m_tool;
+            CreateSimpleBrushTool& m_tool;
             std::weak_ptr<MapDocument> m_document;
 
             vm::vec3 m_initialPoint;
         public:
-            CreateSimpleBrushToolController3D(CreateSimpleBrushTool* tool, std::weak_ptr<MapDocument> document);
+            CreateSimpleBrushToolController3D(CreateSimpleBrushTool& tool, std::weak_ptr<MapDocument> document);
         private:
             Tool& tool() override;
             const Tool& tool() const override;

--- a/common/src/View/EdgeToolController.cpp
+++ b/common/src/View/EdgeToolController.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom {
     namespace View {
         class EdgeToolController::SelectEdgePart : public SelectPartBase<vm::segment3> {
         public:
-            SelectEdgePart(EdgeTool* tool) :
+            SelectEdgePart(EdgeTool& tool) :
             SelectPartBase(tool, EdgeHandleManager::HandleHitType) {}
         private:
             bool equalHandles(const vm::segment3& lhs, const vm::segment3& rhs) const override {
@@ -39,11 +39,11 @@ namespace TrenchBroom {
 
         class EdgeToolController::MoveEdgePart : public MovePartBase {
         public:
-            MoveEdgePart(EdgeTool* tool) :
+            MoveEdgePart(EdgeTool& tool) :
             MovePartBase(tool, EdgeHandleManager::HandleHitType) {}
         };
 
-        EdgeToolController::EdgeToolController(EdgeTool* tool) :
+        EdgeToolController::EdgeToolController(EdgeTool& tool) :
         VertexToolControllerBase(tool) {
             addController(std::make_unique<MoveEdgePart>(tool));
             addController(std::make_unique<SelectEdgePart>(tool));

--- a/common/src/View/EdgeToolController.h
+++ b/common/src/View/EdgeToolController.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
             class SelectEdgePart;
             class MoveEdgePart;
         public:
-            explicit EdgeToolController(EdgeTool* tool);
+            explicit EdgeToolController(EdgeTool& tool);
         };
     }
 }

--- a/common/src/View/FaceToolController.cpp
+++ b/common/src/View/FaceToolController.cpp
@@ -28,7 +28,7 @@ namespace TrenchBroom {
     namespace View {
         class FaceToolController::SelectFacePart : public SelectPartBase<vm::polygon3> {
         public:
-            explicit SelectFacePart(FaceTool* tool) :
+            explicit SelectFacePart(FaceTool& tool) :
             SelectPartBase(tool, FaceHandleManager::HandleHitType) {}
         private:
             bool equalHandles(const vm::polygon3& lhs, const vm::polygon3& rhs) const override {
@@ -38,11 +38,11 @@ namespace TrenchBroom {
 
         class FaceToolController::MoveFacePart : public MovePartBase {
         public:
-            explicit MoveFacePart(FaceTool* tool) :
+            explicit MoveFacePart(FaceTool& tool) :
             MovePartBase(tool, FaceHandleManager::HandleHitType) {}
         };
 
-        FaceToolController::FaceToolController(FaceTool* tool) :
+        FaceToolController::FaceToolController(FaceTool& tool) :
         VertexToolControllerBase(tool) {
             addController(std::make_unique<MoveFacePart>(tool));
             addController(std::make_unique<SelectFacePart>(tool));

--- a/common/src/View/FaceToolController.h
+++ b/common/src/View/FaceToolController.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
             class SelectFacePart;
             class MoveFacePart;
         public:
-            explicit FaceToolController(FaceTool* tool);
+            explicit FaceToolController(FaceTool& tool);
         };
     }
 }

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -659,9 +659,9 @@ namespace TrenchBroom {
             Grid& grid = m_document->grid();
             m_notifierConnection += grid.gridDidChangeNotifier.connect(this, &MapFrame::gridDidChange);
 
-            m_notifierConnection += m_mapView->mapViewToolBox()->toolActivatedNotifier.connect(this, &MapFrame::toolActivated);
-            m_notifierConnection += m_mapView->mapViewToolBox()->toolDeactivatedNotifier.connect(this, &MapFrame::toolDeactivated);
-            m_notifierConnection += m_mapView->mapViewToolBox()->toolHandleSelectionChangedNotifier.connect(this, &MapFrame::toolHandleSelectionChanged);
+            m_notifierConnection += m_mapView->mapViewToolBox().toolActivatedNotifier.connect(this, &MapFrame::toolActivated);
+            m_notifierConnection += m_mapView->mapViewToolBox().toolDeactivatedNotifier.connect(this, &MapFrame::toolDeactivated);
+            m_notifierConnection += m_mapView->mapViewToolBox().toolHandleSelectionChangedNotifier.connect(this, &MapFrame::toolHandleSelectionChanged);
         }
 
         void MapFrame::documentWasCleared(View::MapDocument*) {
@@ -711,15 +711,15 @@ namespace TrenchBroom {
             updateToolBarWidgets();
         }
 
-        void MapFrame::toolActivated(Tool*) {
+        void MapFrame::toolActivated(Tool&) {
             updateActionState();
         }
 
-        void MapFrame::toolDeactivated(Tool*) {
+        void MapFrame::toolDeactivated(Tool&) {
             updateActionState();
         }
 
-        void MapFrame::toolHandleSelectionChanged(Tool*) {
+        void MapFrame::toolHandleSelectionChanged(Tool&) {
             updateActionState();
         }
 
@@ -1156,13 +1156,13 @@ namespace TrenchBroom {
         void MapFrame::deleteSelection() {
             if (canDeleteSelection()) {
                 if (m_mapView->clipToolActive())
-                    m_mapView->clipTool()->removeLastPoint();
+                    m_mapView->clipTool().removeLastPoint();
                 else if (m_mapView->vertexToolActive())
-                    m_mapView->vertexTool()->removeSelection();
+                    m_mapView->vertexTool().removeSelection();
                 else if (m_mapView->edgeToolActive())
-                    m_mapView->edgeTool()->removeSelection();
+                    m_mapView->edgeTool().removeSelection();
                 else if (m_mapView->faceToolActive())
-                    m_mapView->faceTool()->removeSelection();
+                    m_mapView->faceTool().removeSelection();
                 else if (!m_mapView->anyToolActive())
                     m_document->deleteObjects();
             }
@@ -1170,13 +1170,13 @@ namespace TrenchBroom {
 
         bool MapFrame::canDeleteSelection() const {
             if (m_mapView->clipToolActive()) {
-                return m_mapView->clipTool()->canRemoveLastPoint();
+                return m_mapView->clipTool().canRemoveLastPoint();
             } else if (m_mapView->vertexToolActive()) {
-                return m_mapView->vertexTool()->canRemoveSelection();
+                return m_mapView->vertexTool().canRemoveSelection();
             } else if (m_mapView->edgeToolActive()) {
-                return m_mapView->edgeTool()->canRemoveSelection();
+                return m_mapView->edgeTool().canRemoveSelection();
             } else if (m_mapView->faceToolActive()) {
-                return m_mapView->faceTool()->canRemoveSelection();
+                return m_mapView->faceTool().canRemoveSelection();
             } else {
                 return canCutSelection();
             }
@@ -1439,12 +1439,12 @@ namespace TrenchBroom {
 
         void MapFrame::csgConvexMerge() {
             if (canDoCsgConvexMerge()) {
-                if (m_mapView->vertexToolActive() && m_mapView->vertexTool()->canDoCsgConvexMerge()) {
-                    m_mapView->vertexTool()->csgConvexMerge();
-                } else if (m_mapView->edgeToolActive() && m_mapView->edgeTool()->canDoCsgConvexMerge()) {
-                    m_mapView->edgeTool()->csgConvexMerge();
-                } else if (m_mapView->faceToolActive() && m_mapView->faceTool()->canDoCsgConvexMerge()) {
-                    m_mapView->faceTool()->csgConvexMerge();
+                if (m_mapView->vertexToolActive() && m_mapView->vertexTool().canDoCsgConvexMerge()) {
+                    m_mapView->vertexTool().csgConvexMerge();
+                } else if (m_mapView->edgeToolActive() && m_mapView->edgeTool().canDoCsgConvexMerge()) {
+                    m_mapView->edgeTool().csgConvexMerge();
+                } else if (m_mapView->faceToolActive() && m_mapView->faceTool().canDoCsgConvexMerge()) {
+                    m_mapView->faceTool().csgConvexMerge();
                 } else {
                     m_document->csgConvexMerge();
                 }
@@ -1454,9 +1454,9 @@ namespace TrenchBroom {
         bool MapFrame::canDoCsgConvexMerge() const {
             return (m_document->hasSelectedBrushFaces() && m_document->selectedBrushFaces().size() > 1) ||
                    (m_document->selectedNodes().hasOnlyBrushes() && m_document->selectedNodes().brushCount() > 1) ||
-                   (m_mapView->vertexToolActive() && m_mapView->vertexTool()->canDoCsgConvexMerge()) ||
-                   (m_mapView->edgeToolActive() && m_mapView->edgeTool()->canDoCsgConvexMerge()) ||
-                   (m_mapView->faceToolActive() && m_mapView->faceTool()->canDoCsgConvexMerge());
+                   (m_mapView->vertexToolActive() && m_mapView->vertexTool().canDoCsgConvexMerge()) ||
+                   (m_mapView->edgeToolActive() && m_mapView->edgeTool().canDoCsgConvexMerge()) ||
+                   (m_mapView->faceToolActive() && m_mapView->faceTool().canDoCsgConvexMerge());
         }
 
         void MapFrame::csgSubtract() {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -154,9 +154,9 @@ namespace TrenchBroom {
 
             void preferenceDidChange(const IO::Path& path);
             void gridDidChange();
-            void toolActivated(Tool* tool);
-            void toolDeactivated(Tool* tool);
-            void toolHandleSelectionChanged(Tool* tool);
+            void toolActivated(Tool& tool);
+            void toolDeactivated(Tool& tool);
+            void toolHandleSelectionChanged(Tool& tool);
             void selectionDidChange(const Selection& selection);
             void currentLayerDidChange(const TrenchBroom::Model::LayerNode* layer);
             void groupWasOpened(Model::GroupNode* group);

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -122,18 +122,18 @@ namespace TrenchBroom {
 
         void MapView2D::initializeToolChain(MapViewToolBox& toolBox) {
             addTool(std::make_unique<CameraTool2D>(*m_camera));
-            addTool(std::make_unique<MoveObjectsToolController>(toolBox.moveObjectsTool()));
-            addTool(std::make_unique<RotateObjectsToolController2D>(toolBox.rotateObjectsTool()));
-            addTool(std::make_unique<ScaleObjectsToolController2D>(toolBox.scaleObjectsTool(), m_document));
-            addTool(std::make_unique<ShearObjectsToolController2D>(toolBox.shearObjectsTool(), m_document));
-            addTool(std::make_unique<ResizeBrushesToolController2D>(toolBox.resizeBrushesTool()));
-            addTool(std::make_unique<ClipToolController2D>(toolBox.clipTool()));
-            addTool(std::make_unique<VertexToolController>(toolBox.vertexTool()));
-            addTool(std::make_unique<EdgeToolController>(toolBox.edgeTool()));
-            addTool(std::make_unique<FaceToolController>(toolBox.faceTool()));
-            addTool(std::make_unique<CreateEntityToolController2D>(toolBox.createEntityTool()));
+            addTool(std::make_unique<MoveObjectsToolController>(*toolBox.moveObjectsTool()));
+            addTool(std::make_unique<RotateObjectsToolController2D>(*toolBox.rotateObjectsTool()));
+            addTool(std::make_unique<ScaleObjectsToolController2D>(*toolBox.scaleObjectsTool(), m_document));
+            addTool(std::make_unique<ShearObjectsToolController2D>(*toolBox.shearObjectsTool(), m_document));
+            addTool(std::make_unique<ResizeBrushesToolController2D>(*toolBox.resizeBrushesTool()));
+            addTool(std::make_unique<ClipToolController2D>(*toolBox.clipTool()));
+            addTool(std::make_unique<VertexToolController>(*toolBox.vertexTool()));
+            addTool(std::make_unique<EdgeToolController>(*toolBox.edgeTool()));
+            addTool(std::make_unique<FaceToolController>(*toolBox.faceTool()));
+            addTool(std::make_unique<CreateEntityToolController2D>(*toolBox.createEntityTool()));
             addTool(std::make_unique<SelectionTool>(m_document));
-            addTool(std::make_unique<CreateSimpleBrushToolController2D>(toolBox.createSimpleBrushTool(), m_document));
+            addTool(std::make_unique<CreateSimpleBrushToolController2D>(*toolBox.createSimpleBrushTool(), m_document));
         }
 
         void MapView2D::connectObservers() {

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -122,18 +122,18 @@ namespace TrenchBroom {
 
         void MapView2D::initializeToolChain(MapViewToolBox& toolBox) {
             addTool(std::make_unique<CameraTool2D>(*m_camera));
-            addTool(std::make_unique<MoveObjectsToolController>(*toolBox.moveObjectsTool()));
-            addTool(std::make_unique<RotateObjectsToolController2D>(*toolBox.rotateObjectsTool()));
-            addTool(std::make_unique<ScaleObjectsToolController2D>(*toolBox.scaleObjectsTool(), m_document));
-            addTool(std::make_unique<ShearObjectsToolController2D>(*toolBox.shearObjectsTool(), m_document));
-            addTool(std::make_unique<ResizeBrushesToolController2D>(*toolBox.resizeBrushesTool()));
-            addTool(std::make_unique<ClipToolController2D>(*toolBox.clipTool()));
-            addTool(std::make_unique<VertexToolController>(*toolBox.vertexTool()));
-            addTool(std::make_unique<EdgeToolController>(*toolBox.edgeTool()));
-            addTool(std::make_unique<FaceToolController>(*toolBox.faceTool()));
-            addTool(std::make_unique<CreateEntityToolController2D>(*toolBox.createEntityTool()));
+            addTool(std::make_unique<MoveObjectsToolController>(toolBox.moveObjectsTool()));
+            addTool(std::make_unique<RotateObjectsToolController2D>(toolBox.rotateObjectsTool()));
+            addTool(std::make_unique<ScaleObjectsToolController2D>(toolBox.scaleObjectsTool(), m_document));
+            addTool(std::make_unique<ShearObjectsToolController2D>(toolBox.shearObjectsTool(), m_document));
+            addTool(std::make_unique<ResizeBrushesToolController2D>(toolBox.resizeBrushesTool()));
+            addTool(std::make_unique<ClipToolController2D>(toolBox.clipTool()));
+            addTool(std::make_unique<VertexToolController>(toolBox.vertexTool()));
+            addTool(std::make_unique<EdgeToolController>(toolBox.edgeTool()));
+            addTool(std::make_unique<FaceToolController>(toolBox.faceTool()));
+            addTool(std::make_unique<CreateEntityToolController2D>(toolBox.createEntityTool()));
             addTool(std::make_unique<SelectionTool>(m_document));
-            addTool(std::make_unique<CreateSimpleBrushToolController2D>(*toolBox.createSimpleBrushTool(), m_document));
+            addTool(std::make_unique<CreateSimpleBrushToolController2D>(toolBox.createSimpleBrushTool(), m_document));
         }
 
         void MapView2D::connectObservers() {

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -101,20 +101,20 @@ namespace TrenchBroom {
 
         void MapView3D::initializeToolChain(MapViewToolBox& toolBox) {
             addTool(std::make_unique<CameraTool3D>(*m_camera));
-            addTool(std::make_unique<MoveObjectsToolController>(toolBox.moveObjectsTool()));
-            addTool(std::make_unique<RotateObjectsToolController3D>(toolBox.rotateObjectsTool()));
-            addTool(std::make_unique<ScaleObjectsToolController3D>(toolBox.scaleObjectsTool(), m_document));
-            addTool(std::make_unique<ShearObjectsToolController3D>(toolBox.shearObjectsTool(), m_document));
-            addTool(std::make_unique<ResizeBrushesToolController3D>(toolBox.resizeBrushesTool()));
-            addTool(std::make_unique<CreateComplexBrushToolController3D>(toolBox.createComplexBrushTool()));
-            addTool(std::make_unique<ClipToolController3D>(toolBox.clipTool()));
-            addTool(std::make_unique<VertexToolController>(toolBox.vertexTool()));
-            addTool(std::make_unique<EdgeToolController>(toolBox.edgeTool()));
-            addTool(std::make_unique<FaceToolController>(toolBox.faceTool()));
-            addTool(std::make_unique<CreateEntityToolController3D>(toolBox.createEntityTool()));
+            addTool(std::make_unique<MoveObjectsToolController>(*toolBox.moveObjectsTool()));
+            addTool(std::make_unique<RotateObjectsToolController3D>(*toolBox.rotateObjectsTool()));
+            addTool(std::make_unique<ScaleObjectsToolController3D>(*toolBox.scaleObjectsTool(), m_document));
+            addTool(std::make_unique<ShearObjectsToolController3D>(*toolBox.shearObjectsTool(), m_document));
+            addTool(std::make_unique<ResizeBrushesToolController3D>(*toolBox.resizeBrushesTool()));
+            addTool(std::make_unique<CreateComplexBrushToolController3D>(*toolBox.createComplexBrushTool()));
+            addTool(std::make_unique<ClipToolController3D>(*toolBox.clipTool()));
+            addTool(std::make_unique<VertexToolController>(*toolBox.vertexTool()));
+            addTool(std::make_unique<EdgeToolController>(*toolBox.edgeTool()));
+            addTool(std::make_unique<FaceToolController>(*toolBox.faceTool()));
+            addTool(std::make_unique<CreateEntityToolController3D>(*toolBox.createEntityTool()));
             addTool(std::make_unique<SetBrushFaceAttributesTool>(m_document));
             addTool(std::make_unique<SelectionTool>(m_document));
-            addTool(std::make_unique<CreateSimpleBrushToolController3D>(toolBox.createSimpleBrushTool(), m_document));
+            addTool(std::make_unique<CreateSimpleBrushToolController3D>(*toolBox.createSimpleBrushTool(), m_document));
         }
 
         void MapView3D::connectObservers() {

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -101,20 +101,20 @@ namespace TrenchBroom {
 
         void MapView3D::initializeToolChain(MapViewToolBox& toolBox) {
             addTool(std::make_unique<CameraTool3D>(*m_camera));
-            addTool(std::make_unique<MoveObjectsToolController>(*toolBox.moveObjectsTool()));
-            addTool(std::make_unique<RotateObjectsToolController3D>(*toolBox.rotateObjectsTool()));
-            addTool(std::make_unique<ScaleObjectsToolController3D>(*toolBox.scaleObjectsTool(), m_document));
-            addTool(std::make_unique<ShearObjectsToolController3D>(*toolBox.shearObjectsTool(), m_document));
-            addTool(std::make_unique<ResizeBrushesToolController3D>(*toolBox.resizeBrushesTool()));
-            addTool(std::make_unique<CreateComplexBrushToolController3D>(*toolBox.createComplexBrushTool()));
-            addTool(std::make_unique<ClipToolController3D>(*toolBox.clipTool()));
-            addTool(std::make_unique<VertexToolController>(*toolBox.vertexTool()));
-            addTool(std::make_unique<EdgeToolController>(*toolBox.edgeTool()));
-            addTool(std::make_unique<FaceToolController>(*toolBox.faceTool()));
-            addTool(std::make_unique<CreateEntityToolController3D>(*toolBox.createEntityTool()));
+            addTool(std::make_unique<MoveObjectsToolController>(toolBox.moveObjectsTool()));
+            addTool(std::make_unique<RotateObjectsToolController3D>(toolBox.rotateObjectsTool()));
+            addTool(std::make_unique<ScaleObjectsToolController3D>(toolBox.scaleObjectsTool(), m_document));
+            addTool(std::make_unique<ShearObjectsToolController3D>(toolBox.shearObjectsTool(), m_document));
+            addTool(std::make_unique<ResizeBrushesToolController3D>(toolBox.resizeBrushesTool()));
+            addTool(std::make_unique<CreateComplexBrushToolController3D>(toolBox.createComplexBrushTool()));
+            addTool(std::make_unique<ClipToolController3D>(toolBox.clipTool()));
+            addTool(std::make_unique<VertexToolController>(toolBox.vertexTool()));
+            addTool(std::make_unique<EdgeToolController>(toolBox.edgeTool()));
+            addTool(std::make_unique<FaceToolController>(toolBox.faceTool()));
+            addTool(std::make_unique<CreateEntityToolController3D>(toolBox.createEntityTool()));
             addTool(std::make_unique<SetBrushFaceAttributesTool>(m_document));
             addTool(std::make_unique<SelectionTool>(m_document));
-            addTool(std::make_unique<CreateSimpleBrushToolController3D>(*toolBox.createSimpleBrushTool(), m_document));
+            addTool(std::make_unique<CreateSimpleBrushToolController3D>(toolBox.createSimpleBrushTool(), m_document));
         }
 
         void MapView3D::connectObservers() {

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -167,7 +167,7 @@ namespace TrenchBroom {
             update();
         }
 
-        void MapViewBase::toolChanged(Tool*) {
+        void MapViewBase::toolChanged(Tool&) {
             updatePickResult();
             updateActionStates();
             update();

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -127,7 +127,7 @@ namespace TrenchBroom {
             void createActionsAndUpdatePicking();
 
             void nodesDidChange(const std::vector<Model::Node*>& nodes);
-            void toolChanged(Tool* tool);
+            void toolChanged(Tool& tool);
             void commandDone(Command* command);
             void commandUndone(UndoableCommand* command);
             void selectionDidChange(const Selection& selection);

--- a/common/src/View/MapViewToolBox.cpp
+++ b/common/src/View/MapViewToolBox.cpp
@@ -43,52 +43,52 @@ namespace TrenchBroom {
 
         MapViewToolBox::~MapViewToolBox() = default;
 
-        ClipTool* MapViewToolBox::clipTool() const {
-            return m_clipTool.get();
+        ClipTool& MapViewToolBox::clipTool() {
+            return *m_clipTool;
         }
 
-        CreateComplexBrushTool* MapViewToolBox::createComplexBrushTool() const {
-            return m_createComplexBrushTool.get();
+        CreateComplexBrushTool& MapViewToolBox::createComplexBrushTool() {
+            return *m_createComplexBrushTool;
         }
 
-        CreateEntityTool* MapViewToolBox::createEntityTool() const {
-            return m_createEntityTool.get();
+        CreateEntityTool& MapViewToolBox::createEntityTool() {
+            return *m_createEntityTool;
         }
 
-        CreateSimpleBrushTool* MapViewToolBox::createSimpleBrushTool() const {
-            return m_createSimpleBrushTool.get();
+        CreateSimpleBrushTool& MapViewToolBox::createSimpleBrushTool() {
+            return *m_createSimpleBrushTool;
         }
 
-        MoveObjectsTool* MapViewToolBox::moveObjectsTool() const {
-            return m_moveObjectsTool.get();
+        MoveObjectsTool& MapViewToolBox::moveObjectsTool() {
+            return *m_moveObjectsTool;
         }
 
-        ResizeBrushesTool* MapViewToolBox::resizeBrushesTool() const {
-            return m_resizeBrushesTool.get();
+        ResizeBrushesTool& MapViewToolBox::resizeBrushesTool() {
+            return *m_resizeBrushesTool;
         }
 
-        RotateObjectsTool* MapViewToolBox::rotateObjectsTool() const {
-            return m_rotateObjectsTool.get();
+        RotateObjectsTool& MapViewToolBox::rotateObjectsTool() {
+            return *m_rotateObjectsTool;
         }
 
-        ScaleObjectsTool* MapViewToolBox::scaleObjectsTool() const {
-            return m_scaleObjectsTool.get();
+        ScaleObjectsTool& MapViewToolBox::scaleObjectsTool() {
+            return *m_scaleObjectsTool;
         }
 
-        ShearObjectsTool* MapViewToolBox::shearObjectsTool() const {
-            return m_shearObjectsTool.get();
+        ShearObjectsTool& MapViewToolBox::shearObjectsTool() {
+            return *m_shearObjectsTool;
         }
 
-        VertexTool* MapViewToolBox::vertexTool() const {
-            return m_vertexTool.get();
+        VertexTool& MapViewToolBox::vertexTool() {
+            return *m_vertexTool;
         }
 
-        EdgeTool* MapViewToolBox::edgeTool() const {
-            return m_edgeTool.get();
+        EdgeTool& MapViewToolBox::edgeTool() {
+            return *m_edgeTool;
         }
 
-        FaceTool* MapViewToolBox::faceTool() const {
-            return m_faceTool.get();
+        FaceTool& MapViewToolBox::faceTool() {
+            return *m_faceTool;
         }
 
         void MapViewToolBox::toggleCreateComplexBrushTool() {
@@ -96,7 +96,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::createComplexBrushToolActive() const {
-            return toolActive(createComplexBrushTool());
+            return m_createComplexBrushTool->active();
         }
 
         void MapViewToolBox::performCreateComplexBrush() {
@@ -108,7 +108,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::clipToolActive() const {
-            return toolActive(clipTool());
+            return m_clipTool->active();
         }
 
         void MapViewToolBox::toggleClipSide() {
@@ -131,7 +131,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::rotateObjectsToolActive() const {
-            return toolActive(rotateObjectsTool());
+            return m_rotateObjectsTool->active();
         }
 
         double MapViewToolBox::rotateToolAngle() const {
@@ -155,7 +155,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::scaleObjectsToolActive() const {
-            return toolActive(scaleObjectsTool());
+            return m_scaleObjectsTool->active();
         }
 
         void MapViewToolBox::toggleShearObjectsTool() {
@@ -163,7 +163,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::shearObjectsToolActive() const {
-            return toolActive(shearObjectsTool());
+            return m_shearObjectsTool->active();
         }
 
         bool MapViewToolBox::anyVertexToolActive() const {
@@ -175,7 +175,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::vertexToolActive() const {
-            return toolActive(vertexTool());
+            return m_vertexTool->active();
         }
 
         void MapViewToolBox::toggleEdgeTool() {
@@ -183,7 +183,7 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::edgeToolActive() const {
-            return toolActive(edgeTool());
+            return m_edgeTool->active();
         }
 
         void MapViewToolBox::toggleFaceTool() {
@@ -191,17 +191,17 @@ namespace TrenchBroom {
         }
 
         bool MapViewToolBox::faceToolActive() const {
-            return toolActive(faceTool());
+            return m_faceTool->active();
         }
 
         void MapViewToolBox::moveVertices(const vm::vec3& delta) {
             assert(anyVertexToolActive());
             if (vertexToolActive())
-                vertexTool()->moveSelection(delta);
+                vertexTool().moveSelection(delta);
             else if (edgeToolActive())
-                edgeTool()->moveSelection(delta);
+                edgeTool().moveSelection(delta);
             else if (faceToolActive())
-                faceTool()->moveSelection(delta);
+                faceTool().moveSelection(delta);
         }
 
         void MapViewToolBox::createTools(std::weak_ptr<MapDocument> document, QStackedLayout* bookCtrl) {
@@ -257,8 +257,8 @@ namespace TrenchBroom {
             registerTool(createSimpleBrushTool(), bookCtrl);
         }
 
-        void MapViewToolBox::registerTool(Tool* tool, QStackedLayout* bookCtrl) {
-            tool->createPage(bookCtrl);
+        void MapViewToolBox::registerTool(Tool& tool, QStackedLayout* bookCtrl) {
+            tool.createPage(bookCtrl);
             addTool(tool);
         }
 
@@ -271,12 +271,12 @@ namespace TrenchBroom {
             m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &MapViewToolBox::documentWasNewedOrLoaded);
         }
 
-        void MapViewToolBox::toolActivated(Tool* tool) {
+        void MapViewToolBox::toolActivated(Tool& tool) {
             updateEditorContext();
-            tool->showPage();
+            tool.showPage();
         }
 
-        void MapViewToolBox::toolDeactivated(Tool*) {
+        void MapViewToolBox::toolDeactivated(Tool&) {
             updateEditorContext();
             m_moveObjectsTool->showPage();
         }

--- a/common/src/View/MapViewToolBox.h
+++ b/common/src/View/MapViewToolBox.h
@@ -65,18 +65,18 @@ namespace TrenchBroom {
             MapViewToolBox(std::weak_ptr<MapDocument> document, QStackedLayout* bookCtrl);
             ~MapViewToolBox() override;
         public: // tools
-            ClipTool* clipTool() const;
-            CreateComplexBrushTool* createComplexBrushTool() const;
-            CreateEntityTool* createEntityTool() const;
-            CreateSimpleBrushTool* createSimpleBrushTool() const;
-            MoveObjectsTool* moveObjectsTool() const;
-            ResizeBrushesTool* resizeBrushesTool() const;
-            RotateObjectsTool* rotateObjectsTool() const;
-            ScaleObjectsTool* scaleObjectsTool() const;
-            ShearObjectsTool* shearObjectsTool() const;
-            VertexTool* vertexTool() const;
-            EdgeTool* edgeTool() const;
-            FaceTool* faceTool() const;
+            ClipTool& clipTool();
+            CreateComplexBrushTool& createComplexBrushTool();
+            CreateEntityTool& createEntityTool();
+            CreateSimpleBrushTool& createSimpleBrushTool();
+            MoveObjectsTool& moveObjectsTool();
+            ResizeBrushesTool& resizeBrushesTool();
+            RotateObjectsTool& rotateObjectsTool();
+            ScaleObjectsTool& scaleObjectsTool();
+            ShearObjectsTool& shearObjectsTool();
+            VertexTool& vertexTool();
+            EdgeTool& edgeTool();
+            FaceTool& faceTool();
 
             void toggleCreateComplexBrushTool();
             bool createComplexBrushToolActive() const;
@@ -115,10 +115,10 @@ namespace TrenchBroom {
         private: // Tool related methods
             void createTools(std::weak_ptr<MapDocument> document, QStackedLayout* bookCtrl);
         private: // notification
-            void registerTool(Tool* tool, QStackedLayout* bookCtrl);
+            void registerTool(Tool& tool, QStackedLayout* bookCtrl);
             void connectObservers();
-            void toolActivated(Tool* tool);
-            void toolDeactivated(Tool* tool);
+            void toolActivated(Tool& tool);
+            void toolDeactivated(Tool& tool);
             void updateEditorContext();
             void documentWasNewedOrLoaded(MapDocument* document);
         };

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -31,19 +31,17 @@
 
 namespace TrenchBroom {
     namespace View {
-        MoveObjectsToolController::MoveObjectsToolController(MoveObjectsTool* tool) :
-        m_tool(tool) {
-            ensure(m_tool != nullptr, "tool is null");
-        }
+        MoveObjectsToolController::MoveObjectsToolController(MoveObjectsTool& tool) :
+        m_tool(tool) {}
 
         MoveObjectsToolController::~MoveObjectsToolController() {}
 
         Tool& MoveObjectsToolController::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& MoveObjectsToolController::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         namespace {
@@ -102,11 +100,11 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            if (!m_tool->startMove(inputState)) {
+            if (!m_tool.startMove(inputState)) {
                 return nullptr;
             }
 
-            return createMoveHandleDragTracker(MoveObjectsDragDelegate{*m_tool}, inputState, hit.hitPoint(), vm::vec3::zero());
+            return createMoveHandleDragTracker(MoveObjectsDragDelegate{m_tool}, inputState, hit.hitPoint(), vm::vec3::zero());
         }
 
         bool MoveObjectsToolController::cancel() {

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -38,12 +38,12 @@ namespace TrenchBroom {
 
         MoveObjectsToolController::~MoveObjectsToolController() {}
 
-        Tool* MoveObjectsToolController::tool() {
-            return m_tool;
+        Tool& MoveObjectsToolController::tool() {
+            return *m_tool;
         }
 
-        const Tool* MoveObjectsToolController::tool() const {
-            return m_tool;
+        const Tool& MoveObjectsToolController::tool() const {
+            return *m_tool;
         }
 
         namespace {

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
 
         MoveObjectsToolController::~MoveObjectsToolController() {}
 
-        Tool* MoveObjectsToolController::doGetTool() {
+        Tool* MoveObjectsToolController::tool() {
             return m_tool;
         }
 
-        const Tool* MoveObjectsToolController::doGetTool() const {
+        const Tool* MoveObjectsToolController::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -109,7 +109,7 @@ namespace TrenchBroom {
             return createMoveHandleDragTracker(MoveObjectsDragDelegate{*m_tool}, inputState, hit.hitPoint(), vm::vec3::zero());
         }
 
-        bool MoveObjectsToolController::doCancel() {
+        bool MoveObjectsToolController::cancel() {
             return false;
         }
     }

--- a/common/src/View/MoveObjectsToolController.h
+++ b/common/src/View/MoveObjectsToolController.h
@@ -26,7 +26,7 @@ namespace TrenchBroom {
         class DragTracker;
         class MoveObjectsTool;
 
-        class MoveObjectsToolController : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy> {
+        class MoveObjectsToolController : public ToolController {
         private:
             MoveObjectsTool* m_tool;
         public:
@@ -38,7 +38,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/MoveObjectsToolController.h
+++ b/common/src/View/MoveObjectsToolController.h
@@ -28,9 +28,9 @@ namespace TrenchBroom {
 
         class MoveObjectsToolController : public ToolController {
         private:
-            MoveObjectsTool* m_tool;
+            MoveObjectsTool& m_tool;
         public:
-            MoveObjectsToolController(MoveObjectsTool* tool);
+            MoveObjectsToolController(MoveObjectsTool& tool);
             virtual ~MoveObjectsToolController() override;
         private:
             Tool& tool() override;

--- a/common/src/View/MoveObjectsToolController.h
+++ b/common/src/View/MoveObjectsToolController.h
@@ -33,8 +33,8 @@ namespace TrenchBroom {
             MoveObjectsToolController(MoveObjectsTool* tool);
             virtual ~MoveObjectsToolController() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/MoveObjectsToolController.h
+++ b/common/src/View/MoveObjectsToolController.h
@@ -33,8 +33,8 @@ namespace TrenchBroom {
             MoveObjectsToolController(MoveObjectsTool* tool);
             virtual ~MoveObjectsToolController() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -44,11 +44,11 @@ namespace TrenchBroom {
 
         ResizeBrushesToolController::~ResizeBrushesToolController() = default;
 
-        Tool* ResizeBrushesToolController::doGetTool() {
+        Tool* ResizeBrushesToolController::tool() {
             return m_tool;
         }
 
-        const Tool* ResizeBrushesToolController::doGetTool() const {
+        const Tool* ResizeBrushesToolController::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -36,20 +36,18 @@
 
 namespace TrenchBroom {
     namespace View {
-        ResizeBrushesToolController::ResizeBrushesToolController(ResizeBrushesTool* tool) :
+        ResizeBrushesToolController::ResizeBrushesToolController(ResizeBrushesTool& tool) :
         m_tool{tool},
-        m_mode{Mode::Resize} {
-            ensure(m_tool != nullptr, "tool is null");
-        }
+        m_mode{Mode::Resize} {}
 
         ResizeBrushesToolController::~ResizeBrushesToolController() = default;
 
         Tool& ResizeBrushesToolController::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& ResizeBrushesToolController::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         void ResizeBrushesToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
@@ -63,13 +61,13 @@ namespace TrenchBroom {
 
         void ResizeBrushesToolController::modifierKeyChange(const InputState& inputState) {
             if (!anyToolDragging(inputState)) {
-                m_tool->updateProposedDragHandles(inputState.pickResult());
+                m_tool.updateProposedDragHandles(inputState.pickResult());
             }
         }
 
         void ResizeBrushesToolController::mouseMove(const InputState& inputState) {
             if (handleInput(inputState) && !anyToolDragging(inputState)) {
-                m_tool->updateProposedDragHandles(inputState.pickResult());
+                m_tool.updateProposedDragHandles(inputState.pickResult());
             }
         }
 
@@ -114,19 +112,19 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            m_tool->updateProposedDragHandles(inputState.pickResult());
+            m_tool.updateProposedDragHandles(inputState.pickResult());
             m_mode = inputState.modifierKeysDown(ModifierKeys::MKAlt) ? Mode::MoveFace : Mode::Resize;
             if (m_mode == Mode::Resize) {
                 const auto split = inputState.modifierKeysDown(ModifierKeys::MKCtrlCmd);
-                if (m_tool->beginResize(inputState.pickResult(), split)) {
-                    return std::make_unique<ResizeToolDragTracker>(*m_tool, [&](const InputState& inputState_) {
-                        return m_tool->resize(inputState_.pickRay(), inputState_.camera());
+                if (m_tool.beginResize(inputState.pickResult(), split)) {
+                    return std::make_unique<ResizeToolDragTracker>(m_tool, [&](const InputState& inputState_) {
+                        return m_tool.resize(inputState_.pickRay(), inputState_.camera());
                     });
                 }
             } else {
-                if (m_tool->beginMove(inputState.pickResult())) {
-                    return std::make_unique<ResizeToolDragTracker>(*m_tool, [&](const InputState& inputState_) {
-                        return m_tool->move(inputState_.pickRay(), inputState_.camera());
+                if (m_tool.beginMove(inputState.pickResult())) {
+                    return std::make_unique<ResizeToolDragTracker>(m_tool, [&](const InputState& inputState_) {
+                        return m_tool.move(inputState_.pickRay(), inputState_.camera());
                     });
                 }
             }
@@ -150,8 +148,8 @@ namespace TrenchBroom {
         }
 
         void ResizeBrushesToolController::render(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
-            if (m_tool->hasVisualHandles()) {
-                Renderer::DirectEdgeRenderer edgeRenderer = buildEdgeRenderer(m_tool->visualHandles());
+            if (m_tool.hasVisualHandles()) {
+                Renderer::DirectEdgeRenderer edgeRenderer = buildEdgeRenderer(m_tool.visualHandles());
                 edgeRenderer.renderOnTop(renderBatch, pref(Preferences::ResizeHandleColor));
             }
         }
@@ -161,14 +159,14 @@ namespace TrenchBroom {
         }
 
         bool ResizeBrushesToolController::handleInput(const InputState& inputState) const {
-            return (doHandleInput(inputState) && m_tool->applies());
+            return (doHandleInput(inputState) && m_tool.applies());
         }
 
-        ResizeBrushesToolController2D::ResizeBrushesToolController2D(ResizeBrushesTool* tool) :
+        ResizeBrushesToolController2D::ResizeBrushesToolController2D(ResizeBrushesTool& tool) :
         ResizeBrushesToolController{tool} {}
 
         Model::Hit ResizeBrushesToolController2D::doPick(const vm::ray3& pickRay, const Model::PickResult& pickResult) {
-            return m_tool->pick2D(pickRay, pickResult);
+            return m_tool.pick2D(pickRay, pickResult);
         }
 
         bool ResizeBrushesToolController2D::doHandleInput(const InputState& inputState) const {
@@ -177,11 +175,11 @@ namespace TrenchBroom {
                     inputState.modifierKeysPressed(ModifierKeys::MKShift | ModifierKeys::MKAlt));
         }
 
-        ResizeBrushesToolController3D::ResizeBrushesToolController3D(ResizeBrushesTool* tool) :
+        ResizeBrushesToolController3D::ResizeBrushesToolController3D(ResizeBrushesTool& tool) :
         ResizeBrushesToolController{tool} {}
 
         Model::Hit ResizeBrushesToolController3D::doPick(const vm::ray3& pickRay, const Model::PickResult& pickResult) {
-            return m_tool->pick3D(pickRay, pickResult);
+            return m_tool.pick3D(pickRay, pickResult);
         }
 
         bool ResizeBrushesToolController3D::doHandleInput(const InputState& inputState) const {

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        void ResizeBrushesToolController::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void ResizeBrushesToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
             if (handleInput(inputState)) {
                 const Model::Hit hit = doPick(inputState.pickRay(), pickResult);
                 if (hit.isMatch()) {
@@ -61,13 +61,13 @@ namespace TrenchBroom {
             }
         }
 
-        void ResizeBrushesToolController::doModifierKeyChange(const InputState& inputState) {
+        void ResizeBrushesToolController::modifierKeyChange(const InputState& inputState) {
             if (!anyToolDragging(inputState)) {
                 m_tool->updateProposedDragHandles(inputState.pickResult());
             }
         }
 
-        void ResizeBrushesToolController::doMouseMove(const InputState& inputState) {
+        void ResizeBrushesToolController::mouseMove(const InputState& inputState) {
             if (handleInput(inputState) && !anyToolDragging(inputState)) {
                 m_tool->updateProposedDragHandles(inputState.pickResult());
             }
@@ -149,14 +149,14 @@ namespace TrenchBroom {
             return Renderer::DirectEdgeRenderer(Renderer::VertexArray::move(std::move(vertices)), Renderer::PrimType::Lines);
         }
 
-        void ResizeBrushesToolController::doRender(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
+        void ResizeBrushesToolController::render(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             if (m_tool->hasVisualHandles()) {
                 Renderer::DirectEdgeRenderer edgeRenderer = buildEdgeRenderer(m_tool->visualHandles());
                 edgeRenderer.renderOnTop(renderBatch, pref(Preferences::ResizeHandleColor));
             }
         }
 
-        bool ResizeBrushesToolController::doCancel() {
+        bool ResizeBrushesToolController::cancel() {
             return false;
         }
 

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -44,12 +44,12 @@ namespace TrenchBroom {
 
         ResizeBrushesToolController::~ResizeBrushesToolController() = default;
 
-        Tool* ResizeBrushesToolController::tool() {
-            return m_tool;
+        Tool& ResizeBrushesToolController::tool() {
+            return *m_tool;
         }
 
-        const Tool* ResizeBrushesToolController::tool() const {
-            return m_tool;
+        const Tool& ResizeBrushesToolController::tool() const {
+            return *m_tool;
         }
 
         void ResizeBrushesToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/ResizeBrushesToolController.h
+++ b/common/src/View/ResizeBrushesToolController.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class DragTracker;
         class ResizeBrushesTool;
 
-        class ResizeBrushesToolController : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy> {
+        class ResizeBrushesToolController : public ToolController {
         protected:
             ResizeBrushesTool* m_tool;
         private:
@@ -50,17 +50,17 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-            void doModifierKeyChange(const InputState& inputState) override;
+            void modifierKeyChange(const InputState& inputState) override;
 
-            void doMouseMove(const InputState& inputState) override;
+            void mouseMove(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
 
             bool handleInput(const InputState& inputState) const;
         private:

--- a/common/src/View/ResizeBrushesToolController.h
+++ b/common/src/View/ResizeBrushesToolController.h
@@ -47,8 +47,8 @@ namespace TrenchBroom {
         public:
             ~ResizeBrushesToolController() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/ResizeBrushesToolController.h
+++ b/common/src/View/ResizeBrushesToolController.h
@@ -47,8 +47,8 @@ namespace TrenchBroom {
         public:
             ~ResizeBrushesToolController() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/ResizeBrushesToolController.h
+++ b/common/src/View/ResizeBrushesToolController.h
@@ -35,7 +35,7 @@ namespace TrenchBroom {
 
         class ResizeBrushesToolController : public ToolController {
         protected:
-            ResizeBrushesTool* m_tool;
+            ResizeBrushesTool& m_tool;
         private:
             enum class Mode {
                 Resize,
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             };
             Mode m_mode;
         protected:
-            explicit ResizeBrushesToolController(ResizeBrushesTool* tool);
+            explicit ResizeBrushesToolController(ResizeBrushesTool& tool);
         public:
             ~ResizeBrushesToolController() override;
         private:
@@ -70,7 +70,7 @@ namespace TrenchBroom {
 
         class ResizeBrushesToolController2D : public ResizeBrushesToolController {
         public:
-            explicit ResizeBrushesToolController2D(ResizeBrushesTool* tool);
+            explicit ResizeBrushesToolController2D(ResizeBrushesTool& tool);
         private:
             Model::Hit doPick(const vm::ray3& pickRay, const Model::PickResult& pickResult) override;
             bool doHandleInput(const InputState& inputState) const override;
@@ -78,7 +78,7 @@ namespace TrenchBroom {
 
         class ResizeBrushesToolController3D : public ResizeBrushesToolController {
         public:
-            explicit ResizeBrushesToolController3D(ResizeBrushesTool* tool);
+            explicit ResizeBrushesToolController3D(ResizeBrushesTool& tool);
         private:
             Model::Hit doPick(const vm::ray3& pickRay, const Model::PickResult& pickResult) override;
             bool doHandleInput(const InputState& inputState) const override;

--- a/common/src/View/RotateObjectsTool.cpp
+++ b/common/src/View/RotateObjectsTool.cpp
@@ -154,7 +154,7 @@ namespace TrenchBroom {
         QWidget* RotateObjectsTool::doCreatePage(QWidget* parent) {
             assert(m_toolPage == nullptr);
 
-            m_toolPage = new RotateObjectsToolPage(m_document, this, parent);
+            m_toolPage = new RotateObjectsToolPage(m_document, *this, parent);
             return m_toolPage;
         }
     }

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -172,12 +172,12 @@ namespace TrenchBroom {
                     ensure(m_tool != nullptr, "tool is null");
                 }
             private:
-                Tool* tool() override {
-                    return m_tool;
+                Tool& tool() override {
+                    return *m_tool;
                 }
 
-                const Tool* tool() const override {
-                    return m_tool;
+                const Tool& tool() const override {
+                    return *m_tool;
                 }
 
                 bool mouseClick(const InputState& inputState) override {
@@ -296,12 +296,12 @@ namespace TrenchBroom {
                     ensure(m_tool != nullptr, "tool is null");
                 }
 
-                Tool* tool() override {
-                    return m_tool;
+                Tool& tool() override {
+                    return *m_tool;
                 }
 
-                const Tool* tool() const override {
-                    return m_tool;
+                const Tool& tool() const override {
+                    return *m_tool;
                 }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
@@ -395,12 +395,12 @@ namespace TrenchBroom {
 
         RotateObjectsToolController::~RotateObjectsToolController() = default;
 
-        Tool* RotateObjectsToolController::tool() {
-            return m_tool;
+        Tool& RotateObjectsToolController::tool() {
+            return *m_tool;
         }
 
-        const Tool* RotateObjectsToolController::tool() const {
-            return m_tool;
+        const Tool& RotateObjectsToolController::tool() const {
+            return *m_tool;
         }
 
         void RotateObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -163,7 +163,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class RotateObjectsBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy> {
+            class RotateObjectsBase : public ToolController {
             protected:
                 RotateObjectsTool* m_tool;
             protected:
@@ -180,7 +180,7 @@ namespace TrenchBroom {
                     return m_tool;
                 }
 
-                bool doMouseClick(const InputState& inputState) override {
+                bool mouseClick(const InputState& inputState) override {
                     using namespace Model::HitFilters;
 
                     if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft)) {
@@ -237,7 +237,7 @@ namespace TrenchBroom {
                     return createHandleDragTracker(RotateObjectsDragDelegate{*m_tool, area, std::move(renderHighlight)}, inputState, initialHandlePosition, vm::vec3::zero());
                 }
 
-                void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
+                void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
                     using namespace Model::HitFilters;
 
                     if (!anyToolDragging(inputState)) {
@@ -251,7 +251,7 @@ namespace TrenchBroom {
                     }
                 }
 
-                bool doCancel() override {
+                bool cancel() override {
                     return false;
                 }
             private:
@@ -287,7 +287,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class MoveCenterBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy> {
+            class MoveCenterBase : public ToolController {
             protected:
                 RotateObjectsTool* m_tool;
             protected:
@@ -331,7 +331,7 @@ namespace TrenchBroom {
                     return createMoveHandleDragTracker(MoveRotationCenterDragDelegate{*m_tool, std::move(renderHighlight)}, inputState, m_tool->rotationCenter(), handleOffset);
                 }
 
-                void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
+                void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
                     using namespace Model::HitFilters;
 
                     if (!anyToolDragging(inputState)) {
@@ -342,7 +342,7 @@ namespace TrenchBroom {
                     }
                 }
 
-                bool doCancel() override {
+                bool cancel() override {
                     return false;
                 }
             private:

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -165,19 +165,17 @@ namespace TrenchBroom {
 
             class RotateObjectsBase : public ToolController {
             protected:
-                RotateObjectsTool* m_tool;
+                RotateObjectsTool& m_tool;
             protected:
-                explicit RotateObjectsBase(RotateObjectsTool* tool) :
-                m_tool(tool) {
-                    ensure(m_tool != nullptr, "tool is null");
-                }
+                explicit RotateObjectsBase(RotateObjectsTool& tool) :
+                m_tool(tool) {}
             private:
                 Tool& tool() override {
-                    return *m_tool;
+                    return m_tool;
                 }
 
                 const Tool& tool() const override {
-                    return *m_tool;
+                    return m_tool;
                 }
 
                 bool mouseClick(const InputState& inputState) override {
@@ -197,7 +195,7 @@ namespace TrenchBroom {
                         return false;
                     }
 
-                    m_tool->updateToolPageAxis(area);
+                    m_tool.updateToolPageAxis(area);
                     return true;
                 }
 
@@ -221,8 +219,8 @@ namespace TrenchBroom {
 
                     // We cannot use the hit's hitpoint because it is on the surface of the handle torus, whereas our drag snapper expects it to
                     // be on the plane defined by the rotation handle center and the rotation axis.
-                    const auto center = m_tool->rotationCenter();
-                    const auto axis = m_tool->rotationAxis(area);
+                    const auto center = m_tool.rotationCenter();
+                    const auto axis = m_tool.rotationAxis(area);
                     const auto distance = vm::intersect_ray_plane(inputState.pickRay(), vm::plane3{center, axis});
                     if (vm::is_nan(distance)) {
                         return nullptr;
@@ -233,8 +231,8 @@ namespace TrenchBroom {
                         doRenderHighlight(inputState_, renderContext, renderBatch, area_);
                     };
 
-                    m_tool->beginRotation();
-                    return createHandleDragTracker(RotateObjectsDragDelegate{*m_tool, area, std::move(renderHighlight)}, inputState, initialHandlePosition, vm::vec3::zero());
+                    m_tool.beginRotation();
+                    return createHandleDragTracker(RotateObjectsDragDelegate{m_tool, area, std::move(renderHighlight)}, inputState, initialHandlePosition, vm::vec3::zero());
                 }
 
                 void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
@@ -289,19 +287,17 @@ namespace TrenchBroom {
 
             class MoveCenterBase : public ToolController {
             protected:
-                RotateObjectsTool* m_tool;
+                RotateObjectsTool& m_tool;
             protected:
-                explicit MoveCenterBase(RotateObjectsTool* tool) :
-                m_tool(tool) {
-                    ensure(m_tool != nullptr, "tool is null");
-                }
+                explicit MoveCenterBase(RotateObjectsTool& tool) :
+                m_tool(tool) {}
 
                 Tool& tool() override {
-                    return *m_tool;
+                    return m_tool;
                 }
 
                 const Tool& tool() const override {
-                    return *m_tool;
+                    return m_tool;
                 }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
@@ -325,10 +321,10 @@ namespace TrenchBroom {
                         doRenderHighlight(inputState_, renderContext, renderBatch, area_);
                     };
 
-                    const auto initialHandlePosition = m_tool->rotationCenter();
+                    const auto initialHandlePosition = m_tool.rotationCenter();
                     const auto handleOffset = initialHandlePosition - hit.hitPoint();
 
-                    return createMoveHandleDragTracker(MoveRotationCenterDragDelegate{*m_tool, std::move(renderHighlight)}, inputState, m_tool->rotationCenter(), handleOffset);
+                    return createMoveHandleDragTracker(MoveRotationCenterDragDelegate{m_tool, std::move(renderHighlight)}, inputState, m_tool.rotationCenter(), handleOffset);
                 }
 
                 void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
@@ -351,56 +347,56 @@ namespace TrenchBroom {
 
             class MoveCenterPart2D : public MoveCenterBase {
             public:
-                explicit MoveCenterPart2D(RotateObjectsTool* tool) :
+                explicit MoveCenterPart2D(RotateObjectsTool& tool) :
                 MoveCenterBase(tool) {}
             private:
                 void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
-                    m_tool->renderHighlight2D(renderContext, renderBatch, area);
+                    m_tool.renderHighlight2D(renderContext, renderBatch, area);
                 }
             };
 
             class RotateObjectsPart2D : public RotateObjectsBase {
             public:
-                explicit RotateObjectsPart2D(RotateObjectsTool* tool) :
+                explicit RotateObjectsPart2D(RotateObjectsTool& tool) :
                 RotateObjectsBase(tool) {}
             private:
                 void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
-                    m_tool->renderHighlight2D(renderContext, renderBatch, area);
+                    m_tool.renderHighlight2D(renderContext, renderBatch, area);
                 }
             };
 
             class MoveCenterPart3D : public MoveCenterBase {
             public:
-                explicit MoveCenterPart3D(RotateObjectsTool* tool) :
+                explicit MoveCenterPart3D(RotateObjectsTool& tool) :
                 MoveCenterBase(tool) {}
             private:
                 void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
-                    m_tool->renderHighlight3D(renderContext, renderBatch, area);
+                    m_tool.renderHighlight3D(renderContext, renderBatch, area);
                 }
             };
 
             class RotateObjectsPart3D : public RotateObjectsBase {
             public:
-                explicit RotateObjectsPart3D(RotateObjectsTool* tool) :
+                explicit RotateObjectsPart3D(RotateObjectsTool& tool) :
                 RotateObjectsBase(tool) {}
             private:
                 void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
-                    m_tool->renderHighlight3D(renderContext, renderBatch, area);
+                    m_tool.renderHighlight3D(renderContext, renderBatch, area);
                 }
             };
         }
 
-        RotateObjectsToolController::RotateObjectsToolController(RotateObjectsTool* tool) :
+        RotateObjectsToolController::RotateObjectsToolController(RotateObjectsTool& tool) :
         m_tool(tool) {}
 
         RotateObjectsToolController::~RotateObjectsToolController() = default;
 
         Tool& RotateObjectsToolController::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& RotateObjectsToolController::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         void RotateObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
@@ -426,32 +422,32 @@ namespace TrenchBroom {
             return false;
         }
 
-        RotateObjectsToolController2D::RotateObjectsToolController2D(RotateObjectsTool* tool) :
+        RotateObjectsToolController2D::RotateObjectsToolController2D(RotateObjectsTool& tool) :
         RotateObjectsToolController(tool) {
             addController(std::make_unique<MoveCenterPart2D>(tool));
             addController(std::make_unique<RotateObjectsPart2D>(tool));
         }
 
         Model::Hit RotateObjectsToolController2D::doPick(const InputState& inputState) {
-            return m_tool->pick2D(inputState.pickRay(), inputState.camera());
+            return m_tool.pick2D(inputState.pickRay(), inputState.camera());
         }
 
         void RotateObjectsToolController2D::doRenderHandle(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            m_tool->renderHandle2D(renderContext, renderBatch);
+            m_tool.renderHandle2D(renderContext, renderBatch);
         }
 
-        RotateObjectsToolController3D::RotateObjectsToolController3D(RotateObjectsTool* tool) :
+        RotateObjectsToolController3D::RotateObjectsToolController3D(RotateObjectsTool& tool) :
         RotateObjectsToolController(tool) {
             addController(std::make_unique<MoveCenterPart3D>(tool));
             addController(std::make_unique<RotateObjectsPart3D>(tool));
         }
 
         Model::Hit RotateObjectsToolController3D::doPick(const InputState& inputState) {
-            return m_tool->pick3D(inputState.pickRay(), inputState.camera());
+            return m_tool.pick3D(inputState.pickRay(), inputState.camera());
         }
 
         void RotateObjectsToolController3D::doRenderHandle(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            m_tool->renderHandle3D(renderContext, renderBatch);
+            m_tool.renderHandle3D(renderContext, renderBatch);
         }
     }
 }

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -403,26 +403,26 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        void RotateObjectsToolController::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void RotateObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
             const Model::Hit hit = doPick(inputState);
             if (hit.isMatch()) {
                 pickResult.addHit(hit);
             }
         }
 
-        void RotateObjectsToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void RotateObjectsToolController::setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
             using namespace Model::HitFilters;
             if (inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType)).isMatch()) {
                 renderContext.setForceShowSelectionGuide();
             }
         }
 
-        void RotateObjectsToolController::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void RotateObjectsToolController::render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             doRenderHandle(renderContext, renderBatch);
-            ToolControllerGroup::doRender(inputState, renderContext, renderBatch);
+            ToolControllerGroup::render(inputState, renderContext, renderBatch);
         }
 
-        bool RotateObjectsToolController::doCancel() {
+        bool RotateObjectsToolController::cancel() {
             return false;
         }
 

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -172,11 +172,11 @@ namespace TrenchBroom {
                     ensure(m_tool != nullptr, "tool is null");
                 }
             private:
-                Tool* doGetTool() override {
+                Tool* tool() override {
                     return m_tool;
                 }
 
-                const Tool* doGetTool() const override {
+                const Tool* tool() const override {
                     return m_tool;
                 }
 
@@ -296,11 +296,11 @@ namespace TrenchBroom {
                     ensure(m_tool != nullptr, "tool is null");
                 }
 
-                Tool* doGetTool() override {
+                Tool* tool() override {
                     return m_tool;
                 }
 
-                const Tool* doGetTool() const override {
+                const Tool* tool() const override {
                     return m_tool;
                 }
 
@@ -395,11 +395,11 @@ namespace TrenchBroom {
 
         RotateObjectsToolController::~RotateObjectsToolController() = default;
 
-        Tool* RotateObjectsToolController::doGetTool() {
+        Tool* RotateObjectsToolController::tool() {
             return m_tool;
         }
 
-        const Tool* RotateObjectsToolController::doGetTool() const {
+        const Tool* RotateObjectsToolController::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/RotateObjectsToolController.h
+++ b/common/src/View/RotateObjectsToolController.h
@@ -42,12 +42,12 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-            void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         private: // subclassing interface
             virtual Model::Hit doPick(const InputState& inputState) = 0;
             virtual void doRenderHandle(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) = 0;

--- a/common/src/View/RotateObjectsToolController.h
+++ b/common/src/View/RotateObjectsToolController.h
@@ -33,9 +33,9 @@ namespace TrenchBroom {
 
         class RotateObjectsToolController : public ToolControllerGroup {
         protected:
-            RotateObjectsTool* m_tool;
+            RotateObjectsTool& m_tool;
         protected:
-            explicit RotateObjectsToolController(RotateObjectsTool* tool);
+            explicit RotateObjectsToolController(RotateObjectsTool& tool);
         public:
             ~RotateObjectsToolController() override;
         private:
@@ -55,7 +55,7 @@ namespace TrenchBroom {
 
         class RotateObjectsToolController2D : public RotateObjectsToolController {
         public:
-            explicit RotateObjectsToolController2D(RotateObjectsTool* tool);
+            explicit RotateObjectsToolController2D(RotateObjectsTool& tool);
         private:
             Model::Hit doPick(const InputState& inputState) override;
             void doRenderHandle(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
@@ -63,7 +63,7 @@ namespace TrenchBroom {
 
         class RotateObjectsToolController3D : public RotateObjectsToolController {
         public:
-            explicit RotateObjectsToolController3D(RotateObjectsTool* tool);
+            explicit RotateObjectsToolController3D(RotateObjectsTool& tool);
         private:
             Model::Hit doPick(const InputState& inputState) override;
             void doRenderHandle(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;

--- a/common/src/View/RotateObjectsToolController.h
+++ b/common/src/View/RotateObjectsToolController.h
@@ -39,8 +39,8 @@ namespace TrenchBroom {
         public:
             ~RotateObjectsToolController() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/RotateObjectsToolController.h
+++ b/common/src/View/RotateObjectsToolController.h
@@ -39,8 +39,8 @@ namespace TrenchBroom {
         public:
             ~RotateObjectsToolController() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -43,7 +43,7 @@
 
 namespace TrenchBroom {
     namespace View {
-        RotateObjectsToolPage::RotateObjectsToolPage(std::weak_ptr<MapDocument> document, RotateObjectsTool* tool, QWidget* parent) :
+        RotateObjectsToolPage::RotateObjectsToolPage(std::weak_ptr<MapDocument> document, RotateObjectsTool& tool, QWidget* parent) :
         QWidget(parent),
         m_document(std::move(document)),
         m_tool(tool),
@@ -54,7 +54,7 @@ namespace TrenchBroom {
         m_rotateButton(nullptr) {
             createGui();
             connectObservers();
-            m_angle->setValue(vm::to_degrees(m_tool->angle()));
+            m_angle->setValue(vm::to_degrees(m_tool.angle()));
         }
 
         void RotateObjectsToolPage::connectObservers() {
@@ -96,7 +96,7 @@ namespace TrenchBroom {
             auto* text3 = new QLabel(tr("axis"));
             m_angle = new SpinControl(this);
             m_angle->setRange(-360.0, 360.0);
-            m_angle->setValue(vm::to_degrees(m_tool->angle()));
+            m_angle->setValue(vm::to_degrees(m_tool.angle()));
 
             m_axis = new QComboBox();
             m_axis->addItem("X");
@@ -157,22 +157,22 @@ namespace TrenchBroom {
 
         void RotateObjectsToolPage::centerChanged() {
             if (const auto center = vm::parse<FloatType, 3>(m_recentlyUsedCentersList->currentText().toStdString())) {
-                m_tool->setRotationCenter(*center);
+                m_tool.setRotationCenter(*center);
             }
         }
 
         void RotateObjectsToolPage::resetCenterClicked() {
-            m_tool->resetRotationCenter();
+            m_tool.resetRotationCenter();
         }
 
         void RotateObjectsToolPage::angleChanged(double value) {
             const double newAngleDegs = vm::correct(value);
             m_angle->setValue(newAngleDegs);
-            m_tool->setAngle(vm::to_radians(newAngleDegs));
+            m_tool.setAngle(vm::to_radians(newAngleDegs));
         }
 
         void RotateObjectsToolPage::rotateClicked() {
-            const auto center = m_tool->rotationCenter();
+            const auto center = m_tool.rotationCenter();
             const auto axis = getAxis();
             const auto angle = vm::to_radians(m_angle->value());
 

--- a/common/src/View/RotateObjectsToolPage.h
+++ b/common/src/View/RotateObjectsToolPage.h
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             Q_OBJECT
         private:
             std::weak_ptr<MapDocument> m_document;
-            RotateObjectsTool* m_tool;
+            RotateObjectsTool& m_tool;
 
             QComboBox* m_recentlyUsedCentersList;
             QAbstractButton* m_resetCenterButton;
@@ -54,7 +54,7 @@ namespace TrenchBroom {
 
             NotifierConnection m_notifierConnection;
         public:
-            RotateObjectsToolPage(std::weak_ptr<MapDocument> document, RotateObjectsTool* tool, QWidget* parent = nullptr);
+            RotateObjectsToolPage(std::weak_ptr<MapDocument> document, RotateObjectsTool& tool, QWidget* parent = nullptr);
 
             void setAxis(vm::axis::type axis);
             void setRecentlyUsedCenters(const std::vector<vm::vec3>& centers);

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -51,12 +51,12 @@ namespace TrenchBroom {
 
         ScaleObjectsToolController::~ScaleObjectsToolController() = default;
 
-        Tool* ScaleObjectsToolController::tool() {
-            return m_tool;
+        Tool& ScaleObjectsToolController::tool() {
+            return *m_tool;
         }
 
-        const Tool* ScaleObjectsToolController::tool() const {
-            return m_tool;
+        const Tool& ScaleObjectsToolController::tool() const {
+            return *m_tool;
         }
 
         void ScaleObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -59,7 +59,7 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        void ScaleObjectsToolController::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void ScaleObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
             if (m_tool->applies()) {
                 doPick(inputState.pickRay(), inputState.camera(), pickResult);
             }
@@ -108,7 +108,7 @@ namespace TrenchBroom {
             return {centerAnchor, scaleAllAxes};
         }
 
-        void ScaleObjectsToolController::doModifierKeyChange(const InputState& inputState) {
+        void ScaleObjectsToolController::modifierKeyChange(const InputState& inputState) {
             const auto [centerAnchor, scaleAllAxes] = modifierSettingsForInputState(inputState);
 
             if ((centerAnchor != m_tool->anchorPos()) || (scaleAllAxes != m_tool->proportionalAxes())) {
@@ -121,7 +121,7 @@ namespace TrenchBroom {
             m_tool->refreshViews();
         }
 
-        void ScaleObjectsToolController::doMouseMove(const InputState& inputState) {
+        void ScaleObjectsToolController::mouseMove(const InputState& inputState) {
             if (m_tool->applies() && !anyToolDragging(inputState)) {
                 m_tool->updatePickedHandle(inputState.pickResult());
             }
@@ -225,7 +225,7 @@ namespace TrenchBroom {
             return createHandleDragTracker(ScaleObjectsDragDelegate{*m_tool}, inputState, handlePosition, handleOffset);
         }
 
-        void ScaleObjectsToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
+        void ScaleObjectsToolController::setRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             renderContext.setForceHideSelectionGuide();
         }
 
@@ -326,7 +326,7 @@ namespace TrenchBroom {
             });
         }
 
-        void ScaleObjectsToolController::doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ScaleObjectsToolController::render(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             if (!m_tool->bounds().is_empty())  {
                 renderBounds(renderContext, renderBatch, m_tool->bounds());
                 renderCornerHandles(renderContext, renderBatch, visibleCornerHandles(*m_tool, renderContext.camera()));
@@ -347,7 +347,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool ScaleObjectsToolController::doCancel() {
+        bool ScaleObjectsToolController::cancel() {
             return false;
         }
 

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -51,11 +51,11 @@ namespace TrenchBroom {
 
         ScaleObjectsToolController::~ScaleObjectsToolController() = default;
 
-        Tool* ScaleObjectsToolController::doGetTool() {
+        Tool* ScaleObjectsToolController::tool() {
             return m_tool;
         }
 
-        const Tool* ScaleObjectsToolController::doGetTool() const {
+        const Tool* ScaleObjectsToolController::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -43,24 +43,22 @@
 
 namespace TrenchBroom {
     namespace View {
-        ScaleObjectsToolController::ScaleObjectsToolController(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document) :
+        ScaleObjectsToolController::ScaleObjectsToolController(ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document) :
         m_tool{tool},
-        m_document{document} {
-            ensure(m_tool != nullptr, "tool is null");
-        }
+        m_document{document} {}
 
         ScaleObjectsToolController::~ScaleObjectsToolController() = default;
 
         Tool& ScaleObjectsToolController::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& ScaleObjectsToolController::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         void ScaleObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
-            if (m_tool->applies()) {
+            if (m_tool.applies()) {
                 doPick(inputState.pickRay(), inputState.camera(), pickResult);
             }
         }
@@ -111,19 +109,19 @@ namespace TrenchBroom {
         void ScaleObjectsToolController::modifierKeyChange(const InputState& inputState) {
             const auto [centerAnchor, scaleAllAxes] = modifierSettingsForInputState(inputState);
 
-            if ((centerAnchor != m_tool->anchorPos()) || (scaleAllAxes != m_tool->proportionalAxes())) {
+            if ((centerAnchor != m_tool.anchorPos()) || (scaleAllAxes != m_tool.proportionalAxes())) {
                 // update state
-                m_tool->setProportionalAxes(scaleAllAxes);
-                m_tool->setAnchorPos(centerAnchor);
+                m_tool.setProportionalAxes(scaleAllAxes);
+                m_tool.setAnchorPos(centerAnchor);
             }
 
             // Mouse might be over a different handle now
-            m_tool->refreshViews();
+            m_tool.refreshViews();
         }
 
         void ScaleObjectsToolController::mouseMove(const InputState& inputState) {
-            if (m_tool->applies() && !anyToolDragging(inputState)) {
-                m_tool->updatePickedHandle(inputState.pickResult());
+            if (m_tool.applies() && !anyToolDragging(inputState)) {
+                m_tool.updatePickedHandle(inputState.pickResult());
             }
         }
 
@@ -206,7 +204,7 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            if (!m_tool->applies()) {
+            if (!m_tool.applies()) {
                 return nullptr;
             }
             auto document = kdl::mem_lock(m_document);
@@ -219,10 +217,10 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            m_tool->startScaleWithHit(hit);
+            m_tool.startScaleWithHit(hit);
 
-            const auto [handlePosition, handleOffset] = getInitialHandlePositionAndOffset(m_tool->bounds(), hit);
-            return createHandleDragTracker(ScaleObjectsDragDelegate{*m_tool}, inputState, handlePosition, handleOffset);
+            const auto [handlePosition, handleOffset] = getInitialHandlePositionAndOffset(m_tool.bounds(), hit);
+            return createHandleDragTracker(ScaleObjectsDragDelegate{m_tool}, inputState, handlePosition, handleOffset);
         }
 
         void ScaleObjectsToolController::setRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
@@ -327,23 +325,23 @@ namespace TrenchBroom {
         }
 
         void ScaleObjectsToolController::render(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            if (!m_tool->bounds().is_empty())  {
-                renderBounds(renderContext, renderBatch, m_tool->bounds());
-                renderCornerHandles(renderContext, renderBatch, visibleCornerHandles(*m_tool, renderContext.camera()));
+            if (!m_tool.bounds().is_empty())  {
+                renderBounds(renderContext, renderBatch, m_tool.bounds());
+                renderCornerHandles(renderContext, renderBatch, visibleCornerHandles(m_tool, renderContext.camera()));
             }
 
-            renderDragSideHighlights(renderContext, renderBatch, m_tool->polygonsHighlightedByDrag());
+            renderDragSideHighlights(renderContext, renderBatch, m_tool.polygonsHighlightedByDrag());
 
-            if (m_tool->hasDragSide()) {
-                renderDragSide(renderContext, renderBatch, m_tool->dragSide());
+            if (m_tool.hasDragSide()) {
+                renderDragSide(renderContext, renderBatch, m_tool.dragSide());
             }
 
-            if (m_tool->hasDragEdge()) {
-                renderDragEdge(renderContext, renderBatch, m_tool->dragEdge());
+            if (m_tool.hasDragEdge()) {
+                renderDragEdge(renderContext, renderBatch, m_tool.dragEdge());
             }
 
-            if (m_tool->hasDragCorner()) {
-                renderDragCorner(renderContext, renderBatch, m_tool->dragCorner());
+            if (m_tool.hasDragCorner()) {
+                renderDragCorner(renderContext, renderBatch, m_tool.dragCorner());
             }
         }
 
@@ -354,22 +352,22 @@ namespace TrenchBroom {
 
         // ScaleObjectsToolController2D
 
-        ScaleObjectsToolController2D::ScaleObjectsToolController2D(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document) :
+        ScaleObjectsToolController2D::ScaleObjectsToolController2D(ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document) :
         ScaleObjectsToolController(tool, document) {}
 
         void ScaleObjectsToolController2D::doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera,
                                                   Model::PickResult &pickResult) const {
-            m_tool->pick2D(pickRay, camera, pickResult);
+            m_tool.pick2D(pickRay, camera, pickResult);
         }
 
         // ScaleObjectsToolController3D
 
-        ScaleObjectsToolController3D::ScaleObjectsToolController3D(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document) :
+        ScaleObjectsToolController3D::ScaleObjectsToolController3D(ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document) :
         ScaleObjectsToolController(tool, document) {}
 
         void ScaleObjectsToolController3D::doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera,
                                                   Model::PickResult &pickResult) const {
-            m_tool->pick3D(pickRay, camera, pickResult);
+            m_tool.pick3D(pickRay, camera, pickResult);
         }
     }
 }

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -46,8 +46,8 @@ namespace TrenchBroom {
             explicit ScaleObjectsToolController(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document);
             ~ScaleObjectsToolController() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -39,11 +39,11 @@ namespace TrenchBroom {
 
         class ScaleObjectsToolController : public ToolController {
         protected:
-            ScaleObjectsTool* m_tool;
+            ScaleObjectsTool& m_tool;
         private:
             std::weak_ptr<MapDocument> m_document;
         public:
-            explicit ScaleObjectsToolController(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document);
+            explicit ScaleObjectsToolController(ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document);
             ~ScaleObjectsToolController() override;
         private:
             Tool& tool() override;
@@ -67,14 +67,14 @@ namespace TrenchBroom {
 
         class ScaleObjectsToolController2D : public ScaleObjectsToolController {
         public:
-            explicit ScaleObjectsToolController2D(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document);
+            explicit ScaleObjectsToolController2D(ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document);
         private:
             void doPick(const vm::ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override;
         };
 
         class ScaleObjectsToolController3D : public ScaleObjectsToolController {
         public:
-            explicit ScaleObjectsToolController3D(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document);
+            explicit ScaleObjectsToolController3D(ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document);
         private:
             void doPick(const vm::ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override;
         };

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -46,8 +46,8 @@ namespace TrenchBroom {
             explicit ScaleObjectsToolController(ScaleObjectsTool* tool, std::weak_ptr<MapDocument> document);
             ~ScaleObjectsToolController() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -37,7 +37,7 @@ namespace TrenchBroom {
         class MapDocument;
         class ScaleObjectsTool;
 
-        class ScaleObjectsToolController : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy> {
+        class ScaleObjectsToolController : public ToolController {
         protected:
             ScaleObjectsTool* m_tool;
         private:
@@ -49,18 +49,18 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-            void doModifierKeyChange(const InputState& inputState) override;
+            void modifierKeyChange(const InputState& inputState) override;
 
-            void doMouseMove(const InputState& inputState) override;
+            void mouseMove(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         private:
             virtual void doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera, Model::PickResult &pickResult) const = 0;
         };

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -54,8 +54,10 @@ namespace TrenchBroom {
         }
 
         std::vector<Model::Node*> hitsToNodesWithGroupPicking(const std::vector<Model::Hit>& hits) {
-            std::vector<Model::Node*> hitNodes;
-            std::unordered_set<Model::Node*> duplicateCheck;
+            auto hitNodes = std::vector<Model::Node*>{};
+            hitNodes.reserve(hits.size());
+
+            auto duplicateCheck = std::unordered_set<Model::Node*>{};
 
             for (const auto& hit : hits) {
                 Model::Node* node = findOutermostClosedGroupOrNode(Model::hitToNode(hit));
@@ -88,9 +90,9 @@ namespace TrenchBroom {
         }
 
         SelectionTool::SelectionTool(std::weak_ptr<MapDocument> document) :
-        ToolControllerBase(),
-        Tool(true),
-        m_document(document) {}
+        ToolControllerBase{},
+        Tool{true},
+        m_document{std::move(document)} {}
 
         Tool* SelectionTool::doGetTool() {
             return this;
@@ -119,7 +121,7 @@ namespace TrenchBroom {
                                 if (brush->selected()) {
                                     document->deselect(*faceHandle);
                                 } else {
-                                    Transaction transaction(document, "Select Brush Face");
+                                    auto transaction = Transaction{document, "Select Brush Face"};
                                     document->convertToFaceSelection();
                                     document->select(*faceHandle);
                                 }
@@ -131,7 +133,7 @@ namespace TrenchBroom {
                                 }
                             }
                         } else {
-                            Transaction transaction(document, "Select Brush Face");
+                            auto transaction = Transaction{document, "Select Brush Face"};
                             document->deselectAll();
                             document->select(*faceHandle);
                         }
@@ -148,14 +150,14 @@ namespace TrenchBroom {
                             if (node->selected()) {
                                 document->deselect(node);
                             } else {
-                                Transaction transaction(document, "Select Object");
+                                auto transaction = Transaction{document, "Select Object"};
                                 if (document->hasSelectedBrushFaces()) {
                                     document->deselectAll();
                                 }
                                 document->select(node);
                             }
                         } else {
-                            Transaction transaction(document, "Select Object");
+                            auto transaction = Transaction{document, "Select Object"};
                             document->deselectAll();
                             document->select(node);
                         }
@@ -187,7 +189,7 @@ namespace TrenchBroom {
                             }
                             document->select(Model::toHandles(brush));
                         } else {
-                            Transaction transaction(document, "Select Brush Faces");
+                            auto transaction = Transaction{document, "Select Brush Faces"};
                             document->deselectAll();
                             document->select(Model::toHandles(brush));
                         }
@@ -216,7 +218,7 @@ namespace TrenchBroom {
                                     }
                                     document->select(siblings);
                                 } else {
-                                    Transaction transaction(document, "Select Brushes");
+                                    auto transaction = Transaction{document, "Select Brushes"};
                                     document->deselectAll();
                                     document->select(siblings);
                                 }
@@ -296,13 +298,15 @@ namespace TrenchBroom {
             const auto& editorContext = document->editorContext();
 
             const auto forward = (inputState.scrollY() > 0.0f) != (pref(Preferences::CameraMouseWheelInvert));
-            const auto nodePair = forward ? findSelectionPair(std::begin(hitNodes), std::end(hitNodes), editorContext) : findSelectionPair(hitNodes.rbegin(), hitNodes.rend(), editorContext);
+            const auto nodePair = forward 
+                ? findSelectionPair(std::begin(hitNodes), std::end(hitNodes), editorContext) 
+                : findSelectionPair(std::rbegin(hitNodes), std::rend(hitNodes), editorContext);
 
             auto* selectedNode = nodePair.first;
             auto* nextNode = nodePair.second;
 
             if (nextNode != nullptr) {
-                Transaction transaction(document, "Drill Selection");
+                auto transaction = Transaction{document, "Drill Selection"};
                 document->deselect(selectedNode);
                 document->select(nextNode);
             }

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -111,12 +111,12 @@ namespace TrenchBroom {
         Tool{true},
         m_document{std::move(document)} {}
 
-        Tool* SelectionTool::tool() {
-            return this;
+        Tool& SelectionTool::tool() {
+            return *this;
         }
 
-        const Tool* SelectionTool::tool() const {
-            return this;
+        const Tool& SelectionTool::tool() const {
+            return *this;
         }
 
         bool SelectionTool::mouseClick(const InputState& inputState) {

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -111,11 +111,11 @@ namespace TrenchBroom {
         Tool{true},
         m_document{std::move(document)} {}
 
-        Tool* SelectionTool::doGetTool() {
+        Tool* SelectionTool::tool() {
             return this;
         }
 
-        const Tool* SelectionTool::doGetTool() const {
+        const Tool* SelectionTool::tool() const {
             return this;
         }
 

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -107,7 +107,7 @@ namespace TrenchBroom {
         }
 
         SelectionTool::SelectionTool(std::weak_ptr<MapDocument> document) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_document{std::move(document)} {}
 
@@ -119,7 +119,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        bool SelectionTool::doMouseClick(const InputState& inputState) {
+        bool SelectionTool::mouseClick(const InputState& inputState) {
             auto document = kdl::mem_lock(m_document);
             const auto& editorContext = document->editorContext();
             
@@ -188,7 +188,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool SelectionTool::doMouseDoubleClick(const InputState& inputState) {
+        bool SelectionTool::mouseDoubleClick(const InputState& inputState) {
             auto document = kdl::mem_lock(m_document);
             const auto& editorContext = document->editorContext();
 
@@ -308,7 +308,7 @@ namespace TrenchBroom {
             }
         }
 
-        void SelectionTool::doMouseScroll(const InputState& inputState) {
+        void SelectionTool::mouseScroll(const InputState& inputState) {
             const auto document = kdl::mem_lock(m_document);
 
             if (inputState.checkModifierKeys(MK_Yes, MK_Yes, MK_No)) {
@@ -408,7 +408,7 @@ namespace TrenchBroom {
             return nullptr;
         }
 
-        void SelectionTool::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void SelectionTool::setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
             auto document = kdl::mem_lock(m_document);
             const auto& hit = firstHit(inputState, Model::nodeHitType());
             if (hit.isMatch()) {
@@ -420,7 +420,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool SelectionTool::doCancel() {
+        bool SelectionTool::cancel() {
             // closing the current group is handled in MapViewBase
             return false;
         }

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -52,8 +52,8 @@ namespace TrenchBroom {
         public:
             explicit SelectionTool(std::weak_ptr<MapDocument> document);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             bool mouseClick(const InputState& inputState) override;
             bool mouseDoubleClick(const InputState& inputState) override;

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -52,8 +52,8 @@ namespace TrenchBroom {
         public:
             explicit SelectionTool(std::weak_ptr<MapDocument> document);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             bool mouseClick(const InputState& inputState) override;
             bool mouseDoubleClick(const InputState& inputState) override;

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -46,7 +46,7 @@ namespace TrenchBroom {
          */
         std::vector<Model::Node*> hitsToNodesWithGroupPicking(const std::vector<Model::Hit>& hits);
 
-        class SelectionTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, public Tool {
+        class SelectionTool : public ToolController, public Tool {
         private:
             std::weak_ptr<MapDocument> m_document;
         public:
@@ -55,15 +55,15 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            bool doMouseClick(const InputState& inputState) override;
-            bool doMouseDoubleClick(const InputState& inputState) override;
-            void doMouseScroll(const InputState& inputState) override;
+            bool mouseClick(const InputState& inputState) override;
+            bool mouseDoubleClick(const InputState& inputState) override;
+            void mouseScroll(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -40,14 +40,6 @@ namespace TrenchBroom {
         class MapDocument;
 
         /**
-         * Implements the Group picking logic: if `node` is inside a (possibly nested chain of)
-         * closed group(s), the outermost closed group is returned. Otherwise, `node` itself is returned.
-         *
-         * This is used to implement the UI where clicking on a brush inside a group selects the group.
-         */
-        Model::Node* findOutermostClosedGroupOrNode(Model::Node* node);
-
-        /**
          * Applies the group picking logic of findOutermostClosedGroupOrNode() to a list of hits.
          * The order of the hits is preserved, but if multiple hits map to the same group, that group
          * will only be listed once in the output.
@@ -65,12 +57,7 @@ namespace TrenchBroom {
 
             bool doMouseClick(const InputState& inputState) override;
             bool doMouseDoubleClick(const InputState& inputState) override;
-
-            bool handleClick(const InputState& inputState) const;
-
             void doMouseScroll(const InputState& inputState) override;
-            void adjustGrid(const InputState& inputState);
-            void drillSelection(const InputState& inputState);
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -47,11 +47,11 @@ namespace TrenchBroom {
         Tool{true},
         m_document{document} {}
 
-        Tool* SetBrushFaceAttributesTool::doGetTool() {
+        Tool* SetBrushFaceAttributesTool::tool() {
             return this;
         }
 
-        const Tool* SetBrushFaceAttributesTool::doGetTool() const {
+        const Tool* SetBrushFaceAttributesTool::tool() const {
             return this;
         }
 

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
         static const std::string TransferFaceAttributesTransactionName = "Transfer Face Attributes";
 
         SetBrushFaceAttributesTool::SetBrushFaceAttributesTool(std::weak_ptr<MapDocument> document) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_document{document} {}
 
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        bool SetBrushFaceAttributesTool::doMouseClick(const InputState& inputState) {
+        bool SetBrushFaceAttributesTool::mouseClick(const InputState& inputState) {
             if (canCopyAttributesFromSelection(inputState)) {
                 copyAttributesFromSelection(inputState, false);
                 return true;
@@ -64,9 +64,9 @@ namespace TrenchBroom {
             return false;
         }
 
-        bool SetBrushFaceAttributesTool::doMouseDoubleClick(const InputState& inputState) {
+        bool SetBrushFaceAttributesTool::mouseDoubleClick(const InputState& inputState) {
             if (canCopyAttributesFromSelection(inputState)) {
-                // The typical use case is, doMouseClick() previously copied the selected attributes to the clicked face,
+                // The typical use case is, mouseClick() previously copied the selected attributes to the clicked face,
                 // and now the second click has arrived so we're about to copy the selected attributes to the whole brush.
                 // To make undo/redo more intuitivie, undo the application to the single face now, so that if the
                 // double click is later undone/redone, it appears as one atomic action.
@@ -204,7 +204,7 @@ namespace TrenchBroom {
             return std::make_unique<SetBrushFaceAttributesDragTracker>(*kdl::mem_lock(m_document), selectedFaces.front());
         }
 
-        bool SetBrushFaceAttributesTool::doCancel() {
+        bool SetBrushFaceAttributesTool::cancel() {
             return false;
         }
 

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -47,12 +47,12 @@ namespace TrenchBroom {
         Tool{true},
         m_document{document} {}
 
-        Tool* SetBrushFaceAttributesTool::tool() {
-            return this;
+        Tool& SetBrushFaceAttributesTool::tool() {
+            return *this;
         }
 
-        const Tool* SetBrushFaceAttributesTool::tool() const {
-            return this;
+        const Tool& SetBrushFaceAttributesTool::tool() const {
+            return *this;
         }
 
         bool SetBrushFaceAttributesTool::mouseClick(const InputState& inputState) {

--- a/common/src/View/SetBrushFaceAttributesTool.h
+++ b/common/src/View/SetBrushFaceAttributesTool.h
@@ -50,8 +50,8 @@ namespace TrenchBroom {
         public:
             SetBrushFaceAttributesTool(std::weak_ptr<MapDocument> document);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             bool mouseClick(const InputState& inputState) override;
             bool mouseDoubleClick(const InputState& inputState) override;

--- a/common/src/View/SetBrushFaceAttributesTool.h
+++ b/common/src/View/SetBrushFaceAttributesTool.h
@@ -44,7 +44,7 @@ namespace TrenchBroom {
          * - LMB Drag: applies to all faces dragged over
          * - LMB Double click: applies to all faces of target brush
          */
-        class SetBrushFaceAttributesTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
+        class SetBrushFaceAttributesTool : public ToolController, public Tool {
         private:
             std::weak_ptr<MapDocument> m_document;
         public:
@@ -53,10 +53,10 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            bool doMouseClick(const InputState& inputState) override;
-            bool doMouseDoubleClick(const InputState& inputState) override;
+            bool mouseClick(const InputState& inputState) override;
+            bool mouseDoubleClick(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
             
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/SetBrushFaceAttributesTool.h
+++ b/common/src/View/SetBrushFaceAttributesTool.h
@@ -50,8 +50,8 @@ namespace TrenchBroom {
         public:
             SetBrushFaceAttributesTool(std::weak_ptr<MapDocument> document);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             bool mouseClick(const InputState& inputState) override;
             bool mouseDoubleClick(const InputState& inputState) override;

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -58,7 +58,7 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        void ShearObjectsToolController::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void ShearObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
             if (m_tool->applies()) {
                 // forward to either ShearObjectsTool::pick2D or ShearObjectsTool::pick3D
                 doPick(inputState.pickRay(), inputState.camera(), pickResult);
@@ -102,7 +102,7 @@ namespace TrenchBroom {
             );
         }
 
-        void ShearObjectsToolController::doMouseMove(const InputState& inputState) {
+        void ShearObjectsToolController::mouseMove(const InputState& inputState) {
             if (m_tool->applies() && !anyToolDragging(inputState)) {
                 m_tool->updatePickedSide(inputState.pickResult());
             }
@@ -205,11 +205,11 @@ namespace TrenchBroom {
             return createHandleDragTracker(ShearObjectsDragDelegate{*m_tool}, inputState, handlePosition, handleOffset);
         }
 
-        void ShearObjectsToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
+        void ShearObjectsToolController::setRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             renderContext.setForceHideSelectionGuide();
         }
 
-        void ShearObjectsToolController::doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ShearObjectsToolController::render(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             // render sheared box
             {
                 auto renderService = Renderer::RenderService{renderContext, renderBatch};
@@ -244,7 +244,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool ShearObjectsToolController::doCancel() {
+        bool ShearObjectsToolController::cancel() {
             return false;
         }
 

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -50,11 +50,11 @@ namespace TrenchBroom {
 
         ShearObjectsToolController::~ShearObjectsToolController() = default;
 
-        Tool* ShearObjectsToolController::doGetTool() {
+        Tool* ShearObjectsToolController::tool() {
             return m_tool;
         }
 
-        const Tool* ShearObjectsToolController::doGetTool() const {
+        const Tool* ShearObjectsToolController::tool() const {
             return m_tool;
         }
 

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -42,24 +42,22 @@
 
 namespace TrenchBroom {
     namespace View {
-        ShearObjectsToolController::ShearObjectsToolController(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document) :
+        ShearObjectsToolController::ShearObjectsToolController(ShearObjectsTool& tool, std::weak_ptr<MapDocument> document) :
         m_tool{tool},
-        m_document{std::move(document)} {
-            ensure(m_tool != nullptr, "tool is null");
-        }
+        m_document{std::move(document)} {}
 
         ShearObjectsToolController::~ShearObjectsToolController() = default;
 
         Tool& ShearObjectsToolController::tool() {
-            return *m_tool;
+            return m_tool;
         }
 
         const Tool& ShearObjectsToolController::tool() const {
-            return *m_tool;
+            return m_tool;
         }
 
         void ShearObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {
-            if (m_tool->applies()) {
+            if (m_tool.applies()) {
                 // forward to either ShearObjectsTool::pick2D or ShearObjectsTool::pick3D
                 doPick(inputState.pickRay(), inputState.camera(), pickResult);
             }
@@ -103,8 +101,8 @@ namespace TrenchBroom {
         }
 
         void ShearObjectsToolController::mouseMove(const InputState& inputState) {
-            if (m_tool->applies() && !anyToolDragging(inputState)) {
-                m_tool->updatePickedSide(inputState.pickResult());
+            if (m_tool.applies() && !anyToolDragging(inputState)) {
+                m_tool.updatePickedSide(inputState.pickResult());
             }
         }
 
@@ -187,7 +185,7 @@ namespace TrenchBroom {
             if (!(inputState.modifierKeysPressed(ModifierKeys::MKNone) || vertical)) {
                 return nullptr;
             }
-            if (!m_tool->applies()) {
+            if (!m_tool.applies()) {
                 return nullptr;
             }
 
@@ -198,11 +196,11 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            m_tool->startShearWithHit(hit);
-            m_tool->setConstrainVertical(vertical);
+            m_tool.startShearWithHit(hit);
+            m_tool.setConstrainVertical(vertical);
 
-            const auto [handlePosition, handleOffset] = getInitialHandlePositionAndOffset(m_tool->bounds(), hit);
-            return createHandleDragTracker(ShearObjectsDragDelegate{*m_tool}, inputState, handlePosition, handleOffset);
+            const auto [handlePosition, handleOffset] = getInitialHandlePositionAndOffset(m_tool.bounds(), hit);
+            return createHandleDragTracker(ShearObjectsDragDelegate{m_tool}, inputState, handlePosition, handleOffset);
         }
 
         void ShearObjectsToolController::setRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
@@ -214,16 +212,16 @@ namespace TrenchBroom {
             {
                 auto renderService = Renderer::RenderService{renderContext, renderBatch};
                 renderService.setForegroundColor(pref(Preferences::SelectionBoundsColor));
-                const auto mat = m_tool->bboxShearMatrix();
+                const auto mat = m_tool.bboxShearMatrix();
                 const auto op = [&](const vm::vec3& start, const vm::vec3& end) {
                     renderService.renderLine(vm::vec3f(mat * start), vm::vec3f(mat * end));
                 };
-                m_tool->bboxAtDragStart().for_each_edge(op);
+                m_tool.bboxAtDragStart().for_each_edge(op);
             }
 
             // render shear handle
             {
-                const vm::polygon3f poly = m_tool->shearHandle();
+                const vm::polygon3f poly = m_tool.shearHandle();
                 if (poly.vertexCount() != 0) {
                     // fill
                     {
@@ -250,22 +248,22 @@ namespace TrenchBroom {
 
         // ShearObjectsToolController2D
 
-        ShearObjectsToolController2D::ShearObjectsToolController2D(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document) :
+        ShearObjectsToolController2D::ShearObjectsToolController2D(ShearObjectsTool& tool, std::weak_ptr<MapDocument> document) :
         ShearObjectsToolController{tool, std::move(document)} {}
 
         void ShearObjectsToolController2D::doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera,
                                                   Model::PickResult &pickResult) {
-            m_tool->pick2D(pickRay, camera, pickResult);
+            m_tool.pick2D(pickRay, camera, pickResult);
         }
 
         // ShearObjectsToolController3D
 
-        ShearObjectsToolController3D::ShearObjectsToolController3D(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document) :
+        ShearObjectsToolController3D::ShearObjectsToolController3D(ShearObjectsTool& tool, std::weak_ptr<MapDocument> document) :
         ShearObjectsToolController{tool, std::move(document)} {}
 
         void ShearObjectsToolController3D::doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera,
                                                   Model::PickResult &pickResult) {
-            m_tool->pick3D(pickRay, camera, pickResult);
+            m_tool.pick3D(pickRay, camera, pickResult);
         }
     }
 }

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -50,12 +50,12 @@ namespace TrenchBroom {
 
         ShearObjectsToolController::~ShearObjectsToolController() = default;
 
-        Tool* ShearObjectsToolController::tool() {
-            return m_tool;
+        Tool& ShearObjectsToolController::tool() {
+            return *m_tool;
         }
 
-        const Tool* ShearObjectsToolController::tool() const {
-            return m_tool;
+        const Tool& ShearObjectsToolController::tool() const {
+            return *m_tool;
         }
 
         void ShearObjectsToolController::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -38,11 +38,11 @@ namespace TrenchBroom {
 
         class ShearObjectsToolController : public ToolController {
         protected:
-            ShearObjectsTool* m_tool;
+            ShearObjectsTool& m_tool;
         private:
             std::weak_ptr<MapDocument> m_document;
         public:
-            explicit ShearObjectsToolController(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document);
+            explicit ShearObjectsToolController(ShearObjectsTool& tool, std::weak_ptr<MapDocument> document);
             ~ShearObjectsToolController() override;
         private:
             Tool& tool() override;
@@ -64,14 +64,14 @@ namespace TrenchBroom {
 
         class ShearObjectsToolController2D : public ShearObjectsToolController {
         public:
-            explicit ShearObjectsToolController2D(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document);
+            explicit ShearObjectsToolController2D(ShearObjectsTool& tool, std::weak_ptr<MapDocument> document);
         private:
             void doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera, Model::PickResult &pickResult) override;
         };
 
         class ShearObjectsToolController3D : public ShearObjectsToolController {
         public:
-            explicit ShearObjectsToolController3D(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document);
+            explicit ShearObjectsToolController3D(ShearObjectsTool& tool, std::weak_ptr<MapDocument> document);
         private:
             void doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera, Model::PickResult &pickResult) override;
         };

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -45,8 +45,8 @@ namespace TrenchBroom {
             explicit ShearObjectsToolController(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document);
             ~ShearObjectsToolController() override;
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
             virtual void doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera, Model::PickResult &pickResult) = 0;

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -45,8 +45,8 @@ namespace TrenchBroom {
             explicit ShearObjectsToolController(ShearObjectsTool* tool, std::weak_ptr<MapDocument> document);
             ~ShearObjectsToolController() override;
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
             virtual void doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera, Model::PickResult &pickResult) = 0;

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         class MapDocument;
         class ShearObjectsTool;
 
-        class ShearObjectsToolController : public ToolControllerBase<PickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy> {
+        class ShearObjectsToolController : public ToolController {
         protected:
             ShearObjectsTool* m_tool;
         private:
@@ -48,18 +48,18 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
             virtual void doPick(const vm::ray3 &pickRay, const Renderer::Camera &camera, Model::PickResult &pickResult) = 0;
 
-            void doMouseMove(const InputState& inputState) override;
+            void mouseMove(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
 
         class ShearObjectsToolController2D : public ShearObjectsToolController {

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             m_toolBox->toggleClipTool();
         }
 
-        ClipTool* SwitchableMapViewContainer::clipTool() {
+        ClipTool& SwitchableMapViewContainer::clipTool() {
             return m_toolBox->clipTool();
         }
 
@@ -227,20 +227,20 @@ namespace TrenchBroom {
             m_toolBox->toggleFaceTool();
         }
 
-        VertexTool* SwitchableMapViewContainer::vertexTool() {
+        VertexTool& SwitchableMapViewContainer::vertexTool() {
             return m_toolBox->vertexTool();
         }
 
-        EdgeTool* SwitchableMapViewContainer::edgeTool() {
+        EdgeTool& SwitchableMapViewContainer::edgeTool() {
             return m_toolBox->edgeTool();
         }
 
-        FaceTool* SwitchableMapViewContainer::faceTool() {
+        FaceTool& SwitchableMapViewContainer::faceTool() {
             return m_toolBox->faceTool();
         }
 
-        MapViewToolBox* SwitchableMapViewContainer::mapViewToolBox() {
-            return m_toolBox.get();
+        MapViewToolBox& SwitchableMapViewContainer::mapViewToolBox() {
+            return *m_toolBox;
         }
 
         bool SwitchableMapViewContainer::canMoveCameraToNextTracePoint() const {
@@ -297,7 +297,7 @@ namespace TrenchBroom {
             m_notifierConnection += m_toolBox->refreshViewsNotifier.connect(this, &SwitchableMapViewContainer::refreshViews);
         }
 
-        void SwitchableMapViewContainer::refreshViews(Tool*) {
+        void SwitchableMapViewContainer::refreshViews(Tool&) {
             // NOTE: it doesn't work to call QWidget::update() here. The actual OpenGL view is a QWindow embedded in
             // the widget hierarchy with QWidget::createWindowContainer(), and we need to call QWindow::requestUpdate().
             m_mapView->refreshViews();

--- a/common/src/View/SwitchableMapViewContainer.h
+++ b/common/src/View/SwitchableMapViewContainer.h
@@ -86,7 +86,7 @@ namespace TrenchBroom {
             bool clipToolActive() const;
             bool canToggleClipTool() const;
             void toggleClipTool();
-            ClipTool* clipTool();
+            ClipTool& clipTool();
 
             bool rotateObjectsToolActive() const;
             bool canToggleRotateObjectsTool() const;
@@ -108,10 +108,10 @@ namespace TrenchBroom {
             void toggleVertexTool();
             void toggleEdgeTool();
             void toggleFaceTool();
-            VertexTool* vertexTool();
-            EdgeTool* edgeTool();
-            FaceTool* faceTool();
-            MapViewToolBox* mapViewToolBox();
+            VertexTool& vertexTool();
+            EdgeTool& edgeTool();
+            FaceTool& faceTool();
+            MapViewToolBox& mapViewToolBox();
 
             bool canMoveCameraToNextTracePoint() const;
             bool canMoveCameraToPreviousTracePoint() const;
@@ -123,7 +123,7 @@ namespace TrenchBroom {
             void toggleMaximizeCurrentView();
         private:
             void connectObservers();
-            void refreshViews(Tool* tool);
+            void refreshViews(Tool& tool);
         private: // implement MapView interface
             void doInstallActivationTracker(MapViewActivationTracker& activationTracker) override;
             bool doGetIsCurrent() const override;

--- a/common/src/View/Tool.cpp
+++ b/common/src/View/Tool.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             assert(!active());
             if (doActivate()) {
                 m_active = true;
-                toolActivatedNotifier(this);
+                toolActivatedNotifier(*this);
             }
             return m_active;
         }
@@ -52,17 +52,17 @@ namespace TrenchBroom {
             assert(active());
             if (doDeactivate()) {
                 m_active = false;
-                toolDeactivatedNotifier(this);
+                toolDeactivatedNotifier(*this);
             }
             return !m_active;
         }
 
         void Tool::refreshViews() {
-            refreshViewsNotifier(this);
+            refreshViewsNotifier(*this);
         }
 
         void Tool::notifyToolHandleSelectionChanged() {
-            toolHandleSelectionChangedNotifier(this);
+            toolHandleSelectionChangedNotifier(*this);
         }
 
         void Tool::createPage(QStackedLayout* book) {

--- a/common/src/View/Tool.h
+++ b/common/src/View/Tool.h
@@ -33,10 +33,10 @@ namespace TrenchBroom {
             QStackedLayout* m_book;
             int m_pageIndex;
         public:
-            Notifier<Tool*> toolActivatedNotifier;
-            Notifier<Tool*> toolDeactivatedNotifier;
-            Notifier<Tool*> refreshViewsNotifier;
-            Notifier<Tool*> toolHandleSelectionChangedNotifier;
+            Notifier<Tool&> toolActivatedNotifier;
+            Notifier<Tool&> toolDeactivatedNotifier;
+            Notifier<Tool&> refreshViewsNotifier;
+            Notifier<Tool&> toolHandleSelectionChangedNotifier;
         protected:
             explicit Tool(bool initiallyActive);
         public:

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -66,15 +66,15 @@ namespace TrenchBroom {
 
             NotifierConnection m_notifierConnection;
         public:
-            Notifier<Tool*> toolActivatedNotifier;
-            Notifier<Tool*> toolDeactivatedNotifier;
-            Notifier<Tool*> refreshViewsNotifier;
-            Notifier<Tool*> toolHandleSelectionChangedNotifier;
+            Notifier<Tool&> toolActivatedNotifier;
+            Notifier<Tool&> toolDeactivatedNotifier;
+            Notifier<Tool&> refreshViewsNotifier;
+            Notifier<Tool&> toolHandleSelectionChangedNotifier;
         public:
             ToolBox();
             ~ToolBox();
         protected:
-            void addTool(Tool* tool);
+            void addTool(Tool& tool);
         public: // picking
             void pick(ToolChain* chain, const InputState& inputState, Model::PickResult& pickResult);
         public: // event handling
@@ -106,11 +106,10 @@ namespace TrenchBroom {
              * @param suppressedTool the tool that becomes supressed while the other is active
              * @param primaryTool the tool that controls when the suppressed tool is deactivated
              */
-            void suppressWhileActive(Tool* suppressedTool, Tool* primaryTool);
+            void suppressWhileActive(Tool& suppressedTool, Tool& primaryTool);
 
             bool anyToolActive() const;
-            bool toolActive(const Tool* tool) const;
-            void toggleTool(Tool* tool);
+            void toggleTool(Tool& tool);
             void deactivateAllTools();
 
             bool enabled() const;
@@ -120,8 +119,8 @@ namespace TrenchBroom {
             void setRenderOptions(ToolChain* chain, const InputState& inputState, Renderer::RenderContext& renderContext);
             void renderTools(ToolChain* chain, const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
         private:
-            bool activateTool(Tool* tool);
-            void deactivateTool(Tool* tool);
+            bool activateTool(Tool& tool);
+            void deactivateTool(Tool& tool);
         };
     }
 }

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -61,11 +61,29 @@ namespace TrenchBroom {
         Tool* ToolController::tool() { return doGetTool(); }
         const Tool* ToolController::tool() const { return doGetTool(); }
         bool ToolController::toolActive() const { return tool()->active(); }
-        void ToolController::refreshViews() { tool()->refreshViews(); }
 
-        std::unique_ptr<DragTracker> ToolController::acceptMouseDrag(const InputState&) {
-            return nullptr;
-        }
+        void ToolController::pick(const InputState&, Model::PickResult&) {}
+
+        void ToolController::modifierKeyChange(const InputState&) {}
+
+        void ToolController::mouseDown(const InputState&) {}
+        void ToolController::mouseUp(const InputState&) {}
+        bool ToolController::mouseClick(const InputState&) { return false; }
+        bool ToolController::mouseDoubleClick(const InputState&) { return false; }
+        void ToolController::mouseMove(const InputState&) {}
+        void ToolController::mouseScroll(const InputState&) {}
+
+        std::unique_ptr<DragTracker> ToolController::acceptMouseDrag(const InputState&) { return nullptr;}
+        bool ToolController::anyToolDragging(const InputState&) const {return false; }
+
+        std::unique_ptr<DropTracker> acceptDrop(const InputState&, const std::string& /* payload */) { return nullptr; }
+
+        void ToolController::setRenderOptions(const InputState&, Renderer::RenderContext&) {}
+        void ToolController::render(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch&) {}
+
+        bool ToolController::cancel() { return false; }
+
+        void ToolController::refreshViews() { tool()->refreshViews(); }
 
         std::unique_ptr<DropTracker> ToolController::acceptDrop(const InputState&, const std::string& /* payload */) {
             return nullptr;

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -34,29 +34,6 @@
 
 namespace TrenchBroom {
     namespace View {
-        PickingPolicy::~PickingPolicy() = default;
-
-        NoPickingPolicy::~NoPickingPolicy() = default;
-        void NoPickingPolicy::doPick(const InputState&, Model::PickResult&) {}
-
-        KeyPolicy::~KeyPolicy() = default;
-
-        NoKeyPolicy::~NoKeyPolicy() = default;
-        void NoKeyPolicy::doModifierKeyChange(const InputState&) {}
-
-        MousePolicy::~MousePolicy() = default;
-
-        void MousePolicy::doMouseDown(const InputState&) {}
-        void MousePolicy::doMouseUp(const InputState&) {}
-        bool MousePolicy::doMouseClick(const InputState&) { return false; }
-        bool MousePolicy::doMouseDoubleClick(const InputState&) { return false; }
-        void MousePolicy::doMouseMove(const InputState&) {}
-        void MousePolicy::doMouseScroll(const InputState&) {}
-
-        RenderPolicy::~RenderPolicy() = default;
-        void RenderPolicy::doSetRenderOptions(const InputState&, Renderer::RenderContext&) const {}
-        void RenderPolicy::doRender(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch&) {}
-
         ToolController::~ToolController() = default;
         Tool* ToolController::tool() { return doGetTool(); }
         const Tool* ToolController::tool() const { return doGetTool(); }

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -78,7 +78,7 @@ namespace TrenchBroom {
 
         std::unique_ptr<DropTracker> acceptDrop(const InputState&, const std::string& /* payload */) { return nullptr; }
 
-        void ToolController::setRenderOptions(const InputState&, Renderer::RenderContext&) {}
+        void ToolController::setRenderOptions(const InputState&, Renderer::RenderContext&) const {}
         void ToolController::render(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch&) {}
 
         bool ToolController::cancel() { return false; }

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -97,35 +97,35 @@ namespace TrenchBroom {
             m_chain.append(std::move(controller));
         }
 
-        void ToolControllerGroup::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void ToolControllerGroup::pick(const InputState& inputState, Model::PickResult& pickResult) {
             m_chain.pick(inputState, pickResult);
         }
 
-        void ToolControllerGroup::doModifierKeyChange(const InputState& inputState) {
+        void ToolControllerGroup::modifierKeyChange(const InputState& inputState) {
             m_chain.modifierKeyChange(inputState);
         }
 
-        void ToolControllerGroup::doMouseDown(const InputState& inputState) {
+        void ToolControllerGroup::mouseDown(const InputState& inputState) {
             m_chain.mouseDown(inputState);
         }
 
-        void ToolControllerGroup::doMouseUp(const InputState& inputState) {
+        void ToolControllerGroup::mouseUp(const InputState& inputState) {
             m_chain.mouseUp(inputState);
         }
 
-        bool ToolControllerGroup::doMouseClick(const InputState& inputState) {
+        bool ToolControllerGroup::mouseClick(const InputState& inputState) {
             return m_chain.mouseClick(inputState);
         }
 
-        bool ToolControllerGroup::doMouseDoubleClick(const InputState& inputState) {
+        bool ToolControllerGroup::mouseDoubleClick(const InputState& inputState) {
             return m_chain.mouseDoubleClick(inputState);
         }
 
-        void ToolControllerGroup::doMouseMove(const InputState& inputState) {
+        void ToolControllerGroup::mouseMove(const InputState& inputState) {
             m_chain.mouseMove(inputState);
         }
 
-        void ToolControllerGroup::doMouseScroll(const InputState& inputState) {
+        void ToolControllerGroup::mouseScroll(const InputState& inputState) {
             m_chain.mouseScroll(inputState);
         }
 
@@ -144,15 +144,15 @@ namespace TrenchBroom {
             return m_chain.dragEnter(inputState, payload);
         }
 
-        void ToolControllerGroup::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void ToolControllerGroup::setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
             m_chain.setRenderOptions(inputState, renderContext);
         }
 
-        void ToolControllerGroup::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ToolControllerGroup::render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             m_chain.render(inputState, renderContext, renderBatch);
         }
 
-        bool ToolControllerGroup::doCancel() {
+        bool ToolControllerGroup::cancel() {
             return m_chain.cancel();
         }
 

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
     namespace View {
         ToolController::~ToolController() = default;
 
-        bool ToolController::toolActive() const { return tool()->active(); }
+        bool ToolController::toolActive() const { return tool().active(); }
 
         void ToolController::pick(const InputState&, Model::PickResult&) {}
 
@@ -59,7 +59,7 @@ namespace TrenchBroom {
 
         bool ToolController::cancel() { return false; }
 
-        void ToolController::refreshViews() { tool()->refreshViews(); }
+        void ToolController::refreshViews() { tool().refreshViews(); }
 
         std::unique_ptr<DropTracker> ToolController::acceptDrop(const InputState&, const std::string& /* payload */) {
             return nullptr;

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -35,8 +35,7 @@
 namespace TrenchBroom {
     namespace View {
         ToolController::~ToolController() = default;
-        Tool* ToolController::tool() { return doGetTool(); }
-        const Tool* ToolController::tool() const { return doGetTool(); }
+
         bool ToolController::toolActive() const { return tool()->active(); }
 
         void ToolController::pick(const InputState&, Model::PickResult&) {}

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -55,8 +55,8 @@ namespace TrenchBroom {
         public:
             virtual ~ToolController();
 
-            Tool* tool();
-            const Tool* tool() const;
+            virtual Tool* tool() = 0;
+            virtual const Tool* tool() const = 0;
             bool toolActive() const;
 
             virtual void pick(const InputState& inputState, Model::PickResult& pickResult);
@@ -81,9 +81,6 @@ namespace TrenchBroom {
             virtual bool cancel();
         protected:
             void refreshViews();
-        private:
-            virtual Tool* doGetTool() = 0;
-            virtual const Tool* doGetTool() const = 0;
         };
 
         class ToolControllerGroup : public ToolController {

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -112,26 +112,26 @@ namespace TrenchBroom {
             const Tool* tool() const;
             bool toolActive() const;
 
-            virtual void pick(const InputState& inputState, Model::PickResult& pickResult) = 0;
+            virtual void pick(const InputState& inputState, Model::PickResult& pickResult);
 
-            virtual void modifierKeyChange(const InputState& inputState) = 0;
+            virtual void modifierKeyChange(const InputState& inputState);
 
-            virtual void mouseDown(const InputState& inputState) = 0;
-            virtual void mouseUp(const InputState& inputState) = 0;
-            virtual bool mouseClick(const InputState& inputState) = 0;
-            virtual bool mouseDoubleClick(const InputState& inputState) = 0;
-            virtual void mouseMove(const InputState& inputState) = 0;
-            virtual void mouseScroll(const InputState& inputState) = 0;
+            virtual void mouseDown(const InputState& inputState);
+            virtual void mouseUp(const InputState& inputState);
+            virtual bool mouseClick(const InputState& inputState);
+            virtual bool mouseDoubleClick(const InputState& inputState);
+            virtual void mouseMove(const InputState& inputState);
+            virtual void mouseScroll(const InputState& inputState);
 
             virtual std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState);
-            virtual bool anyToolDragging(const InputState& inputState) const = 0;
+            virtual bool anyToolDragging(const InputState& inputState) const;
 
             virtual std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload);
 
-            virtual void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) = 0;
-            virtual void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) = 0;
+            virtual void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext);
+            virtual void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
 
-            virtual bool cancel() = 0;
+            virtual bool cancel();
         protected:
             void refreshViews();
         private:

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -128,7 +128,7 @@ namespace TrenchBroom {
 
             virtual std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload);
 
-            virtual void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext);
+            virtual void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const;
             virtual void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
 
             virtual bool cancel();
@@ -180,8 +180,8 @@ namespace TrenchBroom {
                 return inputState.anyToolDragging();
             }
 
-            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) override {
-                static_cast<RenderPolicyType*>(this)->doSetRenderOptions(inputState, renderContext);
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override {
+                static_cast<const RenderPolicyType*>(this)->doSetRenderOptions(inputState, renderContext);
             }
 
             void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -55,8 +55,8 @@ namespace TrenchBroom {
         public:
             virtual ~ToolController();
 
-            virtual Tool* tool() = 0;
-            virtual const Tool* tool() const = 0;
+            virtual Tool& tool() = 0;
+            virtual const Tool& tool() const = 0;
             bool toolActive() const;
 
             virtual void pick(const InputState& inputState, Model::PickResult& pickResult);

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -46,63 +46,10 @@ namespace TrenchBroom {
     }
 
     namespace View {
-        class InputState;
-        class Tool;
-
-        class PickingPolicy {
-        public:
-            virtual ~PickingPolicy();
-        public:
-            virtual void doPick(const InputState& inputState, Model::PickResult& pickResult) = 0;
-        };
-
-        class NoPickingPolicy : public PickingPolicy {
-        public:
-            ~NoPickingPolicy() override;
-        public:
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
-        };
-
-        class KeyPolicy {
-        public:
-            virtual ~KeyPolicy();
-        public:
-            virtual void doModifierKeyChange(const InputState& inputState) = 0;
-        };
-
-        class NoKeyPolicy : public KeyPolicy {
-        public:
-            ~NoKeyPolicy() override;
-        public:
-            void doModifierKeyChange(const InputState& inputState) override;
-        };
-
-        class MousePolicy {
-        public:
-            virtual ~MousePolicy();
-        public:
-            virtual void doMouseDown(const InputState& inputState);
-            virtual void doMouseUp(const InputState& inputState);
-            virtual bool doMouseClick(const InputState& inputState);
-            virtual bool doMouseDoubleClick(const InputState& inputState);
-            virtual void doMouseMove(const InputState& inputState);
-            virtual void doMouseScroll(const InputState& inputState);
-        };
-
-        using NoMousePolicy = MousePolicy;
-
-        class RenderPolicy {
-        public:
-            virtual ~RenderPolicy();
-        public:
-            virtual void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const;
-            virtual void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
-        };
-
-        using NoRenderPolicy = RenderPolicy;
-
         class DragTracker;
         class DropTracker;
+        class InputState;
+        class Tool;
 
         class ToolController {
         public:
@@ -137,62 +84,6 @@ namespace TrenchBroom {
         private:
             virtual Tool* doGetTool() = 0;
             virtual const Tool* doGetTool() const = 0;
-        };
-
-        template <class PickingPolicyType, class KeyPolicyType, class MousePolicyType, class RenderPolicyType>
-        class ToolControllerBase : public ToolController, protected PickingPolicyType, protected KeyPolicyType, protected MousePolicyType, protected RenderPolicyType {
-        public:
-            ~ToolControllerBase() override = default;
-
-            void pick(const InputState& inputState, Model::PickResult& pickResult) override {
-                static_cast<PickingPolicyType*>(this)->doPick(inputState, pickResult);
-            }
-
-            void modifierKeyChange(const InputState& inputState) override {
-                static_cast<KeyPolicyType*>(this)->doModifierKeyChange(inputState);
-            }
-
-            void mouseDown(const InputState& inputState) override {
-                static_cast<MousePolicyType*>(this)->doMouseDown(inputState);
-            }
-
-            void mouseUp(const InputState& inputState) override {
-                static_cast<MousePolicyType*>(this)->doMouseUp(inputState);
-            }
-
-            bool mouseClick(const InputState& inputState) override {
-                return static_cast<MousePolicyType*>(this)->doMouseClick(inputState);
-            }
-
-            bool mouseDoubleClick(const InputState& inputState) override {
-                return static_cast<MousePolicyType*>(this)->doMouseDoubleClick(inputState);
-            }
-
-            void mouseMove(const InputState& inputState) override {
-                static_cast<MousePolicyType*>(this)->doMouseMove(inputState);
-            }
-
-            void mouseScroll(const InputState& inputState) override {
-                static_cast<MousePolicyType*>(this)->doMouseScroll(inputState);
-            }
-
-            bool anyToolDragging(const InputState& inputState) const override {
-                return inputState.anyToolDragging();
-            }
-
-            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override {
-                static_cast<const RenderPolicyType*>(this)->doSetRenderOptions(inputState, renderContext);
-            }
-
-            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
-                static_cast<RenderPolicyType*>(this)->doRender(inputState, renderContext, renderBatch);
-            }
-
-            bool cancel() override {
-                return doCancel();
-            }
-        private:
-            virtual bool doCancel() = 0;
         };
 
         class ToolControllerGroup : public ToolController {

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -195,7 +195,7 @@ namespace TrenchBroom {
             virtual bool doCancel() = 0;
         };
 
-        class ToolControllerGroup : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy> {
+        class ToolControllerGroup : public ToolController {
         private:
             ToolChain m_chain;
         public:
@@ -203,25 +203,25 @@ namespace TrenchBroom {
             ~ToolControllerGroup() override;
         protected:
             void addController(std::unique_ptr<ToolController> controller);
-        protected:
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+        public:
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-            void doModifierKeyChange(const InputState& inputState) override;
+            void modifierKeyChange(const InputState& inputState) override;
 
-            void doMouseDown(const InputState& inputState) override;
-            void doMouseUp(const InputState& inputState) override;
-            bool doMouseClick(const InputState& inputState) override;
-            bool doMouseDoubleClick(const InputState& inputState) override;
-            void doMouseMove(const InputState& inputState) override;
-            void doMouseScroll(const InputState& inputState) override;
+            void mouseDown(const InputState& inputState) override;
+            void mouseUp(const InputState& inputState) override;
+            bool mouseClick(const InputState& inputState) override;
+            bool mouseDoubleClick(const InputState& inputState) override;
+            void mouseMove(const InputState& inputState) override;
+            void mouseScroll(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
             std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload) override;
 
-            void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         private: // subclassing interface
             virtual bool doShouldHandleMouseDrag(const InputState& inputState) const;
             virtual bool doShouldHandleDrop(const InputState& inputState, const std::string& payload) const;

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -32,12 +32,12 @@ namespace TrenchBroom {
         Tool{true},
         m_camera{camera} {}
 
-        Tool* UVCameraTool::tool() {
-            return this;
+        Tool& UVCameraTool::tool() {
+            return *this;
         }
 
-        const Tool* UVCameraTool::tool() const {
-            return this;
+        const Tool& UVCameraTool::tool() const {
+            return *this;
         }
 
         void UVCameraTool::mouseScroll(const InputState& inputState) {

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -28,7 +28,7 @@
 namespace TrenchBroom {
     namespace View {
         UVCameraTool::UVCameraTool(Renderer::OrthographicCamera& camera) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_camera{camera} {}
 
@@ -40,7 +40,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        void UVCameraTool::doMouseScroll(const InputState& inputState) {
+        void UVCameraTool::mouseScroll(const InputState& inputState) {
             const auto oldWorldPos = m_camera.unproject(float(inputState.mouseX()), float(inputState.mouseY()), 0.0f);
 
             // NOTE: some events will have scrollY() == 0, and have horizontal scorlling. We only care about scrollY().
@@ -94,7 +94,7 @@ namespace TrenchBroom {
             return std::make_unique<UVCameraToolDragTracker>(m_camera);
         }
 
-        bool UVCameraTool::doCancel() {
+        bool UVCameraTool::cancel() {
             return false;
         }
     }

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -32,11 +32,11 @@ namespace TrenchBroom {
         Tool{true},
         m_camera{camera} {}
 
-        Tool* UVCameraTool::doGetTool() {
+        Tool* UVCameraTool::tool() {
             return this;
         }
 
-        const Tool* UVCameraTool::doGetTool() const {
+        const Tool* UVCameraTool::tool() const {
             return this;
         }
 

--- a/common/src/View/UVCameraTool.h
+++ b/common/src/View/UVCameraTool.h
@@ -38,8 +38,8 @@ namespace TrenchBroom {
         public:
             explicit UVCameraTool(Renderer::OrthographicCamera& camera);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void mouseScroll(const InputState& inputState) override;
 

--- a/common/src/View/UVCameraTool.h
+++ b/common/src/View/UVCameraTool.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
     namespace View {
         class DragTracker;
 
-        class UVCameraTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
+        class UVCameraTool : public ToolController, public Tool {
         private:
             Renderer::OrthographicCamera& m_camera;
         public:
@@ -41,11 +41,11 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doMouseScroll(const InputState& inputState) override;
+            void mouseScroll(const InputState& inputState) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/UVCameraTool.h
+++ b/common/src/View/UVCameraTool.h
@@ -38,8 +38,8 @@ namespace TrenchBroom {
         public:
             explicit UVCameraTool(Renderer::OrthographicCamera& camera);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void mouseScroll(const InputState& inputState) override;
 

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -41,7 +41,7 @@
 namespace TrenchBroom {
     namespace View {
         UVOffsetTool::UVOffsetTool(std::weak_ptr<MapDocument> document, const UVViewHelper& helper) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_document{std::move(document)},
         m_helper{helper} {}
@@ -139,7 +139,7 @@ namespace TrenchBroom {
             return std::make_unique<UVOffsetDragTracker>(*kdl::mem_lock(m_document), m_helper, inputState);
         }
 
-        bool UVOffsetTool::doCancel() {
+        bool UVOffsetTool::cancel() {
             return false;
         }
     }

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -46,11 +46,11 @@ namespace TrenchBroom {
         m_document{std::move(document)},
         m_helper{helper} {}
 
-        Tool* UVOffsetTool::doGetTool() {
+        Tool* UVOffsetTool::tool() {
             return this;
         }
 
-        const Tool* UVOffsetTool::doGetTool() const {
+        const Tool* UVOffsetTool::tool() const {
             return this;
         }
 

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -46,12 +46,12 @@ namespace TrenchBroom {
         m_document{std::move(document)},
         m_helper{helper} {}
 
-        Tool* UVOffsetTool::tool() {
-            return this;
+        Tool& UVOffsetTool::tool() {
+            return *this;
         }
 
-        const Tool* UVOffsetTool::tool() const {
-            return this;
+        const Tool& UVOffsetTool::tool() const {
+            return *this;
         }
 
         static vm::vec2f computeHitPoint(const UVViewHelper& helper, const vm::ray3& ray) {

--- a/common/src/View/UVOffsetTool.h
+++ b/common/src/View/UVOffsetTool.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVOffsetTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy>, public Tool {
+        class UVOffsetTool : public ToolController, public Tool {
         private:
             std::weak_ptr<MapDocument> m_document;
             const UVViewHelper& m_helper;
@@ -42,7 +42,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/UVOffsetTool.h
+++ b/common/src/View/UVOffsetTool.h
@@ -37,8 +37,8 @@ namespace TrenchBroom {
         public:
             UVOffsetTool(std::weak_ptr<MapDocument> document, const UVViewHelper& helper);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/UVOffsetTool.h
+++ b/common/src/View/UVOffsetTool.h
@@ -37,8 +37,8 @@ namespace TrenchBroom {
         public:
             UVOffsetTool(std::weak_ptr<MapDocument> document, const UVViewHelper& helper);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -62,12 +62,12 @@ namespace TrenchBroom {
         Tool{true},
         m_helper{helper} {}
 
-        Tool* UVOriginTool::tool() {
-            return this;
+        Tool& UVOriginTool::tool() {
+            return *this;
         }
 
-        const Tool* UVOriginTool::tool() const {
-            return this;
+        const Tool& UVOriginTool::tool() const {
+            return *this;
         }
 
         static std::tuple<vm::line3, vm::line3> computeOriginHandles(const UVViewHelper& helper) {

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -58,7 +58,7 @@ namespace TrenchBroom {
         const float UVOriginTool::OriginHandleRadius =  5.0f;
 
         UVOriginTool::UVOriginTool(UVViewHelper& helper) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_helper{helper} {}
 
@@ -81,7 +81,7 @@ namespace TrenchBroom {
             };
         }
 
-        void UVOriginTool::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void UVOriginTool::pick(const InputState& inputState, Model::PickResult& pickResult) {
             if (m_helper.valid()) {
                 const auto [xHandle, yHandle] = computeOriginHandles(m_helper);
 
@@ -317,7 +317,7 @@ namespace TrenchBroom {
             return std::make_unique<UVOriginDragTracker>(m_helper, inputState);
         }
 
-        void UVOriginTool::doRender(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
+        void UVOriginTool::render(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             if (!m_helper.valid() || anyToolDragging(inputState)) {
                 return;
             }
@@ -336,7 +336,7 @@ namespace TrenchBroom {
             renderOriginHandle(m_helper, xHandleHit.isMatch() || yHandleHit.isMatch(), renderBatch);
         }
 
-        bool UVOriginTool::doCancel() {
+        bool UVOriginTool::cancel() {
             return false;
         }
     }

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -62,11 +62,11 @@ namespace TrenchBroom {
         Tool{true},
         m_helper{helper} {}
 
-        Tool* UVOriginTool::doGetTool() {
+        Tool* UVOriginTool::tool() {
             return this;
         }
 
-        const Tool* UVOriginTool::doGetTool() const {
+        const Tool* UVOriginTool::tool() const {
             return this;
         }
 

--- a/common/src/View/UVOriginTool.h
+++ b/common/src/View/UVOriginTool.h
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         class DragTracker;
         class UVViewHelper;
 
-        class UVOriginTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy>, public Tool {
+        class UVOriginTool : public ToolController, public Tool {
         public:
             static const Model::HitType::Type XHandleHitType;
             static const Model::HitType::Type YHandleHitType;
@@ -53,13 +53,13 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/UVOriginTool.h
+++ b/common/src/View/UVOriginTool.h
@@ -50,8 +50,8 @@ namespace TrenchBroom {
         public:
             explicit UVOriginTool(UVViewHelper& helper);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVOriginTool.h
+++ b/common/src/View/UVOriginTool.h
@@ -50,8 +50,8 @@ namespace TrenchBroom {
         public:
             explicit UVOriginTool(UVViewHelper& helper);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
         static constexpr auto RotateHandleWidth  =  5.0;
 
         UVRotateTool::UVRotateTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_document{document},
         m_helper{helper} {}
@@ -73,7 +73,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        void UVRotateTool::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void UVRotateTool::pick(const InputState& inputState, Model::PickResult& pickResult) {
             if (!m_helper.valid()) {
                 return;
             }
@@ -304,7 +304,7 @@ namespace TrenchBroom {
             return std::make_unique<UVRotateDragTracker>(*kdl::mem_lock(m_document), m_helper, *initialAngle);
         }
 
-        void UVRotateTool::doRender(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
+        void UVRotateTool::render(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             using namespace Model::HitFilters;
 
             if (anyToolDragging(inputState) || !m_helper.valid() || !m_helper.face()->attributes().valid()) {
@@ -315,7 +315,7 @@ namespace TrenchBroom {
             renderBatch.addOneShot(new Render{m_helper, static_cast<float>(CenterHandleRadius), static_cast<float>(RotateHandleRadius), highlight});
         }
 
-        bool UVRotateTool::doCancel() {
+        bool UVRotateTool::cancel() {
             return false;
         }
     }

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -65,12 +65,12 @@ namespace TrenchBroom {
         m_document{document},
         m_helper{helper} {}
 
-        Tool* UVRotateTool::tool() {
-            return this;
+        Tool& UVRotateTool::tool() {
+            return *this;
         }
 
-        const Tool* UVRotateTool::tool() const {
-            return this;
+        const Tool& UVRotateTool::tool() const {
+            return *this;
         }
 
         void UVRotateTool::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -65,11 +65,11 @@ namespace TrenchBroom {
         m_document{document},
         m_helper{helper} {}
 
-        Tool* UVRotateTool::doGetTool() {
+        Tool* UVRotateTool::tool() {
             return this;
         }
 
-        const Tool* UVRotateTool::doGetTool() const {
+        const Tool* UVRotateTool::tool() const {
             return this;
         }
 

--- a/common/src/View/UVRotateTool.h
+++ b/common/src/View/UVRotateTool.h
@@ -49,8 +49,8 @@ namespace TrenchBroom {
         public:
             UVRotateTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVRotateTool.h
+++ b/common/src/View/UVRotateTool.h
@@ -49,8 +49,8 @@ namespace TrenchBroom {
         public:
             UVRotateTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVRotateTool.h
+++ b/common/src/View/UVRotateTool.h
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVRotateTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy>, public Tool {
+        class UVRotateTool : public ToolController, public Tool {
         public:
             static const Model::HitType::Type AngleHandleHitType;
         private:
@@ -52,13 +52,13 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -58,12 +58,12 @@ namespace TrenchBroom {
         m_document{std::move(document)},
         m_helper{helper} {}
 
-        Tool* UVScaleTool::tool() {
-            return this;
+        Tool& UVScaleTool::tool() {
+            return *this;
         }
 
-        const Tool* UVScaleTool::tool() const {
-            return this;
+        const Tool& UVScaleTool::tool() const {
+            return *this;
         }
 
         void UVScaleTool::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
         const Model::HitType::Type UVScaleTool::YHandleHitType = Model::HitType::freeType();
 
         UVScaleTool::UVScaleTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_document{std::move(document)},
         m_helper{helper} {}
@@ -66,7 +66,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        void UVScaleTool::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void UVScaleTool::pick(const InputState& inputState, Model::PickResult& pickResult) {
             static const Model::HitType::Type HitTypes[] = { XHandleHitType, YHandleHitType };
             if (m_helper.valid()) {
                 m_helper.pickTextureGrid(inputState.pickRay(), HitTypes, pickResult);
@@ -257,7 +257,7 @@ namespace TrenchBroom {
             return std::make_unique<UVScaleDragTracker>(*kdl::mem_lock(m_document), m_helper, handle, selector, initialHitPoint);
         }
 
-        void UVScaleTool::doRender(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
+        void UVScaleTool::render(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             using namespace Model::HitFilters;
 
             if (anyToolDragging(inputState) || !m_helper.valid() || !m_helper.face()->attributes().valid()) {
@@ -280,7 +280,7 @@ namespace TrenchBroom {
             renderHighlight(m_helper, handle, selector, renderBatch);
         }
 
-        bool UVScaleTool::doCancel() {
+        bool UVScaleTool::cancel() {
             return false;
         }
     }

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -58,11 +58,11 @@ namespace TrenchBroom {
         m_document{std::move(document)},
         m_helper{helper} {}
 
-        Tool* UVScaleTool::doGetTool() {
+        Tool* UVScaleTool::tool() {
             return this;
         }
 
-        const Tool* UVScaleTool::doGetTool() const {
+        const Tool* UVScaleTool::tool() const {
             return this;
         }
 

--- a/common/src/View/UVScaleTool.h
+++ b/common/src/View/UVScaleTool.h
@@ -41,7 +41,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVScaleTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy>, public Tool {
+        class UVScaleTool : public ToolController, public Tool {
         public:
             static const Model::HitType::Type XHandleHitType;
             static const Model::HitType::Type YHandleHitType;
@@ -54,13 +54,13 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/UVScaleTool.h
+++ b/common/src/View/UVScaleTool.h
@@ -51,8 +51,8 @@ namespace TrenchBroom {
         public:
             UVScaleTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVScaleTool.h
+++ b/common/src/View/UVScaleTool.h
@@ -51,8 +51,8 @@ namespace TrenchBroom {
         public:
             UVScaleTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -45,12 +45,12 @@ namespace TrenchBroom {
         m_document{document},
         m_helper{helper} {}
 
-        Tool* UVShearTool::tool() {
-            return this;
+        Tool& UVShearTool::tool() {
+            return *this;
         }
 
-        const Tool* UVShearTool::tool() const {
-            return this;
+        const Tool& UVShearTool::tool() const {
+            return *this;
         }
 
         void UVShearTool::pick(const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -45,11 +45,11 @@ namespace TrenchBroom {
         m_document{document},
         m_helper{helper} {}
 
-        Tool* UVShearTool::doGetTool() {
+        Tool* UVShearTool::tool() {
             return this;
         }
 
-        const Tool* UVShearTool::doGetTool() const {
+        const Tool* UVShearTool::tool() const {
             return this;
         }
 

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         const Model::HitType::Type UVShearTool::YHandleHitType = Model::HitType::freeType();
 
         UVShearTool::UVShearTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper) :
-        ToolControllerBase{},
+        ToolController{},
         Tool{true},
         m_document{document},
         m_helper{helper} {}
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        void UVShearTool::doPick(const InputState& inputState, Model::PickResult& pickResult) {
+        void UVShearTool::pick(const InputState& inputState, Model::PickResult& pickResult) {
             static const Model::HitType::Type HitTypes[] = { XHandleHitType, YHandleHitType };
             if (m_helper.valid()) {
                 m_helper.pickTextureGrid(inputState.pickRay(), HitTypes, pickResult);
@@ -171,7 +171,7 @@ namespace TrenchBroom {
             return std::make_unique<UVShearDragTracker>(*kdl::mem_lock(m_document), m_helper, selector, xAxis, yAxis, initialHit);
         }
 
-        bool UVShearTool::doCancel() {
+        bool UVShearTool::cancel() {
             return false;
         }
     }

--- a/common/src/View/UVShearTool.h
+++ b/common/src/View/UVShearTool.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         public:
             UVShearTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper);
         private:
-            Tool* tool() override;
-            const Tool* tool() const override;
+            Tool& tool() override;
+            const Tool& tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/UVShearTool.h
+++ b/common/src/View/UVShearTool.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVShearTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy>, public Tool {
+        class UVShearTool : public ToolController, public Tool {
         private:
             static const Model::HitType::Type XHandleHitType;
             static const Model::HitType::Type YHandleHitType;
@@ -44,11 +44,11 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
+            void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
             std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
 
-            bool doCancel() override;
+            bool cancel() override;
         };
     }
 }

--- a/common/src/View/UVShearTool.h
+++ b/common/src/View/UVShearTool.h
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         public:
             UVShearTool(std::weak_ptr<MapDocument> document, UVViewHelper& helper);
         private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            Tool* tool() override;
+            const Tool* tool() const override;
 
             void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -73,7 +73,7 @@ namespace TrenchBroom {
 
         class VertexToolController::SelectVertexPart : public SelectPartBase<vm::vec3> {
         public:
-            explicit SelectVertexPart(VertexTool* tool) :
+            explicit SelectVertexPart(VertexTool& tool) :
             SelectPartBase(tool, VertexHandleManager::HandleHitType) {}
         private:
             Model::Hit doFindDraggableHandle(const InputState& inputState) const override {
@@ -91,20 +91,20 @@ namespace TrenchBroom {
 
         class VertexToolController::MoveVertexPart : public MovePartBase {
         public:
-            explicit MoveVertexPart(VertexTool* tool) :
+            explicit MoveVertexPart(VertexTool& tool) :
             MovePartBase(tool, VertexHandleManager::HandleHitType) {}
         private:
             bool mouseClick(const InputState& inputState) override {
                 if (inputState.mouseButtonsPressed(MouseButtons::MBLeft) &&
                     inputState.modifierKeysPressed(ModifierKeys::MKAlt | ModifierKeys::MKShift) &&
-                    m_tool->handleManager().selectedHandleCount() == 1) {
+                    m_tool.handleManager().selectedHandleCount() == 1) {
 
                     const Model::Hit hit = VertexToolController::findHandleHit(inputState, *this);
                     if (hit.hasType(VertexHandleManager::HandleHitType)) {
-                        const vm::vec3 sourcePos = m_tool->handleManager().selectedHandles().front();
+                        const vm::vec3 sourcePos = m_tool.handleManager().selectedHandles().front();
                         const vm::vec3 targetPos = hit.target<vm::vec3>();
                         const vm::vec3 delta = targetPos - sourcePos;
-                        m_tool->moveSelection(delta);
+                        m_tool.moveSelection(delta);
                         return true;
                     }
                 }
@@ -131,12 +131,12 @@ namespace TrenchBroom {
                 if (!anyToolDragging(inputState)) {
                     const Model::Hit hit = findDraggableHandle(inputState);
                     if (hit.hasType(EdgeHandleManager::HandleHitType | FaceHandleManager::HandleHitType)) {
-                        const vm::vec3 handle = m_tool->getHandlePosition(hit);
+                        const vm::vec3 handle = m_tool.getHandlePosition(hit);
                         if (inputState.mouseButtonsPressed(MouseButtons::MBLeft))
-                            m_tool->renderHandle(renderContext, renderBatch, handle, pref(Preferences::SelectedHandleColor));
+                            m_tool.renderHandle(renderContext, renderBatch, handle, pref(Preferences::SelectedHandleColor));
                         else
-                            m_tool->renderHandle(renderContext, renderBatch, handle);
-                        m_tool->renderHighlight(renderContext, renderBatch, handle);
+                            m_tool.renderHandle(renderContext, renderBatch, handle);
+                        m_tool.renderHighlight(renderContext, renderBatch, handle);
                     }
                 }
             }
@@ -150,7 +150,7 @@ namespace TrenchBroom {
             }
         };
 
-        VertexToolController::VertexToolController(VertexTool* tool) :
+        VertexToolController::VertexToolController(VertexTool& tool) :
         VertexToolControllerBase(tool) {
             addController(std::make_unique<MoveVertexPart>(tool));
             addController(std::make_unique<SelectVertexPart>(tool));

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -94,7 +94,7 @@ namespace TrenchBroom {
             explicit MoveVertexPart(VertexTool* tool) :
             MovePartBase(tool, VertexHandleManager::HandleHitType) {}
         private:
-            bool doMouseClick(const InputState& inputState) override {
+            bool mouseClick(const InputState& inputState) override {
                 if (inputState.mouseButtonsPressed(MouseButtons::MBLeft) &&
                     inputState.modifierKeysPressed(ModifierKeys::MKAlt | ModifierKeys::MKShift) &&
                     m_tool->handleManager().selectedHandleCount() == 1) {
@@ -125,8 +125,8 @@ namespace TrenchBroom {
                         ));
             }
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
-                MovePartBase::doRender(inputState, renderContext, renderBatch);
+            void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
+                MovePartBase::render(inputState, renderContext, renderBatch);
 
                 if (!anyToolDragging(inputState)) {
                     const Model::Hit hit = findDraggableHandle(inputState);

--- a/common/src/View/VertexToolController.h
+++ b/common/src/View/VertexToolController.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
             class SelectVertexPart;
             class MoveVertexPart;
         public:
-            VertexToolController(VertexTool* tool);
+            VertexToolController(VertexTool& tool);
         };
     }
 }

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -140,12 +140,12 @@ namespace TrenchBroom {
                 using PartBase::m_hitType;
                 using PartBase::findDraggableHandle;
             private:
-                Tool* tool() override {
-                    return m_tool;
+                Tool& tool() override {
+                    return *m_tool;
                 }
 
-                const Tool* tool() const override {
-                    return m_tool;
+                const Tool& tool() const override {
+                    return *m_tool;
                 }
 
                 void pick(const InputState& inputState, Model::PickResult& pickResult) override {
@@ -299,12 +299,12 @@ namespace TrenchBroom {
                 using PartBase::findDraggableHandle;
                 using PartBase::findDraggableHandles;
             protected:
-                Tool* tool() override {
-                    return m_tool;
+                Tool& tool() override {
+                    return *m_tool;
                 }
 
-                const Tool* tool() const override {
-                    return m_tool;
+                const Tool& tool() const override {
+                    return *m_tool;
                 }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
@@ -345,12 +345,12 @@ namespace TrenchBroom {
         public:
             ~VertexToolControllerBase() override = default;
         private:
-            Tool* tool() override {
-                return m_tool;
+            Tool& tool() override {
+                return *m_tool;
             }
 
-            const Tool* tool() const override {
-                return m_tool;
+            const Tool& tool() const override {
+                return *m_tool;
             }
         };
     }

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -140,11 +140,11 @@ namespace TrenchBroom {
                 using PartBase::m_hitType;
                 using PartBase::findDraggableHandle;
             private:
-                Tool* doGetTool() override {
+                Tool* tool() override {
                     return m_tool;
                 }
 
-                const Tool* doGetTool() const override {
+                const Tool* tool() const override {
                     return m_tool;
                 }
 
@@ -299,11 +299,11 @@ namespace TrenchBroom {
                 using PartBase::findDraggableHandle;
                 using PartBase::findDraggableHandles;
             protected:
-                Tool* doGetTool() override {
+                Tool* tool() override {
                     return m_tool;
                 }
 
-                const Tool* doGetTool() const override {
+                const Tool* tool() const override {
                     return m_tool;
                 }
 
@@ -345,11 +345,11 @@ namespace TrenchBroom {
         public:
             ~VertexToolControllerBase() override = default;
         private:
-            Tool* doGetTool() override {
+            Tool* tool() override {
                 return m_tool;
             }
 
-            const Tool* doGetTool() const override {
+            const Tool* tool() const override {
                 return m_tool;
             }
         };

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -131,7 +131,7 @@ namespace TrenchBroom {
             };
 
             template <typename H>
-            class SelectPartBase : public ToolControllerBase<PickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, public PartBase {
+            class SelectPartBase : public ToolController, public PartBase {
             protected:
                 SelectPartBase(T* tool, const Model::HitType::Type hitType) :
                 PartBase{tool, hitType} {}
@@ -148,11 +148,11 @@ namespace TrenchBroom {
                     return m_tool;
                 }
 
-                void doPick(const InputState& inputState, Model::PickResult& pickResult) override {
+                void pick(const InputState& inputState, Model::PickResult& pickResult) override {
                     m_tool->pick(inputState.pickRay(), inputState.camera(), pickResult);
                 }
 
-                bool doMouseClick(const InputState& inputState) override {
+                bool mouseClick(const InputState& inputState) override {
                     if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft) ||
                         !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No)) {
                         return false;
@@ -184,15 +184,15 @@ namespace TrenchBroom {
                     return createHandleDragTracker(LassoDragDelegate{*m_tool}, inputState, initialPoint, vm::vec3::zero());
                 }
 
-                bool doCancel() override {
+                bool cancel() override {
                     return m_tool->deselectAll();
                 }
             protected:
-                void doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const override {
+                void setRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const override {
                     renderContext.setForceHideSelectionGuide();
                 }
 
-                void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
+                void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
                     m_tool->renderHandles(renderContext, renderBatch);
                     if (!anyToolDragging(inputState)) {
                         const auto hit = findDraggableHandle(inputState);
@@ -288,7 +288,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class MovePartBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, public PartBase {
+            class MovePartBase : public ToolController, public PartBase {
             protected:
                 MovePartBase(T* tool, const Model::HitType::Type hitType) :
                 PartBase{tool, hitType} {}
@@ -305,10 +305,6 @@ namespace TrenchBroom {
 
                 const Tool* doGetTool() const override {
                     return m_tool;
-                }
-
-                bool doCancel() override {
-                    return m_tool->deselectAll();
                 }
 
                 std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override {
@@ -328,6 +324,10 @@ namespace TrenchBroom {
                     const auto [initialHandlePosition, handleOffset] = m_tool->handlePositionAndOffset(hits);
 
                     return createMoveHandleDragTracker(MoveDragDelegate{*m_tool}, inputState, initialHandlePosition, handleOffset);
+                }
+
+                bool cancel() override {
+                    return m_tool->deselectAll();
                 }
 
                 // Overridden in vertex tool controller to handle special cases for vertex moving.

--- a/common/test/src/View/ClipToolControllerTest.cpp
+++ b/common/test/src/View/ClipToolControllerTest.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             REQUIRE(document->paste(data) == PasteType::Node);
 
             ClipTool tool(document);
-            ClipToolController3D controller(&tool);
+            ClipToolController3D controller(tool);
 
             CHECK(tool.activate());
 


### PR DESCRIPTION
This PR refactors the cool controller system. In a first step, we get rid of the policy pattern and the `ToolControllerBase` class and use `ToolController` as the base class of all tool controllers directly.