### PR TITLE
3781: Refactor Notifier

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -462,6 +462,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/FileLogger.cpp
         ${COMMON_SOURCE_DIR}/Exceptions.cpp
         ${COMMON_SOURCE_DIR}/Logger.cpp
+        ${COMMON_SOURCE_DIR}/NotifierConnection.cpp
         ${COMMON_SOURCE_DIR}/PreferenceManager.cpp
         ${COMMON_SOURCE_DIR}/Preference.cpp
         ${COMMON_SOURCE_DIR}/Preferences.cpp
@@ -980,6 +981,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Logger.h
         ${COMMON_SOURCE_DIR}/Macros.h
         ${COMMON_SOURCE_DIR}/Notifier.h
+        ${COMMON_SOURCE_DIR}/NotifierConnection.h
         ${COMMON_SOURCE_DIR}/Preference.h
         ${COMMON_SOURCE_DIR}/PreferenceManager.h
         ${COMMON_SOURCE_DIR}/Preferences.h

--- a/common/src/Assets/EntityDefinitionManager.cpp
+++ b/common/src/Assets/EntityDefinitionManager.cpp
@@ -50,12 +50,13 @@ namespace TrenchBroom {
             updateIndices();
             updateGroups();
             updateCache();
-            bindObservers();
+            connectObservers();
         }
 
         void EntityDefinitionManager::clear() {
             clearCache();
             clearGroups();
+            m_notifierConnection.disconnect();
             kdl::vec_clear_and_delete(m_definitions);
         }
 
@@ -113,9 +114,9 @@ namespace TrenchBroom {
             }
         }
 
