### PR TITLE
CI-windows.bat: use absolute path to "cpack"

### DIFF
--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -44,7 +44,7 @@ common-benchmark.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 cd "%BUILD_DIR%"
 
-cpack
+"C:\Program Files\CMake\bin\cpack.exe"
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 


### PR DESCRIPTION
was running some random tool unrelated to CMake