### PR TITLE
3824: allow ungrouping with non-groups selected

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1317,7 +1317,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::canUngroupSelectedObjects() const {
-            return m_document->selectedNodes().hasOnlyGroups() && !m_mapView->anyToolActive();
+            return m_document->selectedNodes().hasGroups() && !m_mapView->anyToolActive();
         }
 
         void MapFrame::renameSelectedGroups() {

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -316,6 +316,23 @@ namespace TrenchBroom {
             CHECK(brushNode1->selected());
         }
 
+        // https://github.com/TrenchBroom/TrenchBroom/issues/3824
+        TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupGroupAndPointEntity") {
+            auto* ent1 = new Model::EntityNode();
+            auto* ent2 = new Model::EntityNode();
+
+            addNode(*document, document->parentForNodes(), ent1);
+            addNode(*document, document->parentForNodes(), ent2);
+            document->select(std::vector<Model::Node*>{ ent1 });
+
+            auto* group = document->groupSelection("Group");
+            document->select(std::vector<Model::Node*>{ent2});
+            CHECK_THAT(document->selectedNodes().nodes(), Catch::UnorderedEquals(std::vector<Model::Node*>{group, ent2}));
+            
+            document->ungroupSelection();
+            CHECK_THAT(document->selectedNodes().nodes(), Catch::UnorderedEquals(std::vector<Model::Node*>{ent1, ent2}));
+        }
+
         TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.mergeGroups") {
             document->selectAllNodes();
             document->deleteObjects();

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -318,8 +318,8 @@ namespace TrenchBroom {
 
         // https://github.com/TrenchBroom/TrenchBroom/issues/3824
         TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupGroupAndPointEntity") {
-            auto* ent1 = new Model::EntityNode();
-            auto* ent2 = new Model::EntityNode();
+            auto* ent1 = new Model::EntityNode{};
+            auto* ent2 = new Model::EntityNode{};
 
             addNode(*document, document->parentForNodes(), ent1);
             addNode(*document, document->parentForNodes(), ent2);


### PR DESCRIPTION
The non-group nodes stay selected.

Fixes #3824