### PR TITLE
3816: Parallelize linked group rebuilds, object transforms

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -453,7 +453,7 @@ namespace TrenchBroom {
         static std::vector<std::optional<NodeInfo>> createNodesFromObjectInfos(std::vector<MapReader::ObjectInfo> objectInfos, const vm::bbox3& worldBounds, const Model::MapFormat mapFormat, ParserStatus& status) {
             // create nodes in parallel, moving data out of objectInfos
             // we store optionals in the result vector to make the elements default constructible, which is a requirement for parallel transform
-            std::vector<std::optional<CreateNodeResult>> createNodeResults = kdl::vec_parallel_transform(std::move(objectInfos), [&](auto&& objectInfo) -> std::optional<CreateNodeResult> {
+            std::vector<CreateNodeResult> createNodeResults = kdl::vec_parallel_transform(std::move(objectInfos), [&](auto&& objectInfo) -> CreateNodeResult {
                 return std::visit(kdl::overload(
                     [&](MapReader::EntityInfo&& entityInfo) {
                         return createNodeFromEntityInfo(std::move(entityInfo), mapFormat);

--- a/common/src/Model/NodeVisitor.h
+++ b/common/src/Model/NodeVisitor.h
@@ -91,9 +91,17 @@ namespace TrenchBroom {
         public:
             R&& result() { return std::move(m_result).value(); }
         protected:
+#ifdef _MSC_VER
+// silence a spurious "C4702: unreachable code" warning
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif
             void setResult(R&& result) {
                 m_result = std::move(result);
             }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
         };
 
         class NodeLambdaVisitorNoResult {

--- a/lib/kdl/include/kdl/parallel.h
+++ b/lib/kdl/include/kdl/parallel.h
@@ -18,12 +18,15 @@
 #ifndef KDL_PARALLEL_H
 #define KDL_PARALLEL_H
 
+#include "kdl/vector_utils.h"
+
 #ifdef _WIN32
 #include <ppl.h>
 #endif
 
 #include <atomic>
 #include <future> // for std::async
+#include <optional>
 #include <thread>
 #include <utility> // for std::declval
 #include <vector>
@@ -91,7 +94,7 @@ namespace kdl {
      */
     template<class T, class L>
     auto vec_parallel_transform(std::vector<T> input, L&& transform) {
-        using ResultType = decltype(transform(std::declval<T&&>()));
+        using ResultType = std::optional<decltype(transform(std::declval<T&&>()))>;
 
         std::vector<ResultType> result;
         result.resize(input.size());
@@ -100,7 +103,7 @@ namespace kdl {
             result[index] = transform(std::move(input[index]));
         });
 
-        return result;
+        return vec_transform(std::move(result), [](ResultType&& x) { return std::move(*x); });
     }
 }
 

--- a/lib/kdl/include/kdl/parallel.h
+++ b/lib/kdl/include/kdl/parallel.h
@@ -18,6 +18,10 @@
 #ifndef KDL_PARALLEL_H
 #define KDL_PARALLEL_H
 
+#ifdef _WIN32
+#include <ppl.h>
+#endif
+
 #include <atomic>
 #include <future> // for std::async
 #include <thread>
@@ -39,6 +43,9 @@ namespace kdl {
      */
     template<class L>
     void parallel_for(const size_t count, L&& lambda) {
+#ifdef _WIN32
+        concurrency::parallel_for<size_t>(0, count, lambda);
+#else
         size_t numThreads = static_cast<size_t>(std::thread::hardware_concurrency());
         if (numThreads == 0) {
             numThreads = 1;
@@ -64,6 +71,7 @@ namespace kdl {
         for (size_t i = 0; i < numThreads; ++i) {
             threads[i].wait();
         }
+#endif
     }
 
     /**

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -97,7 +97,7 @@ namespace kdl {
          * @tparam T the type of the value, must match the value type or one of the error types of this result
          * @param v the value
          */
-        template <typename T>
+        template <typename T, typename std::enable_if<std::disjunction_v<std::is_convertible<T, Value>, std::is_convertible<T, Errors>...>>::type* = nullptr>
         result(T&& v)
         : m_value(std::forward<T>(v)) {}
 
@@ -601,7 +601,7 @@ namespace kdl {
          * @tparam T the type of the value, must match detail::void_success_value_type or one of the error types of this result
          * @param v the value
          */
-        template <typename T>
+        template <typename T, typename std::enable_if<std::disjunction_v<std::is_convertible<T, value_type>, std::is_convertible<T, Errors>...>>::type* = nullptr>
         result(T&& v)
         : m_value(std::forward<T>(v)) {}
 


### PR DESCRIPTION
- Partial fix for #3816 (as I mentioned there, this should be good enough for 2021.2)
- also tossed in parallelization of `MapDocument::transformObjects`. This gives a big speedup when dragging the 512-brush groups in the #3816 test case map, or just moving around large chunks of a map with 100s/1000s of brushes.
- also tossed in a lighter weight `kdl::parallel_for` implementation specific to Windows + a performance test. This isn't really critical to have but I was just curious if it would make a difference. 