### PR TITLE
3768: Prevent face actions from being blocked in maps with linked groups

### DIFF
--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -98,8 +98,8 @@ namespace TrenchBroom {
         }
         
         Brush BrushNode::setBrush(Brush brush) {
-            const NotifyNodeChange nodeChange(this);
-            const NotifyPhysicalBoundsChange boundsChange(this);
+            const auto nodeChange = NotifyNodeChange{*this};
+            const auto boundsChange = NotifyPhysicalBoundsChange{*this};
 
             using std::swap;
             swap(m_brush, brush);

--- a/common/src/Model/EntityNodeBase.cpp
+++ b/common/src/Model/EntityNodeBase.cpp
@@ -107,7 +107,7 @@ namespace TrenchBroom {
         }
 
         Entity EntityNodeBase::setEntity(Entity entity) {
-            const NotifyPropertyChange notifyChange(this);
+            const auto notifyChange = NotifyPropertyChange{*this};
             updateIndexAndLinks(entity.properties());
 
             using std::swap;
@@ -120,20 +120,19 @@ namespace TrenchBroom {
                 return;
             }
 
-            const NotifyPropertyChange notifyChange(this);
+            const auto notifyChange = NotifyPropertyChange{*this};
             m_entity.setDefinition(entityPropertyConfig(), definition);
         }
 
-        EntityNodeBase::NotifyPropertyChange::NotifyPropertyChange(EntityNodeBase* node) :
-        m_nodeChange(node),
-        m_node(node),
-        m_oldPhysicalBounds(node->physicalBounds()) {
-            ensure(m_node != nullptr, "node is null");
-            m_node->propertiesWillChange();
+        EntityNodeBase::NotifyPropertyChange::NotifyPropertyChange(EntityNodeBase& node) :
+        m_nodeChange{node},
+        m_node{node},
+        m_oldPhysicalBounds{node.physicalBounds()} {
+            m_node.propertiesWillChange();
         }
 
         EntityNodeBase::NotifyPropertyChange::~NotifyPropertyChange() {
-            m_node->propertiesDidChange(m_oldPhysicalBounds);
+            m_node.propertiesDidChange(m_oldPhysicalBounds);
         }
 
         void EntityNodeBase::propertiesWillChange() {}

--- a/common/src/Model/EntityNodeBase.h
+++ b/common/src/Model/EntityNodeBase.h
@@ -61,10 +61,10 @@ namespace TrenchBroom {
             class NotifyPropertyChange {
             private:
                 NotifyNodeChange m_nodeChange;
-                EntityNodeBase* m_node;
+                EntityNodeBase& m_node;
                 vm::bbox3 m_oldPhysicalBounds;
             public:
-                NotifyPropertyChange(EntityNodeBase* node);
+                NotifyPropertyChange(EntityNodeBase& node);
                 ~NotifyPropertyChange();
             };
 

--- a/common/src/Model/ModelUtils.cpp
+++ b/common/src/Model/ModelUtils.cpp
@@ -134,6 +134,26 @@ namespace TrenchBroom {
             return result;
         }
 
+        std::vector<Model::GroupNode*> findAllLinkedGroups(Model::WorldNode& worldNode) {
+            auto result = std::vector<Model::GroupNode*>{};
+
+            worldNode.accept(kdl::overload(
+                [] (auto&& thisLambda, Model::WorldNode* w) { w->visitChildren(thisLambda); },
+                [] (auto&& thisLambda, Model::LayerNode* l) { l->visitChildren(thisLambda); },
+                [&](auto&& thisLambda, Model::GroupNode* g) {
+                    if (g->group().linkedGroupId()) {
+                        result.push_back(g);
+                    }
+                    g->visitChildren(thisLambda);
+                },
+                [] (Model::EntityNode*) {},
+                [] (Model::BrushNode*)  {},
+                [] (Model::PatchNode*)  {}
+            ));
+
+            return result;
+        }
+
         static void collectWithParents(Node* node, std::vector<Node*>& result) {
             if (node != nullptr) {
                 node->accept(kdl::overload(

--- a/common/src/Model/ModelUtils.h
+++ b/common/src/Model/ModelUtils.h
@@ -55,6 +55,7 @@ namespace TrenchBroom {
         GroupNode* findOutermostClosedGroup(Node* node);
 
         std::vector<Model::GroupNode*> findLinkedGroups(Model::WorldNode& worldNode, const std::string& linkedGroupId);
+        std::vector<Model::GroupNode*> findAllLinkedGroups(Model::WorldNode& worldNode);
 
         std::vector<Node*> collectParents(const std::vector<Node*>& nodes);
         std::vector<Node*> collectParents(const std::map<Node*, std::vector<Node*>>& nodes);

--- a/common/src/Model/ModelUtils.h
+++ b/common/src/Model/ModelUtils.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "Model/BrushFaceHandle.h"
 #include "Model/HitType.h"
 #include "Model/Node.h"
 
@@ -83,6 +84,39 @@ namespace TrenchBroom {
 
         std::vector<BrushNode*> filterBrushNodes(const std::vector<Node*>& nodes);
         std::vector<EntityNode*> filterEntityNodes(const std::vector<Node*>& nodes);
+
+        struct SelectionResult {
+            std::vector<Model::Node*> nodesToSelect;
+            std::vector<Model::GroupNode*> groupsToLock;
+        };
+
+        /**
+         * Given a list of `nodes` the user wants to select, returns the subset that we should allow selection of,
+         * as well as a list of linked groups to lock.
+         *
+         * - Attempting to select nodes inside a linked group will propose locking all other groups in that link set.
+         *  This is intended to prevent users from making conflicting commands as well as communicate which
+         *  specific linked group they are modifying.
+         *
+         * - If `nodes` contains members of different groups in the same link set,
+         *  only those in the first group will be allowed to be selected ("first" in the order of `nodes`).
+         *
+         * Note: no changes are made, just the proposed selection and locking is returned.
+         */
+        SelectionResult nodeSelectionWithLinkedGroupConstraints(Model::WorldNode& world, const std::vector<Model::Node*>& nodes);
+
+        struct FaceSelectionResult {
+            std::vector<Model::BrushFaceHandle> facesToSelect;
+            std::vector<Model::GroupNode*> groupsToLock;
+        };
+
+        /**
+         * Given a list of `faces` the user wants to select, returns the subset that we should allow selection of,
+         * as well as a list of linked groups to lock.
+         *
+         * @see nodeSelectionWithLinkedGroupConstraints()
+         */
+        FaceSelectionResult faceSelectionWithLinkedGroupConstraints(Model::WorldNode& world, const std::vector<Model::BrushFaceHandle>& faces);
     }
 }
 

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -67,6 +67,7 @@ namespace TrenchBroom {
         m_descendantSelectionCount{0},
         m_visibilityState{VisibilityState::Inherited},
         m_lockState{LockState::Inherited},
+        m_lockedByOtherSelection{false},
         m_lineNumber{0},
         m_lineCount{0},
         m_issuesValid{false},
@@ -648,6 +649,9 @@ namespace TrenchBroom {
         }
 
         bool Node::editable() const {
+            if (m_lockedByOtherSelection) {
+                return false;
+            }
             switch (m_lockState) {
                 case LockState::Inherited:
                     return m_parent == nullptr || m_parent->editable();
@@ -674,6 +678,14 @@ namespace TrenchBroom {
             }
             return false;
 
+        }
+
+        bool Node::lockedByOtherSelection() const {
+            return m_lockedByOtherSelection;
+        }
+
+        void Node::setLockedByOtherSelection(const bool lockedByOtherSelection) {
+            m_lockedByOtherSelection = lockedByOtherSelection;
         }
 
         void Node::pick(const EditorContext& editorContext, const vm::ray3& ray, PickResult& pickResult) {

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -60,17 +60,17 @@ namespace TrenchBroom {
         }
 
         Node::Node() :
-        m_parent(nullptr),
-        m_descendantCount(0),
-        m_selected(false),
-        m_childSelectionCount(0),
-        m_descendantSelectionCount(0),
-        m_visibilityState(VisibilityState::Inherited),
-        m_lockState(LockState::Inherited),
-        m_lineNumber(0),
-        m_lineCount(0),
-        m_issuesValid(false),
-        m_hiddenIssues(0) {}
+        m_parent{nullptr},
+        m_descendantCount{0},
+        m_selected{false},
+        m_childSelectionCount{0},
+        m_descendantSelectionCount{0},
+        m_visibilityState{VisibilityState::Inherited},
+        m_lockState{LockState::Inherited},
+        m_lineNumber{0},
+        m_lineCount{0},
+        m_issuesValid{false},
+        m_hiddenIssues{0} {}
 
         Node::~Node() {
             clearChildren();
@@ -142,23 +142,21 @@ namespace TrenchBroom {
         }
 
         std::vector<Node*> Node::clone(const vm::bbox3& worldBounds, const std::vector<Node*>& nodes) {
-            std::vector<Node*> clones;
+            auto clones = std::vector<Node*>{};
             clones.reserve(nodes.size());
             clone(worldBounds, std::begin(nodes), std::end(nodes), std::back_inserter(clones));
             return clones;
         }
 
         std::vector<Node*> Node::cloneRecursively(const vm::bbox3& worldBounds, const std::vector<Node*>& nodes) {
-            std::vector<Node*> clones;
+            auto clones = std::vector<Node*>{};
             clones.reserve(nodes.size());
             cloneRecursively(worldBounds, std::begin(nodes), std::end(nodes), std::back_inserter(clones));
             return clones;
         }
 
         size_t Node::depth() const {
-            if (m_parent == nullptr)
-                return 0;
-            return m_parent->depth() + 1;
+            return m_parent != nullptr ? m_parent->depth() + 1 : 0;
         }
 
         Node* Node::parent() const {
@@ -176,8 +174,9 @@ namespace TrenchBroom {
         bool Node::isDescendantOf(const Node* node) const {
             Node* parent = m_parent;
             while (parent != nullptr) {
-                if (parent == node)
+                if (parent == node) {
                     return true;
+                }
                 parent = parent->parent();
             }
             return false;
@@ -188,7 +187,7 @@ namespace TrenchBroom {
         }
 
         std::vector<Node*> Node::findDescendants(const std::vector<Node*>& nodes) const {
-            std::vector<Node*> result;
+            auto result = std::vector<Node*>{};
             for (auto* node : nodes) {
                 if (node->isDescendantOf(this)) {
                     result.push_back(node);
@@ -272,8 +271,9 @@ namespace TrenchBroom {
         }
 
         bool Node::canAddChild(const Node* child) const {
-            if (child == this || isDescendantOf(child))
+            if (child == this || isDescendantOf(child)) {
                 return false;
+            }
             return doCanAddChild(child);
         }
 
@@ -334,52 +334,61 @@ namespace TrenchBroom {
 
         void Node::descendantWillBeAdded(Node* newParent, Node* node, const size_t depth) {
             doDescendantWillBeAdded(newParent, node, depth);
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->descendantWillBeAdded(newParent, node, depth + 1);
+            }
         }
 
         void Node::descendantWasAdded(Node* node, const size_t depth) {
             doDescendantWasAdded(node, depth);
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->descendantWasAdded(node, depth + 1);
+            }
             invalidateIssues();
         }
 
         void Node::descendantWillBeRemoved(Node* node, const size_t depth) {
             doDescendantWillBeRemoved(node, depth);
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->descendantWillBeRemoved(node, depth + 1);
+            }
         }
 
         void Node::descendantWasRemoved(Node* oldParent, Node* node, const size_t depth) {
             doDescendantWasRemoved(oldParent, node, depth);
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->descendantWasRemoved(oldParent, node, depth + 1);
+            }
             invalidateIssues();
         }
 
         void Node::incDescendantCount(const size_t delta) {
-            if (delta == 0)
+            if (delta == 0) {
                 return;
+            }
             m_descendantCount += delta;
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->incDescendantCount(delta);
+            }
         }
 
         void Node::decDescendantCount(const size_t delta) {
-            if (delta == 0)
-                return;
             assert(m_descendantCount >= delta);
+            if (delta == 0) {
+                return;
+            }
             m_descendantCount -= delta;
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->decDescendantCount(delta);
+            }
         }
 
         void Node::setParent(Node* parent) {
             assert((m_parent == nullptr) ^ (parent == nullptr));
             assert(parent != this);
-            if (parent == m_parent)
+            if (parent == m_parent) {
                 return;
+            }
 
             parentWillChange();
             m_parent = parent;
@@ -413,19 +422,21 @@ namespace TrenchBroom {
         }
 
         void Node::nodeWillChange() {
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->childWillChange(this);
+            }
             invalidateIssues();
         }
 
         void Node::nodeDidChange() {
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->childDidChange(this);
+            }
             invalidateIssues();
         }
 
         Node::NotifyNodeChange::NotifyNodeChange(Node* node) :
-        m_node(node) {
+        m_node{node} {
             ensure(m_node != nullptr, "node is null");
             m_node->nodeWillChange();
         }
@@ -435,7 +446,7 @@ namespace TrenchBroom {
         }
 
         Node::NotifyPhysicalBoundsChange::NotifyPhysicalBoundsChange(Node* node) :
-        m_node(node) {
+        m_node{node} {
             ensure(m_node != nullptr, "node is null");
         }
         
@@ -445,8 +456,9 @@ namespace TrenchBroom {
 
         void Node::nodePhysicalBoundsDidChange() {
             doNodePhysicalBoundsDidChange();
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->childPhysicalBoundsDidChange(this);
+            }
         }
 
         void Node::childWillChange(Node* node) {
@@ -493,21 +505,25 @@ namespace TrenchBroom {
         }
 
         void Node::select() {
-            if (!selectable())
+            if (!selectable()) {
                 return;
+            }
             assert(!m_selected);
             m_selected = true;
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->childWasSelected();
+            }
         }
 
         void Node::deselect() {
-            if (!selectable())
+            if (!selectable()) {
                 return;
+            }
             assert(m_selected);
             m_selected = false;
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->childWasDeselected();
+            }
         }
 
         bool Node::transitivelySelected() const {
@@ -515,10 +531,12 @@ namespace TrenchBroom {
         }
 
         bool Node::parentSelected() const {
-            if (m_parent == nullptr)
+            if (m_parent == nullptr) {
                 return false;
-            if (m_parent->selected())
+            }
+            if (m_parent->selected()) {
                 return true;
+            }
             return m_parent->parentSelected();
         }
 
@@ -552,35 +570,41 @@ namespace TrenchBroom {
         }
 
         void Node::incChildSelectionCount(const size_t delta) {
-            if (delta == 0)
+            if (delta == 0) {
                 return;
+            }
             m_childSelectionCount += delta;
             incDescendantSelectionCount(delta);
         }
 
         void Node::decChildSelectionCount(const size_t delta) {
-            if (delta == 0)
+            if (delta == 0) {
                 return;
+            }
             assert(m_childSelectionCount >= delta);
             m_childSelectionCount -= delta;
             decDescendantSelectionCount(delta);
         }
 
         void Node::incDescendantSelectionCount(const size_t delta) {
-            if (delta == 0)
+            if (delta == 0) {
                 return;
+            }
             m_descendantSelectionCount += delta;
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->incDescendantSelectionCount(delta);
+            }
         }
 
         void Node::decDescendantSelectionCount(const size_t delta) {
-            if (delta == 0)
+            if (delta == 0) {
                 return;
+            }
             assert(m_descendantSelectionCount >= delta);
             m_descendantSelectionCount -= delta;
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->decDescendantSelectionCount(delta);
+            }
         }
 
         bool Node::selectable() const {
@@ -620,8 +644,9 @@ namespace TrenchBroom {
         }
 
         bool Node::ensureVisible() {
-            if (!visible())
+            if (!visible()) {
                 return setVisibilityState(VisibilityState::Shown);
+            }
             return false;
         }
 
@@ -770,23 +795,27 @@ namespace TrenchBroom {
         }
 
         void Node::doFindEntityNodesWithProperty(const std::string& key, const std::string& value, std::vector<EntityNodeBase*>& result) const {
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->findEntityNodesWithProperty(key, value, result);
+            }
         }
 
         void Node::doFindEntityNodesWithNumberedProperty(const std::string& prefix, const std::string& value, std::vector<EntityNodeBase*>& result) const {
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->findEntityNodesWithNumberedProperty(prefix, value, result);
+            }
         }
 
         void Node::doAddToIndex(EntityNodeBase* node, const std::string& key, const std::string& value) {
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->addToIndex(node, key, value);
+            }
         }
 
         void Node::doRemoveFromIndex(EntityNodeBase* node, const std::string& key, const std::string& value) {
-            if (m_parent != nullptr)
+            if (m_parent != nullptr) {
                 m_parent->removeFromIndex(node, key, value);
+            }
         }
     }
 }

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -435,23 +435,20 @@ namespace TrenchBroom {
             invalidateIssues();
         }
 
-        Node::NotifyNodeChange::NotifyNodeChange(Node* node) :
+        Node::NotifyNodeChange::NotifyNodeChange(Node& node) :
         m_node{node} {
-            ensure(m_node != nullptr, "node is null");
-            m_node->nodeWillChange();
+            m_node.nodeWillChange();
         }
 
         Node::NotifyNodeChange::~NotifyNodeChange() {
-            m_node->nodeDidChange();
+            m_node.nodeDidChange();
         }
 
-        Node::NotifyPhysicalBoundsChange::NotifyPhysicalBoundsChange(Node* node) :
-        m_node{node} {
-            ensure(m_node != nullptr, "node is null");
-        }
+        Node::NotifyPhysicalBoundsChange::NotifyPhysicalBoundsChange(Node& node) :
+        m_node{node} {}
         
         Node::NotifyPhysicalBoundsChange::~NotifyPhysicalBoundsChange() {
-            m_node->nodePhysicalBoundsDidChange();
+            m_node.nodePhysicalBoundsDidChange();
         }
 
         void Node::nodePhysicalBoundsDidChange() {

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -66,6 +66,7 @@ namespace TrenchBroom {
 
             VisibilityState m_visibilityState;
             LockState m_lockState;
+            bool m_lockedByOtherSelection;
 
             mutable size_t m_lineNumber;
             mutable size_t m_lineCount;
@@ -320,6 +321,8 @@ namespace TrenchBroom {
             bool locked() const;
             LockState lockState() const;
             bool setLockState(LockState lockState);
+            bool lockedByOtherSelection() const;
+            void setLockedByOtherSelection(bool lockedByOtherSelection);
         public: // picking
             void pick(const EditorContext& editorContext, const vm::ray3& ray, PickResult& result);
             void findNodesContaining(const vm::vec3& point, std::vector<Node*>& result);

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -242,9 +242,9 @@ namespace TrenchBroom {
         protected: // notification for parents
             class NotifyNodeChange {
             private:
-                Node* m_node;
+                Node& m_node;
             public:
-                explicit NotifyNodeChange(Node* node);
+                explicit NotifyNodeChange(Node& node);
                 ~NotifyNodeChange();
             };
 
@@ -255,9 +255,9 @@ namespace TrenchBroom {
             friend class NotifyPhysicalBoundsChange;
             class NotifyPhysicalBoundsChange {
             private:
-                Node* m_node;
+                Node& m_node;
             public:
-                explicit NotifyPhysicalBoundsChange(Node* node);
+                explicit NotifyPhysicalBoundsChange(Node& node);
                 ~NotifyPhysicalBoundsChange();
             };
             void nodePhysicalBoundsDidChange();

--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -95,35 +95,6 @@ namespace TrenchBroom {
             return !empty() && nodeCount() == brushCount();
         }
 
-        bool NodeCollection::hasBrushesRecursively() const {
-            // This is just an optimization of `!brushesRecursively().empty()`
-            // that stops after finding the first brush
-            const auto visitChildrenAndExitEarly = [](auto&& thisLambda, const auto* node) {
-                for (const auto* child : node->children()) {
-                    if (child->accept(thisLambda)) {
-                        return true;
-                    }
-                }
-                return false;
-            };
-
-            for (const auto* node : m_nodes) {
-                const auto hasBrush = node->accept(kdl::overload(
-                    [&](auto&& thisLambda, const WorldNode* world)   -> bool { return visitChildrenAndExitEarly(thisLambda, world); },
-                    [&](auto&& thisLambda, const LayerNode* layer)   -> bool { return visitChildrenAndExitEarly(thisLambda, layer); },
-                    [&](auto&& thisLambda, const GroupNode* group)   -> bool { return visitChildrenAndExitEarly(thisLambda, group); },
-                    [&](auto&& thisLambda, const EntityNode* entity) -> bool { return visitChildrenAndExitEarly(thisLambda, entity); },
-                    [] (const BrushNode*)                            -> bool { return true; },
-                    [] (const PatchNode*)                            -> bool { return false; }
-                ));
-                if (hasBrush) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         bool NodeCollection::hasPatches() const {
             return !m_patches.empty();
         }
@@ -166,21 +137,6 @@ namespace TrenchBroom {
 
         const std::vector<BrushNode*>& NodeCollection::brushes() const {
             return m_brushes;
-        }
-
-        std::vector<BrushNode*> NodeCollection::brushesRecursively() const {
-            auto brushes = std::vector<BrushNode*>{};
-            for (auto* node : m_nodes) {
-                node->accept(kdl::overload(
-                    [] (auto&& thisLambda, WorldNode* world)   { world->visitChildren(thisLambda); },
-                    [] (auto&& thisLambda, LayerNode* layer)   { layer->visitChildren(thisLambda); },
-                    [] (auto&& thisLambda, GroupNode* group)   { group->visitChildren(thisLambda); },
-                    [] (auto&& thisLambda, EntityNode* entity) { entity->visitChildren(thisLambda); },
-                    [&](BrushNode* brush)                      { brushes.push_back(brush); },
-                    [&](PatchNode*)                            {}
-                ));
-            }
-            return brushes;
         }
 
         const std::vector<PatchNode*>& NodeCollection::patches() const {

--- a/common/src/Model/NodeCollection.h
+++ b/common/src/Model/NodeCollection.h
@@ -55,7 +55,6 @@ namespace TrenchBroom {
             bool hasOnlyEntities() const;
             bool hasBrushes() const;
             bool hasOnlyBrushes() const;
-            bool hasBrushesRecursively() const;
             bool hasPatches() const;
             bool hasOnlyPatches() const;
 
@@ -69,7 +68,6 @@ namespace TrenchBroom {
             const std::vector<GroupNode*>& groups() const;
             const std::vector<EntityNode*>& entities() const;
             const std::vector<BrushNode*>& brushes() const;
-            std::vector<BrushNode*> brushesRecursively() const;
             const std::vector<PatchNode*>& patches() const;
 
             void addNodes(const std::vector<Node*>& nodes);

--- a/common/src/Model/PatchNode.cpp
+++ b/common/src/Model/PatchNode.cpp
@@ -277,8 +277,8 @@ namespace TrenchBroom {
         }
 
         BezierPatch PatchNode::setPatch(BezierPatch patch) {
-            const NotifyNodeChange nodeChange(this);
-            const NotifyPhysicalBoundsChange boundsChange(this);
+            const auto nodeChange = NotifyNodeChange{*this};
+            const auto boundsChange = NotifyPhysicalBoundsChange{*this};
 
             auto previousPatch = std::exchange(m_patch, std::move(patch));
             m_grid = makePatchGrid(m_patch, DefaultSubdivisionsPerSurface);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2663,7 +2663,7 @@ namespace TrenchBroom {
             size_t failedBrushCount = 0;
 
             const auto allSelectedBrushes = allSelectedBrushNodes();
-            applyAndSwap(*this, "Snap Brush Vertices", allSelectedBrushes, findContainingLinkedGroupsToUpdate(*m_world, allSelectedBrushes), kdl::overload(
+            const bool applyAndSwapSuccess = applyAndSwap(*this, "Snap Brush Vertices", allSelectedBrushes, findContainingLinkedGroupsToUpdate(*m_world, allSelectedBrushes), kdl::overload(
                 [] (Model::Layer&)  { return true; },
                 [] (Model::Group&)  { return true; },
                 [] (Model::Entity&) { return true; },
@@ -2684,6 +2684,9 @@ namespace TrenchBroom {
                 [] (Model::BezierPatch&) { return true; }
             ));
 
+            if (!applyAndSwapSuccess) {
+                return false;
+            }
             if (succeededBrushCount > 0) {
                 info(kdl::str_to_string("Snapped vertices of ", succeededBrushCount, " ", kdl::str_plural(succeededBrushCount, "brush", "brushes")));
             }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -833,6 +833,50 @@ namespace TrenchBroom {
             return kdl::vec_sort_and_remove_duplicates(std::move(nodes));
         }
 
+        std::vector<Model::BrushNode*> MapDocument::allSelectedBrushNodes() const {
+            auto brushes = std::vector<Model::BrushNode*>{};
+            for (auto* node : m_selectedNodes.nodes()) {
+                node->accept(kdl::overload(
+                    [] (auto&& thisLambda, Model::WorldNode* world)   { world->visitChildren(thisLambda); },
+                    [] (auto&& thisLambda, Model::LayerNode* layer)   { layer->visitChildren(thisLambda); },
+                    [] (auto&& thisLambda, Model::GroupNode* group)   { group->visitChildren(thisLambda); },
+                    [] (auto&& thisLambda, Model::EntityNode* entity) { entity->visitChildren(thisLambda); },
+                    [&](Model::BrushNode* brush)                      { brushes.push_back(brush); },
+                    [&](Model::PatchNode*)                            {}
+                ));
+            }
+            return brushes;
+        }
+
+        bool MapDocument::hasAnySelectedBrushNodes() const {
+            // This is just an optimization of `!allSelectedBrushNodes().empty()`
+            // that stops after finding the first brush
+            const auto visitChildrenAndExitEarly = [](auto&& thisLambda, const auto* node) {
+                for (const auto* child : node->children()) {
+                    if (child->accept(thisLambda)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            for (const auto* node : m_selectedNodes.nodes()) {
+                const auto hasBrush = node->accept(kdl::overload(
+                    [&](auto&& thisLambda, const Model::WorldNode* world)   -> bool { return visitChildrenAndExitEarly(thisLambda, world); },
+                    [&](auto&& thisLambda, const Model::LayerNode* layer)   -> bool { return visitChildrenAndExitEarly(thisLambda, layer); },
+                    [&](auto&& thisLambda, const Model::GroupNode* group)   -> bool { return visitChildrenAndExitEarly(thisLambda, group); },
+                    [&](auto&& thisLambda, const Model::EntityNode* entity) -> bool { return visitChildrenAndExitEarly(thisLambda, entity); },
+                    [] (const Model::BrushNode*)                            -> bool { return true; },
+                    [] (const Model::PatchNode*)                            -> bool { return false; }
+                ));
+                if (hasBrush) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         const Model::NodeCollection& MapDocument::selectedNodes() const {
             return m_selectedNodes;
         }
@@ -2618,7 +2662,7 @@ namespace TrenchBroom {
             size_t succeededBrushCount = 0;
             size_t failedBrushCount = 0;
 
-            const auto allSelectedBrushes = m_selectedNodes.brushesRecursively();
+            const auto allSelectedBrushes = allSelectedBrushNodes();
             applyAndSwap(*this, "Snap Brush Vertices", allSelectedBrushes, findContainingLinkedGroupsToUpdate(*m_world, allSelectedBrushes), kdl::overload(
                 [] (Model::Layer&)  { return true; },
                 [] (Model::Group&)  { return true; },

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -884,7 +884,9 @@ namespace TrenchBroom {
         std::vector<Model::BrushFaceHandle> MapDocument::allSelectedBrushFaces() const {
             if (hasSelectedBrushFaces())
                 return selectedBrushFaces();
-            return Model::collectBrushFaces(m_selectedNodes.nodes());
+
+            const auto faces = Model::collectBrushFaces(m_selectedNodes.nodes());
+            return Model::faceSelectionWithLinkedGroupConstraints(*m_world.get(), faces).facesToSelect;
         }
 
         std::vector<Model::BrushFaceHandle> MapDocument::selectedBrushFaces() const {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -296,10 +296,40 @@ namespace TrenchBroom {
             bool hasSelectedBrushFaces() const override;
             bool hasAnySelectedBrushFaces() const override;
 
+            /**
+             * For commands that modify entities, this returns all entities that should be acted on, based on the current selection.
+             * 
+             * - selected brushes/patches act on their parent entities
+             * - selected groups implicitly act on any contained entities
+             *
+             * If multiple linked groups are selected, returns entities from all of them, so attempting to perform commands
+             * on all of them will be blocked as a conflict.
+             */
             std::vector<Model::EntityNodeBase*> allSelectedEntityNodes() const override;
+
+            /**
+             * For commands that modify brushes, this returns all brushes that should be acted on, based on the current selection.
+             *
+             * - selected groups implicitly act on any contained brushes
+             *
+             * If multiple linked groups are selected, returns brushes from all of them, so attempting to perform commands
+             * on all of them will be blocked as a conflict.
+             */
             std::vector<Model::BrushNode*> allSelectedBrushNodes() const;
             bool hasAnySelectedBrushNodes() const;
             const Model::NodeCollection& selectedNodes() const override;
+
+            /**
+             * For commands that modify brush faces, this returns all that should be acted on, based on the current selection.
+             * 
+             * - if brush faces are explicitly selected (hasSelectedBrushFaces()), use those
+             * - selected groups implicitly act on any contained brushes
+             * - selected brushes implicitly act on their faces
+             *
+             * Unlike allSelectedBrushNodes()/allSelectedEntityNodes(), if multiple groups in a link set are selected,
+             * only return one representative face per brush, so that user actions can be performed without generating conflicts.
+             * (e.g. this allows selecting 2 closed linked groups in a link set and applying textures.)
+             */
             std::vector<Model::BrushFaceHandle> allSelectedBrushFaces() const override;
             std::vector<Model::BrushFaceHandle> selectedBrushFaces() const override;
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -297,6 +297,8 @@ namespace TrenchBroom {
             bool hasAnySelectedBrushFaces() const override;
 
             std::vector<Model::EntityNodeBase*> allSelectedEntityNodes() const override;
+            std::vector<Model::BrushNode*> allSelectedBrushNodes() const;
+            bool hasAnySelectedBrushNodes() const;
             const Model::NodeCollection& selectedNodes() const override;
             std::vector<Model::BrushFaceHandle> allSelectedBrushFaces() const override;
             std::vector<Model::BrushFaceHandle> selectedBrushFaces() const override;

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -188,43 +188,14 @@ namespace TrenchBroom {
         }
 
         void MapDocumentCommandFacade::performDeselectAll() {
-            if (hasSelectedNodes())
-                deselectAllNodes();
-            if (hasSelectedBrushFaces())
-                deselectAllBrushFaces();
-        }
-
-        void MapDocumentCommandFacade::deselectAllNodes() {
-            selectionWillChangeNotifier();
-            updateLastSelectionBounds();
-
-            for (Model::Node* node : m_selectedNodes) {
-                node->deselect();
+            if (hasSelectedNodes()) {
+                const auto previousSelection = m_selectedNodes.nodes();
+                performDeselect(previousSelection);
             }
-
-            Selection selection;
-            selection.addDeselectedNodes(m_selectedNodes.nodes());
-
-            m_selectedNodes.clear();
-
-            selectionDidChangeNotifier(selection);
-            invalidateSelectionBounds();
-        }
-
-        void MapDocumentCommandFacade::deselectAllBrushFaces() {
-            selectionWillChangeNotifier();
-
-            for (const auto& handle : m_selectedBrushFaces) {
-                Model::BrushNode* node = handle.node();
-                node->deselectFace(handle.faceIndex());
+            if (hasSelectedBrushFaces()) {
+                const auto previousSelection = m_selectedBrushFaces;
+                performDeselect(previousSelection);
             }
-
-            Selection selection;
-            selection.addDeselectedBrushFaces(m_selectedBrushFaces);
-
-            m_selectedBrushFaces.clear();
-
-            selectionDidChangeNotifier(selection);
         }
 
         void MapDocumentCommandFacade::performAddNodes(const std::map<Model::Node*, std::vector<Model::Node*>>& nodes) {

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -103,10 +103,17 @@ namespace TrenchBroom {
         void MapDocumentCommandFacade::performSelect(const std::vector<Model::BrushFaceHandle>& faces) {
             selectionWillChangeNotifier();
 
-            std::vector<Model::BrushFaceHandle> selected;
-            selected.reserve(faces.size());
+            const auto constrained = Model::faceSelectionWithLinkedGroupConstraints(*m_world.get(), faces);
 
-            for (const auto& handle : faces) {
+            for (Model::GroupNode* node : constrained.groupsToLock) {
+                node->setLockedByOtherSelection(true);
+            }
+            nodeLockingDidChangeNotifier(kdl::vec_element_cast<Model::Node*>(constrained.groupsToLock));
+
+            std::vector<Model::BrushFaceHandle> selected;
+            selected.reserve(constrained.facesToSelect.size());
+
+            for (const auto& handle : constrained.facesToSelect) {
                 Model::BrushNode* node = handle.node();
                 const Model::BrushFace& face = handle.face();
                 if (!face.selected() && m_editorContext->selectable(node, face)) {
@@ -165,6 +172,8 @@ namespace TrenchBroom {
         }
 
         void MapDocumentCommandFacade::performDeselect(const std::vector<Model::BrushFaceHandle>& faces) {
+            const auto implicitlyLockedGroups = kdl::vector_set<Model::GroupNode*>{kdl::vec_filter(Model::findAllLinkedGroups(*m_world.get()), [](const auto* group) { return group->lockedByOtherSelection(); })};
+
             selectionWillChangeNotifier();
 
             std::vector<Model::BrushFaceHandle> deselected;
@@ -185,6 +194,20 @@ namespace TrenchBroom {
             selection.addDeselectedBrushFaces(deselected);
 
             selectionDidChangeNotifier(selection);
+
+            // Selection change is done. Next, update implicit locking of linked groups.
+            // The strategy is to figure out what needs to be locked given m_selectedBrushFaces, and then un-implicitly-lock all other linked groups.
+            const auto groupsToLock = kdl::vector_set<Model::GroupNode*>{Model::faceSelectionWithLinkedGroupConstraints(*m_world.get(), m_selectedBrushFaces).groupsToLock};
+            for (Model::GroupNode* node : groupsToLock) {
+                node->setLockedByOtherSelection(true);
+            }
+            nodeLockingDidChangeNotifier(kdl::vec_element_cast<Model::Node*>(groupsToLock.get_data()));
+
+            const auto groupsToUnlock = kdl::set_difference(implicitlyLockedGroups, groupsToLock);
+            for (Model::GroupNode* node : groupsToUnlock) {
+                node->setLockedByOtherSelection(false);
+            }
+            nodeLockingDidChangeNotifier(kdl::vec_element_cast<Model::Node*>(groupsToUnlock));
         }
 
         void MapDocumentCommandFacade::performDeselectAll() {

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -68,9 +68,6 @@ namespace TrenchBroom {
             void performDeselect(const std::vector<Model::Node*>& nodes);
             void performDeselect(const std::vector<Model::BrushFaceHandle>& faces);
             void performDeselectAll();
-        private:
-            void deselectAllNodes();
-            void deselectAllBrushFaces();
         public: // adding and removing nodes
             void performAddNodes(const std::map<Model::Node*, std::vector<Model::Node*>>& nodes);
             void performRemoveNodes(const std::map<Model::Node*, std::vector<Model::Node*>>& nodes);

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1524,7 +1524,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::canSnapVertices() const {
-            return m_document->selectedNodes().hasBrushesRecursively();
+            return m_document->hasAnySelectedBrushNodes();
         }
 
         void MapFrame::toggleTextureLock() {

--- a/common/test/src/Model/ModelUtilsTest.cpp
+++ b/common/test/src/Model/ModelUtilsTest.cpp
@@ -162,6 +162,43 @@ namespace TrenchBroom {
             }
         }
 
+        TEST_CASE("ModelUtils.findLinkedGroups") {
+            constexpr auto worldBounds = vm::bbox3d{8192.0};
+            constexpr auto mapFormat = MapFormat::Quake3;
+
+            auto worldNode = WorldNode{{}, {}, mapFormat};
+
+            auto* groupNode1 = new GroupNode{Group{"Group 1"}};
+            auto* groupNode2 = new GroupNode{Group{"Group 2"}};
+            auto* groupNode3 = new GroupNode{Group{"Group 3"}};
+
+            setLinkedGroupId(*groupNode1, "group1");
+            setLinkedGroupId(*groupNode2, "group2");
+
+            auto* linkedGroupNode1_1 = static_cast<Model::GroupNode*>(groupNode1->cloneRecursively(worldBounds));
+
+            auto* linkedGroupNode2_1 = static_cast<Model::GroupNode*>(groupNode2->cloneRecursively(worldBounds));
+            auto* linkedGroupNode2_2 = static_cast<Model::GroupNode*>(groupNode2->cloneRecursively(worldBounds));
+
+            worldNode.defaultLayer()->addChild(groupNode1);
+            worldNode.defaultLayer()->addChild(groupNode2);
+            worldNode.defaultLayer()->addChild(groupNode3);
+            worldNode.defaultLayer()->addChild(linkedGroupNode1_1);
+            worldNode.defaultLayer()->addChild(linkedGroupNode2_1);
+            worldNode.defaultLayer()->addChild(linkedGroupNode2_2);
+
+            auto* entityNode = new EntityNode{Entity{}};
+            worldNode.defaultLayer()->addChild(entityNode);
+
+            CHECK_THAT(findLinkedGroups(worldNode, "asdf"), Catch::Matchers::UnorderedEquals(std::vector<Model::GroupNode*>{}));
+            CHECK_THAT(findLinkedGroups(worldNode, "group1"), Catch::Matchers::UnorderedEquals(std::vector<Model::GroupNode*>{
+                groupNode1, linkedGroupNode1_1
+            }));
+            CHECK_THAT(findLinkedGroups(worldNode, "group2"), Catch::Matchers::UnorderedEquals(std::vector<Model::GroupNode*>{
+                groupNode2, linkedGroupNode2_1, linkedGroupNode2_2
+            }));
+        }
+
         TEST_CASE("ModelUtils.collectWithParents") {
             constexpr auto worldBounds = vm::bbox3d{8192.0};
             constexpr auto mapFormat = MapFormat::Quake3;

--- a/common/test/src/Model/ModelUtilsTest.cpp
+++ b/common/test/src/Model/ModelUtilsTest.cpp
@@ -199,6 +199,42 @@ namespace TrenchBroom {
             }));
         }
 
+        TEST_CASE("ModelUtils.findAllLinkedGroups") {
+            constexpr auto worldBounds = vm::bbox3d{8192.0};
+            constexpr auto mapFormat = MapFormat::Quake3;
+
+            auto worldNode = WorldNode{{}, {}, mapFormat};
+
+            CHECK_THAT(findAllLinkedGroups(worldNode), Catch::Matchers::UnorderedEquals(std::vector<Model::GroupNode*>{}));
+
+            auto* groupNode1 = new GroupNode{Group{"Group 1"}};
+            auto* groupNode2 = new GroupNode{Group{"Group 2"}};
+            auto* groupNode3 = new GroupNode{Group{"Group 3"}};
+
+            setLinkedGroupId(*groupNode1, "group1");
+            setLinkedGroupId(*groupNode2, "group2");
+
+            auto* linkedGroupNode1_1 = static_cast<Model::GroupNode*>(groupNode1->cloneRecursively(worldBounds));
+
+            auto* linkedGroupNode2_1 = static_cast<Model::GroupNode*>(groupNode2->cloneRecursively(worldBounds));
+            auto* linkedGroupNode2_2 = static_cast<Model::GroupNode*>(groupNode2->cloneRecursively(worldBounds));
+
+            worldNode.defaultLayer()->addChild(groupNode1);
+            worldNode.defaultLayer()->addChild(groupNode2);
+            worldNode.defaultLayer()->addChild(groupNode3);
+            worldNode.defaultLayer()->addChild(linkedGroupNode1_1);
+            worldNode.defaultLayer()->addChild(linkedGroupNode2_1);
+            worldNode.defaultLayer()->addChild(linkedGroupNode2_2);
+
+            auto* entityNode = new EntityNode{Entity{}};
+            worldNode.defaultLayer()->addChild(entityNode);
+
+            CHECK_THAT(findAllLinkedGroups(worldNode), Catch::Matchers::UnorderedEquals(std::vector<Model::GroupNode*>{
+                groupNode1, linkedGroupNode1_1,
+                groupNode2, linkedGroupNode2_1, linkedGroupNode2_2
+            }));
+        }
+
         TEST_CASE("ModelUtils.collectWithParents") {
             constexpr auto worldBounds = vm::bbox3d{8192.0};
             constexpr auto mapFormat = MapFormat::Quake3;

--- a/common/test/src/Model/NodeCollectionTest.cpp
+++ b/common/test/src/Model/NodeCollectionTest.cpp
@@ -108,7 +108,6 @@ namespace TrenchBroom {
             REQUIRE_FALSE(nodeCollection.hasOnlyEntities());
             REQUIRE_FALSE(nodeCollection.hasBrushes());
             REQUIRE_FALSE(nodeCollection.hasOnlyBrushes());
-            REQUIRE_FALSE(nodeCollection.hasBrushesRecursively());
             REQUIRE_FALSE(nodeCollection.hasPatches());
             REQUIRE_FALSE(nodeCollection.hasOnlyPatches());
 
@@ -147,12 +146,10 @@ namespace TrenchBroom {
                     nodeCollection.addNode(&brushNode);
                     CHECK(nodeCollection.hasBrushes());
                     CHECK(nodeCollection.hasOnlyBrushes());
-                    CHECK(nodeCollection.hasBrushesRecursively());
 
                     nodeCollection.addNode(&layerNode);
                     CHECK(nodeCollection.hasBrushes());
                     CHECK_FALSE(nodeCollection.hasOnlyBrushes());
-                    CHECK(nodeCollection.hasBrushesRecursively());
                 }
 
                 SECTION("nested brushes") {
@@ -166,19 +163,16 @@ namespace TrenchBroom {
                         nodeCollection.addNode(node);
                         CHECK_FALSE(nodeCollection.hasBrushes());
                         CHECK_FALSE(nodeCollection.hasOnlyBrushes());
-                        CHECK(nodeCollection.hasBrushesRecursively());
                     }
 
                     SECTION("adding brushes to containers") {
                         nodeCollection.addNode(node);
                         REQUIRE_FALSE(nodeCollection.hasBrushes());
                         REQUIRE_FALSE(nodeCollection.hasOnlyBrushes());
-                        REQUIRE_FALSE(nodeCollection.hasBrushesRecursively());
 
                         node->addChild(brushNode.clone(worldBounds));
                         CHECK_FALSE(nodeCollection.hasBrushes());
                         CHECK_FALSE(nodeCollection.hasOnlyBrushes());
-                        CHECK(nodeCollection.hasBrushesRecursively());
                     }
                 }
             }
@@ -264,9 +258,6 @@ namespace TrenchBroom {
                 layerNode.addChild(brushInLayer);
                 groupNode.addChild(brushInGroup);
                 entityNode.addChild(brushInEntity);
-
-            CHECK_THAT(nodeCollection.brushesRecursively(), 
-                Catch::Matchers::UnorderedEquals(std::vector<BrushNode*>{&brushNode, brushInLayer, brushInGroup, brushInEntity}));
             }
         }
 

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -270,6 +270,11 @@ namespace TrenchBroom {
             checkFaceTexCoordSystem(faces[5], expectParallel);
         }
 
+        void setLinkedGroupId(GroupNode& groupNode, std::string linkedGroupId) {
+            auto group = groupNode.group();
+            group.setLinkedGroupId(std::move(linkedGroupId));
+            groupNode.setGroup(std::move(group));
+        }
     }
 
     namespace View {

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -57,6 +57,7 @@ namespace TrenchBroom {
         class BrushNode;
         class Game;
         struct GameConfig;
+        class GroupNode;
         class Node;
 
         BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
@@ -87,6 +88,8 @@ namespace TrenchBroom {
         const Model::BrushFace* findFaceByPoints(const std::vector<Model::BrushFace>& faces, const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2);
         void checkFaceTexCoordSystem(const Model::BrushFace& face, const bool expectParallel);
         void checkBrushTexCoordSystem(const Model::BrushNode* brushNode, const bool expectParallel);
+
+        void setLinkedGroupId(GroupNode& groupNode, std::string linkedGroupId);
     }
 
     namespace View {

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -306,8 +306,8 @@ namespace TrenchBroom {
             CHECK_THAT(group->children(), Catch::Equals(std::vector<Model::Node*> {ent1}));
             CHECK_THAT(ent1->children(), Catch::Equals(std::vector<Model::Node*> { brushNode1}));
             CHECK_THAT(document->selectedNodes().nodes(), Catch::Equals(std::vector<Model::Node*> {group}));
-            CHECK(document->selectedNodes().brushesRecursively() == std::vector<Model::BrushNode*>{ brushNode1});
-            CHECK(document->selectedNodes().hasBrushesRecursively());
+            CHECK(document->allSelectedBrushNodes() == std::vector<Model::BrushNode*>{ brushNode1});
+            CHECK(document->hasAnySelectedBrushNodes());
             CHECK(!document->selectedNodes().hasBrushes());
 
             document->ungroupSelection();

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -25,6 +25,10 @@
 #include "IO/WorldReader.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
+#include "Model/Entity.h"
+#include "Model/EntityNode.h"
+#include "Model/Group.h"
+#include "Model/GroupNode.h"
 #include "Model/LayerNode.h"
 #include "Model/PatchNode.h"
 #include "Model/TestGame.h"
@@ -32,6 +36,7 @@
 #include "View/MapDocumentCommandFacade.h"
 
 #include <kdl/result.h>
+#include <kdl/vector_utils.h>
 
 #include "Catch2.h"
 
@@ -115,6 +120,88 @@ namespace TrenchBroom {
             // map has both Standard and Valve brushes
             CHECK_THROWS_AS(View::loadMapDocument(IO::Path("fixture/test/View/MapDocumentTest/mixedFormats.map"),
                                                   "Quake", Model::MapFormat::Unknown), IO::WorldReaderException);
+        }
+
+        TEST_CASE_METHOD(MapDocumentTest, "Brush Node Selection") {
+            auto* brushNodeInDefaultLayer = createBrushNode("brushNodeInDefaultLayer");
+            auto* brushNodeInCustomLayer = createBrushNode("brushNodeInCustomLayer");
+            auto* brushNodeInEntity = createBrushNode("brushNodeInEntity");
+            auto* brushNodeInGroup = createBrushNode("brushNodeInGroup");
+            auto* brushNodeInNestedGroup = createBrushNode("brushNodeInNestedGroup");
+
+            auto* customLayerNode = new Model::LayerNode{Model::Layer{"customLayerNode"}};
+            auto* brushEntityNode = new Model::EntityNode{Model::Entity{}};
+            auto* pointEntityNode = new Model::EntityNode{Model::Entity{}};
+            auto* outerGroupNode = new Model::GroupNode{Model::Group{"outerGroupNode"}};
+            auto* innerGroupNode = new Model::GroupNode{Model::Group{"outerGroupNode"}};
+
+            document->addNodes({
+                {document->world()->defaultLayer(), {brushNodeInDefaultLayer, brushEntityNode, pointEntityNode, outerGroupNode}},
+                {document->world(), {customLayerNode}}
+            });
+
+            document->addNodes({
+                {customLayerNode, {brushNodeInCustomLayer}},
+                {outerGroupNode, {innerGroupNode, brushNodeInGroup}},
+                {brushEntityNode, {brushNodeInEntity}},
+            });
+
+            document->addNodes({
+                {innerGroupNode, {brushNodeInNestedGroup}}
+            });
+
+            const auto getPath = [&](const Model::Node* node) { return node->pathFrom(*document->world()); };
+            const auto resolvePaths = [&](const std::vector<Model::NodePath>& paths) { 
+                auto result = std::vector<Model::Node*>{};
+                for (const auto& path : paths) {
+                    result.push_back(document->world()->resolvePath(path));
+                }
+                return result;
+             };
+
+            SECTION("allSelectedBrushNodes") {
+                using T = std::vector<Model::NodePath>;
+
+                const auto paths = GENERATE_COPY(values<T>({
+                    {},
+                    {getPath(brushNodeInDefaultLayer)},
+                    {getPath(brushNodeInDefaultLayer), getPath(brushNodeInCustomLayer)},
+                    {getPath(brushNodeInDefaultLayer), getPath(brushNodeInCustomLayer), getPath(brushNodeInEntity)},
+                    {getPath(brushNodeInGroup)},
+                    {getPath(brushNodeInGroup), getPath(brushNodeInNestedGroup)},
+                }));
+
+                const auto nodes = resolvePaths(paths);
+                const auto brushNodes = kdl::vec_element_cast<Model::BrushNode*>(nodes);
+
+                document->select(nodes);
+
+                CHECK_THAT(document->allSelectedBrushNodes(), Catch::Matchers::UnorderedEquals(brushNodes));
+            }
+
+            SECTION("hasAnySelectedBrushNodes") {
+                using T = std::tuple<std::vector<Model::NodePath>, bool>;
+
+                const auto 
+                    [pathsToSelect, expectedResult] = GENERATE_COPY(values<T>({
+                    {std::vector<Model::NodePath>{}, false},
+                    {{getPath(pointEntityNode)}, false},
+                    {{getPath(brushEntityNode)}, true},
+                    {{getPath(outerGroupNode)}, true},
+                    {{getPath(brushNodeInDefaultLayer)}, true},
+                    {{getPath(brushNodeInCustomLayer)}, true},
+                    {{getPath(brushNodeInEntity)}, true},
+                    {{getPath(brushNodeInGroup)}, true},
+                    {{getPath(brushNodeInNestedGroup)}, true},
+                }));
+
+                CAPTURE(pathsToSelect);
+
+                const auto nodes = resolvePaths(pathsToSelect);
+                document->select(nodes);
+
+                CHECK(document->hasAnySelectedBrushNodes() == expectedResult);
+            }
         }
     }
 }

--- a/common/test/src/View/UpdateLinkedGroupsHelperTest.cpp
+++ b/common/test/src/View/UpdateLinkedGroupsHelperTest.cpp
@@ -46,12 +46,6 @@
 
 namespace TrenchBroom {
     namespace View {
-        static void setLinkedGroupId(Model::GroupNode& groupNode, std::string linkedGroupId) {
-            auto group = groupNode.group();
-            group.setLinkedGroupId(std::move(linkedGroupId));
-            groupNode.setGroup(std::move(group));
-        }
-
         TEST_CASE("UpdateLinkedGroupsHelperTest.checkLinkedGroupsToUpdate") {
             auto groupNode1 = Model::GroupNode{Model::Group{"test"}};
             auto linkedGroupNode = Model::GroupNode{Model::Group{"test"}};


### PR DESCRIPTION
Fixes #3768

This evolved a bit from what I was originally thinking, and now only affects face selections.

The last commit has all of the real changes, I'll just repeat the commit message here:

- `MapDocument::allSelectedBrushFaces()`: if multiple groups in a link set are selected, only return one representative face per link set so that user actions can be performed without generating conflicts. (e.g. this allows selecting 2 closed linked groups in a link set and applying textures.)

- `MapDocumentCommandFacade::performSelect(const std::vector<Model::BrushFaceHandle>&)`: "fix up" face selections (if faces in multiple closed groups are attempted to be selected, only select one representative face per link set). Also implicitly lock/unlock other groups in the link set.

You can experiment with the second point by selecting/deselecting faces on a linked group and seeing the other groups in the link set automatically lock/unlock.

---

I did experiment with applying similar "filtering out of duplicates from other linked groups in a link set" to `MapDocument::allSelectedBrushNodes()` and `MapDocument::allSelectedEntityNodes()` but ultimately decided it was a bad idea:

- allSelectedBrushNodes is only used in `MapDocument::snapVertices`, and doing a "select all" + "snap vertices" is kind of incompatible with linked groups, because snapping one might unsnap another instance. So having that action refuse to execute seems OK.
- allSelectedEntityNodes - for this one, I don't see much of a use case for "selecting all" (or selecting multiple closed linked groups in a link set) and then using the entity inspector, so I think it's OK if these actions are refused when attempted with multiple groups in a link set selected.