### PR TITLE
Make exported .obj material paths relative to export path.

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -377,6 +377,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/MoveObjectsToolPage.cpp
         ${COMMON_SOURCE_DIR}/View/MultiCompletionLineEdit.cpp
         ${COMMON_SOURCE_DIR}/View/MultiMapView.cpp
+        ${COMMON_SOURCE_DIR}/View/ObjExportDialog.cpp
         ${COMMON_SOURCE_DIR}/View/OnePaneMapView.cpp
         ${COMMON_SOURCE_DIR}/View/PickRequest.cpp
         ${COMMON_SOURCE_DIR}/View/PopupButton.cpp

--- a/common/src/IO/ExportOptions.h
+++ b/common/src/IO/ExportOptions.h
@@ -1,0 +1,41 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "IO/Path.h"
+
+namespace TrenchBroom {
+    namespace IO {
+        class ExportOptions {
+        public:
+            Path exportPath;
+        };
+
+        class MapExportOptions : public ExportOptions {
+
+        };
+
+        class ObjExportOptions : public ExportOptions {
+        public:
+            bool gameDirRelativePaths = false;
+        };
+    }
+}
+

--- a/common/src/IO/ExportOptions.h
+++ b/common/src/IO/ExportOptions.h
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2010-2017 Kristian Duske
+ Copyright (C) 2010-2021 Amara M. Kilic
 
  This file is part of TrenchBroom.
 