-        void EntityDefinitionManager::bindObservers() {
+        void EntityDefinitionManager::connectObservers() {
             for (EntityDefinition* definition : m_definitions) {
-                definition->usageCountDidChangeNotifier.addObserver(usageCountDidChangeNotifier);
+                m_notifierConnection += definition->usageCountDidChangeNotifier.connect(usageCountDidChangeNotifier);
             }
         }
 

--- a/common/src/Assets/EntityDefinitionManager.h
+++ b/common/src/Assets/EntityDefinitionManager.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Notifier.h"
+#include "NotifierConnection.h"
 
 #include <map>
 #include <string>
@@ -48,6 +49,8 @@ namespace TrenchBroom {
             std::vector<EntityDefinition*> m_definitions;
             std::vector<EntityDefinitionGroup> m_groups;
             Cache m_cache;
+
+            NotifierConnection m_notifierConnection;
         public:
             Notifier<> usageCountDidChangeNotifier;
         public:
@@ -67,7 +70,7 @@ namespace TrenchBroom {
             void updateIndices();
             void updateGroups();
             void updateCache();
-            void bindObservers();
+            void connectObservers();
             void clearCache();
             void clearGroups();
         };

--- a/common/src/NotifierConnection.cpp
+++ b/common/src/NotifierConnection.cpp
@@ -1,0 +1,49 @@
+/*
+ Copyright (C) 2021 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "NotifierConnection.h"
+#include "Notifier.h"
+
+namespace TrenchBroom {
+    NotifierConnection::NotifierConnection() = default;
+
+    NotifierConnection::NotifierConnection(NotifierBase& notifier, const size_t id) :
+    m_connections{{notifier, id}} {}
+
+    NotifierConnection::NotifierConnection(NotifierConnection&&) noexcept = default;
+
+    NotifierConnection& NotifierConnection::operator=(NotifierConnection&&) noexcept = default;
+
+    NotifierConnection::~NotifierConnection() {
+        disconnect();
+    }
+
+    NotifierConnection& NotifierConnection::operator+=(NotifierConnection&& other) {
+        m_connections.insert(std::end(m_connections), std::begin(other.m_connections), std::end(other.m_connections));
+        other.m_connections.clear();
+        return *this;
+    }
+
+    void NotifierConnection::disconnect() {
+        for (auto& [notifier, id] : m_connections) {
+            notifier.disconnect(id);
+        }
+        m_connections.clear();
+    }
+}

--- a/common/src/NotifierConnection.h
+++ b/common/src/NotifierConnection.h
@@ -1,0 +1,67 @@
+/*
+ Copyright (C) 2021 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace TrenchBroom {
+    class NotifierBase;
+
+    /**
+     * Manages one or multiple connections of observer calllbacks to notifiers.
+     *
+     * All connections are disconnected when an instance of this class is destroyed.
+     */
+    class NotifierConnection {
+    private:
+        std::vector<std::tuple<NotifierBase&, size_t>> m_connections;
+    public:
+        /**
+         * Creates a new instance that contains no connections.
+         */
+        NotifierConnection();
+
+        /**
+         * Creates a new instance that contains one connection to the given notifier with the given id.
+         */
+        NotifierConnection(NotifierBase& notifier, const size_t id);
+
+        NotifierConnection(const NotifierConnection&) = delete;
+        NotifierConnection(NotifierConnection&&) noexcept;
+
+        NotifierConnection& operator=(const NotifierConnection&) = delete;
+        NotifierConnection& operator=(NotifierConnection&&) noexcept;
+
+        /**
+         * Disconnects all connected observers.
+         */
+        ~NotifierConnection();
+
+        /**
+         * Transfers the connections from the given instance to this one. The given instance will lose its connections.
+         */
+        NotifierConnection& operator+=(NotifierConnection&& other);
+
+        /**
+         * Disconnects all connected observers.
+         */
+        void disconnect();
+    };
+}

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Macros.h"
+#include "NotifierConnection.h"
 
 #include <map>
 #include <memory>
@@ -68,6 +69,8 @@ namespace TrenchBroom {
             std::unique_ptr<ObjectRenderer> m_lockedRenderer;
             std::unique_ptr<EntityLinkRenderer> m_entityLinkRenderer;
             std::unique_ptr<GroupLinkRenderer> m_groupLinkRenderer;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit MapRenderer(std::weak_ptr<View::MapDocument> document);
             ~MapRenderer();
@@ -122,8 +125,7 @@ namespace TrenchBroom {
             void invalidateGroupLinkRenderer();
             void reloadEntityModels();
         private: // notification
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasCleared(View::MapDocument* document);
             void documentWasNewedOrLoaded(View::MapDocument* document);

--- a/common/src/View/CameraLinkHelper.cpp
+++ b/common/src/View/CameraLinkHelper.cpp
@@ -35,23 +35,11 @@ namespace TrenchBroom {
         CameraLinkHelper::CameraLinkHelper() :
         m_ignoreNotifications(false) {}
 
-        CameraLinkHelper::~CameraLinkHelper() {
-            for (Renderer::Camera* camera : m_cameras) {
-                camera->cameraDidChangeNotifier.removeObserver(this, &CameraLinkHelper::cameraDidChange);
-            }
-        }
-
         void CameraLinkHelper::addCamera(Renderer::Camera* camera) {
             ensure(camera != nullptr, "camera is null");
             assert(!kdl::vec_contains(m_cameras, camera));
             m_cameras.push_back(camera);
-            camera->cameraDidChangeNotifier.addObserver(this, &CameraLinkHelper::cameraDidChange);
-        }
-
-        void CameraLinkHelper::removeCamera(Renderer::Camera* camera) {
-            ensure(camera != nullptr, "camera is null");
-            m_cameras = kdl::vec_erase(std::move(m_cameras), camera);
-            camera->cameraDidChangeNotifier.removeObserver(this, &CameraLinkHelper::cameraDidChange);
+            m_notifierConnection += camera->cameraDidChangeNotifier.connect(this, &CameraLinkHelper::cameraDidChange);
         }
 
         void CameraLinkHelper::cameraDidChange(const Renderer::Camera* camera) {

--- a/common/src/View/CameraLinkHelper.h
+++ b/common/src/View/CameraLinkHelper.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <vector>
 
 namespace TrenchBroom {
@@ -31,12 +33,11 @@ namespace TrenchBroom {
         private:
             std::vector<Renderer::Camera*> m_cameras;
             bool m_ignoreNotifications;
+            NotifierConnection m_notifierConnection;
         public:
             CameraLinkHelper();
-            ~CameraLinkHelper();
 
             void addCamera(Renderer::Camera* camera);
-            void removeCamera(Renderer::Camera* camera);
         private:
             void cameraDidChange(const Renderer::Camera* camera);
         };

--- a/common/src/View/ClipTool.h
+++ b/common/src/View/ClipTool.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 #include "Model/HitType.h"
 #include "View/Tool.h"
 
@@ -127,6 +128,8 @@ namespace TrenchBroom {
 
             bool m_ignoreNotifications;
             bool m_dragging;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit ClipTool(std::weak_ptr<MapDocument> document);
             ~ClipTool() override;
@@ -188,8 +191,7 @@ namespace TrenchBroom {
 
             bool doRemove();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void selectionDidChange(const Selection& selection);
             void nodesWillChange(const std::vector<Model::Node*>& nodes);
             void nodesDidChange(const std::vector<Model::Node*>& nodes);

--- a/common/src/View/DirectoryTextureCollectionEditor.h
+++ b/common/src/View/DirectoryTextureCollectionEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 #include <vector>
 
@@ -46,9 +48,10 @@ namespace TrenchBroom {
             QAbstractButton* m_addCollectionsButton;
             QAbstractButton* m_removeCollectionsButton;
             QAbstractButton* m_reloadCollectionsButton;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit DirectoryTextureCollectionEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~DirectoryTextureCollectionEditor() override;
         private:
             void addSelectedTextureCollections();
             void removeSelectedTextureCollections();
@@ -63,8 +66,7 @@ namespace TrenchBroom {
             void createGui();
             void updateButtons();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void textureCollectionsDidChange();
             void modsDidChange();

--- a/common/src/View/EntityBrowser.h
+++ b/common/src/View/EntityBrowser.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 
 #include <QWidget>
@@ -48,16 +50,16 @@ namespace TrenchBroom {
             QLineEdit* m_filterBox;
             QScrollBar* m_scrollBar;
             EntityBrowserView* m_view;
+
+            NotifierConnection m_notifierConnection;
         public:
             EntityBrowser(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
-            ~EntityBrowser() override;
 
             void reload();
         private:
             void createGui(GLContextManager& contextManager);
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -85,11 +85,10 @@ namespace TrenchBroom {
             const vm::quatf vRotation = vm::quatf(vm::vec3f::pos_y(), vm::to_radians(20.0f));
             m_rotation = vRotation * hRotation;
 
-            m_entityDefinitionManager.usageCountDidChangeNotifier.addObserver(this, &EntityBrowserView::usageCountDidChange);
+            m_notifierConnection += m_entityDefinitionManager.usageCountDidChangeNotifier.connect(this, &EntityBrowserView::usageCountDidChange);
         }
 
         EntityBrowserView::~EntityBrowserView() {
-            m_entityDefinitionManager.usageCountDidChangeNotifier.removeObserver(this, &EntityBrowserView::usageCountDidChange);
             clear();
         }
 

--- a/common/src/View/EntityBrowserView.h
+++ b/common/src/View/EntityBrowserView.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "Renderer/FontDescriptor.h"
 #include "Renderer/GLVertexType.h"
 #include "View/CellView.h"
@@ -78,6 +79,8 @@ namespace TrenchBroom {
             bool m_hideUnused;
             Assets::EntityDefinitionSortOrder m_sortOrder;
             std::string m_filterText;
+
+            NotifierConnection m_notifierConnection;
         public:
             EntityBrowserView(QScrollBar* scrollBar,
                               GLContextManager& contextManager,

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -73,11 +73,7 @@ namespace TrenchBroom {
         m_document(document) {
             createGui();
             bindEvents();
-            bindObservers();
-        }
-
-        EntityDefinitionFileChooser::~EntityDefinitionFileChooser() {
-            unbindObservers();
+            connectObservers();
         }
 
         void EntityDefinitionFileChooser::createGui() {
@@ -131,20 +127,11 @@ namespace TrenchBroom {
                 &EntityDefinitionFileChooser::reloadExternalClicked);
         }
 
-        void EntityDefinitionFileChooser::bindObservers() {
+        void EntityDefinitionFileChooser::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->documentWasNewedNotifier.addObserver(this, &EntityDefinitionFileChooser::documentWasNewed);
-            document->documentWasLoadedNotifier.addObserver(this, &EntityDefinitionFileChooser::documentWasLoaded);
-            document->entityDefinitionsDidChangeNotifier.addObserver(this, &EntityDefinitionFileChooser::entityDefinitionsDidChange);
-        }
-
-        void EntityDefinitionFileChooser::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasNewedNotifier.removeObserver(this, &EntityDefinitionFileChooser::documentWasNewed);
-                document->documentWasLoadedNotifier.removeObserver(this, &EntityDefinitionFileChooser::documentWasLoaded);
-                document->entityDefinitionsDidChangeNotifier.removeObserver(this, &EntityDefinitionFileChooser::entityDefinitionsDidChange);
-            }
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &EntityDefinitionFileChooser::documentWasNewed);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &EntityDefinitionFileChooser::documentWasLoaded);
+            m_notifierConnection += document->entityDefinitionsDidChangeNotifier.connect(this, &EntityDefinitionFileChooser::entityDefinitionsDidChange);
         }
 
         void EntityDefinitionFileChooser::documentWasNewed(MapDocument*) {

--- a/common/src/View/EntityDefinitionFileChooser.h
+++ b/common/src/View/EntityDefinitionFileChooser.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 
 #include <QListWidget>
@@ -53,15 +55,15 @@ namespace TrenchBroom {
             QLabel* m_external;
             QPushButton* m_chooseExternal;
             QPushButton* m_reloadExternal;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit EntityDefinitionFileChooser(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~EntityDefinitionFileChooser() override;
         private:
             void createGui();
             void bindEvents();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/EntityPropertyEditor.cpp
+++ b/common/src/View/EntityPropertyEditor.cpp
@@ -49,11 +49,10 @@ namespace TrenchBroom {
         m_documentationText(nullptr),
         m_currentDefinition(nullptr) {
         createGui(document);
-        bindObservers();
+        connectObservers();
         }
 
         EntityPropertyEditor::~EntityPropertyEditor() {
-            unbindObservers();
             saveWindowState(m_splitter);
         }
 
@@ -61,18 +60,10 @@ namespace TrenchBroom {
             updateDocumentationAndSmartEditor();
         }
 
-        void EntityPropertyEditor::bindObservers() {
+        void EntityPropertyEditor::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->selectionDidChangeNotifier.addObserver(this, &EntityPropertyEditor::selectionDidChange);
-            document->nodesDidChangeNotifier.addObserver(this, &EntityPropertyEditor::nodesDidChange);
-        }
-
-        void EntityPropertyEditor::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->selectionDidChangeNotifier.removeObserver(this, &EntityPropertyEditor::selectionDidChange);
-                document->nodesDidChangeNotifier.removeObserver(this, &EntityPropertyEditor::nodesDidChange);
-            }
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &EntityPropertyEditor::selectionDidChange);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &EntityPropertyEditor::nodesDidChange);
         }
 
         void EntityPropertyEditor::selectionDidChange(const Selection&) {

--- a/common/src/View/EntityPropertyEditor.h
+++ b/common/src/View/EntityPropertyEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -57,14 +59,15 @@ namespace TrenchBroom {
             SmartPropertyEditorManager* m_smartEditorManager;
             QTextEdit* m_documentationText;
             const Assets::EntityDefinition* m_currentDefinition;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit EntityPropertyEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
             ~EntityPropertyEditor() override;
         private:
             void OnCurrentRowChanged();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void selectionDidChange(const Selection& selection);
             void nodesDidChange(const std::vector<Model::Node*>& nodes);

--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -55,11 +55,7 @@ namespace TrenchBroom {
         QWidget(parent),
         m_document(document) {
             createGui(document);
-            bindObservers();
-        }
-
-        EntityPropertyGrid::~EntityPropertyGrid() {
-            unbindObservers();
+            connectObservers();
         }
 
         void EntityPropertyGrid::backupSelection() {
@@ -301,24 +297,13 @@ namespace TrenchBroom {
             m_table->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::AnyKeyPressed);
         }
 
-        void EntityPropertyGrid::bindObservers() {
+        void EntityPropertyGrid::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->documentWasNewedNotifier.addObserver(this, &EntityPropertyGrid::documentWasNewed);
-            document->documentWasLoadedNotifier.addObserver(this, &EntityPropertyGrid::documentWasLoaded);
-            document->nodesDidChangeNotifier.addObserver(this, &EntityPropertyGrid::nodesDidChange);
-            document->selectionWillChangeNotifier.addObserver(this, &EntityPropertyGrid::selectionWillChange);
-            document->selectionDidChangeNotifier.addObserver(this, &EntityPropertyGrid::selectionDidChange);
-        }
-
-        void EntityPropertyGrid::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasNewedNotifier.removeObserver(this, &EntityPropertyGrid::documentWasNewed);
-                document->documentWasLoadedNotifier.removeObserver(this, &EntityPropertyGrid::documentWasLoaded);
-                document->nodesDidChangeNotifier.removeObserver(this, &EntityPropertyGrid::nodesDidChange);
-                document->selectionWillChangeNotifier.removeObserver(this, &EntityPropertyGrid::selectionWillChange);
-                document->selectionDidChangeNotifier.removeObserver(this, &EntityPropertyGrid::selectionDidChange);
-            }
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &EntityPropertyGrid::documentWasNewed);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &EntityPropertyGrid::documentWasLoaded);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &EntityPropertyGrid::nodesDidChange);
+            m_notifierConnection += document->selectionWillChangeNotifier.connect(this, &EntityPropertyGrid::selectionWillChange);
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &EntityPropertyGrid::selectionDidChange);
         }
 
         void EntityPropertyGrid::documentWasNewed(MapDocument*) {

--- a/common/src/View/EntityPropertyGrid.h
+++ b/common/src/View/EntityPropertyGrid.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -64,9 +66,10 @@ namespace TrenchBroom {
             QAbstractButton* m_removePropertiesButton;
             QCheckBox* m_showDefaultPropertiesCheckBox;
             std::vector<PropertyGridSelection> m_selectionBackup;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit EntityPropertyGrid(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~EntityPropertyGrid() override;
         private:
             void backupSelection();
             void restoreSelection();
@@ -79,8 +82,7 @@ namespace TrenchBroom {
         private:
             void createGui(std::weak_ptr<MapDocument> document);
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -76,12 +76,8 @@ namespace TrenchBroom {
         m_colorEditor(nullptr) {
             createGui(contextManager);
             bindEvents();
-            bindObservers();
+            connectObservers();
             updateIncrements();
-        }
-
-        FaceAttribsEditor::~FaceAttribsEditor() {
-            unbindObservers();
         }
 
         bool FaceAttribsEditor::cancelMouseDrag() {
@@ -380,28 +376,15 @@ namespace TrenchBroom {
             connect(m_colorEditor, &QLineEdit::textEdited, this, &FaceAttribsEditor::colorValueChanged);
         }
 
-        void FaceAttribsEditor::bindObservers() {
+        void FaceAttribsEditor::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->documentWasNewedNotifier.addObserver(this, &FaceAttribsEditor::documentWasNewed);
-            document->documentWasLoadedNotifier.addObserver(this, &FaceAttribsEditor::documentWasLoaded);
-            document->nodesDidChangeNotifier.addObserver(this, &FaceAttribsEditor::nodesDidChange);
-            document->brushFacesDidChangeNotifier.addObserver(this, &FaceAttribsEditor::brushFacesDidChange);
-            document->selectionDidChangeNotifier.addObserver(this, &FaceAttribsEditor::selectionDidChange);
-            document->textureCollectionsDidChangeNotifier.addObserver(this, &FaceAttribsEditor::textureCollectionsDidChange);
-            document->grid().gridDidChangeNotifier.addObserver(this, &FaceAttribsEditor::updateIncrements);
-        }
-
-        void FaceAttribsEditor::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasNewedNotifier.removeObserver(this, &FaceAttribsEditor::documentWasNewed);
-                document->documentWasLoadedNotifier.removeObserver(this, &FaceAttribsEditor::documentWasLoaded);
-                document->nodesDidChangeNotifier.removeObserver(this, &FaceAttribsEditor::nodesDidChange);
-                document->brushFacesDidChangeNotifier.removeObserver(this, &FaceAttribsEditor::brushFacesDidChange);
-                document->selectionDidChangeNotifier.removeObserver(this, &FaceAttribsEditor::selectionDidChange);
-                document->textureCollectionsDidChangeNotifier.removeObserver(this, &FaceAttribsEditor::textureCollectionsDidChange);
-                document->grid().gridDidChangeNotifier.removeObserver(this, &FaceAttribsEditor::updateIncrements);
-            }
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &FaceAttribsEditor::documentWasNewed);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &FaceAttribsEditor::documentWasLoaded);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &FaceAttribsEditor::nodesDidChange);
+            m_notifierConnection += document->brushFacesDidChangeNotifier.connect(this, &FaceAttribsEditor::brushFacesDidChange);
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &FaceAttribsEditor::selectionDidChange);
+            m_notifierConnection += document->textureCollectionsDidChangeNotifier.connect(this, &FaceAttribsEditor::textureCollectionsDidChange);
+            m_notifierConnection += document->grid().gridDidChangeNotifier.connect(this, &FaceAttribsEditor::updateIncrements);
         }
 
         void FaceAttribsEditor::documentWasNewed(MapDocument*) {

--- a/common/src/View/FaceAttribsEditor.h
+++ b/common/src/View/FaceAttribsEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <QWidget>
 
 #include <memory>
@@ -65,9 +67,10 @@ namespace TrenchBroom {
 
             QLabel* m_colorLabel;
             QLineEdit* m_colorEditor;
+
+            NotifierConnection m_notifierConnection;
         public:
             FaceAttribsEditor(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
-            ~FaceAttribsEditor() override;
 
             bool cancelMouseDrag();
         private:
@@ -85,8 +88,7 @@ namespace TrenchBroom {
             void createGui(GLContextManager& contextManager);
             void bindEvents();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -54,12 +54,8 @@ namespace TrenchBroom {
         m_moveTextureCollectionDownButton(nullptr),
         m_reloadTextureCollectionsButton(nullptr) {
             createGui();
-            bindObservers();
+            connectObservers();
             updateControls();
-        }
-
-        FileTextureCollectionEditor::~FileTextureCollectionEditor() {
-            unbindObservers();
         }
 
         bool FileTextureCollectionEditor::debugUIConsistency() const {
@@ -274,22 +270,12 @@ namespace TrenchBroom {
             m_reloadTextureCollectionsButton->setEnabled(canReloadTextureCollections());
         }
 
-        void FileTextureCollectionEditor::bindObservers() {
+        void FileTextureCollectionEditor::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->textureCollectionsDidChangeNotifier.addObserver(this, &FileTextureCollectionEditor::textureCollectionsDidChange);
+            m_notifierConnection += document->textureCollectionsDidChangeNotifier.connect(this, &FileTextureCollectionEditor::textureCollectionsDidChange);
 
             auto& prefs = PreferenceManager::instance();
-            prefs.preferenceDidChangeNotifier.addObserver(this, &FileTextureCollectionEditor::preferenceDidChange);
-        }
-
-        void FileTextureCollectionEditor::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->textureCollectionsDidChangeNotifier.removeObserver(this, &FileTextureCollectionEditor::textureCollectionsDidChange);
-            }
-
-            auto& prefs = PreferenceManager::instance();
-            prefs.preferenceDidChangeNotifier.removeObserver(this, &FileTextureCollectionEditor::preferenceDidChange);
+            m_notifierConnection += prefs.preferenceDidChangeNotifier.connect(this, &FileTextureCollectionEditor::preferenceDidChange);
         }
 
         void FileTextureCollectionEditor::textureCollectionsDidChange() {

--- a/common/src/View/FileTextureCollectionEditor.h
+++ b/common/src/View/FileTextureCollectionEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 
 #include <QWidget>
@@ -48,9 +50,10 @@ namespace TrenchBroom {
             QAbstractButton* m_moveTextureCollectionUpButton;
             QAbstractButton* m_moveTextureCollectionDownButton;
             QAbstractButton* m_reloadTextureCollectionsButton;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit FileTextureCollectionEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~FileTextureCollectionEditor() override;
 
             bool debugUIConsistency() const;
             bool canRemoveTextureCollections() const;
@@ -68,8 +71,7 @@ namespace TrenchBroom {
         private slots:
             void updateButtons();
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void textureCollectionsDidChange();
             void preferenceDidChange(const IO::Path& path);

--- a/common/src/View/GameDialog.cpp
+++ b/common/src/View/GameDialog.cpp
@@ -41,10 +41,6 @@ Q_DECLARE_METATYPE(TrenchBroom::Model::MapFormat)
 
 namespace TrenchBroom {
     namespace View {
-        GameDialog::~GameDialog() {
-            unbindObservers();
-        }
-
         bool GameDialog::showNewDocumentDialog(QWidget* parent, std::string& gameName, Model::MapFormat& mapFormat) {
             GameDialog dialog("Select Game", "Select a game from the list on the right, then click OK. Once the new document is created, you can set up mod directories, entity definitions and textures by going to the map inspector, the entity inspector and the face inspector, respectively.", GameDialog::DialogType::New, parent);
             if (dialog.exec() == QDialog::Rejected) {
@@ -114,7 +110,7 @@ namespace TrenchBroom {
         m_okButton(nullptr) {
             createGui(title, infoText);
             updateMapFormats("");
-            bindObservers();
+            connectObservers();
         }
 
         void GameDialog::createGui(const QString& title, const QString& infoText) {
@@ -234,14 +230,9 @@ namespace TrenchBroom {
             }
         }
 
-        void GameDialog::bindObservers() {
+        void GameDialog::connectObservers() {
             auto& prefs = PreferenceManager::instance();
-            prefs.preferenceDidChangeNotifier.addObserver(this, &GameDialog::preferenceDidChange);
-        }
-
-        void GameDialog::unbindObservers() {
-            auto& prefs = PreferenceManager::instance();
-            prefs.preferenceDidChangeNotifier.removeObserver(this, &GameDialog::preferenceDidChange);
+            m_notifierConnection += prefs.preferenceDidChangeNotifier.connect(this, &GameDialog::preferenceDidChange);
         }
 
         void GameDialog::preferenceDidChange(const IO::Path& /* path */) {

--- a/common/src/View/GameDialog.h
+++ b/common/src/View/GameDialog.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "Model/MapFormat.h"
 
 #include <string>
@@ -47,9 +48,9 @@ namespace TrenchBroom {
             QComboBox* m_mapFormatComboBox;
             QPushButton* m_openPreferencesButton;
             QPushButton* m_okButton;
-        public:
-            ~GameDialog() override;
 
+            NotifierConnection m_notifierConnection;
+        public:
             // FIXME: return a tuple instead of taking in/out parameters
             static bool showNewDocumentDialog(QWidget* parent, std::string& gameName, Model::MapFormat& mapFormat);
             static bool showOpenDocumentDialog(QWidget* parent, std::string& gameName, Model::MapFormat& mapFormat);
@@ -69,8 +70,7 @@ namespace TrenchBroom {
         private:
             void updateMapFormats(const std::string& gameName);
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void preferenceDidChange(const IO::Path& path);
         };
     }

--- a/common/src/View/IssueBrowser.cpp
+++ b/common/src/View/IssueBrowser.cpp
@@ -46,11 +46,7 @@ namespace TrenchBroom {
             sizer->addWidget(m_view);
             setLayout(sizer);
 
-            bindObservers();
-        }
-
-        IssueBrowser::~IssueBrowser() {
-            unbindObservers();
+            connectObservers();
         }
 
         QWidget* IssueBrowser::createTabBarPage(QWidget* parent) {
@@ -72,28 +68,15 @@ namespace TrenchBroom {
             return barPage;
         }
 
-        void IssueBrowser::bindObservers() {
+        void IssueBrowser::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->documentWasSavedNotifier.addObserver(this, &IssueBrowser::documentWasSaved);
-            document->documentWasNewedNotifier.addObserver(this, &IssueBrowser::documentWasNewedOrLoaded);
-            document->documentWasLoadedNotifier.addObserver(this, &IssueBrowser::documentWasNewedOrLoaded);
-            document->nodesWereAddedNotifier.addObserver(this, &IssueBrowser::nodesWereAdded);
-            document->nodesWereRemovedNotifier.addObserver(this, &IssueBrowser::nodesWereRemoved);
-            document->nodesDidChangeNotifier.addObserver(this, &IssueBrowser::nodesDidChange);
-            document->brushFacesDidChangeNotifier.addObserver(this, &IssueBrowser::brushFacesDidChange);
-        }
-
-        void IssueBrowser::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasSavedNotifier.removeObserver(this, &IssueBrowser::documentWasSaved);
-                document->documentWasNewedNotifier.removeObserver(this, &IssueBrowser::documentWasNewedOrLoaded);
-                document->documentWasLoadedNotifier.removeObserver(this, &IssueBrowser::documentWasNewedOrLoaded);
-                document->nodesWereAddedNotifier.removeObserver(this, &IssueBrowser::nodesWereAdded);
-                document->nodesWereRemovedNotifier.removeObserver(this, &IssueBrowser::nodesWereRemoved);
-                document->nodesDidChangeNotifier.removeObserver(this, &IssueBrowser::nodesDidChange);
-                document->brushFacesDidChangeNotifier.removeObserver(this, &IssueBrowser::brushFacesDidChange);
-            }
+            m_notifierConnection += document->documentWasSavedNotifier.connect(this, &IssueBrowser::documentWasSaved);
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &IssueBrowser::documentWasNewedOrLoaded);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &IssueBrowser::documentWasNewedOrLoaded);
+            m_notifierConnection += document->nodesWereAddedNotifier.connect(this, &IssueBrowser::nodesWereAdded);
+            m_notifierConnection += document->nodesWereRemovedNotifier.connect(this, &IssueBrowser::nodesWereRemoved);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &IssueBrowser::nodesDidChange);
+            m_notifierConnection += document->brushFacesDidChangeNotifier.connect(this, &IssueBrowser::brushFacesDidChange);
         }
 
         void IssueBrowser::documentWasNewedOrLoaded(MapDocument*) {

--- a/common/src/View/IssueBrowser.h
+++ b/common/src/View/IssueBrowser.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "View/TabBook.h"
 
 #include <memory>
@@ -52,14 +53,14 @@ namespace TrenchBroom {
             IssueBrowserView* m_view;
             QCheckBox* m_showHiddenIssuesCheckBox;
             FlagsPopupEditor* m_filterEditor;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit IssueBrowser(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~IssueBrowser() override;
 
             QWidget* createTabBarPage(QWidget* parent) override;
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void documentWasNewedOrLoaded(MapDocument* document);
             void documentWasSaved(MapDocument* document);
             void nodesWereAdded(const std::vector<Model::Node*>& nodes);

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -155,11 +155,7 @@ namespace TrenchBroom {
         LayerListBox::LayerListBox(std::weak_ptr<MapDocument> document, QWidget* parent) :
         ControlListBox("", true, parent),
         m_document(std::move(document)) {
-            bindObservers();
-        }
-
-        LayerListBox::~LayerListBox() {
-            unbindObservers();
+            connectObservers();
         }
 
         Model::LayerNode* LayerListBox::selectedLayer() const {
@@ -176,32 +172,17 @@ namespace TrenchBroom {
             setCurrentRow(-1);
         }
 
-        void LayerListBox::bindObservers() {
+        void LayerListBox::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->documentWasNewedNotifier.addObserver(this, &LayerListBox::documentDidChange);
-            document->documentWasLoadedNotifier.addObserver(this, &LayerListBox::documentDidChange);
-            document->documentWasClearedNotifier.addObserver(this, &LayerListBox::documentDidChange);
-            document->currentLayerDidChangeNotifier.addObserver(this, &LayerListBox::currentLayerDidChange);
-            document->nodesWereAddedNotifier.addObserver(this, &LayerListBox::nodesDidChange);
-            document->nodesWereRemovedNotifier.addObserver(this, &LayerListBox::nodesDidChange);
-            document->nodesDidChangeNotifier.addObserver(this, &LayerListBox::nodesDidChange);
-            document->nodeVisibilityDidChangeNotifier.addObserver(this, &LayerListBox::nodesDidChange);
-            document->nodeLockingDidChangeNotifier.addObserver(this, &LayerListBox::nodesDidChange);
-        }
-
-        void LayerListBox::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasNewedNotifier.removeObserver(this, &LayerListBox::documentDidChange);
-                document->documentWasLoadedNotifier.removeObserver(this, &LayerListBox::documentDidChange);
-                document->documentWasClearedNotifier.removeObserver(this, &LayerListBox::documentDidChange);
-                document->currentLayerDidChangeNotifier.removeObserver(this, &LayerListBox::currentLayerDidChange);
-                document->nodesWereAddedNotifier.removeObserver(this, &LayerListBox::nodesDidChange);
-                document->nodesWereRemovedNotifier.removeObserver(this, &LayerListBox::nodesDidChange);
-                document->nodesDidChangeNotifier.removeObserver(this, &LayerListBox::nodesDidChange);
-                document->nodeVisibilityDidChangeNotifier.removeObserver(this, &LayerListBox::nodesDidChange);
-                document->nodeLockingDidChangeNotifier.removeObserver(this, &LayerListBox::nodesDidChange);
-            }
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &LayerListBox::documentDidChange);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &LayerListBox::documentDidChange);
+            m_notifierConnection += document->documentWasClearedNotifier.connect(this, &LayerListBox::documentDidChange);
+            m_notifierConnection += document->currentLayerDidChangeNotifier.connect(this, &LayerListBox::currentLayerDidChange);
+            m_notifierConnection += document->nodesWereAddedNotifier.connect(this, &LayerListBox::nodesDidChange);
+            m_notifierConnection += document->nodesWereRemovedNotifier.connect(this, &LayerListBox::nodesDidChange);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &LayerListBox::nodesDidChange);
+            m_notifierConnection += document->nodeVisibilityDidChangeNotifier.connect(this, &LayerListBox::nodesDidChange);
+            m_notifierConnection += document->nodeLockingDidChangeNotifier.connect(this, &LayerListBox::nodesDidChange);
         }
 
         void LayerListBox::documentDidChange(MapDocument*) {

--- a/common/src/View/LayerListBox.h
+++ b/common/src/View/LayerListBox.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "View/ControlListBox.h"
 
 #include <memory>
@@ -71,9 +72,10 @@ namespace TrenchBroom {
             Q_OBJECT
         private:
             std::weak_ptr<MapDocument> m_document;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit LayerListBox(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~LayerListBox() override;
 
             Model::LayerNode* selectedLayer() const;
             void setSelectedLayer(Model::LayerNode* layer);
@@ -84,8 +86,7 @@ namespace TrenchBroom {
 
             void selectedRowChanged(int index) override;
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentDidChange(MapDocument* document);
             void nodesDidChange(const std::vector<Model::Node*>& nodes);

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -21,6 +21,7 @@
 
 #include "FloatType.h"
 #include "Notifier.h"
+#include "NotifierConnection.h"
 #include "IO/Path.h"
 #include "Model/Game.h"
 #include "Model/MapFacade.h"
@@ -187,6 +188,8 @@ namespace TrenchBroom {
 
             Notifier<> portalFileWasLoadedNotifier;
             Notifier<> portalFileWasUnloadedNotifier;
+        private:
+            NotifierConnection m_notifierConnection;
         protected:
             MapDocument();
         public:
@@ -585,7 +588,7 @@ namespace TrenchBroom {
             bool isRegisteredSmartTag(size_t index) const;
             const Model::SmartTag& smartTag(size_t index) const;
         private:
-            void initializeNodeTags(MapDocument* document);
+            void initializeAllNodeTags(MapDocument* document);
             void initializeNodeTags(const std::vector<Model::Node*>& nodes);
             void clearNodeTags(const std::vector<Model::Node*>& nodes);
             void updateNodeTags(const std::vector<Model::Node*>& nodes);
@@ -605,8 +608,7 @@ namespace TrenchBroom {
             void setLastSaveModificationCount();
             void clearModificationCount();
         private: // observers
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void textureCollectionsWillChange();
             void textureCollectionsDidChange();
             void entityDefinitionsWillChange();

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 #include "Model/NodeContents.h"
 #include "View/MapDocument.h"
 
@@ -49,6 +50,8 @@ namespace TrenchBroom {
         class MapDocumentCommandFacade : public MapDocument {
         private:
             std::unique_ptr<CommandProcessor> m_commandProcessor;
+
+            NotifierConnection m_notifierConnection;
         public:
             static std::shared_ptr<MapDocument> newMapDocument();
         private:
@@ -103,7 +106,7 @@ namespace TrenchBroom {
             void incModificationCount(size_t delta = 1);
             void decModificationCount(size_t delta = 1);
         private: // notification
-            void bindObservers();
+            void connectObservers();
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);
         private: // implement MapDocument interface

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "Model/MapFormat.h"
 #include "View/Selection.h"
 
@@ -103,6 +104,8 @@ namespace TrenchBroom {
             QLabel* m_statusBarLabel;
 
             QPointer<QDialog> m_compilationDialog;
+
+            NotifierConnection m_notifierConnection;
         private: // shortcuts
             using ActionMap = std::map<const Action*, QAction*>;
             ActionMap m_actionMap;
@@ -140,8 +143,7 @@ namespace TrenchBroom {
         private: // gui creation
             void createGui();
         private: // notification handlers
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasCleared(View::MapDocument* document);
             void documentDidChange(View::MapDocument* document);

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -134,11 +134,7 @@ namespace TrenchBroom {
         m_softBoundsFromMapMinEdit(nullptr),
         m_softBoundsFromMapMaxEdit(nullptr) {
             createGui();
-            bindObservers();
-        }
-
-        MapPropertiesEditor::~MapPropertiesEditor() {
-            unbindObservers();
+            connectObservers();
         }
 
         static std::optional<vm::vec3> parseVec(const QString& qString) {
@@ -288,20 +284,11 @@ namespace TrenchBroom {
             updateGui();
         }
 
-        void MapPropertiesEditor::bindObservers() {
+        void MapPropertiesEditor::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->documentWasNewedNotifier.addObserver(this, &MapPropertiesEditor::documentWasNewed);
-            document->documentWasLoadedNotifier.addObserver(this, &MapPropertiesEditor::documentWasLoaded);
-            document->nodesDidChangeNotifier.addObserver(this, &MapPropertiesEditor::nodesDidChange);
-        }
-
-        void MapPropertiesEditor::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasNewedNotifier.removeObserver(this, &MapPropertiesEditor::documentWasNewed);
-                document->documentWasLoadedNotifier.removeObserver(this, &MapPropertiesEditor::documentWasLoaded);
-                document->nodesDidChangeNotifier.removeObserver(this, &MapPropertiesEditor::nodesDidChange);
-            }
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &MapPropertiesEditor::documentWasNewed);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &MapPropertiesEditor::documentWasLoaded);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &MapPropertiesEditor::nodesDidChange);
         }
 
         void MapPropertiesEditor::documentWasNewed(MapDocument*) {

--- a/common/src/View/MapInspector.h
+++ b/common/src/View/MapInspector.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 #include "View/TabBook.h"
 
 #include <memory>
@@ -72,15 +73,15 @@ namespace TrenchBroom {
             QRadioButton* m_softBoundsFromMap;
             QLineEdit* m_softBoundsFromMapMinEdit;
             QLineEdit* m_softBoundsFromMapMaxEdit;         
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit MapPropertiesEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~MapPropertiesEditor() override;
         private:
             std::optional<vm::bbox3> parseLineEdits();
             void createGui();
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -76,7 +76,7 @@ namespace TrenchBroom {
                              GLContextManager& contextManager, ViewPlane viewPlane, Logger* logger) :
         MapViewBase(logger, document, toolBox, renderer, contextManager),
         m_camera(std::make_unique<Renderer::OrthographicCamera>()) {
-            bindObservers();
+            connectObservers();
             initializeCamera(viewPlane);
             initializeToolChain(toolBox);
 
@@ -94,10 +94,6 @@ namespace TrenchBroom {
             }
 
             mapViewBaseVirtualInit();
-        }
-
-        MapView2D::~MapView2D() {
-            unbindObservers();
         }
 
         void MapView2D::initializeCamera(const ViewPlane viewPlane) {
@@ -140,12 +136,8 @@ namespace TrenchBroom {
             addTool(std::make_unique<CreateSimpleBrushToolController2D>(toolBox.createSimpleBrushTool(), m_document));
         }
 
-        void MapView2D::bindObservers() {
-            m_camera->cameraDidChangeNotifier.addObserver(this, &MapView2D::cameraDidChange);
-        }
-
-        void MapView2D::unbindObservers() {
-            m_camera->cameraDidChangeNotifier.removeObserver(this, &MapView2D::cameraDidChange);
+        void MapView2D::connectObservers() {
+            m_notifierConnection += m_camera->cameraDidChangeNotifier.connect(this, &MapView2D::cameraDidChange);
         }
 
         void MapView2D::cameraDidChange(const Renderer::Camera*) {

--- a/common/src/View/MapView2D.h
+++ b/common/src/View/MapView2D.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "View/MapViewBase.h"
 
 #include <vecmath/forward.h>
@@ -51,16 +52,16 @@ namespace TrenchBroom {
             } ViewPlane;
         private:
             std::unique_ptr<Renderer::OrthographicCamera> m_camera;
+
+            NotifierConnection m_notifierConnection;
         public:
             MapView2D(std::weak_ptr<MapDocument> document, MapViewToolBox& toolBox, Renderer::MapRenderer& renderer,
                       GLContextManager& contextManager, ViewPlane viewPlane, Logger* logger);
-            ~MapView2D() override;
         private:
             void initializeCamera(ViewPlane viewPlane);
             void initializeToolChain(MapViewToolBox& toolBox);
         private: // notification
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void cameraDidChange(const Renderer::Camera* camera);
         private: // implement ToolBoxConnector interface
             PickRequest doGetPickRequest(float x, float y) const override;

--- a/common/src/View/MapView3D.h
+++ b/common/src/View/MapView3D.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "View/MapViewBase.h"
 
 #include <vecmath/forward.h>
@@ -44,6 +45,8 @@ namespace TrenchBroom {
             std::unique_ptr<Renderer::PerspectiveCamera> m_camera;
             std::unique_ptr<FlyModeHelper> m_flyModeHelper;
             bool m_ignoreCameraChangeEvents;
+
+            NotifierConnection m_notifierConnection;
         public:
             MapView3D(std::weak_ptr<MapDocument> document, MapViewToolBox& toolBox, Renderer::MapRenderer& renderer,
                       GLContextManager& contextManager, Logger* logger);
@@ -52,8 +55,7 @@ namespace TrenchBroom {
             void initializeCamera();
             void initializeToolChain(MapViewToolBox& toolBox);
         private: // notification
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void cameraDidChange(const Renderer::Camera* camera);
             void preferenceDidChange(const IO::Path& path);
         protected: // QWidget overrides

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -98,7 +98,7 @@ namespace TrenchBroom {
         m_portalFileRenderer(nullptr),
         m_isCurrent(false) {
             setToolBox(toolBox);
-            bindObservers();
+            connectObservers();
 
             setAcceptDrops(true);
         }
@@ -112,8 +112,6 @@ namespace TrenchBroom {
         }
 
         MapViewBase::~MapViewBase() {
-            unbindObservers();
-
             // Deleting m_compass will access the VBO so we need to be current
             // see: http://doc.qt.io/qt-5/qopenglwidget.html#resource-initialization-and-cleanup
             makeCurrent();
@@ -123,70 +121,36 @@ namespace TrenchBroom {
             m_isCurrent = isCurrent;
         }
 
-        void MapViewBase::bindObservers() {
+        void MapViewBase::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->nodesWereAddedNotifier.addObserver(this, &MapViewBase::nodesDidChange);
-            document->nodesWereRemovedNotifier.addObserver(this, &MapViewBase::nodesDidChange);
-            document->nodesDidChangeNotifier.addObserver(this, &MapViewBase::nodesDidChange);
-            document->nodeVisibilityDidChangeNotifier.addObserver(this, &MapViewBase::nodesDidChange);
-            document->nodeLockingDidChangeNotifier.addObserver(this, &MapViewBase::nodesDidChange);
-            document->commandDoneNotifier.addObserver(this, &MapViewBase::commandDone);
-            document->commandUndoneNotifier.addObserver(this, &MapViewBase::commandUndone);
-            document->selectionDidChangeNotifier.addObserver(this, &MapViewBase::selectionDidChange);
-            document->textureCollectionsDidChangeNotifier.addObserver(this, &MapViewBase::textureCollectionsDidChange);
-            document->entityDefinitionsDidChangeNotifier.addObserver(this, &MapViewBase::entityDefinitionsDidChange);
-            document->modsDidChangeNotifier.addObserver(this, &MapViewBase::modsDidChange);
-            document->editorContextDidChangeNotifier.addObserver(this, &MapViewBase::editorContextDidChange);
-            document->documentWasNewedNotifier.addObserver(this, &MapViewBase::documentDidChange);
-            document->documentWasClearedNotifier.addObserver(this, &MapViewBase::documentDidChange);
-            document->documentWasLoadedNotifier.addObserver(this, &MapViewBase::documentDidChange);
-            document->pointFileWasLoadedNotifier.addObserver(this, &MapViewBase::pointFileDidChange);
-            document->pointFileWasUnloadedNotifier.addObserver(this, &MapViewBase::pointFileDidChange);
-            document->portalFileWasLoadedNotifier.addObserver(this, &MapViewBase::portalFileDidChange);
-            document->portalFileWasUnloadedNotifier.addObserver(this, &MapViewBase::portalFileDidChange);
+            m_notifierConnection += document->nodesWereAddedNotifier.connect(this, &MapViewBase::nodesDidChange);
+            m_notifierConnection += document->nodesWereRemovedNotifier.connect(this, &MapViewBase::nodesDidChange);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &MapViewBase::nodesDidChange);
+            m_notifierConnection += document->nodeVisibilityDidChangeNotifier.connect(this, &MapViewBase::nodesDidChange);
+            m_notifierConnection += document->nodeLockingDidChangeNotifier.connect(this, &MapViewBase::nodesDidChange);
+            m_notifierConnection += document->commandDoneNotifier.connect(this, &MapViewBase::commandDone);
+            m_notifierConnection += document->commandUndoneNotifier.connect(this, &MapViewBase::commandUndone);
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &MapViewBase::selectionDidChange);
+            m_notifierConnection += document->textureCollectionsDidChangeNotifier.connect(this, &MapViewBase::textureCollectionsDidChange);
+            m_notifierConnection += document->entityDefinitionsDidChangeNotifier.connect(this, &MapViewBase::entityDefinitionsDidChange);
+            m_notifierConnection += document->modsDidChangeNotifier.connect(this, &MapViewBase::modsDidChange);
+            m_notifierConnection += document->editorContextDidChangeNotifier.connect(this, &MapViewBase::editorContextDidChange);
+            m_notifierConnection += document->documentWasNewedNotifier.connect(this, &MapViewBase::documentDidChange);
+            m_notifierConnection += document->documentWasClearedNotifier.connect(this, &MapViewBase::documentDidChange);
+            m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &MapViewBase::documentDidChange);
+            m_notifierConnection += document->pointFileWasLoadedNotifier.connect(this, &MapViewBase::pointFileDidChange);
+            m_notifierConnection += document->pointFileWasUnloadedNotifier.connect(this, &MapViewBase::pointFileDidChange);
+            m_notifierConnection += document->portalFileWasLoadedNotifier.connect(this, &MapViewBase::portalFileDidChange);
+            m_notifierConnection += document->portalFileWasUnloadedNotifier.connect(this, &MapViewBase::portalFileDidChange);
 
             Grid& grid = document->grid();
-            grid.gridDidChangeNotifier.addObserver(this, &MapViewBase::gridDidChange);
+            m_notifierConnection += grid.gridDidChangeNotifier.connect(this, &MapViewBase::gridDidChange);
 
-            m_toolBox.toolActivatedNotifier.addObserver(this, &MapViewBase::toolChanged);
-            m_toolBox.toolDeactivatedNotifier.addObserver(this, &MapViewBase::toolChanged);
-
-            PreferenceManager& prefs = PreferenceManager::instance();
-            prefs.preferenceDidChangeNotifier.addObserver(this, &MapViewBase::preferenceDidChange);
-        }
-
-        void MapViewBase::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->nodesWereAddedNotifier.removeObserver(this, &MapViewBase::nodesDidChange);
-                document->nodesWereRemovedNotifier.removeObserver(this, &MapViewBase::nodesDidChange);
-                document->nodesDidChangeNotifier.removeObserver(this, &MapViewBase::nodesDidChange);
-                document->nodeVisibilityDidChangeNotifier.removeObserver(this, &MapViewBase::nodesDidChange);
-                document->nodeLockingDidChangeNotifier.removeObserver(this, &MapViewBase::nodesDidChange);
-                document->commandDoneNotifier.removeObserver(this, &MapViewBase::commandDone);
-                document->commandUndoneNotifier.removeObserver(this, &MapViewBase::commandUndone);
-                document->selectionDidChangeNotifier.removeObserver(this, &MapViewBase::selectionDidChange);
-                document->textureCollectionsDidChangeNotifier.removeObserver(this, &MapViewBase::textureCollectionsDidChange);
-                document->entityDefinitionsDidChangeNotifier.removeObserver(this, &MapViewBase::entityDefinitionsDidChange);
-                document->modsDidChangeNotifier.removeObserver(this, &MapViewBase::modsDidChange);
-                document->editorContextDidChangeNotifier.removeObserver(this, &MapViewBase::editorContextDidChange);
-                document->documentWasNewedNotifier.removeObserver(this, &MapViewBase::documentDidChange);
-                document->documentWasClearedNotifier.removeObserver(this, &MapViewBase::documentDidChange);
-                document->documentWasLoadedNotifier.removeObserver(this, &MapViewBase::documentDidChange);
-                document->pointFileWasLoadedNotifier.removeObserver(this, &MapViewBase::pointFileDidChange);
-                document->pointFileWasUnloadedNotifier.removeObserver(this, &MapViewBase::pointFileDidChange);
-                document->portalFileWasLoadedNotifier.removeObserver(this, &MapViewBase::portalFileDidChange);
-                document->portalFileWasUnloadedNotifier.removeObserver(this, &MapViewBase::portalFileDidChange);
-
-                Grid& grid = document->grid();
-                grid.gridDidChangeNotifier.removeObserver(this, &MapViewBase::gridDidChange);
-            }
-
-            m_toolBox.toolActivatedNotifier.removeObserver(this, &MapViewBase::toolChanged);
-            m_toolBox.toolDeactivatedNotifier.removeObserver(this, &MapViewBase::toolChanged);
+            m_notifierConnection += m_toolBox.toolActivatedNotifier.connect(this, &MapViewBase::toolChanged);
+            m_notifierConnection += m_toolBox.toolDeactivatedNotifier.connect(this, &MapViewBase::toolChanged);
 
             PreferenceManager& prefs = PreferenceManager::instance();
-            prefs.preferenceDidChangeNotifier.removeObserver(this, &MapViewBase::preferenceDidChange);
+            m_notifierConnection += prefs.preferenceDidChangeNotifier.connect(this, &MapViewBase::preferenceDidChange);
         }
 
         /**

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "View/ActionContext.h"
 #include "View/CameraLinkHelper.h"
 #include "View/MapView.h"
@@ -85,6 +86,7 @@ namespace TrenchBroom {
             MapViewToolBox& m_toolBox;
 
             std::unique_ptr<AnimationManager> m_animationManager;
+
         private:
             Renderer::MapRenderer& m_renderer;
             std::unique_ptr<Renderer::Compass> m_compass;
@@ -95,6 +97,8 @@ namespace TrenchBroom {
              * MapViewActivationTracker instance.
              */
             bool m_isCurrent;
+
+            NotifierConnection m_notifierConnection;
         private: // shortcuts
             std::vector<std::pair<QShortcut*, const Action*>> m_shortcuts;
         protected:
@@ -118,8 +122,7 @@ namespace TrenchBroom {
         public:
             void setIsCurrent(bool isCurrent);
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void createActionsAndUpdatePicking();
 

--- a/common/src/View/MapViewToolBox.h
+++ b/common/src/View/MapViewToolBox.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 #include "View/ToolBox.h"
 
 #include <memory>
@@ -58,9 +59,11 @@ namespace TrenchBroom {
             std::unique_ptr<VertexTool> m_vertexTool;
             std::unique_ptr<EdgeTool> m_edgeTool;
             std::unique_ptr<FaceTool> m_faceTool;
+
+            NotifierConnection m_notifierConnection;
         public:
             MapViewToolBox(std::weak_ptr<MapDocument> document, QStackedLayout* bookCtrl);
-            ~MapViewToolBox();
+            ~MapViewToolBox() override;
         public: // tools
             ClipTool* clipTool() const;
             CreateComplexBrushTool* createComplexBrushTool() const;
@@ -113,8 +116,7 @@ namespace TrenchBroom {
             void createTools(std::weak_ptr<MapDocument> document, QStackedLayout* bookCtrl);
         private: // notification
             void registerTool(Tool* tool, QStackedLayout* bookCtrl);
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void toolActivated(Tool* tool);
             void toolDeactivated(Tool* tool);
             void updateEditorContext();

--- a/common/src/View/ModEditor.h
+++ b/common/src/View/ModEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -52,16 +54,16 @@ namespace TrenchBroom {
             QAbstractButton* m_moveModDownButton;
 
             std::vector<std::string> m_availableMods;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit ModEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~ModEditor() override;
         private:
             void createGui();
         private slots:
             void updateButtons();
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/MoveObjectsToolPage.cpp
+++ b/common/src/View/MoveObjectsToolPage.cpp
@@ -39,24 +39,13 @@ namespace TrenchBroom {
         m_offset(nullptr),
         m_button(nullptr) {
             createGui();
-            bindObservers();
+            connectObservers();
             updateGui();
         }
 
-        MoveObjectsToolPage::~MoveObjectsToolPage() {
-            unbindObservers();
-        }
-
-        void MoveObjectsToolPage::bindObservers() {
+        void MoveObjectsToolPage::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->selectionDidChangeNotifier.addObserver(this, &MoveObjectsToolPage::selectionDidChange);
-        }
-
-        void MoveObjectsToolPage::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->selectionDidChangeNotifier.removeObserver(this, &MoveObjectsToolPage::selectionDidChange);
-            }
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &MoveObjectsToolPage::selectionDidChange);
         }
 
         void MoveObjectsToolPage::createGui() {

--- a/common/src/View/MoveObjectsToolPage.h
+++ b/common/src/View/MoveObjectsToolPage.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 
 #include <QWidget>
@@ -38,12 +40,12 @@ namespace TrenchBroom {
 
             QLineEdit* m_offset;
             QAbstractButton* m_button;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit MoveObjectsToolPage(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~MoveObjectsToolPage() override;
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void createGui();
             void updateGui();

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -93,11 +93,7 @@ namespace TrenchBroom {
         m_document(std::move(document)),
         m_dragging(false),
         m_splitBrushes(false) {
-            bindObservers();
-        }
-
-        ResizeBrushesTool::~ResizeBrushesTool() {
-            unbindObservers();
+            connectObservers();
         }
 
         bool ResizeBrushesTool::applies() const {
@@ -641,22 +637,12 @@ namespace TrenchBroom {
             }
         }
 
-        void ResizeBrushesTool::bindObservers() {
+        void ResizeBrushesTool::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->nodesWereAddedNotifier.addObserver(this, &ResizeBrushesTool::nodesDidChange);
-            document->nodesWillChangeNotifier.addObserver(this, &ResizeBrushesTool::nodesDidChange);
-            document->nodesWillBeRemovedNotifier.addObserver(this, &ResizeBrushesTool::nodesDidChange);
-            document->selectionDidChangeNotifier.addObserver(this, &ResizeBrushesTool::selectionDidChange);
-        }
-
-        void ResizeBrushesTool::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->nodesWereAddedNotifier.removeObserver(this, &ResizeBrushesTool::nodesDidChange);
-                document->nodesWillChangeNotifier.removeObserver(this, &ResizeBrushesTool::nodesDidChange);
-                document->nodesWillBeRemovedNotifier.removeObserver(this, &ResizeBrushesTool::nodesDidChange);
-                document->selectionDidChangeNotifier.removeObserver(this, &ResizeBrushesTool::selectionDidChange);
-            }
+            m_notifierConnection += document->nodesWereAddedNotifier.connect(this, &ResizeBrushesTool::nodesDidChange);
+            m_notifierConnection += document->nodesWillChangeNotifier.connect(this, &ResizeBrushesTool::nodesDidChange);
+            m_notifierConnection += document->nodesWillBeRemovedNotifier.connect(this, &ResizeBrushesTool::nodesDidChange);
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &ResizeBrushesTool::selectionDidChange);
         }
 
         void ResizeBrushesTool::nodesDidChange(const std::vector<Model::Node*>&) {

--- a/common/src/View/ResizeBrushesTool.h
+++ b/common/src/View/ResizeBrushesTool.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 #include "Model/Brush.h"
 #include "Model/HitType.h"
 #include "View/Tool.h"
@@ -100,6 +101,8 @@ namespace TrenchBroom {
              */
             std::vector<DragHandle> m_proposedDragHandles;
             bool m_dragging;
+
+            NotifierConnection m_notifierConnection;
         private: // drag state - should only be accessed when m_dragging is true
             std::vector<Model::BrushFaceHandle> m_currentDragVisualHandles;
             std::vector<DragHandle> m_dragHandlesAtDragStart;
@@ -116,7 +119,6 @@ namespace TrenchBroom {
             vm::vec3 m_totalDelta;
         public:
             explicit ResizeBrushesTool(std::weak_ptr<MapDocument> document);
-            ~ResizeBrushesTool() override;
 
             bool applies() const;
 
@@ -147,8 +149,7 @@ namespace TrenchBroom {
             std::vector<vm::polygon3> polygonsAtDragStart() const;
             void updateCurrentDragVisualHandles();
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void nodesDidChange(const std::vector<Model::Node*>& nodes);
             void selectionDidChange(const Selection& selection);
         };

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -53,24 +53,13 @@ namespace TrenchBroom {
         m_axis(nullptr),
         m_rotateButton(nullptr) {
             createGui();
-            bindObservers();
+            connectObservers();
             m_angle->setValue(vm::to_degrees(m_tool->angle()));
         }
 
-        RotateObjectsToolPage::~RotateObjectsToolPage() {
-            unbindObservers();
-        }
-
-        void RotateObjectsToolPage::bindObservers() {
+        void RotateObjectsToolPage::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->selectionDidChangeNotifier.addObserver(this, &RotateObjectsToolPage::selectionDidChange);
-        }
-
-        void RotateObjectsToolPage::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->selectionDidChangeNotifier.removeObserver(this, &RotateObjectsToolPage::selectionDidChange);
-            }
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &RotateObjectsToolPage::selectionDidChange);
         }
 
         void RotateObjectsToolPage::setAxis(const vm::axis::type axis) {

--- a/common/src/View/RotateObjectsToolPage.h
+++ b/common/src/View/RotateObjectsToolPage.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/util.h>
@@ -50,16 +51,16 @@ namespace TrenchBroom {
             SpinControl* m_angle;
             QComboBox* m_axis;
             QAbstractButton* m_rotateButton;
+
+            NotifierConnection m_notifierConnection;
         public:
             RotateObjectsToolPage(std::weak_ptr<MapDocument> document, RotateObjectsTool* tool, QWidget* parent = nullptr);
-            ~RotateObjectsToolPage() override;
 
             void setAxis(vm::axis::type axis);
             void setRecentlyUsedCenters(const std::vector<vm::vec3>& centers);
             void setCurrentCenter(const vm::vec3& center);
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void createGui();
             void updateGui();

--- a/common/src/View/ScaleObjectsToolPage.cpp
+++ b/common/src/View/ScaleObjectsToolPage.cpp
@@ -50,24 +50,13 @@ namespace TrenchBroom {
         m_scaleFactorsOrSize(nullptr),
         m_button(nullptr) {
             createGui();
-            bindObservers();
+            connectObservers();
             updateGui();
         }
 
-        ScaleObjectsToolPage::~ScaleObjectsToolPage() {
-            unbindObservers();
-        }
-
-        void ScaleObjectsToolPage::bindObservers() {
+        void ScaleObjectsToolPage::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->selectionDidChangeNotifier.addObserver(this, &ScaleObjectsToolPage::selectionDidChange);
-        }
-
-        void ScaleObjectsToolPage::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->selectionDidChangeNotifier.removeObserver(this, &ScaleObjectsToolPage::selectionDidChange);
-            }
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &ScaleObjectsToolPage::selectionDidChange);
         }
 
         void ScaleObjectsToolPage::activate() {

--- a/common/src/View/ScaleObjectsToolPage.h
+++ b/common/src/View/ScaleObjectsToolPage.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 
 #include <vecmath/forward.h>
 
@@ -50,13 +51,13 @@ namespace TrenchBroom {
 
             QComboBox* m_scaleFactorsOrSize;
             QAbstractButton* m_button;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit ScaleObjectsToolPage(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~ScaleObjectsToolPage() override;
             void activate();
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void createGui();
             void updateGui();

--- a/common/src/View/SmartPropertyEditorManager.cpp
+++ b/common/src/View/SmartPropertyEditorManager.cpp
@@ -44,11 +44,7 @@ namespace TrenchBroom {
             m_stackedLayout(nullptr) {
             createEditors();
             activateEditor(defaultEditor(), "");
-            bindObservers();
-        }
-
-        SmartPropertyEditorManager::~SmartPropertyEditorManager() {
-            unbindObservers();
+            connectObservers();
         }
 
         void SmartPropertyEditorManager::switchEditor(const std::string& propertyKey, const std::vector<Model::EntityNodeBase*>& nodes) {
@@ -85,18 +81,10 @@ namespace TrenchBroom {
             setLayout(m_stackedLayout);
         }
 
-        void SmartPropertyEditorManager::bindObservers() {
+        void SmartPropertyEditorManager::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->selectionDidChangeNotifier.addObserver(this, &SmartPropertyEditorManager::selectionDidChange);
-            document->nodesDidChangeNotifier.addObserver(this, &SmartPropertyEditorManager::nodesDidChange);
-        }
-
-        void SmartPropertyEditorManager::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->selectionDidChangeNotifier.removeObserver(this, &SmartPropertyEditorManager::selectionDidChange);
-                document->nodesDidChangeNotifier.removeObserver(this, &SmartPropertyEditorManager::nodesDidChange);
-            }
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &SmartPropertyEditorManager::selectionDidChange);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &SmartPropertyEditorManager::nodesDidChange);
         }
 
         void SmartPropertyEditorManager::selectionDidChange(const Selection&) {

--- a/common/src/View/SmartPropertyEditorManager.h
+++ b/common/src/View/SmartPropertyEditorManager.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -51,9 +53,10 @@ namespace TrenchBroom {
             EditorList m_editors;
             std::string m_propertyKey;
             QStackedLayout* m_stackedLayout;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit SmartPropertyEditorManager(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~SmartPropertyEditorManager();
 
             void switchEditor(const std::string& propertyKey, const std::vector<Model::EntityNodeBase*>& nodes);
             bool isDefaultEditorActive() const;
@@ -61,8 +64,7 @@ namespace TrenchBroom {
             SmartPropertyEditor* activeEditor() const;
             void createEditors();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void selectionDidChange(const Selection& selection);
             void nodesDidChange(const std::vector<Model::Node*>& nodes);

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -56,12 +56,10 @@ namespace TrenchBroom {
         m_activationTracker(std::make_unique<MapViewActivationTracker>()) {
             setObjectName("SwitchableMapViewContainer");
             switchToMapView(static_cast<MapViewLayout>(pref(Preferences::MapViewLayout)));
-            bindObservers();
+            connectObservers();
         }
 
         SwitchableMapViewContainer::~SwitchableMapViewContainer() {
-            unbindObservers();
-
             // we must destroy our children before we destroy our resources because they might still use them in their destructors
             m_activationTracker->clear();
             delete m_mapView;
@@ -295,12 +293,8 @@ namespace TrenchBroom {
             m_mapView->toggleMaximizeCurrentView();
         }
 
-        void SwitchableMapViewContainer::bindObservers() {
-            m_toolBox->refreshViewsNotifier.addObserver(this, &SwitchableMapViewContainer::refreshViews);
-        }
-
-        void SwitchableMapViewContainer::unbindObservers() {
-            m_toolBox->refreshViewsNotifier.removeObserver(this, &SwitchableMapViewContainer::refreshViews);
+        void SwitchableMapViewContainer::connectObservers() {
+            m_notifierConnection += m_toolBox->refreshViewsNotifier.connect(this, &SwitchableMapViewContainer::refreshViews);
         }
 
         void SwitchableMapViewContainer::refreshViews(Tool*) {

--- a/common/src/View/SwitchableMapViewContainer.h
+++ b/common/src/View/SwitchableMapViewContainer.h
@@ -19,13 +19,15 @@
 
 #pragma once
 
-#include <QWidget>
 
 #include "FloatType.h"
 #include "Macros.h"
+#include "NotifierConnection.h"
 #include "View/MapView.h"
 
 #include <memory>
+
+#include <QWidget>
 
 namespace TrenchBroom {
     class Logger;
@@ -61,6 +63,8 @@ namespace TrenchBroom {
 
             MapViewContainer* m_mapView;
             std::unique_ptr<MapViewActivationTracker> m_activationTracker;
+
+            NotifierConnection m_notifierConnection;
         public:
             SwitchableMapViewContainer(Logger* logger, std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
             ~SwitchableMapViewContainer() override;
@@ -118,8 +122,7 @@ namespace TrenchBroom {
             bool currentViewMaximized() const;
             void toggleMaximizeCurrentView();
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
             void refreshViews(Tool* tool);
         private: // implement MapView interface
             void doInstallActivationTracker(MapViewActivationTracker& activationTracker) override;

--- a/common/src/View/TextureBrowser.h
+++ b/common/src/View/TextureBrowser.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -60,9 +62,10 @@ namespace TrenchBroom {
             QLineEdit* m_filterBox;
             QScrollBar* m_scrollBar;
             TextureBrowserView* m_view;
+
+            NotifierConnection m_notifierConnection;
         public:
             TextureBrowser(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
-            ~TextureBrowser() override;
 
             const Assets::Texture* selectedTexture() const;
             void setSelectedTexture(const Assets::Texture* selectedTexture);
@@ -78,8 +81,7 @@ namespace TrenchBroom {
             void createGui(GLContextManager& contextManager);
             void bindEvents();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewed(MapDocument* document);
             void documentWasLoaded(MapDocument* document);

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -65,14 +65,10 @@ namespace TrenchBroom {
         m_sortOrder(TextureSortOrder::Name),
         m_selectedTexture(nullptr) {
             auto doc = kdl::mem_lock(m_document);
-            doc->textureUsageCountsDidChangeNotifier.addObserver(this, &TextureBrowserView::usageCountDidChange);
+            m_notifierConnection += doc->textureUsageCountsDidChangeNotifier.connect(this, &TextureBrowserView::usageCountDidChange);
         }
 
         TextureBrowserView::~TextureBrowserView() {
-            if (!kdl::mem_expired(m_document)) {
-                auto doc = kdl::mem_lock(m_document);
-                doc->textureUsageCountsDidChangeNotifier.removeObserver(this, &TextureBrowserView::usageCountDidChange);
-            }
             clear();
         }
 

--- a/common/src/View/TextureBrowserView.h
+++ b/common/src/View/TextureBrowserView.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "Renderer/FontDescriptor.h"
 #include "Renderer/GLVertexType.h"
 #include "View/CellView.h"
@@ -69,6 +70,8 @@ namespace TrenchBroom {
             std::string m_filterText;
 
             const Assets::Texture* m_selectedTexture;
+
+            NotifierConnection m_notifierConnection;
         public:
             TextureBrowserView(QScrollBar* scrollBar,
                                GLContextManager& contextManager,

--- a/common/src/View/TextureCollectionEditor.cpp
+++ b/common/src/View/TextureCollectionEditor.cpp
@@ -35,16 +35,8 @@ namespace TrenchBroom {
         QWidget(parent),
         m_document(std::move(document)) {
             auto doc = kdl::mem_lock(m_document);
-            doc->documentWasNewedNotifier.addObserver(this, &TextureCollectionEditor::documentWasNewedOrLoaded);
-            doc->documentWasLoadedNotifier.addObserver(this, &TextureCollectionEditor::documentWasNewedOrLoaded);
-        }
-
-        TextureCollectionEditor::~TextureCollectionEditor() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->documentWasNewedNotifier.removeObserver(this, &TextureCollectionEditor::documentWasNewedOrLoaded);
-                document->documentWasLoadedNotifier.removeObserver(this, &TextureCollectionEditor::documentWasNewedOrLoaded);
-            }
+            m_notifierConnection += doc->documentWasNewedNotifier.connect(this, &TextureCollectionEditor::documentWasNewedOrLoaded);
+            m_notifierConnection += doc->documentWasLoadedNotifier.connect(this, &TextureCollectionEditor::documentWasNewedOrLoaded);
         }
 
         void TextureCollectionEditor::documentWasNewedOrLoaded(MapDocument*) {

--- a/common/src/View/TextureCollectionEditor.h
+++ b/common/src/View/TextureCollectionEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 
 #include <QWidget>
@@ -31,9 +33,10 @@ namespace TrenchBroom {
             Q_OBJECT
         private:
             std::weak_ptr<MapDocument> m_document;
+            
+            NotifierConnection m_notifierConnection;
         public:
             explicit TextureCollectionEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~TextureCollectionEditor() override ;
         private:
             void documentWasNewedOrLoaded(MapDocument* document);
 

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -44,8 +44,8 @@ namespace TrenchBroom {
 
         void ToolBox::addTool(Tool* tool) {
             ensure(tool != nullptr, "tool is null");
-            tool->refreshViewsNotifier.addObserver(refreshViewsNotifier);
-            tool->toolHandleSelectionChangedNotifier.addObserver(toolHandleSelectionChangedNotifier);
+            m_notifierConnection += tool->refreshViewsNotifier.connect(refreshViewsNotifier);
+            m_notifierConnection += tool->toolHandleSelectionChangedNotifier.connect(toolHandleSelectionChangedNotifier);
         }
 
         void ToolBox::pick(ToolChain* chain, const InputState& inputState, Model::PickResult& pickResult) {

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -20,8 +20,10 @@
 #pragma once
 
 #include "Notifier.h"
+#include "NotifierConnection.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -61,6 +63,8 @@ namespace TrenchBroom {
             ToolMap m_suppressedTools;
 
             bool m_enabled;
+
+            NotifierConnection m_notifierConnection;
         public:
             Notifier<Tool*> toolActivatedNotifier;
             Notifier<Tool*> toolDeactivatedNotifier;

--- a/common/src/View/UVEditor.cpp
+++ b/common/src/View/UVEditor.cpp
@@ -50,11 +50,7 @@ namespace TrenchBroom {
         m_rotateTextureCCWButton(nullptr),
         m_rotateTextureCWButton(nullptr) {
             createGui(contextManager);
-            bindObservers();
-        }
-
-        UVEditor::~UVEditor() {
-            unbindObservers();
+            connectObservers();
         }
 
         bool UVEditor::cancelMouseDrag() {
@@ -138,16 +134,9 @@ namespace TrenchBroom {
             updateButtons();
         }
 
-        void UVEditor::bindObservers() {
+        void UVEditor::connectObservers() {
             auto document = kdl::mem_lock(m_document);
-            document->selectionDidChangeNotifier.addObserver(this, &UVEditor::selectionDidChange);
-        }
-
-        void UVEditor::unbindObservers() {
-            if (!kdl::mem_expired(m_document)) {
-                auto document = kdl::mem_lock(m_document);
-                document->selectionDidChangeNotifier.removeObserver(this, &UVEditor::selectionDidChange);
-            }
+            m_notifierConnection += document->selectionDidChangeNotifier.connect(this, &UVEditor::selectionDidChange);
         }
 
         void UVEditor::resetTextureClicked() {

--- a/common/src/View/UVEditor.h
+++ b/common/src/View/UVEditor.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
+
 #include <memory>
 
 #include <QWidget>
@@ -49,9 +51,10 @@ namespace TrenchBroom {
             QAbstractButton* m_flipTextureVButton;
             QAbstractButton* m_rotateTextureCCWButton;
             QAbstractButton* m_rotateTextureCWButton;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit UVEditor(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
-            ~UVEditor() override;
 
             bool cancelMouseDrag();
         private:
@@ -61,8 +64,7 @@ namespace TrenchBroom {
 
             void selectionDidChange(const Selection& selection);
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void resetTextureClicked();
             void resetTextureToWorldClicked();

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "FloatType.h"
+#include "NotifierConnection.h"
 #include "Model/HitType.h"
 #include "Model/PickResult.h"
 #include "Renderer/OrthographicCamera.h"
@@ -75,16 +76,16 @@ namespace TrenchBroom {
             UVViewHelper m_helper;
 
             ToolBox m_toolBox;
+
+            NotifierConnection m_notifierConnection;
         public:
             UVView(std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
-            ~UVView() override;
 
             void setSubDivisions(const vm::vec2i& subDivisions);
         private:
             void createTools();
 
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void selectionDidChange(const Selection& selection);
             void documentWasCleared(MapDocument* document);

--- a/common/src/View/ViewEditor.h
+++ b/common/src/View/ViewEditor.h
@@ -19,12 +19,14 @@
 
 #pragma once
 
-#include <QWidget>
+#include "NotifierConnection.h"
+#include "Model/TagType.h"
 
 #include <memory>
 #include <vector>
 
-#include "Model/TagType.h"
+
+#include <QWidget>
 
 class QCheckBox;
 class QWidget;
@@ -102,12 +104,12 @@ namespace TrenchBroom {
             QButtonGroup* m_entityLinkRadioGroup;
 
             QCheckBox* m_showSoftBoundsCheckBox;
+
+            NotifierConnection m_notifierConnection;
         public:
             explicit ViewEditor(std::weak_ptr<MapDocument> document, QWidget* parent = nullptr);
-            ~ViewEditor() override;
         private:
-            void bindObservers();
-            void unbindObservers();
+            void connectObservers();
 
             void documentWasNewedOrLoaded(MapDocument* document);
             void editorContextDidChange();

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Macros.h"
+#include "NotifierConnection.h"
 #include "View/UndoableCommand.h"
 #include "View/CommandProcessor.h"
 
@@ -43,16 +44,17 @@ namespace TrenchBroom {
         class TestObserver {
         private:
             std::vector<NotificationTuple> m_notifications;
+            NotifierConnection m_notifierConnection;
         public:
             explicit TestObserver(CommandProcessor& commandProcessor) {                
-                commandProcessor.commandDoNotifier.addObserver(this, &TestObserver::commandDo);
-                commandProcessor.commandDoneNotifier.addObserver(this, &TestObserver::commandDone);
-                commandProcessor.commandDoFailedNotifier.addObserver(this, &TestObserver::commandDoFailed);
-                commandProcessor.commandUndoNotifier.addObserver(this, &TestObserver::commandUndo);
-                commandProcessor.commandUndoneNotifier.addObserver(this, &TestObserver::commandUndone);
-                commandProcessor.commandUndoFailedNotifier.addObserver(this, &TestObserver::commandUndoFailed);
-                commandProcessor.transactionDoneNotifier.addObserver(this, &TestObserver::transactionDone);
-                commandProcessor.transactionUndoneNotifier.addObserver(this, &TestObserver::transactionUndone);
+                m_notifierConnection += commandProcessor.commandDoNotifier.connect(this, &TestObserver::commandDo);
+                m_notifierConnection += commandProcessor.commandDoneNotifier.connect(this, &TestObserver::commandDone);
+                m_notifierConnection += commandProcessor.commandDoFailedNotifier.connect(this, &TestObserver::commandDoFailed);
+                m_notifierConnection += commandProcessor.commandUndoNotifier.connect(this, &TestObserver::commandUndo);
+                m_notifierConnection += commandProcessor.commandUndoneNotifier.connect(this, &TestObserver::commandUndone);
+                m_notifierConnection += commandProcessor.commandUndoFailedNotifier.connect(this, &TestObserver::commandUndoFailed);
+                m_notifierConnection += commandProcessor.transactionDoneNotifier.connect(this, &TestObserver::transactionDone);
+                m_notifierConnection += commandProcessor.transactionUndoneNotifier.connect(this, &TestObserver::transactionUndone);
             }
 
             // FIXME: should probably unregister from the notifications in the destructor

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/string_utils.h"
     "${KDL_INCLUDE_DIR}/kdl/transform_range.h"
     "${KDL_INCLUDE_DIR}/kdl/tuple_io.h"
+    "${KDL_INCLUDE_DIR}/kdl/tuple_utils.h"
     "${KDL_INCLUDE_DIR}/kdl/vector_set_forward.h"
     "${KDL_INCLUDE_DIR}/kdl/vector_set.h"
     "${KDL_INCLUDE_DIR}/kdl/vector_utils.h"

--- a/lib/kdl/include/kdl/tuple_utils.h
+++ b/lib/kdl/include/kdl/tuple_utils.h
@@ -1,0 +1,56 @@
+/*
+ Copyright 2021 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <tuple>
+
+namespace kdl {
+    inline auto tup_capture() {
+        return std::tuple<>{};
+    }
+
+    template <typename Type>
+    auto tup_capture(Type&& arg) {
+        if constexpr (std::is_rvalue_reference_v<Type>) {
+            return std::tuple<std::decay_t<Type>>{std::forward<Type>(arg)};
+        }
+        return std::tuple<Type>{std::forward<Type>(arg)};
+    }
+
+    /**
+     * Capture the given values as a tuple. The resulting tuple has the same number of elements as the number of the
+     * given arguments. For each argument x of type X, the corresponding tuple member has type
+     * 
+     * - const X& if x is a const lvalue reference,
+     * - X& if x is an lvalue reference,
+     * - X if x is an rvalue.
+     *
+     * In the last case where x is an rvalue, the value of x is moved into the tuple.
+     *
+     * @tparam First the type of the first argument
+     * @tparam Rest the types of the remaining arguments
+     * @param first the first argument
+     * @param rest the remaining arguments
+     *
+     * @return a tuple containing the values of the arguments, as per the rules defined above
+     */
+    template <typename First, typename... Rest>
+    auto tup_capture(First&& first, Rest&&... rest) {
+        return std::tuple_cat(tup_capture(std::forward<First>(first)), tup_capture(std::forward<Rest>(rest)...));
+    }
+}

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_temp_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/test_utils.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_range_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/tuple_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/vector_set_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/vector_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/zip_iterator_test.cpp"

--- a/lib/kdl/test/src/tuple_utils_test.cpp
+++ b/lib/kdl/test/src/tuple_utils_test.cpp
@@ -1,0 +1,56 @@
+/*
+ Copyright 2021 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <kdl/tuple_utils.h>
+
+#include <catch2/catch.hpp>
+
+namespace kdl {
+    struct move_only {
+        move_only() = default;
+        move_only(const move_only&) = delete;
+        move_only(move_only&&) = default;
+    };
+
+    TEST_CASE("tup_capture") {
+        SECTION("Capturing single objects") {
+            auto str = std::string{};
+            const auto cstr = std::string{};
+
+            static_assert(std::is_same_v<decltype(tup_capture(std::string{})), std::tuple<std::string>>, "rvalues must be captured by value");
+            static_assert(std::is_same_v<decltype(tup_capture(str)), std::tuple<std::string&>>, "lvalue references must be captured by by lvalue reference");
+            static_assert(std::is_same_v<decltype(tup_capture(cstr)), std::tuple<const std::string&>>, "const lvalue references must be captured by const lvalue reference");
+
+            tup_capture(move_only{}); // rvalues are moved
+        }
+
+        SECTION("Capturing primitive types") {
+            int i = 1;
+            const size_t y = 2;
+
+            static_assert(std::is_same_v<decltype(tup_capture(i)), std::tuple<int&>>, "rvalues must be captured by value");
+            static_assert(std::is_same_v<decltype(tup_capture(y)), std::tuple<const size_t&>>, "rvalues must be captured by value");
+        }
+
+        SECTION("Capturing multiple values") {
+            int i = 1;
+            const auto cstr = std::string{};
+
+            static_assert(std::is_same_v<decltype(tup_capture(std::string{}, i, cstr)), std::tuple<std::string, int&, const std::string&>>, "can capture multiple arguments");
+        }
+    }
+}


### PR DESCRIPTION
This refactoring makes Notifier a little simpler, incl. using the
corresponding classes NotifyBefore, NotifyAfter, and such. It also fixes
some issues related to forwarding the notification arguments correctly
to notifiers.

We also change how observers are connected and disconnected. Previously,
to disconnect an observer, we had to pass the same observer to the
removeObserver function. This relied on comparing function pointers.
We now avoid this by returning a new object that represents one or 
multiple connections from observers to notifiers. This object will 
disconnect its connections when it falls out of scope, which allows us 
to remove a lot of code that did this manually.

Since the return value of connectObserver is marked as nodiscard, the
compiler will warn us when we drop a connection immediately.

Unfortunately, it was not possible to split this refactoring into
multiple smaller steps in a natural way, so we did it in one big commit.

The need for this refactoring came up when working on #3781, where we
ran into errors due to the faulty forwarding of notification parameters.