### PR TITLE
3834: fix crash when right clicking on a scale tool handle with a group selected

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1250,10 +1250,10 @@ namespace TrenchBroom {
             Model::Node* newGroup = nullptr;
 
             auto document = kdl::mem_lock(m_document);
-            const Model::Hit& hit = pickResult().empty() ? Model::Hit::NoHit : pickResult().all().front();
-            if (hit.isMatch())
-                newGroup = Model::findOutermostClosedGroup(Model::hitToNode(hit));
-
+            const auto hits = pickResult().all(type(Model::nodeHitType()));
+            if (!hits.empty()) {
+                newGroup = Model::findOutermostClosedGroup(Model::hitToNode(hits.front()));
+            }
             if (newGroup != nullptr && canReparentNodes(nodes, newGroup))
                 return newGroup;
             return nullptr;
@@ -1278,9 +1278,9 @@ namespace TrenchBroom {
             Model::GroupNode* mergeTarget = nullptr;
 
             auto document = kdl::mem_lock(m_document);
-            const Model::Hit& hit = pickResult().empty() ? Model::Hit::NoHit : pickResult().all().front();
-            if (hit.isMatch()) {
-                mergeTarget = findOutermostClosedGroup(Model::hitToNode(hit));
+            const auto hits = pickResult().all(type(Model::nodeHitType()));
+            if (!hits.empty()) {
+                mergeTarget = findOutermostClosedGroup(Model::hitToNode(hits.front()));
             }
             if (mergeTarget == nullptr) {
                 return nullptr;


### PR DESCRIPTION
Fixes #3834

This corrects a bad refactoring in 1a45f8278ef75ad6d3b9dcea62a010a1909dfaf2 where the hit type filtering of pickable() was relied on in these lines.