### PR TITLE
3860: fix repeat with transactions

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1329,11 +1329,13 @@ namespace TrenchBroom {
 
                 nodesToSelect.push_back(clone);
             }
-
-            Transaction transaction(this, "Duplicate Objects");
-            deselectAll();
-            addNodes(nodesToAdd);
-            select(nodesToSelect);
+            
+            {
+                Transaction transaction(this, "Duplicate Objects");
+                deselectAll();
+                addNodes(nodesToAdd);
+                select(nodesToSelect);
+            }
 
             if (m_viewEffectsService) {
                 m_viewEffectsService->flashSelection();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2897,10 +2897,13 @@ namespace TrenchBroom {
 
         void MapDocument::undoCommand() {
             doUndoCommand();
+            // Undo/redo in the repeat system is not supported for now, so just clear the repeat stack
+            m_repeatStack->clear();
         }
 
         void MapDocument::redoCommand() {
             doRedoCommand();
+            m_repeatStack->clear();
         }
 
         bool MapDocument::canRepeatCommands() const {
@@ -2918,22 +2921,27 @@ namespace TrenchBroom {
         void MapDocument::startTransaction(const std::string& name) {
             debug("Starting transaction '" + name + "'");
             doStartTransaction(name);
+            m_repeatStack->startTransaction();
         }
 
         void MapDocument::rollbackTransaction() {
             debug("Rolling back transaction");
             doRollbackTransaction();
+            m_repeatStack->rollbackTransaction();
         }
 
         void MapDocument::commitTransaction() {
             debug("Committing transaction");
             doCommitTransaction();
+            m_repeatStack->commitTransaction();
         }
 
         void MapDocument::cancelTransaction() {
             debug("Cancelling transaction");
             doRollbackTransaction();
+            m_repeatStack->rollbackTransaction();
             doCommitTransaction();
+            m_repeatStack->commitTransaction();
         }
 
         std::unique_ptr<CommandResult> MapDocument::execute(std::unique_ptr<Command>&& command) {

--- a/common/src/View/RepeatStack.cpp
+++ b/common/src/View/RepeatStack.cpp
@@ -53,7 +53,9 @@ namespace TrenchBroom {
         }
 
         void RepeatStack::repeat() const {
-            ensure(m_openTransactionsStack.empty(), "must not be called with open transactions");
+            if (!m_openTransactionsStack.empty()) {
+                return;
+            }
 
             const kdl::set_temp repeating(m_repeating);
 

--- a/common/src/View/RepeatStack.cpp
+++ b/common/src/View/RepeatStack.cpp
@@ -19,6 +19,8 @@
 
 #include "RepeatStack.h"
 
+#include "Ensure.h"
+
 #include <kdl/overload.h>
 #include <kdl/set_temp.h>
 
@@ -74,6 +76,7 @@ namespace TrenchBroom {
         void RepeatStack::clear() {
             assert(!m_repeating);
             m_stack.clear();
+            m_openTransactionsStack.clear();
         }
 
         void RepeatStack::clearOnNextPush() {
@@ -91,11 +94,12 @@ namespace TrenchBroom {
             if (m_repeating) {
                 return;
             }
-            assert(!m_openTransactionsStack.empty());
+            ensure(!m_openTransactionsStack.empty(), "a transaction is open");
 
             auto transaction = std::move(m_openTransactionsStack.back());
             m_openTransactionsStack.pop_back();
 
+            // discard empty transactions
             if (transaction->actions.empty()) {
                 return;
             }
@@ -114,7 +118,7 @@ namespace TrenchBroom {
             if (m_repeating) {
                 return;
             }
-            assert(!m_openTransactionsStack.empty());
+            ensure(!m_openTransactionsStack.empty(), "a transaction is open");
 
             auto& openTransaction = m_openTransactionsStack.back();
             openTransaction->actions.clear();

--- a/common/src/View/RepeatStack.cpp
+++ b/common/src/View/RepeatStack.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom {
 
         void RepeatStack::push(RepeatableAction repeatableAction) {
             if (!m_repeating) {
-                if (m_clearOnNextPush) {
+                if (m_clearOnNextPush && m_openTransactionsStack.empty()) {
                     m_clearOnNextPush = false;
                     clear();
                 }
@@ -74,9 +74,9 @@ namespace TrenchBroom {
         }
 
         void RepeatStack::clear() {
-            assert(!m_repeating);
+            ensure(!m_repeating, "The stack must not be repeating actions when this function is called");
+            ensure(m_openTransactionsStack.empty(), "must not be called with open transactions");
             m_stack.clear();
-            m_openTransactionsStack.clear();
         }
 
         void RepeatStack::clearOnNextPush() {

--- a/common/src/View/RepeatStack.cpp
+++ b/common/src/View/RepeatStack.cpp
@@ -76,8 +76,10 @@ namespace TrenchBroom {
         }
 
         void RepeatStack::clear() {
-            ensure(!m_repeating, "The stack must not be repeating actions when this function is called");
-            ensure(m_openTransactionsStack.empty(), "must not be called with open transactions");
+            if (!m_openTransactionsStack.empty()) {
+                return;
+            }
+            assert(!m_repeating);
             m_stack.clear();
         }
 

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -75,7 +75,7 @@ namespace TrenchBroom {
              * 
              * @param repeatableAction the action to add
              */
-            void push(RepeatableAction repeatableAction);
+            void push(CompositeAction repeatableAction);
 
             /**
              * Repeats the actions on this stack in the order in which they were added.

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -90,11 +90,13 @@ namespace TrenchBroom {
              * Discards any open transactions without committing them.
              * 
              * The stack must not be repeating actions when this function is called.
+             * There also must not be any open transaction.
              */ 
             void clear();
 
             /**
-             * Prime the stack so that it is cleared when the next action is pushed.
+             * Prime the stack so that it is cleared when the next action is pushed
+             * (to the main stack, not to an open transaction).
              * 
              * The effect is that the action currently on the stack can still be repeated
              * (even multiple times). But when the next action is pushed onto the stack, it

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -87,10 +87,10 @@ namespace TrenchBroom {
 
             /**
              * Clears all repeatable actions on this stack.
-             * Discards any open transactions without committing them.
              * 
              * The stack must not be repeating actions when this function is called.
-             * There also must not be any open transaction.
+             * 
+             * Has no effect if any transaction is currently open.
              */ 
             void clear();
 
@@ -101,6 +101,8 @@ namespace TrenchBroom {
              * The effect is that the action currently on the stack can still be repeated
              * (even multiple times). But when the next action is pushed onto the stack, it
              * is cleared.
+             * 
+             * Has no effect if any transaction is currently open.
              */
             void clearOnNextPush();
         public: // transactions

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -82,6 +82,8 @@ namespace TrenchBroom {
              *
              * No new actions will be added to the stack while it is repeating, so the list of
              * actions on the stack will be the same when this function finishes.
+             * 
+             * Has no effect if any transaction is currently open.
              */
             void repeat() const;
 

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -87,6 +87,7 @@ namespace TrenchBroom {
 
             /**
              * Clears all repeatable actions on this stack.
+             * Discards any open transactions without committing them.
              * 
              * The stack must not be repeating actions when this function is called.
              */ 
@@ -106,18 +107,24 @@ namespace TrenchBroom {
              * 
              * The main use of transactions is you can call rollbackTransaction() 
              * to clear all repeatable actions/transactions in the currently open transaction.
+             * 
+             * Has no effect if we are currently repeating actions.
              */
             void startTransaction();
             /**
              * Closes the currently open transaction. If there is a parent transaction,
              * pushes it to the end of that transaction, which becomes the new currently open transaction,
              * otherwise pushes it to the end of the main action stack.
+             * 
+             * Has no effect if we are currently repeating actions.
              */
             void commitTransaction();
             /**
              * Clear all repeatable actions/transactions in the currently open transaction.
              * The transaction remains open, i.e. you still need to call commitTransaction()
              * or can push more actions.
+             * 
+             * Has no effect if we are currently repeating actions.
              */
             void rollbackTransaction();
         };

--- a/common/src/View/RepeatStack.h
+++ b/common/src/View/RepeatStack.h
@@ -70,8 +70,8 @@ namespace TrenchBroom {
              * If a transaction is open, the action is added to the transaction.
              * 
              * If this stack is currently repeating actions, the given action is not added.
-             * If clearOnNextPush() was called, the repeat stack will be cleared before the given action
-             * is added.
+             * If clearOnNextPush() was called, and no transactions are open, 
+             * the repeat stack will be cleared before the given action is added.
              * 
              * @param repeatableAction the action to add
              */

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -205,5 +205,61 @@ namespace TrenchBroom {
             document->select(entityNode1);
             CHECK(document->canRepeatCommands());
         }
+
+        TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTransaction") {
+            auto* entityNode1 = new Model::EntityNode();
+            addNode(*document, document->parentForNodes(), entityNode1);
+
+            document->select(entityNode1);
+            CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
+
+            document->startTransaction();
+            document->translateObjects(vm::vec3(0, 0, 10));
+            document->rollbackTransaction();
+            document->translateObjects(vm::vec3(10, 0, 0));
+            document->commitTransaction();
+            // overall result: x += 10
+
+            CHECK(entityNode1->entity().origin() == vm::vec3(10, 0, 0));
+
+            // now repeat the transaction on a second entity
+
+            auto* entityNode2 = new Model::EntityNode();
+            addNode(*document, document->parentForNodes(), entityNode2);
+
+            document->deselectAll();
+            document->select(entityNode2);
+            CHECK(entityNode2->entity().origin() == vm::vec3(0, 0, 0));
+
+            CHECK(document->canRepeatCommands());
+            document->repeatCommands();
+            CHECK(entityNode2->entity().origin() == vm::vec3(10, 0, 0));
+
+            document->repeatCommands();
+            CHECK(entityNode2->entity().origin() == vm::vec3(20, 0, 0));
+
+            // ensure entityNode1 was unmodified 
+
+            CHECK(entityNode1->entity().origin() == vm::vec3(10, 0, 0));
+        }
+
+        TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatUndo") {
+            auto* entityNode1 = new Model::EntityNode();
+            addNode(*document, document->parentForNodes(), entityNode1);
+
+            document->select(entityNode1);
+            CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
+
+            document->translateObjects(vm::vec3(0, 0, 10));
+            CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 10));
+            CHECK(document->canRepeatCommands());
+
+            document->undoCommand();
+            CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
+
+            // For now, we won't support repeating a sequence of commands
+            // containing undo/redo (it just clears the repeat stack)
+            CHECK(!document->canRepeatCommands());
+        }
     }
 }

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -248,20 +248,33 @@ namespace TrenchBroom {
             addNode(*document, document->parentForNodes(), entityNode1);
 
             document->select(entityNode1);
-            CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
+            CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));            
 
-            document->duplicateObjects();
+            SECTION("transaction containing a rollback") {
+                document->duplicateObjects();
 
-            SECTION("one transaction containing a rollback") {
                 document->startTransaction();
                 document->translateObjects(vm::vec3(0, 0, 10));
                 document->rollbackTransaction();
                 document->translateObjects(vm::vec3(10, 0, 0));
                 document->commitTransaction();
             }
-            SECTION("commands that get coalesced") {
+            SECTION("translations that get coalesced") {
+                document->duplicateObjects();
+
                 document->translateObjects(vm::vec3(5, 0, 0));
                 document->translateObjects(vm::vec3(5, 0, 0));
+            }
+            SECTION("duplicate inside transaction, then standalone movements") {
+                document->startTransaction();
+                document->duplicateObjects();
+                document->translateObjects(vm::vec3(2, 0, 0));
+                document->translateObjects(vm::vec3(2, 0, 0));
+                document->commitTransaction();
+
+                document->translateObjects(vm::vec3(2, 0, 0));
+                document->translateObjects(vm::vec3(2, 0, 0));
+                document->translateObjects(vm::vec3(2, 0, 0));
             }
             
             // repeatable actions:


### PR DESCRIPTION
Fixes #3860

- add several tests for repeating a transaction
- add test for repeating an undo (which is unsupported - just clears the repeat stack)

This is pretty messy - RepeatStack now has its own transaction system with lots of subtleties to produce the bnehaviour MapDocument wants. Now it looks like integrating the repeat system with the undo system, like we had before, would be better... but not practical for 2021.2.

Meant to be squashed, please review overall diff.