### PR TITLE
3822: rework MapRenderer notification handling to only invalidate necessary nodes

### DIFF
--- a/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
+++ b/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
@@ -111,12 +111,10 @@ namespace TrenchBroom {
             }, "validate after removing one brush");
 
             // Large change: keep every second brush
-            size_t numRemoved = 0;
             timeLambda([&](){
                 for (size_t i = 0; i < brushes.size(); ++i) {
                     if ((i % 2) == 0) {
                         r.removeBrush(brushes[i]);
-                        ++numRemoved;
                     }
                 }
             }, "remove every second brush");

--- a/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
+++ b/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
@@ -75,7 +75,9 @@ namespace TrenchBroom {
             // want it mixed into the timing
 
             BrushRenderer tempRenderer;
-            tempRenderer.addBrushes(result);
+            for (auto* brushNode : result) {
+                tempRenderer.addBrush(brushNode);
+            }
             tempRenderer.validate();
             tempRenderer.clear();
 
@@ -89,7 +91,11 @@ namespace TrenchBroom {
 
             BrushRenderer r;
 
-            timeLambda([&](){ r.addBrushes(brushes); }, "add " + std::to_string(brushes.size()) + " brushes to BrushRenderer");
+            timeLambda([&](){ 
+                for (auto* brush : brushes) {
+                    r.addBrush(brush);
+                }
+            }, "add " + std::to_string(brushes.size()) + " brushes to BrushRenderer");
             timeLambda([&](){
                 if (!r.valid()) {
                     r.validate();
@@ -97,11 +103,7 @@ namespace TrenchBroom {
             }, "validate after adding " + std::to_string(brushes.size()) + " brushes to BrushRenderer");
 
             // Tiny change: remove the last brush
-            std::vector<Model::BrushNode*> brushesMinusOne = brushes;
-            assert(!brushesMinusOne.empty());
-            brushesMinusOne.pop_back();
-
-            timeLambda([&](){ r.setBrushes(brushesMinusOne); }, "setBrushes to " + std::to_string(brushesMinusOne.size()) + " (removing one)");
+            timeLambda([&](){ r.removeBrush(brushes.back()); }, "call removeBrush once");
             timeLambda([&](){
                 if (!r.valid()) {
                     r.validate();
@@ -109,22 +111,21 @@ namespace TrenchBroom {
             }, "validate after removing one brush");
 
             // Large change: keep every second brush
-            std::vector<Model::BrushNode*> brushesToKeep;
-            for (size_t i = 0; i < brushes.size(); ++i) {
-                if ((i % 2) == 0) {
-                    brushesToKeep.push_back(brushes.at(i));
+            size_t numRemoved = 0;
+            timeLambda([&](){
+                for (size_t i = 0; i < brushes.size(); ++i) {
+                    if ((i % 2) == 0) {
+                        r.removeBrush(brushes[i]);
+                        ++numRemoved;
+                    }
                 }
-            }
-
-            timeLambda([&](){ r.setBrushes(brushesToKeep); },
-                       "set brushes from " + std::to_string(brushes.size()) +
-                       " to " + std::to_string(brushesToKeep.size()));
+            }, "remove every second brush");
 
             timeLambda([&](){
                            if (!r.valid()) {
                                r.validate();
                            }
-                       }, "validate with " + std::to_string(brushesToKeep.size()) + " brushes");
+                       }, "validate remaining brushes");
 
             kdl::vec_clear_and_delete(brushes);
             kdl::vec_clear_and_delete(textures);

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -177,17 +177,21 @@ namespace TrenchBroom {
         }
 
         void BrushRenderer::invalidateBrushes(const std::vector<Model::BrushNode*>& brushes) {
-            for (auto& brush : brushes) {
-                // skip brushes that are not in the renderer
-                if (m_allBrushes.find(brush) == std::end(m_allBrushes)) {
-                    assert(m_brushInfo.find(brush) == std::end(m_brushInfo));
-                    assert(m_invalidBrushes.find(brush) == std::end(m_invalidBrushes));
-                    continue;
-                }
-                // if it's not in the invalid set, put it in
-                if (m_invalidBrushes.insert(brush).second) {
-                    removeBrushFromVbo(brush);
-                }
+            for (auto* brush : brushes) {
+                invalidateBrush(brush);
+            }
+        }
+
+        void BrushRenderer::invalidateBrush(const Model::BrushNode* brush) {
+            // skip brushes that are not in the renderer
+            if (m_allBrushes.find(brush) == std::end(m_allBrushes)) {
+                assert(m_brushInfo.find(brush) == std::end(m_brushInfo));
+                assert(m_invalidBrushes.find(brush) == std::end(m_invalidBrushes));
+                return;
+            }
+            // if it's not in the invalid set, put it in
+            if (m_invalidBrushes.insert(brush).second) {
+                removeBrushFromVbo(brush);
             }
         }
 

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -552,7 +552,7 @@ namespace TrenchBroom {
 
         void BrushRenderer::removeBrush(const Model::BrushNode* brush) {
             // update m_brushValid
-            assertResult(m_allBrushes.erase(brush) > 0u);
+            m_allBrushes.erase(brush);
 
             if (m_invalidBrushes.erase(brush) > 0u) {
                 // invalid brushes are not in the VBO, so we can return  now.

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -137,32 +137,6 @@ namespace TrenchBroom {
             clear();
         }
 
-        void BrushRenderer::addBrushes(const std::vector<Model::BrushNode*>& brushes) {
-            for (auto* brush : brushes) {
-                addBrush(brush);
-            }
-        }
-
-        void BrushRenderer::setBrushes(const std::vector<Model::BrushNode*>& brushes) {
-            // start with adding nothing, and removing everything
-            std::unordered_set<const Model::BrushNode*> toAdd;
-            std::unordered_set<const Model::BrushNode*> toRemove = m_allBrushes;
-
-            // update toAdd and toRemove using the input list
-            for (const auto* brush : brushes) {
-                if (toRemove.erase(brush) == 0u) {
-                    toAdd.insert(brush);
-                }
-            }
-
-            for (auto brush : toRemove) {
-                removeBrush(brush);
-            }
-            for (auto brush : toAdd) {
-                addBrush(brush);
-            }
-        }
-
         void BrushRenderer::invalidate() {
             for (auto& brush : m_allBrushes) {
                 // this will also invalidate already invalid brushes, which
@@ -174,12 +148,6 @@ namespace TrenchBroom {
             assert(m_brushInfo.empty());
             assert(m_transparentFaces->empty());
             assert(m_opaqueFaces->empty());
-        }
-
-        void BrushRenderer::invalidateBrushes(const std::vector<Model::BrushNode*>& brushes) {
-            for (auto* brush : brushes) {
-                invalidateBrush(brush);
-            }
         }
 
         void BrushRenderer::invalidateBrush(const Model::BrushNode* brush) {

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -185,6 +185,9 @@ namespace TrenchBroom {
              * New brushes are invalidated, brushes already in the BrushRenderer are not invalidated.
              */
             void setBrushes(const std::vector<Model::BrushNode*>& brushes);
+            /**
+             * Remove all brushes.
+             */
             void clear();
 
             /**
@@ -198,6 +201,10 @@ namespace TrenchBroom {
              * maps will be empty, so the BrushRenderer will not have any lingering Texture* pointers.
              */
             void invalidate();
+            /**
+             * Invalidates the given brushes, if they were previously added with addBrushes()/setBrushes().
+             * Brushes not in the renderer are ignored.
+             */
             void invalidateBrushes(const std::vector<Model::BrushNode*>& brushes);
             bool valid() const;
 

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -206,6 +206,7 @@ namespace TrenchBroom {
              * Brushes not in the renderer are ignored.
              */
             void invalidateBrushes(const std::vector<Model::BrushNode*>& brushes);
+            void invalidateBrush(const Model::BrushNode* brush);
             bool valid() const;
 
             /**
@@ -289,9 +290,10 @@ namespace TrenchBroom {
         private:
             bool shouldDrawFaceInTransparentPass(const Model::BrushNode* brush, const Model::BrushFace& face) const;
             void validateBrush(const Model::BrushNode* brush);
+        public:
             void addBrush(const Model::BrushNode* brush);
             void removeBrush(const Model::BrushNode* brush);
-
+        private:
             /**
              * If the given brush is not currently in the VBO, it's silently ignored.
              * Otherwise, it's removed from the VBO (having its indices zeroed out, causing it to no longer draw).

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -278,7 +278,13 @@ namespace TrenchBroom {
             bool shouldDrawFaceInTransparentPass(const Model::BrushNode* brush, const Model::BrushFace& face) const;
             void validateBrush(const Model::BrushNode* brush);
         public:
+            /**
+             * Adds a brush. Calling with an already-added brush is allowed, but ignored (not guaranteed to invalidate it).
+             */
             void addBrush(const Model::BrushNode* brush);
+            /**
+             * Removes a brush. Calling with an unknown brush is allowed, but ignored.
+             */
             void removeBrush(const Model::BrushNode* brush);
         private:
             /**

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -178,14 +178,6 @@ namespace TrenchBroom {
             BrushRenderer();
 
             /**
-             * New brushes are invalidated, brushes already in the BrushRenderer are not invalidated.
-             */
-            void addBrushes(const std::vector<Model::BrushNode*>& brushes);
-            /**
-             * New brushes are invalidated, brushes already in the BrushRenderer are not invalidated.
-             */
-            void setBrushes(const std::vector<Model::BrushNode*>& brushes);
-            /**
              * Remove all brushes.
              */
             void clear();
@@ -201,11 +193,6 @@ namespace TrenchBroom {
              * maps will be empty, so the BrushRenderer will not have any lingering Texture* pointers.
              */
             void invalidate();
-            /**
-             * Invalidates the given brushes, if they were previously added with addBrushes()/setBrushes().
-             * Brushes not in the renderer are ignored.
-             */
-            void invalidateBrushes(const std::vector<Model::BrushNode*>& brushes);
             void invalidateBrush(const Model::BrushNode* brush);
             bool valid() const;
 

--- a/common/src/Renderer/EntityModelRenderer.cpp
+++ b/common/src/Renderer/EntityModelRenderer.cpp
@@ -68,12 +68,7 @@ namespace TrenchBroom {
         }
 
         void EntityModelRenderer::removeEntity(const Model::EntityNode* entityNode) {
-            // Because calling addEntity() doesn't necessairily mean the entity will be added,
-            // this needs to be safe to call for entities that weren't added.
-            auto it = m_entities.find(entityNode);
-            if (it != std::end(m_entities)) {
-                m_entities.erase(it);
-            }
+            m_entities.erase(entityNode);
         }
 
         void EntityModelRenderer::updateEntity(const Model::EntityNode* entityNode) {

--- a/common/src/Renderer/EntityModelRenderer.cpp
+++ b/common/src/Renderer/EntityModelRenderer.cpp
@@ -68,9 +68,12 @@ namespace TrenchBroom {
         }
 
         void EntityModelRenderer::removeEntity(const Model::EntityNode* entityNode) {
+            // Because calling addEntity() doesn't necessairily mean the entity will be added,
+            // this needs to be safe to call for entities that weren't added.
             auto it = m_entities.find(entityNode);
-            assert(it != m_entities.end());
-            m_entities.erase(it);
+            if (it != std::end(m_entities)) {
+                m_entities.erase(it);
+            }
         }
 
         void EntityModelRenderer::updateEntity(const Model::EntityNode* entityNode) {

--- a/common/src/Renderer/EntityModelRenderer.cpp
+++ b/common/src/Renderer/EntityModelRenderer.cpp
@@ -67,6 +67,12 @@ namespace TrenchBroom {
             }
         }
 
+        void EntityModelRenderer::removeEntity(const Model::EntityNode* entityNode) {
+            auto it = m_entities.find(entityNode);
+            assert(it != m_entities.end());
+            m_entities.erase(it);
+        }
+
         void EntityModelRenderer::updateEntity(const Model::EntityNode* entityNode) {
             const auto modelSpec = Assets::safeGetModelSpecification(m_logger, entityNode->entity().classname(), [&]() {
                 return entityNode->entity().modelSpecification();

--- a/common/src/Renderer/EntityModelRenderer.h
+++ b/common/src/Renderer/EntityModelRenderer.h
@@ -81,6 +81,7 @@ namespace TrenchBroom {
             }
 
             void addEntity(const Model::EntityNode* entityNode);
+            void removeEntity(const Model::EntityNode* entityNode);
             void updateEntity(const Model::EntityNode* entityNode);
             void clear();
 

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -42,6 +42,7 @@
 #include <vecmath/mat_ext.h>
 #include <vecmath/scalar.h>
 
+#include <algorithm>
 #include <vector>
 
 namespace TrenchBroom {
@@ -99,6 +100,25 @@ namespace TrenchBroom {
 
         void EntityRenderer::reloadModels() {
             m_modelRenderer.updateEntities(std::begin(m_entities), std::end(m_entities));
+        }
+
+        void EntityRenderer::addEntity(Model::EntityNode* entity) {
+            m_entities.push_back(entity);
+            m_modelRenderer.addEntity(entity);
+            invalidateBounds();
+        }
+
+        void EntityRenderer::removeEntity(Model::EntityNode* entity) {
+            auto it = std::find(std::begin(m_entities), std::end(m_entities), entity);
+            assert(it != m_entities.end());
+            m_entities.erase(it);
+            m_modelRenderer.removeEntity(entity);
+            invalidateBounds();
+        }
+
+        void EntityRenderer::invalidateEntity(Model::EntityNode* entity) {
+            m_modelRenderer.updateEntity(entity);
+            invalidateBounds();
         }
 
         void EntityRenderer::setShowOverlays(const bool showOverlays) {

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -95,14 +95,14 @@ namespace TrenchBroom {
             m_modelRenderer.updateEntities(std::begin(m_entities), std::end(m_entities));
         }
 
-        void EntityRenderer::addEntity(Model::EntityNode* entity) {
+        void EntityRenderer::addEntity(const Model::EntityNode* entity) {
             if (m_entities.insert(entity).second) {
                 m_modelRenderer.addEntity(entity);
                 invalidateBounds();
             }
         }
 
-        void EntityRenderer::removeEntity(Model::EntityNode* entity) {
+        void EntityRenderer::removeEntity(const Model::EntityNode* entity) {
             if (auto it = m_entities.find(entity); it != std::end(m_entities)) {
                 m_entities.erase(it);
                 m_modelRenderer.removeEntity(entity);
@@ -110,7 +110,7 @@ namespace TrenchBroom {
             }
         }
 
-        void EntityRenderer::invalidateEntity(Model::EntityNode* entity) {
+        void EntityRenderer::invalidateEntity(const Model::EntityNode* entity) {
             m_modelRenderer.updateEntity(entity);
             invalidateBounds();
         }

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -42,7 +42,6 @@
 #include <vecmath/mat_ext.h>
 #include <vecmath/scalar.h>
 
-#include <algorithm>
 #include <vector>
 
 namespace TrenchBroom {

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -97,17 +97,18 @@ namespace TrenchBroom {
         }
 
         void EntityRenderer::addEntity(Model::EntityNode* entity) {
-            m_entities.push_back(entity);
-            m_modelRenderer.addEntity(entity);
-            invalidateBounds();
+            if (m_entities.insert(entity).second) {
+                m_modelRenderer.addEntity(entity);
+                invalidateBounds();
+            }
         }
 
         void EntityRenderer::removeEntity(Model::EntityNode* entity) {
-            auto it = std::find(std::begin(m_entities), std::end(m_entities), entity);
-            assert(it != m_entities.end());
-            m_entities.erase(it);
-            m_modelRenderer.removeEntity(entity);
-            invalidateBounds();
+            if (auto it = m_entities.find(entity); it != std::end(m_entities)) {
+                m_entities.erase(it);
+                m_modelRenderer.removeEntity(entity);
+                invalidateBounds();
+            }
         }
 
         void EntityRenderer::invalidateEntity(Model::EntityNode* entity) {

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -79,12 +79,6 @@ namespace TrenchBroom {
         m_showAngles(false),
         m_showHiddenEntities(false) {}
 
-        void EntityRenderer::setEntities(const std::vector<Model::EntityNode*>& entities) {
-            m_entities = entities;
-            m_modelRenderer.setEntities(std::begin(m_entities), std::end(m_entities));
-            invalidate();
-        }
-
         void EntityRenderer::invalidate() {
             invalidateBounds();
             reloadModels();

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -80,6 +80,10 @@ namespace TrenchBroom {
             void clear();
             void reloadModels();
 
+            void addEntity(Model::EntityNode* entity);
+            void removeEntity(Model::EntityNode* entity);
+            void invalidateEntity(Model::EntityNode* entity);
+
             void setShowOverlays(bool showOverlays);
             void setOverlayTextColor(const Color& overlayTextColor);
             void setOverlayBackgroundColor(const Color& overlayBackgroundColor);

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -25,6 +25,7 @@
 #include "Renderer/Renderable.h"
 #include "Renderer/TriangleRenderer.h"
 
+#include <kdl/vector_set.h>
 #include <vecmath/forward.h>
 
 #include <vector>
@@ -50,7 +51,7 @@ namespace TrenchBroom {
 
             Assets::EntityModelManager& m_entityModelManager;
             const Model::EditorContext& m_editorContext;
-            std::vector<Model::EntityNode*> m_entities;
+            kdl::vector_set<Model::EntityNode*> m_entities;
 
             DirectEdgeRenderer m_pointEntityWireframeBoundsRenderer;
             DirectEdgeRenderer m_brushEntityWireframeBoundsRenderer;
@@ -75,12 +76,27 @@ namespace TrenchBroom {
         public:
             EntityRenderer(Logger& logger, Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext);
 
+            /**
+             * Equivalent to invalidateEntity() on all added entities.
+             */
             void invalidate();
+            /**
+             * Equivalent to removeEntity() on all added entities.
+             */
             void clear();
             void reloadModels();
 
+            /**
+             * Adds an entity. Calling with an already-added entity is allowed, but ignored (not guaranteed to invalidate it).
+             */
             void addEntity(Model::EntityNode* entity);
+            /**
+             * Removes an entity. Calling with an unknown entity is allowed, but ignored.
+             */
             void removeEntity(Model::EntityNode* entity);
+            /**
+             * Causes cached renderer data to be rebuilt for the given entity (on the next render() call).
+             */
             void invalidateEntity(Model::EntityNode* entity);
 
             void setShowOverlays(bool showOverlays);

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -75,7 +75,6 @@ namespace TrenchBroom {
         public:
             EntityRenderer(Logger& logger, Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext);
 
-            void setEntities(const std::vector<Model::EntityNode*>& entities);
             void invalidate();
             void clear();
             void reloadModels();

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -51,7 +51,7 @@ namespace TrenchBroom {
 
             Assets::EntityModelManager& m_entityModelManager;
             const Model::EditorContext& m_editorContext;
-            kdl::vector_set<Model::EntityNode*> m_entities;
+            kdl::vector_set<const Model::EntityNode*> m_entities;
 
             DirectEdgeRenderer m_pointEntityWireframeBoundsRenderer;
             DirectEdgeRenderer m_brushEntityWireframeBoundsRenderer;
@@ -89,15 +89,15 @@ namespace TrenchBroom {
             /**
              * Adds an entity. Calling with an already-added entity is allowed, but ignored (not guaranteed to invalidate it).
              */
-            void addEntity(Model::EntityNode* entity);
+            void addEntity(const Model::EntityNode* entity);
             /**
              * Removes an entity. Calling with an unknown entity is allowed, but ignored.
              */
-            void removeEntity(Model::EntityNode* entity);
+            void removeEntity(const Model::EntityNode* entity);
             /**
              * Causes cached renderer data to be rebuilt for the given entity (on the next render() call).
              */
-            void invalidateEntity(Model::EntityNode* entity);
+            void invalidateEntity(const Model::EntityNode* entity);
 
             void setShowOverlays(bool showOverlays);
             void setOverlayTextColor(const Color& overlayTextColor);

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -30,8 +30,8 @@
 #include "Renderer/RenderService.h"
 #include "Renderer/TextAnchor.h"
 
-#include <vector>
-
+#include <cassert>
+#include <algorithm>
 #include <vector>
 
 namespace TrenchBroom {
@@ -75,6 +75,25 @@ namespace TrenchBroom {
         void GroupRenderer::clear() {
             m_groups.clear();
             m_boundsRenderer = DirectEdgeRenderer();
+        }
+
+        void GroupRenderer::addGroup(Model::GroupNode* group) {
+            // caller responsible for ensuring the same group is not added twice
+            assert(std::find(std::begin(m_groups), std::end(m_groups), group)
+                   == m_groups.end());
+            m_groups.push_back(group);
+            invalidate();
+        }
+
+        void GroupRenderer::removeGroup(Model::GroupNode* group) {
+            auto it = std::find(std::begin(m_groups), std::end(m_groups), group);
+            assert(it != m_groups.end());
+            m_groups.erase(it);
+            invalidate();
+        }
+
+        void GroupRenderer::invalidateGroup(Model::GroupNode*) {
+            invalidate();
         }
 
         void GroupRenderer::setOverrideColors(const bool overrideColors) {

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -70,20 +70,20 @@ namespace TrenchBroom {
             m_boundsRenderer = DirectEdgeRenderer();
         }
 
-        void GroupRenderer::addGroup(Model::GroupNode* group) {
+        void GroupRenderer::addGroup(const Model::GroupNode* group) {
             if (m_groups.insert(group).second) {
                 invalidate();
             }
         }
 
-        void GroupRenderer::removeGroup(Model::GroupNode* group) {
+        void GroupRenderer::removeGroup(const Model::GroupNode* group) {
             if (auto it = m_groups.find(group); it != std::end(m_groups)) {
                 m_groups.erase(it);
                 invalidate();
             }
         }
 
-        void GroupRenderer::invalidateGroup(Model::GroupNode*) {
+        void GroupRenderer::invalidateGroup(const Model::GroupNode*) {
             invalidate();
         }
 

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -30,8 +30,6 @@
 #include "Renderer/RenderService.h"
 #include "Renderer/TextAnchor.h"
 
-#include <cassert>
-#include <algorithm>
 #include <vector>
 
 namespace TrenchBroom {

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -63,11 +63,6 @@ namespace TrenchBroom {
         m_showOccludedOverlays(false),
         m_showOccludedBounds(false) {}
 
-        void GroupRenderer::setGroups(const std::vector<Model::GroupNode*>& groups) {
-            m_groups = groups;
-            invalidate();
-        }
-
         void GroupRenderer::invalidate() {
             invalidateBounds();
         }

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -73,18 +73,16 @@ namespace TrenchBroom {
         }
 
         void GroupRenderer::addGroup(Model::GroupNode* group) {
-            // caller responsible for ensuring the same group is not added twice
-            assert(std::find(std::begin(m_groups), std::end(m_groups), group)
-                   == m_groups.end());
-            m_groups.push_back(group);
-            invalidate();
+            if (m_groups.insert(group).second) {
+                invalidate();
+            }
         }
 
         void GroupRenderer::removeGroup(Model::GroupNode* group) {
-            auto it = std::find(std::begin(m_groups), std::end(m_groups), group);
-            assert(it != m_groups.end());
-            m_groups.erase(it);
-            invalidate();
+            if (auto it = m_groups.find(group); it != std::end(m_groups)) {
+                m_groups.erase(it);
+                invalidate();
+            }
         }
 
         void GroupRenderer::invalidateGroup(Model::GroupNode*) {

--- a/common/src/Renderer/GroupRenderer.h
+++ b/common/src/Renderer/GroupRenderer.h
@@ -60,6 +60,10 @@ namespace TrenchBroom {
             void invalidate();
             void clear();
 
+            void addGroup(Model::GroupNode* group);
+            void removeGroup(Model::GroupNode* group);
+            void invalidateGroup(Model::GroupNode* group);
+
             template <typename Iter>
             void addGroups(Iter cur, const Iter end) {
                 while (cur != end) {

--- a/common/src/Renderer/GroupRenderer.h
+++ b/common/src/Renderer/GroupRenderer.h
@@ -80,29 +80,6 @@ namespace TrenchBroom {
              */
             void invalidateGroup(const Model::GroupNode* group);
 
-            template <typename Iter>
-            void addGroups(Iter cur, const Iter end) {
-                while (cur != end) {
-                    addGroup(*cur);
-                    ++cur;
-                }
-            }
-            template <typename Iter>
-            void updateGroups(Iter cur, const Iter end) {
-                while (cur != end) {
-                    updateGroup(*cur);
-                    ++cur;
-                }
-            }
-
-            template <typename Iter>
-            void removeGroups(Iter cur, const Iter end) {
-                while (cur != end) {
-                    removeGroup(*cur);
-                    ++cur;
-                }
-            }
-
             void setOverrideColors(bool overrideColors);
 
             void setShowOverlays(bool showOverlays);

--- a/common/src/Renderer/GroupRenderer.h
+++ b/common/src/Renderer/GroupRenderer.h
@@ -56,7 +56,6 @@ namespace TrenchBroom {
         public:
             GroupRenderer(const Model::EditorContext& editorContext);
 
-            void setGroups(const std::vector<Model::GroupNode*>& groups);
             void invalidate();
             void clear();
 

--- a/common/src/Renderer/GroupRenderer.h
+++ b/common/src/Renderer/GroupRenderer.h
@@ -23,6 +23,8 @@
 #include "Color.h"
 #include "Renderer/EdgeRenderer.h"
 
+#include <kdl/vector_set.h>
+
 #include <vector>
 
 namespace TrenchBroom {
@@ -40,7 +42,7 @@ namespace TrenchBroom {
             class GroupNameAnchor;
 
             const Model::EditorContext& m_editorContext;
-            std::vector<Model::GroupNode*> m_groups;
+            kdl::vector_set<Model::GroupNode*> m_groups;
 
             DirectEdgeRenderer m_boundsRenderer;
             bool m_boundsValid;
@@ -56,11 +58,26 @@ namespace TrenchBroom {
         public:
             GroupRenderer(const Model::EditorContext& editorContext);
 
+            /**
+             * Equivalent to invalidateGroup() on all added groups.
+             */
             void invalidate();
+            /**
+             * Equivalent to removeGroup() on all added groups.
+             */
             void clear();
 
+            /**
+             * Adds a group. Calling with an already-added group is allowed, but ignored (not guaranteed to invalidate it).
+             */
             void addGroup(Model::GroupNode* group);
+            /**
+             * Removes a group. Calling with an unknown group is allowed, but ignored.
+             */
             void removeGroup(Model::GroupNode* group);
+            /**
+             * Causes cached renderer data to be rebuilt for the given group (on the next render() call).
+             */
             void invalidateGroup(Model::GroupNode* group);
 
             template <typename Iter>

--- a/common/src/Renderer/GroupRenderer.h
+++ b/common/src/Renderer/GroupRenderer.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             class GroupNameAnchor;
 
             const Model::EditorContext& m_editorContext;
-            kdl::vector_set<Model::GroupNode*> m_groups;
+            kdl::vector_set<const Model::GroupNode*> m_groups;
 
             DirectEdgeRenderer m_boundsRenderer;
             bool m_boundsValid;
@@ -70,15 +70,15 @@ namespace TrenchBroom {
             /**
              * Adds a group. Calling with an already-added group is allowed, but ignored (not guaranteed to invalidate it).
              */
-            void addGroup(Model::GroupNode* group);
+            void addGroup(const Model::GroupNode* group);
             /**
              * Removes a group. Calling with an unknown group is allowed, but ignored.
              */
-            void removeGroup(Model::GroupNode* group);
+            void removeGroup(const Model::GroupNode* group);
             /**
              * Causes cached renderer data to be rebuilt for the given group (on the next render() call).
              */
-            void invalidateGroup(Model::GroupNode* group);
+            void invalidateGroup(const Model::GroupNode* group);
 
             template <typename Iter>
             void addGroups(Iter cur, const Iter end) {

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -429,6 +429,31 @@ namespace TrenchBroom {
             }
         }
 
+        /**
+         * Calls updateAndInvalidateNode() on every node in the world.
+         */
+        void MapRenderer::updateAllNodes() {
+            auto document = kdl::mem_lock(m_document);
+            document->world()->accept(kdl::overload(
+                [](auto&& thisLambda, Model::WorldNode* world) { world->visitChildren(thisLambda); },
+                [](auto&& thisLambda, Model::LayerNode* layer) { layer->visitChildren(thisLambda); },
+                [&](auto&& thisLambda, Model::GroupNode* group) {
+                    updateAndInvalidateNode(group);
+                    group->visitChildren(thisLambda);
+                },
+                [&](auto&& thisLambda, Model::EntityNode* entity) {
+                    updateAndInvalidateNode(entity);
+                    entity->visitChildren(thisLambda);
+                },
+                [&](Model::BrushNode* brush) {
+                    updateAndInvalidateNode(brush);
+                },
+                [&](Model::PatchNode* patchNode) {
+                    updateAndInvalidateNode(patchNode);
+                }
+            ));
+        }
+
         void MapRenderer::updateRenderers(const Renderer renderers) {
             const auto renderDefault   = (renderers & Renderer_Default) != 0;
             const auto renderSelection = (renderers & Renderer_Selection) != 0;

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -423,10 +423,14 @@ namespace TrenchBroom {
                     m_lockedRenderer->removeNode(node);
                 }
 
+                m_trackedNodes.erase(it);
+
                 // At this point, none of the default/selection/locked renderers,
                 // or their underlying node-type specific renderers, have a reference 
                 // to `node` anymore, and they won't render it.
             }
+
+            assert(m_trackedNodes.find(node) == std::end(m_trackedNodes));
         }
 
         /**

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -513,7 +513,6 @@ namespace TrenchBroom {
                                              lockedNodes.brushes,
                                              lockedNodes.patches);
             }
-            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::invalidateRenderers(Renderer renderers) {
@@ -583,16 +582,19 @@ namespace TrenchBroom {
         void MapRenderer::documentWasNewedOrLoaded(View::MapDocument*) {
             clear();
             updateRenderers(Renderer_All);
+            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::nodesWereAdded(const std::vector<Model::Node*>&) {
             updateRenderers(Renderer_All);
             invalidateGroupLinkRenderer();
+            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::nodesWereRemoved(const std::vector<Model::Node*>&) {
             updateRenderers(Renderer_All);
             invalidateGroupLinkRenderer();
+            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::nodesDidChange(const std::vector<Model::Node*>&) {
@@ -607,16 +609,19 @@ namespace TrenchBroom {
 
         void MapRenderer::nodeLockingDidChange(const std::vector<Model::Node*>&) {
             updateRenderers(Renderer_Default_Locked);
+            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::groupWasOpened(Model::GroupNode*) {
             updateRenderers(Renderer_Default_Selection);
             invalidateGroupLinkRenderer();
+            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::groupWasClosed(Model::GroupNode*) {
             updateRenderers(Renderer_Default_Selection);
             invalidateGroupLinkRenderer();
+            invalidateEntityLinkRenderer();
         }
 
         void MapRenderer::brushFacesDidChange(const std::vector<Model::BrushFaceHandle>&) {
@@ -625,6 +630,7 @@ namespace TrenchBroom {
 
         void MapRenderer::selectionDidChange(const View::Selection& selection) {
             updateRenderers(Renderer_All); // need to update locked objects also because a selected object may have been reparented into a locked layer before deselection
+            invalidateEntityLinkRenderer();
 
             // selecting faces needs to invalidate the brushes
             if (!selection.selectedBrushFaces().empty()

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -378,6 +378,12 @@ namespace TrenchBroom {
             return static_cast<Renderer>(result);
         }
         
+        /**
+         * - Determine which renderers the given node should be in
+         * - Remove from any renderers the node shouldn't be in
+         * - Add to new renderers, if not already present
+         * - Invalidate, for any renderers it was already present in
+         */
         void MapRenderer::updateAndInvalidateNode(Model::Node* node) {
             const Renderer desiredRenderers = determineRenderers(node);
             Renderer currentRenderers;
@@ -483,6 +489,10 @@ namespace TrenchBroom {
             updateAndInvalidateNodeRecursive(document->world());
         }
 
+        /**
+         * Marks the nodes that are already tracked in the given renderers as invalid, i.e.
+         * needing to be re-rendered.
+         */
         void MapRenderer::invalidateRenderers(Renderer renderers) {
             if ((renderers & Renderer_Default) != 0)
                 m_defaultRenderer->invalidate();

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -434,6 +434,13 @@ namespace TrenchBroom {
                     updateAndInvalidateNode(patchNode);
                 }
             ));
+
+            // Due to the definition of `selected()` above, we also need to update the parent.
+            // (not recursively, though, so this has little performance impact.) 
+            // This handles clicking on a brush in a brush entity -> the entity label needs to render as selected.
+            if (node->parent()) {
+                updateAndInvalidateNode(node->parent());
+            }
         }
 
         void MapRenderer::removeNode(Model::Node* node) {

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -326,11 +326,11 @@ namespace TrenchBroom {
             renderer.setBrushEdgeColor(pref(Preferences::LockedEdgeColor));
         }
 
-        MapRenderer::Renderer MapRenderer::determineRenderers(Model::Node* node) {
-            const auto selected = [](const auto* node) {
-                return node->selected() || node->descendantSelected() || node->parentSelected();
-            };
+        static bool selected(const Model::Node* node) {
+            return node->selected() || node->descendantSelected() || node->parentSelected();
+        }
 
+        MapRenderer::Renderer MapRenderer::determineRenderers(Model::Node* node) {
             int result = 0;
 
             node->accept(kdl::overload(

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -570,7 +570,9 @@ namespace TrenchBroom {
 
         void MapRenderer::nodesDidChange(const std::vector<Model::Node*>& nodes) {
             for (auto* node : nodes) {
-                // don't use the Recursive variant here
+                // nodesDidChange() will report ancestors changing, e.g. the world and layer are reported as 
+                // changing when a brush is dragged. So, don't update recursively here as it would cause 
+                // the entire map to be invalidated on every change.
                 updateAndInvalidateNode(node);
             }
             invalidateEntityLinkRenderer();

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -172,6 +172,7 @@ namespace TrenchBroom {
             m_lockedRenderer->clear();
             m_entityLinkRenderer->invalidate();
             m_groupLinkRenderer->invalidate();
+            m_trackedNodes.clear();
         }
 
         void MapRenderer::overrideSelectionColors(const Color& color, const float mix) {

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -123,6 +123,7 @@ namespace TrenchBroom {
              */
             void updateAndInvalidateNode(Model::Node* node);
             void removeNode(Model::Node* node);
+            void updateAllNodes();
             /**
              * Clears the set of nodes being tracked and repopulates it by traversing the node tree from the world.
              *

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -113,12 +113,18 @@ namespace TrenchBroom {
             } Renderer;
 
             /**
+             * Clears the set of nodes being tracked and repopulates it by traversing the node tree from the world.
+             *
              * This moves nodes between default / selection / locked renderers as needed,
              * but doesn't otherwise invalidate them.
              * (in particular, brushes are not updated unless they move between renderers.)
              * If brushes are modified, you need to call invalidateRenderers() or invalidateObjectsInRenderers()
              */
             void updateRenderers(Renderer renderers);
+            /**
+             * Marks the nodes that are already tracked in the given renderers as invalid, i.e.
+             * needing to be re-rendered.
+             */
             void invalidateRenderers(Renderer renderers);
             void invalidateBrushesInRenderers(Renderer renderers, const std::vector<Model::BrushNode*>& brushes);
             void invalidateEntityLinkRenderer();

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -70,6 +70,17 @@ namespace TrenchBroom {
             std::unique_ptr<EntityLinkRenderer> m_entityLinkRenderer;
             std::unique_ptr<GroupLinkRenderer> m_groupLinkRenderer;
 
+            typedef enum {
+                Renderer_Default            = 1,
+                Renderer_Selection          = 2,
+                Renderer_Locked             = 4,
+                Renderer_Default_Selection  = Renderer_Default | Renderer_Selection,
+                Renderer_Default_Locked     = Renderer_Default | Renderer_Locked,
+                Renderer_All                = Renderer_Default | Renderer_Selection | Renderer_Locked
+            } Renderer;
+
+            std::unordered_map<Model::Node*, Renderer> m_trackedNodes;
+
             NotifierConnection m_notifierConnection;
         public:
             explicit MapRenderer(std::weak_ptr<View::MapDocument> document);
@@ -103,15 +114,15 @@ namespace TrenchBroom {
             void setupSelectionRenderer(ObjectRenderer& renderer);
             void setupLockedRenderer(ObjectRenderer& renderer);
 
-            typedef enum {
-                Renderer_Default            = 1,
-                Renderer_Selection          = 2,
-                Renderer_Locked             = 4,
-                Renderer_Default_Selection  = Renderer_Default | Renderer_Selection,
-                Renderer_Default_Locked     = Renderer_Default | Renderer_Locked,
-                Renderer_All                = Renderer_Default | Renderer_Selection | Renderer_Locked
-            } Renderer;
-
+            Renderer determineRenderers(Model::Node* node);
+            /**
+             * - Determine which renderers the given node should be in
+             * - Remove from any renderers the node shouldn't be in
+             * - Add to new renderers, if not already present
+             * - Invalidate, for any renderers it was already present in
+             */
+            void updateAndInvalidateNode(Model::Node* node);
+            void removeNode(Model::Node* node);
             /**
              * Clears the set of nodes being tracked and repopulates it by traversing the node tree from the world.
              *

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -122,7 +122,9 @@ namespace TrenchBroom {
              * - Invalidate, for any renderers it was already present in
              */
             void updateAndInvalidateNode(Model::Node* node);
+            void updateAndInvalidateNodeRecursive(Model::Node* node);
             void removeNode(Model::Node* node);
+            void removeNodeRecursive(Model::Node* node);
             void updateAllNodes();
             /**
              * Marks the nodes that are already tracked in the given renderers as invalid, i.e.

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -22,7 +22,7 @@
 #include "Macros.h"
 #include "NotifierConnection.h"
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <vector>
 
@@ -60,8 +60,6 @@ namespace TrenchBroom {
             class LockedBrushRendererFilter;
             class UnselectedBrushRendererFilter;
 
-            using RendererMap = std::map<Model::LayerNode*, ObjectRenderer*>;
-
             std::weak_ptr<View::MapDocument> m_document;
 
             std::unique_ptr<ObjectRenderer> m_defaultRenderer;
@@ -74,9 +72,6 @@ namespace TrenchBroom {
                 Renderer_Default            = 1,
                 Renderer_Selection          = 2,
                 Renderer_Locked             = 4,
-                Renderer_Default_Selection  = Renderer_Default | Renderer_Selection,
-                Renderer_Default_Locked     = Renderer_Default | Renderer_Locked,
-                Renderer_All                = Renderer_Default | Renderer_Selection | Renderer_Locked
             } Renderer;
 
             std::unordered_map<Model::Node*, Renderer> m_trackedNodes;

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -72,6 +72,7 @@ namespace TrenchBroom {
                 Renderer_Default            = 1,
                 Renderer_Selection          = 2,
                 Renderer_Locked             = 4,
+                Renderer_All                = Renderer_Default | Renderer_Selection | Renderer_Locked
             } Renderer;
 
             std::unordered_map<Model::Node*, Renderer> m_trackedNodes;

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -111,21 +111,12 @@ namespace TrenchBroom {
             void setupLockedRenderer(ObjectRenderer& renderer);
 
             Renderer determineRenderers(Model::Node* node);
-            /**
-             * - Determine which renderers the given node should be in
-             * - Remove from any renderers the node shouldn't be in
-             * - Add to new renderers, if not already present
-             * - Invalidate, for any renderers it was already present in
-             */
             void updateAndInvalidateNode(Model::Node* node);
             void updateAndInvalidateNodeRecursive(Model::Node* node);
             void removeNode(Model::Node* node);
             void removeNodeRecursive(Model::Node* node);
             void updateAllNodes();
-            /**
-             * Marks the nodes that are already tracked in the given renderers as invalid, i.e.
-             * needing to be re-rendered.
-             */
+
             void invalidateRenderers(Renderer renderers);
             void invalidateEntityLinkRenderer();
             void invalidateGroupLinkRenderer();

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -110,7 +110,7 @@ namespace TrenchBroom {
             void setupSelectionRenderer(ObjectRenderer& renderer);
             void setupLockedRenderer(ObjectRenderer& renderer);
 
-            Renderer determineRenderers(Model::Node* node);
+            static Renderer determineDesiredRenderers(Model::Node* node);
             void updateAndInvalidateNode(Model::Node* node);
             void updateAndInvalidateNodeRecursive(Model::Node* node);
             void removeNode(Model::Node* node);

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -125,20 +125,10 @@ namespace TrenchBroom {
             void removeNode(Model::Node* node);
             void updateAllNodes();
             /**
-             * Clears the set of nodes being tracked and repopulates it by traversing the node tree from the world.
-             *
-             * This moves nodes between default / selection / locked renderers as needed,
-             * but doesn't otherwise invalidate them.
-             * (in particular, brushes are not updated unless they move between renderers.)
-             * If brushes are modified, you need to call invalidateRenderers() or invalidateObjectsInRenderers()
-             */
-            void updateRenderers(Renderer renderers);
-            /**
              * Marks the nodes that are already tracked in the given renderers as invalid, i.e.
              * needing to be re-rendered.
              */
             void invalidateRenderers(Renderer renderers);
-            void invalidateBrushesInRenderers(Renderer renderers, const std::vector<Model::BrushNode*>& brushes);
             void invalidateEntityLinkRenderer();
             void invalidateGroupLinkRenderer();
             void reloadEntityModels();

--- a/common/src/Renderer/ObjectRenderer.cpp
+++ b/common/src/Renderer/ObjectRenderer.cpp
@@ -21,6 +21,8 @@
 
 #include "Model/GroupNode.h"
 
+#include <kdl/overload.h>
+
 namespace TrenchBroom {
     namespace Renderer {
         void ObjectRenderer::setObjects(const std::vector<Model::GroupNode*>& groups, const std::vector<Model::EntityNode*>& entities, const std::vector<Model::BrushNode*>& brushes, const std::vector<Model::PatchNode*>& patches) {
@@ -28,6 +30,63 @@ namespace TrenchBroom {
             m_entityRenderer.setEntities(entities);
             m_brushRenderer.setBrushes(brushes);
             m_patchRenderer.setPatches(patches);
+        }
+
+        void ObjectRenderer::addNode(Model::Node* node) {
+            node->accept(kdl::overload(
+                [](Model::WorldNode*) {},
+                [](Model::LayerNode*) {},
+                [&](Model::GroupNode* group) {
+                    m_groupRenderer.addGroup(group);
+                },
+                [&](Model::EntityNode* entity) {
+                    m_entityRenderer.addEntity(entity);
+                },
+                [&](Model::BrushNode* brush) {
+                    m_brushRenderer.addBrush(brush);
+                },
+                [&](Model::PatchNode* patch) {
+                    m_patchRenderer.addPatch(patch);
+                }
+            ));
+        }
+
+        void ObjectRenderer::removeNode(Model::Node* node) {
+            node->accept(kdl::overload(
+                [](Model::WorldNode*) {},
+                [](Model::LayerNode*) {},
+                [&](Model::GroupNode* group) {
+                    m_groupRenderer.removeGroup(group);
+                },
+                [&](Model::EntityNode* entity) {
+                    m_entityRenderer.removeEntity(entity);
+                },
+                [&](Model::BrushNode* brush) {
+                    m_brushRenderer.removeBrush(brush);
+                },
+                [&](Model::PatchNode* patch) {
+                    m_patchRenderer.removePatch(patch);
+                }
+            ));
+        }
+
+        void ObjectRenderer::invalidateNode(Model::Node* node) {
+            node->accept(kdl::overload(
+                [](Model::WorldNode*) {},
+                [](Model::LayerNode*) {},
+                [&](Model::GroupNode* group) {
+                    m_groupRenderer.invalidateGroup(group);
+                },
+                [&](Model::EntityNode* entity) {
+                    m_entityRenderer.invalidateEntity(entity);
+                },
+                [&](Model::BrushNode* brush) {
+                    m_brushRenderer.invalidateBrush(brush);
+                },
+                [&](Model::PatchNode* patch) {
+                    m_patchRenderer.invalidatePatch(patch);
+                }
+            ));
         }
 
         void ObjectRenderer::invalidate() {

--- a/common/src/Renderer/ObjectRenderer.cpp
+++ b/common/src/Renderer/ObjectRenderer.cpp
@@ -25,13 +25,6 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        void ObjectRenderer::setObjects(const std::vector<Model::GroupNode*>& groups, const std::vector<Model::EntityNode*>& entities, const std::vector<Model::BrushNode*>& brushes, const std::vector<Model::PatchNode*>& patches) {
-            m_groupRenderer.setGroups(groups);
-            m_entityRenderer.setEntities(entities);
-            m_brushRenderer.setBrushes(brushes);
-            m_patchRenderer.setPatches(patches);
-        }
-
         void ObjectRenderer::addNode(Model::Node* node) {
             node->accept(kdl::overload(
                 [](Model::WorldNode*) {},
@@ -94,10 +87,6 @@ namespace TrenchBroom {
             m_entityRenderer.invalidate();
             m_brushRenderer.invalidate();
             m_patchRenderer.invalidate();
-        }
-
-        void ObjectRenderer::invalidateBrushes(const std::vector<Model::BrushNode*>& brushes) {
-            m_brushRenderer.invalidateBrushes(brushes);
         }
 
         void ObjectRenderer::clear() {

--- a/common/src/Renderer/ObjectRenderer.h
+++ b/common/src/Renderer/ObjectRenderer.h
@@ -39,6 +39,7 @@ namespace TrenchBroom {
         class EditorContext;
         class EntityNode;
         class GroupNode;
+        class Node;
         class PatchNode;
     }
 
@@ -61,6 +62,9 @@ namespace TrenchBroom {
             m_patchRenderer{} {}
         public: // object management
             void setObjects(const std::vector<Model::GroupNode*>& groups, const std::vector<Model::EntityNode*>& entities, const std::vector<Model::BrushNode*>& brushes, const std::vector<Model::PatchNode*>& patches);
+            void addNode(Model::Node* node);
+            void removeNode(Model::Node* node);
+            void invalidateNode(Model::Node* node);
             void invalidate();
             void invalidateBrushes(const std::vector<Model::BrushNode*>& brushes);
             void clear();

--- a/common/src/Renderer/ObjectRenderer.h
+++ b/common/src/Renderer/ObjectRenderer.h
@@ -61,12 +61,10 @@ namespace TrenchBroom {
             m_brushRenderer(brushFilter),
             m_patchRenderer{} {}
         public: // object management
-            void setObjects(const std::vector<Model::GroupNode*>& groups, const std::vector<Model::EntityNode*>& entities, const std::vector<Model::BrushNode*>& brushes, const std::vector<Model::PatchNode*>& patches);
             void addNode(Model::Node* node);
             void removeNode(Model::Node* node);
             void invalidateNode(Model::Node* node);
             void invalidate();
-            void invalidateBrushes(const std::vector<Model::BrushNode*>& brushes);
             void clear();
             void reloadModels();
         public: // configuration

--- a/common/src/Renderer/PatchRenderer.cpp
+++ b/common/src/Renderer/PatchRenderer.cpp
@@ -94,20 +94,20 @@ namespace TrenchBroom {
             invalidate();
         }
 
-        void PatchRenderer::addPatch(Model::PatchNode* patchNode) {
+        void PatchRenderer::addPatch(const Model::PatchNode* patchNode) {
             if (m_patchNodes.insert(patchNode).second) {
                 invalidate();
             }
         }
 
-        void PatchRenderer::removePatch(Model::PatchNode* patchNode) {
+        void PatchRenderer::removePatch(const Model::PatchNode* patchNode) {
             if (auto it = m_patchNodes.find(patchNode); it != std::end(m_patchNodes)) {
                 m_patchNodes.erase(it);
                 invalidate();
             }
         }
 
-        void PatchRenderer::invalidatePatch(Model::PatchNode*) {
+        void PatchRenderer::invalidatePatch(const Model::PatchNode*) {
             invalidate();
         }
 
@@ -128,7 +128,7 @@ namespace TrenchBroom {
             }
         }
 
-        static TexturedIndexArrayRenderer buildMeshRenderer(const std::vector<Model::PatchNode*>& patchNodes) {
+        static TexturedIndexArrayRenderer buildMeshRenderer(const std::vector<const Model::PatchNode*>& patchNodes) {
                 size_t vertexCount = 0u;
                 auto indexArrayMapSize = TexturedIndexArrayMap::Size{};
                 
@@ -175,7 +175,7 @@ namespace TrenchBroom {
                 return TexturedIndexArrayRenderer{std::move(vertexArray), std::move(indexArray), std::move(indexArrayMapBuilder.ranges())};
         }
 
-        static DirectEdgeRenderer buildEdgeRenderer(const std::vector<Model::PatchNode*>& patchNodes) {
+        static DirectEdgeRenderer buildEdgeRenderer(const std::vector<const Model::PatchNode*>& patchNodes) {
                 size_t vertexCount = 0u;
                 auto indexRangeMapSize = IndexRangeMap::Size{};
 

--- a/common/src/Renderer/PatchRenderer.cpp
+++ b/common/src/Renderer/PatchRenderer.cpp
@@ -95,15 +95,16 @@ namespace TrenchBroom {
         }
 
         void PatchRenderer::addPatch(Model::PatchNode* patchNode) {
-            m_patchNodes.push_back(patchNode);
-            invalidate();
+            if (m_patchNodes.insert(patchNode).second) {
+                invalidate();
+            }
         }
 
         void PatchRenderer::removePatch(Model::PatchNode* patchNode) {
-            auto it = std::find(std::begin(m_patchNodes), std::end(m_patchNodes), patchNode);
-            assert(it != std::end(m_patchNodes));
-            m_patchNodes.erase(it);
-            invalidate();
+            if (auto it = m_patchNodes.find(patchNode); it != std::end(m_patchNodes)) {
+                m_patchNodes.erase(it);
+                invalidate();
+            }
         }
 
         void PatchRenderer::invalidatePatch(Model::PatchNode*) {
@@ -232,8 +233,8 @@ namespace TrenchBroom {
 
         void PatchRenderer::validate() {
             if (!m_valid) {
-                m_patchMeshRenderer = buildMeshRenderer(m_patchNodes);
-                m_edgeRenderer = buildEdgeRenderer(m_patchNodes);
+                m_patchMeshRenderer = buildMeshRenderer(m_patchNodes.get_data());
+                m_edgeRenderer = buildEdgeRenderer(m_patchNodes.get_data());
 
                 m_valid = true;
             }

--- a/common/src/Renderer/PatchRenderer.cpp
+++ b/common/src/Renderer/PatchRenderer.cpp
@@ -99,6 +99,22 @@ namespace TrenchBroom {
             invalidate();
         }
 
+        void PatchRenderer::addPatch(Model::PatchNode* patchNode) {
+            m_patchNodes.push_back(patchNode);
+            invalidate();
+        }
+
+        void PatchRenderer::removePatch(Model::PatchNode* patchNode) {
+            auto it = std::find(std::begin(m_patchNodes), std::end(m_patchNodes), patchNode);
+            assert(it != std::end(m_patchNodes));
+            m_patchNodes.erase(it);
+            invalidate();
+        }
+
+        void PatchRenderer::invalidatePatch(Model::PatchNode*) {
+            invalidate();
+        }
+
         void PatchRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_valid) {
                 validate();

--- a/common/src/Renderer/PatchRenderer.cpp
+++ b/common/src/Renderer/PatchRenderer.cpp
@@ -85,11 +85,6 @@ namespace TrenchBroom {
             m_occludedEdgeColor = occludedEdgeColor;
         }
 
-        void PatchRenderer::setPatches(std::vector<Model::PatchNode*> patchNodes) {
-            m_patchNodes = std::move(patchNodes);
-            invalidate();
-        }
-
         void PatchRenderer::invalidate() {
             m_valid = false;
         }

--- a/common/src/Renderer/PatchRenderer.h
+++ b/common/src/Renderer/PatchRenderer.h
@@ -87,6 +87,10 @@ namespace TrenchBroom {
             void invalidate();
             void clear();
 
+            void addPatch(Model::PatchNode* patchNode);
+            void removePatch(Model::PatchNode* patchNode);
+            void invalidatePatch(Model::PatchNode* patchNode);
+
             void render(RenderContext& renderContext, RenderBatch& renderBatch);
         private:
             void validate();

--- a/common/src/Renderer/PatchRenderer.h
+++ b/common/src/Renderer/PatchRenderer.h
@@ -41,7 +41,7 @@ namespace TrenchBroom {
         class PatchRenderer : public IndexedRenderable {
         private:
             bool m_valid = true;
-            kdl::vector_set<Model::PatchNode*> m_patchNodes;
+            kdl::vector_set<const Model::PatchNode*> m_patchNodes;
 
             TexturedIndexArrayRenderer m_patchMeshRenderer;
             DirectEdgeRenderer m_edgeRenderer;
@@ -97,15 +97,15 @@ namespace TrenchBroom {
             /**
              * Adds a patch. Calling with an already-added patch is allowed, but ignored (not guaranteed to invalidate it).
              */
-            void addPatch(Model::PatchNode* patchNode);
+            void addPatch(const Model::PatchNode* patchNode);
             /**
              * Removes a patch. Calling with an unknown patch is allowed, but ignored.
              */
-            void removePatch(Model::PatchNode* patchNode);
+            void removePatch(const Model::PatchNode* patchNode);
             /**
              * Causes cached renderer data to be rebuilt for the given patch (on the next render() call).
              */
-            void invalidatePatch(Model::PatchNode* patchNode);
+            void invalidatePatch(const Model::PatchNode* patchNode);
 
             void render(RenderContext& renderContext, RenderBatch& renderBatch);
         private:

--- a/common/src/Renderer/PatchRenderer.h
+++ b/common/src/Renderer/PatchRenderer.h
@@ -83,7 +83,6 @@ namespace TrenchBroom {
              */
             void setOccludedEdgeColor(const Color& occludedEdgeColor);
 
-            void setPatches(std::vector<Model::PatchNode*> patchNodes);
             void invalidate();
             void clear();
 

--- a/common/src/Renderer/PatchRenderer.h
+++ b/common/src/Renderer/PatchRenderer.h
@@ -24,6 +24,8 @@
 #include "Renderer/Renderable.h"
 #include "Renderer/TexturedIndexArrayRenderer.h"
 
+#include <kdl/vector_set.h>
+
 #include <vector>
 
 namespace TrenchBroom {
@@ -39,7 +41,7 @@ namespace TrenchBroom {
         class PatchRenderer : public IndexedRenderable {
         private:
             bool m_valid = true;
-            std::vector<Model::PatchNode*> m_patchNodes;
+            kdl::vector_set<Model::PatchNode*> m_patchNodes;
 
             TexturedIndexArrayRenderer m_patchMeshRenderer;
             DirectEdgeRenderer m_edgeRenderer;
@@ -83,11 +85,26 @@ namespace TrenchBroom {
              */
             void setOccludedEdgeColor(const Color& occludedEdgeColor);
 
+            /**
+             * Equivalent to invalidatePatch() on all added patches.
+             */
             void invalidate();
+            /**
+             * Equivalent to removePatch() on all added patches.
+             */
             void clear();
 
+            /**
+             * Adds a patch. Calling with an already-added patch is allowed, but ignored (not guaranteed to invalidate it).
+             */
             void addPatch(Model::PatchNode* patchNode);
+            /**
+             * Removes a patch. Calling with an unknown patch is allowed, but ignored.
+             */
             void removePatch(Model::PatchNode* patchNode);
+            /**
+             * Causes cached renderer data to be rebuilt for the given patch (on the next render() call).
+             */
             void invalidatePatch(Model::PatchNode* patchNode);
 
             void render(RenderContext& renderContext, RenderBatch& renderBatch);

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -833,8 +833,6 @@ namespace TrenchBroom {
         }
 
         void ClipTool::addBrushesToRenderer(const std::map<Model::Node*, std::vector<Model::Node*>>& map, Renderer::BrushRenderer& renderer) {
-            std::vector<Model::BrushNode*> brushes;
-
             for (const auto& [parent, nodes] : map) {
                 for (auto* node : nodes) {
                     node->accept(kdl::overload(
@@ -842,13 +840,11 @@ namespace TrenchBroom {
                         [] (const Model::LayerNode*)  {},
                         [] (const Model::GroupNode*)  {},
                         [] (const Model::EntityNode*) {},
-                        [&](Model::BrushNode* brush)  { brushes.push_back(brush); },
+                        [&](Model::BrushNode* brush)  { renderer.addBrush(brush); },
                         [] (Model::PatchNode*)        {}
                     ));
                 }
             }
-            
-            renderer.addBrushes(brushes);
         }
 
         bool ClipTool::keepFrontBrushes() const {

--- a/common/src/View/CreateBrushToolBase.cpp
+++ b/common/src/View/CreateBrushToolBase.cpp
@@ -81,6 +81,7 @@ namespace TrenchBroom {
             m_brushRenderer->setForceTransparent(true);
             m_brushRenderer->setTransparencyAlpha(0.7f);
 
+            m_brushRenderer->clear();
             m_brushRenderer->addBrush(m_brush);
             m_brushRenderer->render(renderContext, renderBatch);
 

--- a/common/src/View/CreateBrushToolBase.cpp
+++ b/common/src/View/CreateBrushToolBase.cpp
@@ -81,7 +81,7 @@ namespace TrenchBroom {
             m_brushRenderer->setForceTransparent(true);
             m_brushRenderer->setTransparencyAlpha(0.7f);
 
-            m_brushRenderer->setBrushes({ m_brush });
+            m_brushRenderer->addBrush(m_brush);
             m_brushRenderer->render(renderContext, renderBatch);
 
             Renderer::SelectionBoundsRenderer boundsRenderer(m_brush->logicalBounds());


### PR DESCRIPTION
Partial fix for https://github.com/TrenchBroom/TrenchBroom/issues/3822

The main bottleneck in #3822 was an unnecessary renderer invalidation on all brushes. The MapRenderer notification handlers mostly ignored the "changed nodes" arguments, as a result, whether or not a given MapDocument change hits a fast path or slow path was unpredictable.

So the change summary here is:

- all MapRenderer notification handlers now use the provided nodes instead of ignoring them. (This means we could hit bugs we weren't catching before, but the notification arguments seem to be accurate in my testing.) The update/invalidate code in MapRenderer is reworked and it makes all changes on a node granularity. This avoids surprises where before, hiding or showing 1 node would cause a hitch, invalidating the entire map.

- the ObjectRenderer (as well as the Brush,Entity,Group,Patch renderers) API was revamped to `addFoo`,`removeFoo`,`invalidateFoo`,`invalidate`,`clear`. BrushRenderer already had this kind of API, and the setObjects/setBrushes API is no longer useful or needed with the MapRenderer changes. Also documented what each of these methods mean.

This also fixes a hitch when adding a brush to a large map (e.g. there's a noticeable hitch in 2021.1 for every time you drag out a brush in a ad_sepulcher sized map).

BTW this is intended to be squashed (it's an "all or nothing" change) so best to look at the overall diff, rather than commits.