### PR TITLE
Introduce drop tracker

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -302,6 +302,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/CyclingMapView.cpp
         ${COMMON_SOURCE_DIR}/View/DirectoryTextureCollectionEditor.cpp
         ${COMMON_SOURCE_DIR}/View/DragTracker.cpp
+        ${COMMON_SOURCE_DIR}/View/DropTracker.cpp
         ${COMMON_SOURCE_DIR}/View/EdgeTool.cpp
         ${COMMON_SOURCE_DIR}/View/EdgeToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ElidedLabel.cpp
@@ -812,6 +813,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/CyclingMapView.h
         ${COMMON_SOURCE_DIR}/View/DirectoryTextureCollectionEditor.h
         ${COMMON_SOURCE_DIR}/View/DragTracker.h
+        ${COMMON_SOURCE_DIR}/View/DropTracker.h
         ${COMMON_SOURCE_DIR}/View/EdgeTool.h
         ${COMMON_SOURCE_DIR}/View/EdgeToolController.h
         ${COMMON_SOURCE_DIR}/View/ElidedLabel.h

--- a/common/src/View/CameraTool2D.h
+++ b/common/src/View/CameraTool2D.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
     namespace View {
         class DragTracker;
 
-        class CameraTool2D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy, NoDropPolicy>, public Tool {
+        class CameraTool2D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
         private:
             Renderer::OrthographicCamera& m_camera;
             vm::vec2f m_lastMousePos;

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -35,7 +35,7 @@ namespace TrenchBroom {
     namespace View {
         class DragTracker;
 
-        class CameraTool3D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy, NoDropPolicy>, public Tool {
+        class CameraTool3D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
         private:
             Renderer::PerspectiveCamera& m_camera;
         public:

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -287,7 +287,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class AddClipPointPart : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy>, protected PartBase {
+            class AddClipPointPart : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, protected PartBase {
             public:
                 explicit AddClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}
@@ -370,7 +370,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class MoveClipPointPart : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy>, protected PartBase {
+            class MoveClipPointPart : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy>, protected PartBase {
             public:
                 explicit MoveClipPointPart(std::unique_ptr<PartDelegateBase> delegate) :
                 PartBase{std::move(delegate)} {}

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -122,7 +122,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class DrawFacePart : public Part, public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy> {
+            class DrawFacePart : public Part, public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
             private:
                 vm::plane3 m_plane;
                 vm::vec3 m_initialPoint;
@@ -197,7 +197,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class DuplicateFacePart : public Part, public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy> {
+            class DuplicateFacePart : public Part, public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
             private:
                 vm::vec3 m_dragDir;
             public:

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -21,10 +21,12 @@
 
 #include "Ensure.h"
 #include "View/CreateEntityTool.h"
+#include "View/DropTracker.h"
 #include "View/InputState.h"
 
 #include <kdl/string_utils.h>
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -45,50 +47,64 @@ namespace TrenchBroom {
             return m_tool;
         }
 
-        bool CreateEntityToolController::doDragEnter(const InputState& inputState, const std::string& payload) {
-            const std::vector<std::string> parts = kdl::str_split(payload, ":");
-            if (parts.size() != 2)
-                return false;
-            if (parts[0] != "entity")
-                return false;
-
-            if (m_tool->createEntity(parts[1])) {
-                doUpdateEntityPosition(inputState);
-                return true;
+        std::unique_ptr<DropTracker> CreateEntityToolController::acceptDrop(const InputState& inputState, const std::string& payload) {
+            const auto parts = kdl::str_split(payload, ":");
+            if (parts.size() != 2 || parts[0] != "entity") {
+                return nullptr;
             }
-            return false;
-        }
 
-        bool CreateEntityToolController::doDragMove(const InputState& inputState) {
-            doUpdateEntityPosition(inputState);
-            return true;
-        }
+            if (!m_tool->createEntity(parts[1])) {
+                return nullptr;
+            }
 
-        void CreateEntityToolController::doDragLeave(const InputState&) {
-            m_tool->removeEntity();
-        }
-
-        bool CreateEntityToolController::doDragDrop(const InputState&) {
-            m_tool->commitEntity();
-            return true;
+            return createDropTracker(inputState);
         }
 
         bool CreateEntityToolController::doCancel() {
             return false;
         }
 
+        namespace {
+            class CreateEntityDropTracker : public DropTracker {
+            private:
+                CreateEntityTool& m_tool;
+                std::function<void(const InputState&, CreateEntityTool& tool)> m_updateEntityPosition;
+            public:
+                explicit CreateEntityDropTracker(const InputState& inputState, CreateEntityTool& tool, std::function<void(const InputState&, CreateEntityTool& tool)> updateEntityPosition) :
+                m_tool{tool},
+                m_updateEntityPosition{std::move(updateEntityPosition)} {
+                    m_updateEntityPosition(inputState, m_tool);
+                }
+
+                bool move(const InputState& inputState) override {
+                    m_updateEntityPosition(inputState, m_tool);
+                    return true;
+                }
+
+                bool drop(const InputState&) override {
+                    m_tool.commitEntity();
+                    return true;
+                }
+
+                void leave(const InputState&) override {
+                    m_tool.removeEntity();
+                }
+
+            };
+        }
+
         CreateEntityToolController2D::CreateEntityToolController2D(CreateEntityTool* tool) :
         CreateEntityToolController(tool) {}
 
-        void CreateEntityToolController2D::doUpdateEntityPosition(const InputState& inputState) {
-            m_tool->updateEntityPosition2D(inputState.pickRay());
+        std::unique_ptr<DropTracker> CreateEntityToolController2D::createDropTracker(const InputState& inputState) const {
+            return std::make_unique<CreateEntityDropTracker>(inputState, *m_tool, [](const auto& is, auto& t) { t.updateEntityPosition2D(is.pickRay()); });
         }
 
         CreateEntityToolController3D::CreateEntityToolController3D(CreateEntityTool* tool) :
         CreateEntityToolController(tool) {}
 
-        void CreateEntityToolController3D::doUpdateEntityPosition(const InputState& inputState) {
-            m_tool->updateEntityPosition3D(inputState.pickRay(), inputState.pickResult());
+        std::unique_ptr<DropTracker> CreateEntityToolController3D::createDropTracker(const InputState& inputState) const {
+            return std::make_unique<CreateEntityDropTracker>(inputState, *m_tool, [](const auto& is, auto& t) { t.updateEntityPosition3D(is.pickRay(), is.pickResult()); });
         }
     }
 }

--- a/common/src/View/CreateEntityToolController.h
+++ b/common/src/View/CreateEntityToolController.h
@@ -27,7 +27,7 @@ namespace TrenchBroom {
     namespace View {
         class CreateEntityTool;
 
-        class CreateEntityToolController : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, DropPolicy> {
+        class CreateEntityToolController : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
         protected:
             CreateEntityTool* m_tool;
         protected:
@@ -38,29 +38,25 @@ namespace TrenchBroom {
             Tool* doGetTool() override;
             const Tool* doGetTool() const override;
 
-            bool doDragEnter(const InputState& inputState, const std::string& payload) override;
-            bool doDragMove(const InputState& inputState) override;
-            void doDragLeave(const InputState& inputState) override;
-            bool doDragDrop(const InputState& inputState) override;
-            void updateEntityPosition(const InputState& inputState);
+            std::unique_ptr<DropTracker> acceptDrop(const InputState& inputState, const std::string& payload) override;
 
             bool doCancel() override;
         private:
-            virtual void doUpdateEntityPosition(const InputState& inputState) = 0;
+            virtual std::unique_ptr<DropTracker> createDropTracker(const InputState& inputState) const = 0;
         };
 
         class CreateEntityToolController2D : public CreateEntityToolController {
         public:
             CreateEntityToolController2D(CreateEntityTool* tool);
         private:
-            void doUpdateEntityPosition(const InputState& inputState) override;
+            std::unique_ptr<DropTracker> createDropTracker(const InputState& inputState) const override;
         };
 
         class CreateEntityToolController3D : public CreateEntityToolController {
         public:
             CreateEntityToolController3D(CreateEntityTool* tool);
         private:
-            void doUpdateEntityPosition(const InputState& inputState) override;
+            std::unique_ptr<DropTracker> createDropTracker(const InputState& inputState) const override;
         };
     }
 }

--- a/common/src/View/CreateSimpleBrushToolController2D.h
+++ b/common/src/View/CreateSimpleBrushToolController2D.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class DragTracker;
         class MapDocument;
 
-        class CreateSimpleBrushToolController2D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy> {
+        class CreateSimpleBrushToolController2D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
         private:
             CreateSimpleBrushTool* m_tool;
             std::weak_ptr<MapDocument> m_document;

--- a/common/src/View/CreateSimpleBrushToolController3D.h
+++ b/common/src/View/CreateSimpleBrushToolController3D.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         class DragTracker;
         class MapDocument;
 
-        class CreateSimpleBrushToolController3D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy> {
+        class CreateSimpleBrushToolController3D : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy> {
         private:
             CreateSimpleBrushTool* m_tool;
             std::weak_ptr<MapDocument> m_document;

--- a/common/src/View/DropTracker.cpp
+++ b/common/src/View/DropTracker.cpp
@@ -1,0 +1,26 @@
+/*
+ Copyright (C) 2021 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DropTracker.h"
+
+namespace TrenchBroom {
+    namespace View {
+        DropTracker::~DropTracker() = default;
+    }
+}

--- a/common/src/View/DropTracker.h
+++ b/common/src/View/DropTracker.h
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2010-2017 Kristian Duske
+ Copyright (C) 2021 Kristian Duske
 
  This file is part of TrenchBroom.
 
@@ -19,27 +19,17 @@
 
 #pragma once
 
-#include "View/ToolController.h"
-
 namespace TrenchBroom {
     namespace View {
-        class DragTracker;
-        class MoveObjectsTool;
+        class InputState;
 
-        class MoveObjectsToolController : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy> {
-        private:
-            MoveObjectsTool* m_tool;
+        class DropTracker {
         public:
-            MoveObjectsToolController(MoveObjectsTool* tool);
-            virtual ~MoveObjectsToolController() override;
-        private:
-            Tool* doGetTool() override;
-            const Tool* doGetTool() const override;
+            virtual ~DropTracker();
 
-            std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
-
-            bool doCancel() override;
+            virtual bool move(const InputState& inputState) = 0;
+            virtual bool drop(const InputState& inputState) = 0;
+            virtual void leave(const InputState& inputState) = 0;
         };
     }
 }
-

--- a/common/src/View/ResizeBrushesToolController.h
+++ b/common/src/View/ResizeBrushesToolController.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class DragTracker;
         class ResizeBrushesTool;
 
-        class ResizeBrushesToolController : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy> {
+        class ResizeBrushesToolController : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy> {
         protected:
             ResizeBrushesTool* m_tool;
         private:

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -163,7 +163,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class RotateObjectsBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy> {
+            class RotateObjectsBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy> {
             protected:
                 RotateObjectsTool* m_tool;
             protected:
@@ -287,7 +287,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class MoveCenterBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy, NoDropPolicy> {
+            class MoveCenterBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy> {
             protected:
                 RotateObjectsTool* m_tool;
             protected:

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -37,7 +37,7 @@ namespace TrenchBroom {
         class MapDocument;
         class ScaleObjectsTool;
 
-        class ScaleObjectsToolController : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy> {
+        class ScaleObjectsToolController : public ToolControllerBase<PickingPolicy, KeyPolicy, MousePolicy, RenderPolicy> {
         protected:
             ScaleObjectsTool* m_tool;
         private:

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -54,7 +54,7 @@ namespace TrenchBroom {
          */
         std::vector<Model::Node*> hitsToNodesWithGroupPicking(const std::vector<Model::Hit>& hits);
 
-        class SelectionTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy>, public Tool {
+        class SelectionTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, public Tool {
         private:
             std::weak_ptr<MapDocument> m_document;
         public:

--- a/common/src/View/SetBrushFaceAttributesTool.h
+++ b/common/src/View/SetBrushFaceAttributesTool.h
@@ -44,7 +44,7 @@ namespace TrenchBroom {
          * - LMB Drag: applies to all faces dragged over
          * - LMB Double click: applies to all faces of target brush
          */
-        class SetBrushFaceAttributesTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy, NoDropPolicy>, public Tool {
+        class SetBrushFaceAttributesTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
         private:
             std::weak_ptr<MapDocument> m_document;
         public:

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         class MapDocument;
         class ShearObjectsTool;
 
-        class ShearObjectsToolController : public ToolControllerBase<PickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy> {
+        class ShearObjectsToolController : public ToolControllerBase<PickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy> {
         protected:
             ShearObjectsTool* m_tool;
         private:

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -21,6 +21,7 @@
 
 #include "Ensure.h"
 #include "View/DragTracker.h"
+#include "View/DropTracker.h"
 #include "View/InputState.h"
 #include "View/Tool.h"
 #include "View/ToolController.h"
@@ -36,7 +37,6 @@
 namespace TrenchBroom {
     namespace View {
         ToolBox::ToolBox() :
-        m_dropReceiver(nullptr),
         m_modalTool(nullptr),
         m_enabled(true) {}
 
@@ -57,40 +57,40 @@ namespace TrenchBroom {
                 return false;
             }
 
-            if (m_dropReceiver != nullptr) {
+            if (m_dropTracker) {
                 dragLeave(chain, inputState);
             }
 
             deactivateAllTools();
-            m_dropReceiver = chain->dragEnter(inputState, text);
-            return m_dropReceiver != nullptr;
+            m_dropTracker = chain->dragEnter(inputState, text);
+            return m_dropTracker != nullptr;
         }
 
         bool ToolBox::dragMove(ToolChain* /* chain */, const InputState& inputState, const std::string& /* text */) {
-            if (!m_enabled || m_dropReceiver == nullptr) {
+            if (!m_enabled || m_dropTracker == nullptr) {
                 return false;
             }
 
-            m_dropReceiver->dragMove(inputState);
+            m_dropTracker->move(inputState);
             return true;
         }
 
         void ToolBox::dragLeave(ToolChain* /* chain */, const InputState& inputState) {
-            if (!m_enabled || m_dropReceiver == nullptr) {
+            if (!m_enabled || m_dropTracker == nullptr) {
                 return;
             }
 
-            m_dropReceiver->dragLeave(inputState);
-            m_dropReceiver = nullptr;
+            m_dropTracker->leave(inputState);
+            m_dropTracker = nullptr;
         }
 
         bool ToolBox::dragDrop(ToolChain* /* chain */, const InputState& inputState, const std::string& /* text */) {
-            if (!m_enabled || m_dropReceiver == nullptr) {
+            if (!m_enabled || m_dropTracker == nullptr) {
                 return false;
             }
 
-            const auto result = m_dropReceiver->dragDrop(inputState);
-            m_dropReceiver = nullptr;
+            const auto result = m_dropTracker->drop(inputState);
+            m_dropTracker = nullptr;
             return result;
         }
 

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -43,6 +43,7 @@ namespace TrenchBroom {
 
     namespace View {
         class DragTracker;
+        class DropTracker;
         class InputState;
         class Tool;
         class ToolController;
@@ -52,7 +53,7 @@ namespace TrenchBroom {
             Q_OBJECT
         private:
             std::unique_ptr<DragTracker> m_dragTracker;
-            ToolController* m_dropReceiver;
+            std::unique_ptr<DropTracker> m_dropTracker;
             Tool* m_modalTool;
 
             using ToolList = std::vector<Tool*>;

--- a/common/src/View/ToolChain.cpp
+++ b/common/src/View/ToolChain.cpp
@@ -21,6 +21,7 @@
 
 #include "Ensure.h"
 #include "View/DragTracker.h"
+#include "View/DropTracker.h"
 #include "View/ToolController.h"
 
 #include <cassert>
@@ -140,13 +141,15 @@ namespace TrenchBroom {
             return m_suffix->startMouseDrag(inputState);
         }
 
-        ToolController* ToolChain::dragEnter(const InputState& inputState, const std::string& payload) {
+        std::unique_ptr<DropTracker> ToolChain::dragEnter(const InputState& inputState, const std::string& payload) {
             assert(checkInvariant());
             if (chainEndsHere()) {
                 return nullptr;
             }
-            if (m_tool->toolActive() && m_tool->dragEnter(inputState, payload)) {
-                return m_tool.get();
+            if (m_tool->toolActive()) {
+                if (auto dropTracker = m_tool->acceptDrop(inputState, payload)) {
+                    return dropTracker;
+                }
             }
             return m_suffix->dragEnter(inputState, payload);
         }

--- a/common/src/View/ToolChain.h
+++ b/common/src/View/ToolChain.h
@@ -34,6 +34,7 @@ namespace TrenchBroom {
 
     namespace View {
         class DragTracker;
+        class DropTracker;
         class InputState;
         class ToolController;
 
@@ -59,7 +60,7 @@ namespace TrenchBroom {
             void mouseMove(const InputState& inputState);
 
             std::unique_ptr<DragTracker> startMouseDrag(const InputState& inputState);
-            ToolController* dragEnter(const InputState& inputState, const std::string& payload);
+            std::unique_ptr<DropTracker> dragEnter(const InputState& inputState, const std::string& payload);
 
             void setRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const;
             void render(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);

--- a/common/src/View/UVCameraTool.h
+++ b/common/src/View/UVCameraTool.h
@@ -32,7 +32,7 @@ namespace TrenchBroom {
     namespace View {
         class DragTracker;
 
-        class UVCameraTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy, NoDropPolicy>, public Tool {
+        class UVCameraTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, NoRenderPolicy>, public Tool {
         private:
             Renderer::OrthographicCamera& m_camera;
         public:

--- a/common/src/View/UVOffsetTool.h
+++ b/common/src/View/UVOffsetTool.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVOffsetTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy>, public Tool {
+        class UVOffsetTool : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy>, public Tool {
         private:
             std::weak_ptr<MapDocument> m_document;
             const UVViewHelper& m_helper;

--- a/common/src/View/UVOriginTool.h
+++ b/common/src/View/UVOriginTool.h
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         class DragTracker;
         class UVViewHelper;
 
-        class UVOriginTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy, NoDropPolicy>, public Tool {
+        class UVOriginTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy>, public Tool {
         public:
             static const Model::HitType::Type XHandleHitType;
             static const Model::HitType::Type YHandleHitType;

--- a/common/src/View/UVRotateTool.h
+++ b/common/src/View/UVRotateTool.h
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVRotateTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy, NoDropPolicy>, public Tool {
+        class UVRotateTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy>, public Tool {
         public:
             static const Model::HitType::Type AngleHandleHitType;
         private:

--- a/common/src/View/UVScaleTool.h
+++ b/common/src/View/UVScaleTool.h
@@ -41,7 +41,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVScaleTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy, NoDropPolicy>, public Tool {
+        class UVScaleTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, RenderPolicy>, public Tool {
         public:
             static const Model::HitType::Type XHandleHitType;
             static const Model::HitType::Type YHandleHitType;

--- a/common/src/View/UVShearTool.h
+++ b/common/src/View/UVShearTool.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         class MapDocument;
         class UVViewHelper;
 
-        class UVShearTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy, NoDropPolicy>, public Tool {
+        class UVShearTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, NoRenderPolicy>, public Tool {
         private:
             static const Model::HitType::Type XHandleHitType;
             static const Model::HitType::Type YHandleHitType;

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -131,7 +131,7 @@ namespace TrenchBroom {
             };
 
             template <typename H>
-            class SelectPartBase : public ToolControllerBase<PickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy>, public PartBase {
+            class SelectPartBase : public ToolControllerBase<PickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, public PartBase {
             protected:
                 SelectPartBase(T* tool, const Model::HitType::Type hitType) :
                 PartBase{tool, hitType} {}
@@ -288,7 +288,7 @@ namespace TrenchBroom {
                 }
             };
 
-            class MovePartBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy, NoDropPolicy>, public PartBase {
+            class MovePartBase : public ToolControllerBase<NoPickingPolicy, NoKeyPolicy, MousePolicy, RenderPolicy>, public PartBase {
             protected:
                 MovePartBase(T* tool, const Model::HitType::Type hitType) :
                 PartBase{tool, hitType} {}


### PR DESCRIPTION
This small PR replaces TB's current handling for drag and drop with an approach similar to https://github.com/TrenchBroom/TrenchBroom/pull/3823. Since this is really only used by `CreateEntityTool`, the actual change is really small.