### PR TITLE
3856: Threading issue in MapDocument::transformObjects with NodeContents

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -466,6 +466,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/PreferenceManager.cpp
         ${COMMON_SOURCE_DIR}/Preference.cpp
         ${COMMON_SOURCE_DIR}/Preferences.cpp
+        ${COMMON_SOURCE_DIR}/Thread.cpp
         ${COMMON_SOURCE_DIR}/TrenchBroomApp.cpp
         ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.cpp
         ${COMMON_SOURCE_DIR}/Uuid.cpp
@@ -986,6 +987,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/PreferenceManager.h
         ${COMMON_SOURCE_DIR}/Preferences.h
         ${COMMON_SOURCE_DIR}/RecoverableExceptions.h
+        ${COMMON_SOURCE_DIR}/Thread.h
         ${COMMON_SOURCE_DIR}/TrenchBroomApp.h
         ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.h
         ${COMMON_SOURCE_DIR}/Uuid.h

--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -71,7 +71,7 @@ namespace TrenchBroom {
         }
 
         size_t EntityDefinition::usageCount() const {
-            return m_usageCount.load();
+            return static_cast<size_t>(m_usageCount);
         }
 
         void EntityDefinition::incUsageCount() {

--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -71,15 +71,15 @@ namespace TrenchBroom {
         }
 
         size_t EntityDefinition::usageCount() const {
-            return m_usageCount->load();
+            return m_usageCount.load();
         }
 
         void EntityDefinition::incUsageCount() {
-            m_usageCount->fetch_add(1u);
+            m_usageCount.fetch_add(1u);
         }
 
         void EntityDefinition::decUsageCount() {
-            const size_t previous = m_usageCount->fetch_sub(1u);
+            const size_t previous = m_usageCount.fetch_sub(1u);
             assert(previous > 0);
             unused(previous);
         }
@@ -160,7 +160,7 @@ namespace TrenchBroom {
             m_name(name),
             m_color(color),
             m_description(description),
-            m_usageCount(std::make_unique<std::atomic<size_t>>(0u)),
+            m_usageCount(0u),
             m_propertyDefinitions(propertyDefinitions) {}
 
         PointEntityDefinition::PointEntityDefinition(const std::string& name, const Color& color, const vm::bbox3& bounds, const std::string& description, const PropertyDefinitionList& propertyDefinitions, const ModelDefinition& modelDefinition) :

--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -19,7 +19,6 @@
 
 #include "EntityDefinition.h"
 
-#include "Ensure.h"
 #include "Macros.h"
 #include "Assets/PropertyDefinition.h"
 #include "Model/EntityProperties.h"

--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -75,11 +75,11 @@ namespace TrenchBroom {
         }
 
         void EntityDefinition::incUsageCount() {
-            m_usageCount.fetch_add(1u);
+            ++m_usageCount;
         }
 
         void EntityDefinition::decUsageCount() {
-            const size_t previous = m_usageCount.fetch_sub(1u);
+            const size_t previous = m_usageCount--;
             assert(previous > 0);
             unused(previous);
         }

--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -19,6 +19,8 @@
 
 #include "EntityDefinition.h"
 
+#include "Ensure.h"
+#include "Macros.h"
 #include "Assets/PropertyDefinition.h"
 #include "Model/EntityProperties.h"
 
@@ -69,18 +71,17 @@ namespace TrenchBroom {
         }
 
         size_t EntityDefinition::usageCount() const {
-            return m_usageCount;
+            return m_usageCount->load();
         }
 
         void EntityDefinition::incUsageCount() {
-            ++m_usageCount;
-            usageCountDidChangeNotifier();
+            m_usageCount->fetch_add(1u);
         }
 
         void EntityDefinition::decUsageCount() {
-            assert(m_usageCount > 0);
-            --m_usageCount;
-            usageCountDidChangeNotifier();
+            const size_t previous = m_usageCount->fetch_sub(1u);
+            assert(previous > 0);
+            unused(previous);
         }
 
         const FlagsPropertyDefinition* EntityDefinition::spawnflags() const {
@@ -159,7 +160,7 @@ namespace TrenchBroom {
             m_name(name),
             m_color(color),
             m_description(description),
-            m_usageCount(0),
+            m_usageCount(std::make_unique<std::atomic<size_t>>(0u)),
             m_propertyDefinitions(propertyDefinitions) {}
 
         PointEntityDefinition::PointEntityDefinition(const std::string& name, const Color& color, const vm::bbox3& bounds, const std::string& description, const PropertyDefinitionList& propertyDefinitions, const ModelDefinition& modelDefinition) :

--- a/common/src/Assets/EntityDefinition.h
+++ b/common/src/Assets/EntityDefinition.h
@@ -21,7 +21,6 @@
 
 #include "Color.h"
 #include "FloatType.h"
-#include "Notifier.h"
 #include "Assets/ModelDefinition.h"
 
 #include <vecmath/bbox.h>
@@ -62,8 +61,6 @@ namespace TrenchBroom {
             std::string m_description;
             std::unique_ptr<std::atomic<size_t>> m_usageCount;
             PropertyDefinitionList m_propertyDefinitions;
-        public:
-            Notifier<> usageCountDidChangeNotifier;
         public:
             virtual ~EntityDefinition();
 

--- a/common/src/Assets/EntityDefinition.h
+++ b/common/src/Assets/EntityDefinition.h
@@ -26,6 +26,7 @@
 
 #include <vecmath/bbox.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -59,7 +60,7 @@ namespace TrenchBroom {
             std::string m_name;
             Color m_color;
             std::string m_description;
-            size_t m_usageCount;
+            std::unique_ptr<std::atomic<size_t>> m_usageCount;
             PropertyDefinitionList m_propertyDefinitions;
         public:
             Notifier<> usageCountDidChangeNotifier;

--- a/common/src/Assets/EntityDefinition.h
+++ b/common/src/Assets/EntityDefinition.h
@@ -59,7 +59,7 @@ namespace TrenchBroom {
             std::string m_name;
             Color m_color;
             std::string m_description;
-            std::unique_ptr<std::atomic<size_t>> m_usageCount;
+            std::atomic<size_t> m_usageCount;
             PropertyDefinitionList m_propertyDefinitions;
         public:
             virtual ~EntityDefinition();

--- a/common/src/Assets/EntityDefinitionManager.cpp
+++ b/common/src/Assets/EntityDefinitionManager.cpp
@@ -114,11 +114,7 @@ namespace TrenchBroom {
             }
         }
 
-        void EntityDefinitionManager::connectObservers() {
-            for (EntityDefinition* definition : m_definitions) {
-                m_notifierConnection += definition->usageCountDidChangeNotifier.connect(usageCountDidChangeNotifier);
-            }
-        }
+        void EntityDefinitionManager::connectObservers() {}
 
         void EntityDefinitionManager::clearCache() {
             m_cache.clear();

--- a/common/src/Assets/EntityDefinitionManager.cpp
+++ b/common/src/Assets/EntityDefinitionManager.cpp
@@ -50,13 +50,11 @@ namespace TrenchBroom {
             updateIndices();
             updateGroups();
             updateCache();
-            connectObservers();
         }
 
         void EntityDefinitionManager::clear() {
             clearCache();
             clearGroups();
-            m_notifierConnection.disconnect();
             kdl::vec_clear_and_delete(m_definitions);
         }
 
@@ -113,8 +111,6 @@ namespace TrenchBroom {
                 m_cache[definition->name()] = definition;
             }
         }
-
-        void EntityDefinitionManager::connectObservers() {}
 
         void EntityDefinitionManager::clearCache() {
             m_cache.clear();

--- a/common/src/Assets/EntityDefinitionManager.h
+++ b/common/src/Assets/EntityDefinitionManager.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "Notifier.h"
 #include "NotifierConnection.h"
 
 #include <map>
@@ -51,8 +50,6 @@ namespace TrenchBroom {
             Cache m_cache;
 
             NotifierConnection m_notifierConnection;
-        public:
-            Notifier<> usageCountDidChangeNotifier;
         public:
             ~EntityDefinitionManager();
 

--- a/common/src/Assets/EntityDefinitionManager.h
+++ b/common/src/Assets/EntityDefinitionManager.h
@@ -19,8 +19,6 @@
 
 #pragma once
 
-#include "NotifierConnection.h"
-
 #include <map>
 #include <string>
 #include <vector>
@@ -48,8 +46,6 @@ namespace TrenchBroom {
             std::vector<EntityDefinition*> m_definitions;
             std::vector<EntityDefinitionGroup> m_groups;
             Cache m_cache;
-
-            NotifierConnection m_notifierConnection;
         public:
             ~EntityDefinitionManager();
 
@@ -67,7 +63,6 @@ namespace TrenchBroom {
             void updateIndices();
             void updateGroups();
             void updateCache();
-            void connectObservers();
             void clearCache();
             void clearGroups();
         };

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         m_width(width),
         m_height(height),
         m_averageColor(averageColor),
-        m_usageCount(std::make_unique<std::atomic<size_t>>(0u)),
+        m_usageCount(0u),
         m_overridden(false),
         m_format(format),
         m_type(type),
@@ -51,7 +51,7 @@ namespace TrenchBroom {
         m_width(width),
         m_height(height),
         m_averageColor(averageColor),
-        m_usageCount(std::make_unique<std::atomic<size_t>>(0u)),
+        m_usageCount(0u),
         m_overridden(false),
         m_format(format),
         m_type(type),
@@ -76,7 +76,7 @@ namespace TrenchBroom {
         m_width(width),
         m_height(height),
         m_averageColor(Color(0.0f, 0.0f, 0.0f, 1.0f)),
-        m_usageCount(std::make_unique<std::atomic<size_t>>(0u)),
+        m_usageCount(0u),
         m_overridden(false),
         m_format(format),
         m_type(type),
@@ -85,6 +85,34 @@ namespace TrenchBroom {
         m_textureId(0) {}
 
         Texture::~Texture() = default;
+
+        Texture::Texture(Texture&& other) :
+        m_name{std::move(other.m_name)},
+        m_width{std::move(other.m_width)},
+        m_height{std::move(other.m_height)},
+        m_averageColor{std::move(other.m_averageColor)},
+        m_usageCount{other.m_usageCount.load()},
+        m_overridden{std::move(other.m_overridden)},
+        m_format{std::move(other.m_format)},
+        m_type{std::move(other.m_type)},
+        m_culling{std::move(other.m_culling)},
+        m_blendFunc{std::move(other.m_blendFunc)},
+        m_textureId{std::move(other.m_textureId)} {}
+
+        Texture& Texture::operator=(Texture&& other) {
+            m_name = std::move(other.m_name);
+            m_width = std::move(other.m_width);
+            m_height = std::move(other.m_height);
+            m_averageColor = std::move(other.m_averageColor);
+            m_usageCount = other.m_usageCount.load();
+            m_overridden = std::move(other.m_overridden);
+            m_format = std::move(other.m_format);
+            m_type = std::move(other.m_type);
+            m_culling = std::move(other.m_culling);
+            m_blendFunc = std::move(other.m_blendFunc);
+            m_textureId = std::move(other.m_textureId);
+            return *this;
+        }
 
         TextureType Texture::selectTextureType(const bool masked) {
             if (masked) {
@@ -161,15 +189,15 @@ namespace TrenchBroom {
         }
 
         size_t Texture::usageCount() const {
-            return m_usageCount->load();
+            return m_usageCount.load();
         }
 
         void Texture::incUsageCount() {
-            m_usageCount->fetch_add(1u);
+            m_usageCount.fetch_add(1u);
         }
 
         void Texture::decUsageCount() {
-            const size_t previous = m_usageCount->fetch_sub(1u);
+            const size_t previous = m_usageCount.fetch_sub(1u);
             assert(previous > 0);
             unused(previous);
         }

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -91,7 +91,7 @@ namespace TrenchBroom {
         m_width{std::move(other.m_width)},
         m_height{std::move(other.m_height)},
         m_averageColor{std::move(other.m_averageColor)},
-        m_usageCount{other.m_usageCount.load()},
+        m_usageCount{static_cast<size_t>(other.m_usageCount)},
         m_overridden{std::move(other.m_overridden)},
         m_format{std::move(other.m_format)},
         m_type{std::move(other.m_type)},
@@ -104,7 +104,7 @@ namespace TrenchBroom {
             m_width = std::move(other.m_width);
             m_height = std::move(other.m_height);
             m_averageColor = std::move(other.m_averageColor);
-            m_usageCount = other.m_usageCount.load();
+            m_usageCount = static_cast<size_t>(other.m_usageCount);
             m_overridden = std::move(other.m_overridden);
             m_format = std::move(other.m_format);
             m_type = std::move(other.m_type);
@@ -189,7 +189,7 @@ namespace TrenchBroom {
         }
 
         size_t Texture::usageCount() const {
-            return m_usageCount.load();
+            return static_cast<size_t>(m_usageCount);
         }
 
         void Texture::incUsageCount() {

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -88,6 +88,8 @@ namespace TrenchBroom {
 
         Texture::Texture(Texture&& other) :
         m_name{std::move(other.m_name)},
+        m_absolutePath{std::move(other.m_absolutePath)},
+        m_relativePath{std::move(other.m_relativePath)},
         m_width{std::move(other.m_width)},
         m_height{std::move(other.m_height)},
         m_averageColor{std::move(other.m_averageColor)},
@@ -95,12 +97,16 @@ namespace TrenchBroom {
         m_overridden{std::move(other.m_overridden)},
         m_format{std::move(other.m_format)},
         m_type{std::move(other.m_type)},
+        m_surfaceParms{std::move(other.m_surfaceParms)},
         m_culling{std::move(other.m_culling)},
         m_blendFunc{std::move(other.m_blendFunc)},
-        m_textureId{std::move(other.m_textureId)} {}
+        m_textureId{std::move(other.m_textureId)},
+        m_buffers{std::move(other.m_buffers)} {}
 
         Texture& Texture::operator=(Texture&& other) {
             m_name = std::move(other.m_name);
+            m_absolutePath = std::move(other.m_absolutePath);
+            m_relativePath = std::move(other.m_relativePath);
             m_width = std::move(other.m_width);
             m_height = std::move(other.m_height);
             m_averageColor = std::move(other.m_averageColor);
@@ -108,9 +114,11 @@ namespace TrenchBroom {
             m_overridden = std::move(other.m_overridden);
             m_format = std::move(other.m_format);
             m_type = std::move(other.m_type);
+            m_surfaceParms = std::move(other.m_surfaceParms);
             m_culling = std::move(other.m_culling);
             m_blendFunc = std::move(other.m_blendFunc);
             m_textureId = std::move(other.m_textureId);
+            m_buffers = std::move(other.m_buffers);
             return *this;
         }
 

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -193,11 +193,11 @@ namespace TrenchBroom {
         }
 
         void Texture::incUsageCount() {
-            m_usageCount.fetch_add(1u);
+            ++m_usageCount;
         }
 
         void Texture::decUsageCount() {
-            const size_t previous = m_usageCount.fetch_sub(1u);
+            const size_t previous = m_usageCount--;
             assert(previous > 0);
             unused(previous);
         }

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -26,6 +26,8 @@
 
 #include <vecmath/forward.h>
 
+#include <atomic>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -84,7 +86,7 @@ namespace TrenchBroom {
             size_t m_height;
             Color m_averageColor;
 
-            size_t m_usageCount;
+            std::unique_ptr<std::atomic<size_t>> m_usageCount;
             bool m_overridden;
 
             GLenum m_format;

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -27,7 +27,6 @@
 #include <vecmath/forward.h>
 
 #include <atomic>
-#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -86,7 +85,7 @@ namespace TrenchBroom {
             size_t m_height;
             Color m_averageColor;
 
-            std::unique_ptr<std::atomic<size_t>> m_usageCount;
+            std::atomic<size_t> m_usageCount;
             bool m_overridden;
 
             GLenum m_format;
@@ -111,8 +110,8 @@ namespace TrenchBroom {
             Texture(const Texture&) = delete;
             Texture& operator=(const Texture&) = delete;
             
-            Texture(Texture&& other) = default;
-            Texture& operator=(Texture&& other) = default;
+            Texture(Texture&& other);
+            Texture& operator=(Texture&& other);
 
             ~Texture();
 

--- a/common/src/Thread.cpp
+++ b/common/src/Thread.cpp
@@ -1,0 +1,32 @@
+/*
+ Copyright (C) 2021 Eric Wasylishen
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Thread.h"
+
+#include "Ensure.h"
+
+#include <QApplication>
+#include <QThread>
+
+namespace TrenchBroom {
+    bool isMainThread() {
+        ensure(qApp != nullptr, "QApplication must have been created");
+        return (qApp->thread() == QThread::currentThread());
+    }
+}

--- a/common/src/Thread.h
+++ b/common/src/Thread.h
@@ -1,0 +1,24 @@
+/*
+ Copyright (C) 2021 Eric Wasylishen
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace TrenchBroom {
+    bool isMainThread();
+}

--- a/common/src/View/EntityBrowser.cpp
+++ b/common/src/View/EntityBrowser.cpp
@@ -135,6 +135,7 @@ namespace TrenchBroom {
             m_notifierConnection += document->documentWasLoadedNotifier.connect(this, &EntityBrowser::documentWasLoaded);
             m_notifierConnection += document->modsDidChangeNotifier.connect(this, &EntityBrowser::modsDidChange);
             m_notifierConnection += document->entityDefinitionsDidChangeNotifier.connect(this, &EntityBrowser::entityDefinitionsDidChange);
+            m_notifierConnection += document->nodesDidChangeNotifier.connect(this, &EntityBrowser::nodesDidChange);
 
             PreferenceManager& prefs = PreferenceManager::instance();
             m_notifierConnection += prefs.preferenceDidChangeNotifier.connect(this, &EntityBrowser::preferenceDidChange);
@@ -149,6 +150,11 @@ namespace TrenchBroom {
         }
 
         void EntityBrowser::modsDidChange() {
+            reload();
+        }
+
+        void EntityBrowser::nodesDidChange(const std::vector<Model::Node*>&) {
+            // to handle definition usage count changes
             reload();
         }
 

--- a/common/src/View/EntityBrowser.h
+++ b/common/src/View/EntityBrowser.h
@@ -22,6 +22,7 @@
 #include "NotifierConnection.h"
 
 #include <memory>
+#include <vector>
 
 #include <QWidget>
 
@@ -33,6 +34,9 @@ class QScrollBar;
 namespace TrenchBroom {
     namespace IO {
         class Path;
+    }
+    namespace Model {
+        class Node;
     }
 
     namespace View {
@@ -65,6 +69,7 @@ namespace TrenchBroom {
             void documentWasLoaded(MapDocument* document);
 
             void modsDidChange();
+            void nodesDidChange(const std::vector<Model::Node*>& nodes);
             void entityDefinitionsDidChange();
             void preferenceDidChange(const IO::Path& path);
         };

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -84,8 +84,6 @@ namespace TrenchBroom {
             const vm::quatf hRotation = vm::quatf(vm::vec3f::pos_z(), vm::to_radians(-30.0f));
             const vm::quatf vRotation = vm::quatf(vm::vec3f::pos_y(), vm::to_radians(20.0f));
             m_rotation = vRotation * hRotation;
-
-            m_notifierConnection += m_entityDefinitionManager.usageCountDidChangeNotifier.connect(this, &EntityBrowserView::usageCountDidChange);
         }
 
         EntityBrowserView::~EntityBrowserView() {
@@ -124,11 +122,6 @@ namespace TrenchBroom {
                 return;
             }
             m_filterText = filterText;
-            invalidate();
-            update();
-        }
-
-        void EntityBrowserView::usageCountDidChange() {
             invalidate();
             update();
         }

--- a/common/src/View/EntityBrowserView.h
+++ b/common/src/View/EntityBrowserView.h
@@ -94,8 +94,6 @@ namespace TrenchBroom {
             void setHideUnused(bool hideUnused);
             void setFilterText(const std::string& filterText);
         private:
-            void usageCountDidChange();
-
             void doInitLayout(Layout& layout) override;
             void doReloadLayout(Layout& layout) override;
 

--- a/common/test/src/View/UndoTest.cpp
+++ b/common/test/src/View/UndoTest.cpp
@@ -62,6 +62,15 @@ namespace TrenchBroom {
                 CHECK(texture->usageCount() == 6u);
             }
 
+            SECTION("delete brush") {
+                document->select(brushNode);
+                document->deleteObjects();
+                CHECK(texture->usageCount() == 0u);
+
+                document->undoCommand();
+                CHECK(texture->usageCount() == 6u);
+            }
+
             SECTION("select top face, move texture") {
                 auto topFaceIndex = brushNode->brush().findFace(vm::vec3::pos_z());
                 REQUIRE(topFaceIndex.has_value());


### PR DESCRIPTION
Fixes #3856

The overall issues here are:

- we want to be able to copy Entity / Brush in background threads
- but when doing so, AssetReference copy constructor calls incUsageCount()/decUsageCount() on Texture/EntityDefinition
- none of the inc/decUsageCount() are threadsafe
- the EntityDefinition inc/decUsageCount() calls a notifier, which triggers a crash.

So as a quick fix, I've made inc/decUsageCount() threadsafe, and removed the entity definition usageCountDidChangeNotifier. This is just used to rebuild the entity browser for the purposes of sorting by usage, or showing only used entities. Now it invalidates the browser on every node change, but I'm not seeing any noticeable performance impact from this.


For future work: having AssetReference in Entity/Brush etc. update these usage counts feels wrong to me. The usage counts in Texture/EntityDefinition are used to track what is actually in use in the map document - i.e. they update when nodes are attached and removed from the world node tree - they shouldn't track temporary Brush, Entity, etc. objects.