### PR TITLE
3862: fix updating Undo/Redo menu items when a document is newed/loaded

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -479,6 +479,7 @@ namespace TrenchBroom {
             info("Creating new document");
 
             clearRepeatableCommands();
+            doClearCommandProcessor();
             clearDocument();
             createWorld(mapFormat, worldBounds, game);
 
@@ -496,6 +497,7 @@ namespace TrenchBroom {
             info("Loading document from " + path.asString());
 
             clearRepeatableCommands();
+            doClearCommandProcessor();
             clearDocument();
             loadWorld(mapFormat, worldBounds, game, path);
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -503,6 +503,7 @@ namespace TrenchBroom {
             virtual void doUndoCommand() = 0;
             virtual void doRedoCommand() = 0;
 
+            virtual void doClearCommandProcessor() = 0;
             virtual void doStartTransaction(const std::string& name) = 0;
             virtual void doCommitTransaction() = 0;
             virtual void doRollbackTransaction() = 0;

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -481,16 +481,6 @@ namespace TrenchBroom {
             m_notifierConnection += m_commandProcessor->commandUndoFailedNotifier.connect(commandUndoFailedNotifier);
             m_notifierConnection += m_commandProcessor->transactionDoneNotifier.connect(transactionDoneNotifier);
             m_notifierConnection += m_commandProcessor->transactionUndoneNotifier.connect(transactionUndoneNotifier);
-            m_notifierConnection += documentWasNewedNotifier.connect(this, &MapDocumentCommandFacade::documentWasNewed);
-            m_notifierConnection += documentWasLoadedNotifier.connect(this, &MapDocumentCommandFacade::documentWasLoaded);
-        }
-
-        void MapDocumentCommandFacade::documentWasNewed(MapDocument*) {
-            m_commandProcessor->clear();
-        }
-
-        void MapDocumentCommandFacade::documentWasLoaded(MapDocument*) {
-            m_commandProcessor->clear();
         }
 
         bool MapDocumentCommandFacade::doCanUndoCommand() const {
@@ -515,6 +505,10 @@ namespace TrenchBroom {
 
         void MapDocumentCommandFacade::doRedoCommand() {
             m_commandProcessor->redo();
+        }
+
+        void MapDocumentCommandFacade::doClearCommandProcessor() {
+            m_commandProcessor->clear();
         }
 
         void MapDocumentCommandFacade::doStartTransaction(const std::string& name) {

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -117,6 +117,7 @@ namespace TrenchBroom {
             void doUndoCommand() override;
             void doRedoCommand() override;
 
+            void doClearCommandProcessor() override;
             void doStartTransaction(const std::string& name) override;
             void doCommitTransaction() override;
             void doRollbackTransaction() override;

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -667,11 +667,13 @@ namespace TrenchBroom {
         void MapFrame::documentWasCleared(View::MapDocument*) {
             updateTitle();
             updateActionState();
+            updateUndoRedoActions();
         }
 
         void MapFrame::documentDidChange(View::MapDocument*) {
             updateTitle();
             updateActionState();
+            updateUndoRedoActions();
             updateRecentDocumentsMenu();
         }
 


### PR DESCRIPTION
Fixes #3862

There were multiple bugs here:
- MapFrame not calling updateUndoRedoActions() when necessary
- m_commandProcessor->clear() was being called in response to
  documentWasLoadedNotifier/documentWasNewedNotifier, which was too late.