### PR TITLE
Grammar fix in "Cancelling Operations and Tools"

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -364,7 +364,7 @@ You can learn more about these tools in later sections. But before you can learn
 
 ### Cancelling Operations and Tools {#cancelling}
 
-To cancel a mouse drag by hitting #action(Controls/Map view/Cancel). The operation will be undone immediately. The same keyboard shortcut can be used to cancel all kinds of things in the editor. The following table lists the effects of cancelling depending on the current state of the editor.
+To cancel a mouse drag, hit #action(Controls/Map view/Cancel). The operation will be undone immediately. The same keyboard shortcut can be used to cancel all kinds of things in the editor. The following table lists the effects of cancelling depending on the current state of the editor.
 
 State                 Effect
 -----                 ------


### PR DESCRIPTION
There was a very small grammar mistake in the manual, so this is an attempt to fix it.

For context see this [comment](https://discord.com/channels/308480171353309184/308480171353309184/901076254260854814) in the TrenchBroom Discord-Channel.
Thanks to _oGkspAz_ and _xaGe_ for their help and background information!