@@ -23,17 +23,12 @@
 
 namespace TrenchBroom {
     namespace IO {
-        class ExportOptions {
-        public:
+        struct MapExportOptions {
             Path exportPath;
         };
 
-        class MapExportOptions : public ExportOptions {
-
-        };
-
-        class ObjExportOptions : public ExportOptions {
-        public:
+        struct ObjExportOptions {
+            Path exportPath;
             bool gameDirRelativePaths = false;
         };
     }

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -21,6 +21,7 @@
 
 #include "FloatType.h"
 #include "IO/NodeSerializer.h"
+#include "Path.h"
 
 #include <vecmath/forward.h>
 
@@ -116,7 +117,7 @@ namespace TrenchBroom {
         private:
             std::ostream& m_objStream;
             std::ostream& m_mtlStream;
-            std::string m_mtlFilename;
+            Path m_mtlPath;
 
             IndexMap<vm::vec3> m_vertices;
             IndexMap<vm::vec2f> m_texCoords;
@@ -125,7 +126,7 @@ namespace TrenchBroom {
             std::optional<BrushObject> m_currentBrush;
             std::vector<Object> m_objects;
         public:
-            explicit ObjSerializer(std::ostream& objStream, std::ostream& mtlStream, std::string mtlFilename);
+            explicit ObjSerializer(std::ostream& objStream, std::ostream& mtlStream, const Path& mtlPath);
         private:
             void doBeginFile(const std::vector<const Model::Node*>& rootNodes) override;
             void doEndFile() override;

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -20,8 +20,9 @@
 #pragma once
 
 #include "FloatType.h"
+#include "IO/ExportOptions.h"
 #include "IO/NodeSerializer.h"
-#include "Path.h"
+#include "IO/Path.h"
 
 #include <vecmath/forward.h>
 
@@ -120,7 +121,7 @@ namespace TrenchBroom {
             std::ostream& m_objStream;
             std::ostream& m_mtlStream;
             Path m_mtlPath;
-            std::shared_ptr<IO::ObjExportOptions> m_options;
+            IO::ObjExportOptions m_options;
 
             IndexMap<vm::vec3> m_vertices;
             IndexMap<vm::vec2f> m_texCoords;
@@ -129,7 +130,7 @@ namespace TrenchBroom {
             std::optional<BrushObject> m_currentBrush;
             std::vector<Object> m_objects;
         public:
-            explicit ObjSerializer(std::ostream& objStream, std::ostream& mtlStream, const Path& mtlPath, std::shared_ptr<IO::ObjExportOptions>  options);
+            ObjSerializer(std::ostream& objStream, std::ostream& mtlStream, Path mtlPath, IO::ObjExportOptions options);
         private:
             void doBeginFile(const std::vector<const Model::Node*>& rootNodes) override;
             void doEndFile() override;

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -46,6 +46,8 @@ namespace TrenchBroom {
     }
 
     namespace IO {
+        class ObjExportOptions;
+
         class ObjSerializer : public NodeSerializer {
         public:
             template <typename V>
@@ -118,6 +120,7 @@ namespace TrenchBroom {
             std::ostream& m_objStream;
             std::ostream& m_mtlStream;
             Path m_mtlPath;
+            std::shared_ptr<IO::ObjExportOptions> m_options;
 
             IndexMap<vm::vec3> m_vertices;
             IndexMap<vm::vec2f> m_texCoords;
@@ -126,7 +129,7 @@ namespace TrenchBroom {
             std::optional<BrushObject> m_currentBrush;
             std::vector<Object> m_objects;
         public:
-            explicit ObjSerializer(std::ostream& objStream, std::ostream& mtlStream, const Path& mtlPath);
+            explicit ObjSerializer(std::ostream& objStream, std::ostream& mtlStream, const Path& mtlPath, std::shared_ptr<IO::ObjExportOptions>  options);
         private:
             void doBeginFile(const std::vector<const Model::Node*>& rootNodes) override;
             void doEndFile() override;

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -86,8 +86,8 @@ namespace TrenchBroom {
             doWriteMap(world, path);
         }
 
-        void Game::exportMap(WorldNode& world, const Model::ExportFormat format, const IO::Path& path) const {
-            doExportMap(world, format, path);
+        void Game::exportMap(WorldNode& world, const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const {
+            doExportMap(world, format, options);
         }
 
         std::vector<Node*> Game::parseNodes(const std::string& str, const MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const {

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -20,6 +20,7 @@
 #include "Game.h"
 
 #include "Assets/EntityDefinitionFileSpec.h"
+#include "IO/ExportOptions.h"
 #include "Model/BrushFace.h"
 #include "Model/GameFactory.h"
 #include "Model/WorldNode.h"
@@ -86,8 +87,8 @@ namespace TrenchBroom {
             doWriteMap(world, path);
         }
 
-        void Game::exportMap(WorldNode& world, const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const {
-            doExportMap(world, format, options);
+        void Game::exportMap(WorldNode& world, IO::ExportOptions options) const {
+            doExportMap(world, std::move(options));
         }
 
         std::vector<Node*> Game::parseNodes(const std::string& str, const MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const {

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -43,6 +43,10 @@ namespace TrenchBroom {
         class TextureManager;
     }
 
+    namespace IO {
+        class ExportOptions;
+    }
+
     namespace Model {
         class EntityNodeBase;
         class BrushFace;
@@ -98,7 +102,7 @@ namespace TrenchBroom {
             std::unique_ptr<WorldNode> newMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const;
             std::unique_ptr<WorldNode> loadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const;
             void writeMap(WorldNode& world, const IO::Path& path) const;
-            void exportMap(WorldNode& world, Model::ExportFormat format, const IO::Path& path) const;
+            void exportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>&) const;
         public: // parsing and serializing objects
             std::vector<Node*> parseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const;
             std::vector<BrushFace> parseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const;
@@ -147,7 +151,7 @@ namespace TrenchBroom {
             virtual std::unique_ptr<WorldNode> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const = 0;
             virtual std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const = 0;
             virtual void doWriteMap(WorldNode& world, const IO::Path& path) const = 0;
-            virtual void doExportMap(WorldNode& world, Model::ExportFormat format, const IO::Path& path) const = 0;
+            virtual void doExportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const = 0;
 
             virtual std::vector<Node*> doParseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const = 0;
             virtual std::vector<BrushFace> doParseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const = 0;

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -44,7 +44,9 @@ namespace TrenchBroom {
     }
 
     namespace IO {
-        class ExportOptions;
+        struct MapExportOptions;
+        struct ObjExportOptions;
+        using ExportOptions = std::variant<MapExportOptions, ObjExportOptions>;
     }
 
     namespace Model {
@@ -102,7 +104,7 @@ namespace TrenchBroom {
             std::unique_ptr<WorldNode> newMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const;
             std::unique_ptr<WorldNode> loadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const;
             void writeMap(WorldNode& world, const IO::Path& path) const;
-            void exportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>&) const;
+            void exportMap(WorldNode& world, IO::ExportOptions options) const;
         public: // parsing and serializing objects
             std::vector<Node*> parseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const;
             std::vector<BrushFace> parseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const;
@@ -151,7 +153,7 @@ namespace TrenchBroom {
             virtual std::unique_ptr<WorldNode> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const = 0;
             virtual std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const = 0;
             virtual void doWriteMap(WorldNode& world, const IO::Path& path) const = 0;
-            virtual void doExportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const = 0;
+            virtual void doExportMap(WorldNode& world, IO::ExportOptions options) const = 0;
 
             virtual std::vector<Node*> doParseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const = 0;
             virtual std::vector<BrushFace> doParseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const = 0;

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -223,7 +223,7 @@ namespace TrenchBroom {
                         throw FileSystemException("Cannot open file: " + mtlPath.asString());
                     }
 
-                    IO::NodeWriter writer(world, std::make_unique<IO::ObjSerializer>(objFile, mtlFile, mtlPath.filename()));
+                    IO::NodeWriter writer(world, std::make_unique<IO::ObjSerializer>(objFile, mtlFile, mtlPath));
                     writer.setExporting(true);
                     writer.writeMap();
                     break;

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -67,7 +67,7 @@ namespace TrenchBroom {
             std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
             void doWriteMap(WorldNode& world, const IO::Path& path, bool exporting) const;
             void doWriteMap(WorldNode& world, const IO::Path& path) const override;
-            void doExportMap(WorldNode& world, Model::ExportFormat format, const IO::Path& path) const override;
+            void doExportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const override;
 
             std::vector<Node*> doParseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::vector<BrushFace> doParseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -67,7 +67,7 @@ namespace TrenchBroom {
             std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
             void doWriteMap(WorldNode& world, const IO::Path& path, bool exporting) const;
             void doWriteMap(WorldNode& world, const IO::Path& path) const override;
-            void doExportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const override;
+            void doExportMap(WorldNode& world, IO::ExportOptions options) const override;
 
             std::vector<Node*> doParseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::vector<BrushFace> doParseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -21,6 +21,7 @@
 
 #include "Exceptions.h"
 #include "IO/DiskIO.h"
+#include "IO/ExportOptions.h"
 #include "IO/FileMatcher.h"
 #include "IO/Path.h"
 #include "IO/PathQt.h"
@@ -82,8 +83,11 @@ namespace TrenchBroom {
                             IO::Disk::createDirectory(directoryPath);
                         }
 
+                        std::shared_ptr<IO::MapExportOptions> options = std::make_shared<IO::MapExportOptions>();
+                        options->exportPath = targetPath;
+
                         const auto document = m_context.document();
-                        document->exportDocumentAs(Model::ExportFormat::Map, targetPath);
+                        document->exportDocumentAs(Model::ExportFormat::Map, options);
                     }
                     emit end();
                 } catch (const Exception& e) {

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -83,11 +83,11 @@ namespace TrenchBroom {
                             IO::Disk::createDirectory(directoryPath);
                         }
 
-                        std::shared_ptr<IO::MapExportOptions> options = std::make_shared<IO::MapExportOptions>();
-                        options->exportPath = targetPath;
+                        IO::MapExportOptions options;
+                        options.exportPath = targetPath;
 
                         const auto document = m_context.document();
-                        document->exportDocumentAs(Model::ExportFormat::Map, options);
+                        document->exportDocumentAs(options);
                     }
                     emit end();
                 } catch (const Exception& e) {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -33,6 +33,7 @@
 #include "Assets/Texture.h"
 #include "Assets/TextureManager.h"
 #include "EL/ELExceptions.h"
+#include "IO/ExportOptions.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/GameConfigParser.h"
@@ -523,8 +524,8 @@ namespace TrenchBroom {
             m_game->writeMap(*m_world, path);
         }
 
-        void MapDocument::exportDocumentAs(const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) {
-            m_game->exportMap(*m_world, format, options);
+        void MapDocument::exportDocumentAs(IO::ExportOptions options) {
+            m_game->exportMap(*m_world, std::move(options));
         }
 
         void MapDocument::doSaveDocument(const IO::Path& path) {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -523,8 +523,8 @@ namespace TrenchBroom {
             m_game->writeMap(*m_world, path);
         }
 
-        void MapDocument::exportDocumentAs(const Model::ExportFormat format, const IO::Path& path) {
-            m_game->exportMap(*m_world, format, path);
+        void MapDocument::exportDocumentAs(const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) {
+            m_game->exportMap(*m_world, format, options);
         }
 
         void MapDocument::doSaveDocument(const IO::Path& path) {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -52,10 +52,6 @@ namespace TrenchBroom {
         class TextureManager;
     }
 
-    namespace IO {
-        class ExportOptions;
-    }
-
     namespace Model {
         class Brush;
         class BrushFace;
@@ -268,7 +264,7 @@ namespace TrenchBroom {
             void saveDocument();
             void saveDocumentAs(const IO::Path& path);
             void saveDocumentTo(const IO::Path& path);
-            void exportDocumentAs(const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options);
+            void exportDocumentAs(IO::ExportOptions options);
         private:
             void doSaveDocument(const IO::Path& path);
             void clearDocument();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -52,6 +52,10 @@ namespace TrenchBroom {
         class TextureManager;
     }
 
+    namespace IO {
+        class ExportOptions;
+    }
+
     namespace Model {
         class Brush;
         class BrushFace;
@@ -264,7 +268,7 @@ namespace TrenchBroom {
             void saveDocument();
             void saveDocumentAs(const IO::Path& path);
             void saveDocumentTo(const IO::Path& path);
-            void exportDocumentAs(Model::ExportFormat format, const IO::Path& path);
+            void exportDocumentAs(const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options);
         private:
             void doSaveDocument(const IO::Path& path);
             void clearDocument();

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -25,6 +25,7 @@
 #include "Preferences.h"
 #include "PreferenceManager.h"
 #include "TrenchBroomApp.h"
+#include "IO/ExportOptions.h"
 #include "IO/PathQt.h"
 #include "Model/BrushNode.h"
 #include "Model/EditorContext.h"
@@ -61,6 +62,7 @@
 #include "View/LaunchGameEngineDialog.h"
 #include "View/MainMenuBuilder.h"
 #include "View/MapDocument.h"
+#include "View/ObjExportDialog.h"
 #include "View/PasteType.h"
 #include "View/RenderView.h"
 #include "View/ReplaceTextureDialog.h"
@@ -873,14 +875,11 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::exportDocumentAsObj() {
-            const IO::Path& originalPath = m_document->path();
-            const IO::Path objPath = originalPath.replaceExtension("obj");
-
-            const QString newFileName = QFileDialog::getSaveFileName(this, tr("Export Wavefront OBJ file"), IO::pathAsQString(objPath), "Wavefront OBJ files (*.obj)");
-            if (newFileName.isEmpty())
-                return false;
-
-            return exportDocument(Model::ExportFormat::WavefrontObj, IO::pathFromQString(newFileName));
+            if (m_objExportDialog == nullptr) {
+                m_objExportDialog = new ObjExportDialog(this);
+            }
+            showModelessDialog(m_objExportDialog);
+            return true;
         }
 
         bool MapFrame::exportDocumentAsMap() {
@@ -891,23 +890,26 @@ namespace TrenchBroom {
                 return false;
             }
 
-            return exportDocument(Model::ExportFormat::Map, IO::pathFromQString(newFileName));
+            std::shared_ptr<IO::MapExportOptions> options = std::make_shared<IO::MapExportOptions>();
+            options->exportPath = IO::pathFromQString(newFileName);
+
+            return exportDocument(Model::ExportFormat::Map, options);
         }
 
-        bool MapFrame::exportDocument(const Model::ExportFormat format, const IO::Path& path) {
-            if (path == m_document->path()) {
+        bool MapFrame::exportDocument(const Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) {
+            if (options->exportPath == m_document->path()) {
                 QMessageBox::critical(this, "", tr("You can't overwrite the current document.\nPlease choose a different file name to export to."));
                 return false;
             }
             try {
-                m_document->exportDocumentAs(format, path);
-                logger().info() << "Exported " << path;
+                m_document->exportDocumentAs(format, options);
+                logger().info() << "Exported " << options->exportPath;
                 return true;
             } catch (const FileSystemException& e) {
                 QMessageBox::critical(this, "", e.what());
                 return false;
             } catch (...) {
-                QMessageBox::critical(this, "", QString::fromStdString("Unknown error while exporting " + path.asString()), QMessageBox::Ok);
+                QMessageBox::critical(this, "", QString::fromStdString("Unknown error while exporting " + options->exportPath.asString()), QMessageBox::Ok);
                 return false;
             }
         }

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -51,6 +51,7 @@ namespace TrenchBroom {
 
     namespace IO {
         class Path;
+        class ExportOptions;
     }
 
     namespace Model {
@@ -105,6 +106,7 @@ namespace TrenchBroom {
             QLabel* m_statusBarLabel;
 
             QPointer<QDialog> m_compilationDialog;
+            QPointer<QDialog> m_objExportDialog;
 
             NotifierConnection m_notifierConnection;
         private: // shortcuts
@@ -181,7 +183,7 @@ namespace TrenchBroom {
             bool revertDocument();
             bool exportDocumentAsObj();
             bool exportDocumentAsMap();
-            bool exportDocument(Model::ExportFormat format, const IO::Path& path);
+            bool exportDocument(Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options);
         private:
             bool confirmOrDiscardChanges();
             bool confirmRevertDocument();

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -51,7 +51,9 @@ namespace TrenchBroom {
 
     namespace IO {
         class Path;
-        class ExportOptions;
+        class MapExportOptions;
+        class ObjExportOptions;
+        using ExportOptions = std::variant<MapExportOptions, ObjExportOptions>;
     }
 
     namespace Model {
@@ -183,7 +185,7 @@ namespace TrenchBroom {
             bool revertDocument();
             bool exportDocumentAsObj();
             bool exportDocumentAsMap();
-            bool exportDocument(Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options);
+            bool exportDocument(IO::ExportOptions options);
         private:
             bool confirmOrDiscardChanges();
             bool confirmRevertDocument();

--- a/common/src/View/ObjExportDialog.cpp
+++ b/common/src/View/ObjExportDialog.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2010-2017 Kristian Duske
+ Copyright (C) 2010-2021 Amara M. Kilic
 
  This file is part of TrenchBroom.
 
@@ -34,12 +34,12 @@
 namespace TrenchBroom {
     namespace View {
         ObjExportDialog::ObjExportDialog(MapFrame* mapFrame) :
-        m_mapFrame(mapFrame),
-        m_exportButton(nullptr),
-        m_closeButton(nullptr),
-        m_relativeCheckBox(nullptr),
-        m_pathEdit(nullptr),
-        m_browseButton(nullptr) {
+        m_mapFrame{mapFrame},
+        m_exportButton{nullptr},
+        m_closeButton{nullptr},
+        m_relativeCheckBox{nullptr},
+        m_pathEdit{nullptr},
+        m_browseButton{nullptr} {
             createGui();
             resize(600, 0);
         }
@@ -96,10 +96,10 @@ namespace TrenchBroom {
                 }
             });
             connect(m_exportButton, &QPushButton::clicked, this, [&]() {
-                std::shared_ptr<IO::ObjExportOptions> options = std::make_shared<IO::ObjExportOptions>();
-                options->exportPath = IO::pathFromQString(m_pathEdit->text());
-                options->gameDirRelativePaths = m_relativeCheckBox->isChecked();
-                m_mapFrame->exportDocument(Model::ExportFormat::WavefrontObj, options);
+                IO::ObjExportOptions options;
+                options.exportPath = IO::pathFromQString(m_pathEdit->text());
+                options.gameDirRelativePaths = m_relativeCheckBox->isChecked();
+                m_mapFrame->exportDocument(options);
                 close();
             });
         }

--- a/common/src/View/ObjExportDialog.cpp
+++ b/common/src/View/ObjExportDialog.cpp
@@ -1,0 +1,107 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ObjExportDialog.h"
+
+#include "Model/ExportFormat.h"
+#include "IO/ExportOptions.h"
+#include "IO/Path.h"
+#include "IO/PathQt.h"
+#include "View/MapDocument.h"
+#include "View/MapFrame.h"
+#include "QtUtils.h"
+
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFormLayout>
+
+namespace TrenchBroom {
+    namespace View {
+        ObjExportDialog::ObjExportDialog(MapFrame* mapFrame) :
+        m_mapFrame(mapFrame),
+        m_exportButton(nullptr),
+        m_closeButton(nullptr),
+        m_relativeCheckBox(nullptr),
+        m_pathEdit(nullptr),
+        m_browseButton(nullptr) {
+            createGui();
+            resize(600, 0);
+        }
+
+        void ObjExportDialog::createGui() {
+            setWindowIconTB(this);
+            setWindowTitle("Export as Wavefront OBJ");
+
+            // Bottom button row.
+            auto* buttonBox = new QDialogButtonBox();
+            m_closeButton = buttonBox->addButton("Close", QDialogButtonBox::RejectRole);
+            m_exportButton = buttonBox->addButton("Export", QDialogButtonBox::AcceptRole);
+
+            auto* buttonLayout = new QHBoxLayout();
+            buttonLayout->setContentsMargins(0, 0, 0, 0);
+            buttonLayout->setSpacing(LayoutConstants::WideHMargin);
+            buttonLayout->addWidget(buttonBox);
+
+            // Compilation options.
+            auto* pathLayout = new QHBoxLayout();
+            m_pathEdit = new QLineEdit();
+            pathLayout->addWidget(m_pathEdit);
+
+            auto document = m_mapFrame->document();
+            const IO::Path& originalPath = document->path();
+            const IO::Path objPath = originalPath.replaceExtension("obj");
+
+            m_pathEdit->setText(IO::pathAsQString(objPath));
+
+            m_browseButton = new QPushButton();
+            m_browseButton->setText("Browse...");
+            pathLayout->addWidget(m_browseButton);
+
+            m_relativeCheckBox = new QCheckBox();
+            m_relativeCheckBox->setText(tr("Use texture paths relative to game directory."));
+
+            auto* dialogLayout = new QVBoxLayout();
+            dialogLayout->setContentsMargins(5, 5, 5, 5);
+            dialogLayout->setSpacing(5);
+            dialogLayout->addLayout(pathLayout);
+            dialogLayout->addWidget(m_relativeCheckBox);
+            dialogLayout->addLayout(wrapDialogButtonBox(buttonLayout));
+            insertTitleBarSeparator(dialogLayout);
+
+            setLayout(dialogLayout);
+
+            m_exportButton->setDefault(true);
+
+            connect(m_closeButton, &QPushButton::clicked, this, &ObjExportDialog::close);
+            connect(m_browseButton, &QPushButton::clicked, this, [&]() {
+                const QString newFileName = QFileDialog::getSaveFileName(this, tr("Export Wavefront OBJ file"), m_pathEdit->text(), "Wavefront OBJ files (*.obj)");
+                if (!newFileName.isEmpty()) {
+                    m_pathEdit->setText(newFileName);
+                }
+            });
+            connect(m_exportButton, &QPushButton::clicked, this, [&]() {
+                std::shared_ptr<IO::ObjExportOptions> options = std::make_shared<IO::ObjExportOptions>();
+                options->exportPath = IO::pathFromQString(m_pathEdit->text());
+                options->gameDirRelativePaths = m_relativeCheckBox->isChecked();
+                m_mapFrame->exportDocument(Model::ExportFormat::WavefrontObj, options);
+                close();
+            });
+        }
+    }
+}

--- a/common/src/View/ObjExportDialog.h
+++ b/common/src/View/ObjExportDialog.h
@@ -1,0 +1,44 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QDialog>
+
+namespace TrenchBroom {
+    namespace View {
+        class MapFrame;
+
+        class ObjExportDialog : public QDialog {
+            Q_OBJECT
+        private:
+            MapFrame* m_mapFrame;
+            QPushButton* m_exportButton;
+            QPushButton* m_closeButton;
+            QCheckBox* m_relativeCheckBox;
+            QLineEdit* m_pathEdit;
+            QPushButton* m_browseButton;
+        public:
+            explicit ObjExportDialog(MapFrame* mapFrame);
+        private:
+            void createGui();
+        };
+    }
+}
+

--- a/common/src/View/ObjExportDialog.h
+++ b/common/src/View/ObjExportDialog.h
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2010-2017 Kristian Duske
+ Copyright (C) 2010-2021 Amara M. Kilic
 
  This file is part of TrenchBroom.
 
@@ -20,6 +20,11 @@
 #pragma once
 
 #include <QDialog>
+
+class QPushButton;
+class QCheckBox;
+class QLineEdit;
+class QPushButton;
 
 namespace TrenchBroom {
     namespace View {

--- a/common/test/src/IO/ObjSerializerTest.cpp
+++ b/common/test/src/IO/ObjSerializerTest.cpp
@@ -50,9 +50,9 @@ namespace TrenchBroom {
 
             auto objStream = std::ostringstream{};
             auto mtlStream = std::ostringstream{};
-            const auto mtlFilename = "some_file_name.mtl";
+            const auto mtlPath = Path("some_file_name.mtl");
 
-            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlFilename)};
+            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath)};
             writer.writeMap();
 
             CHECK(objStream.str() == R"(mtllib some_file_name.mtl
@@ -114,9 +114,9 @@ f  8/4/6  5/3/6  6/2/6  7/1/6
 
             auto objStream = std::ostringstream{};
             auto mtlStream = std::ostringstream{};
-            const auto mtlFilename = "some_file_name.mtl";
+            const auto mtlPath = Path("some_file_name.mtl");
 
-            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlFilename)};
+            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath)};
             writer.writeMap();
 
             CHECK(objStream.str() == R"(mtllib some_file_name.mtl

--- a/common/test/src/IO/ObjSerializerTest.cpp
+++ b/common/test/src/IO/ObjSerializerTest.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Logger.h"
+#include "IO/ExportOptions.h"
 #include "IO/NodeWriter.h"
 #include "IO/ObjSerializer.h"
 #include "Model/BezierPatch.h"
@@ -52,7 +53,10 @@ namespace TrenchBroom {
             auto mtlStream = std::ostringstream{};
             const auto mtlPath = Path("some_file_name.mtl");
 
-            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath)};
+            std::shared_ptr<IO::ObjExportOptions> objOptions = std::make_shared<IO::ObjExportOptions>();
+            objOptions->gameDirRelativePaths = false;
+
+            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath, objOptions)};
             writer.writeMap();
 
             CHECK(objStream.str() == R"(mtllib some_file_name.mtl
@@ -116,7 +120,10 @@ f  8/4/6  5/3/6  6/2/6  7/1/6
             auto mtlStream = std::ostringstream{};
             const auto mtlPath = Path("some_file_name.mtl");
 
-            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath)};
+            std::shared_ptr<IO::ObjExportOptions> objOptions = std::make_shared<IO::ObjExportOptions>();
+            objOptions->gameDirRelativePaths = false;
+
+            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath, objOptions)};
             writer.writeMap();
 
             CHECK(objStream.str() == R"(mtllib some_file_name.mtl

--- a/common/test/src/IO/ObjSerializerTest.cpp
+++ b/common/test/src/IO/ObjSerializerTest.cpp
@@ -51,12 +51,12 @@ namespace TrenchBroom {
 
             auto objStream = std::ostringstream{};
             auto mtlStream = std::ostringstream{};
-            const auto mtlPath = Path("some_file_name.mtl");
+            const Path mtlPath{"some_file_name.mtl"};
 
-            std::shared_ptr<IO::ObjExportOptions> objOptions = std::make_shared<IO::ObjExportOptions>();
+            IO::ObjExportOptions objOptions;
             objOptions->gameDirRelativePaths = false;
 
-            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath, objOptions)};
+            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, std::move(mtlPath), objOptions)};
             writer.writeMap();
 
             CHECK(objStream.str() == R"(mtllib some_file_name.mtl
@@ -118,12 +118,12 @@ f  8/4/6  5/3/6  6/2/6  7/1/6
 
             auto objStream = std::ostringstream{};
             auto mtlStream = std::ostringstream{};
-            const auto mtlPath = Path("some_file_name.mtl");
+            const Path mtlPath{"some_file_name.mtl"};
 
-            std::shared_ptr<IO::ObjExportOptions> objOptions = std::make_shared<IO::ObjExportOptions>();
+            IO::ObjExportOptions objOptions;
             objOptions->gameDirRelativePaths = false;
 
-            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, mtlPath, objOptions)};
+            auto writer = NodeWriter{map, std::make_unique<ObjSerializer>(objStream, mtlStream, std::move(mtlPath), objOptions)};
             writer.writeMap();
 
             CHECK(objStream.str() == R"(mtllib some_file_name.mtl

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -23,6 +23,7 @@
 #include "IO/BrushFaceReader.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
+#include "IO/ExportOptions.h"
 #include "IO/IOUtils.h"
 #include "IO/NodeReader.h"
 #include "IO/NodeWriter.h"
@@ -120,7 +121,7 @@ namespace TrenchBroom {
             writer.writeMap();
         }
 
-        void TestGame::doExportMap(WorldNode& /* world */, const Model::ExportFormat /* format */, const std::shared_ptr<IO::ExportOptions>& /* options */) const {}
+        void TestGame::doExportMap(WorldNode& /* world */, IO::ExportOptions /* options */) const {}
 
         std::vector<Node*> TestGame::doParseNodes(const std::string& str, const MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& /* logger */) const {
             IO::TestParserStatus status;

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -120,7 +120,7 @@ namespace TrenchBroom {
             writer.writeMap();
         }
 
-        void TestGame::doExportMap(WorldNode& /* world */, const Model::ExportFormat /* format */, const IO::Path& /* path */) const {}
+        void TestGame::doExportMap(WorldNode& /* world */, const Model::ExportFormat /* format */, const std::shared_ptr<IO::ExportOptions>& /* options */) const {}
 
         std::vector<Node*> TestGame::doParseNodes(const std::string& str, const MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& /* logger */) const {
             IO::TestParserStatus status;

--- a/common/test/src/Model/TestGame.h
+++ b/common/test/src/Model/TestGame.h
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             std::unique_ptr<WorldNode> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
             void doWriteMap(WorldNode& world, const IO::Path& path) const override;
-            void doExportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const override;
+            void doExportMap(WorldNode& world, IO::ExportOptions options) const override;
 
             std::vector<Node*> doParseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::vector<BrushFace> doParseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;

--- a/common/test/src/Model/TestGame.h
+++ b/common/test/src/Model/TestGame.h
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             std::unique_ptr<WorldNode> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
             void doWriteMap(WorldNode& world, const IO::Path& path) const override;
-            void doExportMap(WorldNode& world, Model::ExportFormat format, const IO::Path& path) const override;
+            void doExportMap(WorldNode& world, Model::ExportFormat format, const std::shared_ptr<IO::ExportOptions>& options) const override;
 
             std::vector<Node*> doParseNodes(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::vector<BrushFace> doParseBrushFaces(const std::string& str, MapFormat mapFormat, const vm::bbox3& worldBounds, Logger& logger) const override;


### PR DESCRIPTION
This fixes an annoyance I have with the current `.obj` exporter where the paths to the texture files are always relative to the base game folder, instead of the path the `.obj` file is exported to.

So if a texture is in `textures/tex.png` and the map is in `maps/map.obj`, then in the `.mtl` file the path will still refer to `textures/tex.png` instead of `../textures/tex.png`. 

This means that if you want to export a `.obj` file and have programs like Blender automatically import the textures you'll have to either place every exported .obj file in the project's root folder which is very messy, or rewrite the texture file manually. This PR is to make the texture file path relative to wherever you export it.

This is my first time making a C++ PR, so hopefully I'm doing this right!