### PR TITLE
Add Standard format option for Half-Life maps

### DIFF
--- a/app/resources/games/Halflife/GameConfig.cfg
+++ b/app/resources/games/Halflife/GameConfig.cfg
@@ -3,7 +3,7 @@
     "name": "Half-Life",
     "experimental": true,
     "icon": "Icon.png",
-    "fileformats": [ { "format": "Valve" }, { "format": "Generic" } ],
+    "fileformats": [ { "format": "Valve" }, { "format": "Standard" } ],
     "filesystem": {
         "searchpath": "valve",
         "packageformat": { "extension": "pak", "format": "idpak" }

--- a/app/resources/games/Halflife/GameConfig.cfg
+++ b/app/resources/games/Halflife/GameConfig.cfg
@@ -3,7 +3,7 @@
     "name": "Half-Life",
     "experimental": true,
     "icon": "Icon.png",
-    "fileformats": [ { "format": "Valve" } ],
+    "fileformats": [ { "format": "Valve" }, { "format": "Generic" } ],
     "filesystem": {
         "searchpath": "valve",
         "packageformat": { "extension": "pak", "format": "idpak" }


### PR DESCRIPTION
Non-Valve-extended format MAP files are used for Half-Life in some circumstances. Obviously the better option for actual work on a map is usually conversion to the Valve-extended format, but that's not always an option especially as then you need a program to do the conversion, and... well... even if TrenchBroom had an option for it, without the format option, it wouldn't happen anyway.
