### PR TITLE
3781: Fix notifier forwarding

### DIFF
--- a/common/src/Notifier.h
+++ b/common/src/Notifier.h
@@ -120,7 +120,7 @@ namespace TrenchBroom {
          */
         [[nodiscard]] NotifierConnection connect(Notifier& notifier) {
             const auto id = m_nextId++;
-            auto callback = [&](auto... a) { notifier(std::forward<decltype(a)>(a)...); };
+            auto callback = [&](auto&&... a) { notifier(std::forward<decltype(a)>(a)...); };
             if (m_notifying) {
                 m_toAdd.emplace_back(std::move(callback), id);
             } else {


### PR DESCRIPTION
We need to forward the notifier arguments, but doing so requires a forwarding reference.