### PR TITLE
Initial implementation justify texture tools.

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -279,6 +279,24 @@ vm::vec3 BrushFace::center() const {
   return vm::average(std::begin(boundary), std::end(boundary), BrushGeometry::GetVertexPosition());
 }
 
+vm::bbox3 BrushFace::getBounds() const {
+  ensure(m_geometry != nullptr, "geometry is null");
+
+  const auto* first = m_geometry->boundary().front();
+  const auto* current = first;
+
+  vm::bbox3 bounds;
+  bounds.min = bounds.max = current->origin()->position();
+
+  current = current->next();
+  while (current != first) {
+    bounds = merge(bounds, current->origin()->position());
+    current = current->next();
+  }
+
+  return bounds;
+}
+
 vm::vec3 BrushFace::boundsCenter() const {
   ensure(m_geometry != nullptr, "geometry is null");
 
@@ -298,6 +316,7 @@ vm::vec3 BrushFace::boundsCenter() const {
     bounds = merge(bounds, toPlane * current->origin()->position());
     current = current->next();
   }
+
   return fromPlane * bounds.center();
 }
 

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -170,6 +170,7 @@ public:
   const vm::plane3& boundary() const;
   const vm::vec3& normal() const;
   vm::vec3 center() const;
+  vm::bbox3 getBounds() const;
   vm::vec3 boundsCenter() const;
   FloatType projectedArea(vm::axis::type axis) const;
   FloatType area() const;

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -116,7 +116,8 @@ ChangeBrushFaceAttributesRequest::ChangeBrushFaceAttributesRequest()
   , m_surfaceFlagsOp(FlagOp_None)
   , m_contentFlagsOp(FlagOp_None)
   , m_surfaceValueOp(ValueOp_None)
-  , m_colorValueOp(ValueOp_None) {}
+  , m_colorValueOp(ValueOp_None)
+  , m_justifyOp(JustifyOp_None) {}
 
 void ChangeBrushFaceAttributesRequest::clear() {
   m_textureName = "";
@@ -133,6 +134,7 @@ void ChangeBrushFaceAttributesRequest::clear() {
   m_surfaceFlagsOp = m_contentFlagsOp = FlagOp_None;
   m_surfaceValueOp = ValueOp_None;
   m_colorValueOp = ValueOp_None;
+  m_justifyOp = JustifyOp_None;
 }
 
 const std::string ChangeBrushFaceAttributesRequest::name() const {
@@ -203,6 +205,10 @@ void ChangeBrushFaceAttributesRequest::resetAllToParaxial(
   setOffset(vm::vec2f::zero());
   setRotation(0.0f);
   setScale(defaultFaceAttributes.scale());
+}
+
+void ChangeBrushFaceAttributesRequest::setJustifyOperation(const JustifyOp justifyOp) {
+  m_justifyOp = justifyOp;
 }
 
 void ChangeBrushFaceAttributesRequest::setTextureName(const std::string& textureName) {

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.h
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.h
@@ -69,6 +69,19 @@ public:
     TextureOp_Set
   } TextureOp;
 
+  // TODO: replace with class based enum
+  typedef enum
+  {
+    JustifyOp_None,
+    JustifyOp_FitH,
+    JustifyOp_FitV,
+    JustifyOp_Center,
+    JustifyOp_Top,
+    JustifyOp_Left,
+    JustifyOp_Right,
+    JustifyOp_Bottom,
+  } JustifyOp;
+
 private:
   std::string m_textureName;
   float m_xOffset;
@@ -92,6 +105,7 @@ private:
   FlagOp m_contentFlagsOp;
   ValueOp m_surfaceValueOp;
   ValueOp m_colorValueOp;
+  JustifyOp m_justifyOp;
 
 public:
   ChangeBrushFaceAttributesRequest();
@@ -103,6 +117,8 @@ public:
 
   void resetAll(const BrushFaceAttributes& defaultFaceAttributes);
   void resetAllToParaxial(const BrushFaceAttributes& defaultFaceAttributes);
+
+  void setJustifyOperation(const JustifyOp justifyOp);
 
   void setTextureName(const std::string& textureName);
 

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -248,7 +248,7 @@ void ParaxialTexCoordSystem::doTransform(
   const vm::vec2f newInvariantTexCoords = computeTexCoords(newInvariant, newScale);
 
   // since the center should be invariant, the offsets are determined by the difference of the
-  // current and the original texture coordiknates of the center
+  // current and the original texture coordinates of the center
   const vm::vec2f newOffset =
     correct(attribs.modOffset(oldInvariantTexCoords - newInvariantTexCoords, textureSize), 4);
 

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -85,6 +85,13 @@ FaceAttribsEditor::FaceAttribsEditor(
   , m_colorEditorLayout(nullptr)
   , m_colorEditor(nullptr)
   , m_colorUnsetButton(nullptr)
+  , m_fitHTextureButton(nullptr)
+  , m_fitVTextureButton(nullptr)
+  , m_centerTextureButton(nullptr)
+  , m_topTextureButton(nullptr)
+  , m_leftTextureButton(nullptr)
+  , m_rightTextureButton(nullptr)
+  , m_bottomTextureButton(nullptr)
   , m_updateControlsSignalDelayer{new SignalDelayer{this}} {
   createGui(contextManager);
   bindEvents();
@@ -234,6 +241,15 @@ void FaceAttribsEditor::colorValueChanged(const QString& /* text */) {
   }
 }
 
+void FaceAttribsEditor::justifyPressed(int justifyOp) {
+  auto document = kdl::mem_lock(m_document);
+  if (!document->hasAnySelectedBrushFaces()) {
+    return;
+  }
+
+  document->justifySelectedFaces(justifyOp);
+}
+
 void FaceAttribsEditor::surfaceFlagsUnset() {
   auto document = kdl::mem_lock(m_document);
   if (!document->hasAnySelectedBrushFaces()) {
@@ -380,6 +396,15 @@ void FaceAttribsEditor::createGui(GLContextManager& contextManager) {
   makeEmphasized(m_colorLabel);
   m_colorEditor = new QLineEdit();
   m_colorUnsetButton = createBitmapButton("ResetTexture.svg", tr("Unset color"));
+
+  m_fitHTextureButton = createButton("FitH", tr("Fits the texture horizontally to the face"), this);
+  m_fitVTextureButton = createButton("FitV", tr("Fits the texture vertically to the face"), this);
+  m_centerTextureButton = createButton("C", tr("Aligns texture to center"), this);
+  m_topTextureButton = createButton("T", tr("Aligns texture to top"), this);
+  m_leftTextureButton = createButton("L", tr("Aligns texture to left"), this);
+  m_rightTextureButton = createButton("R", tr("Aligns texture to right"), this);
+  m_bottomTextureButton = createButton("B", tr("Aligns texture to bottom"), this);
+
   m_colorEditorLayout = createUnsetButtonLayout(m_colorEditor, m_colorUnsetButton);
 
   const Qt::Alignment LabelFlags = Qt::AlignVCenter | Qt::AlignRight;
@@ -441,12 +466,31 @@ void FaceAttribsEditor::createGui(GLContextManager& contextManager) {
   faceAttribsLayout->setColumnStretch(1, 1);
   faceAttribsLayout->setColumnStretch(3, 1);
 
+  auto* justifyAttribsLayout = new QGridLayout();
+  justifyAttribsLayout->setContentsMargins(
+    LayoutConstants::NarrowHMargin, LayoutConstants::MediumVMargin, LayoutConstants::NarrowHMargin,
+    LayoutConstants::MediumVMargin);
+  justifyAttribsLayout->setHorizontalSpacing(LayoutConstants::MediumHMargin);
+  justifyAttribsLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
+
+  justifyAttribsLayout->addWidget(m_fitHTextureButton, 0, 0);
+  justifyAttribsLayout->addWidget(m_topTextureButton, 0, 1);
+  justifyAttribsLayout->addWidget(m_fitVTextureButton, 0, 2);
+
+  justifyAttribsLayout->addWidget(m_leftTextureButton, 1, 0);
+  justifyAttribsLayout->addWidget(m_centerTextureButton, 1, 1);
+  justifyAttribsLayout->addWidget(m_rightTextureButton, 1, 2);
+
+  justifyAttribsLayout->addWidget(m_bottomTextureButton, 2, 1);
+
   auto* outerLayout = new QVBoxLayout();
   outerLayout->setContentsMargins(0, 0, 0, 0);
   outerLayout->setSpacing(LayoutConstants::NarrowVMargin);
   outerLayout->addWidget(m_uvEditor, 1);
   outerLayout->addWidget(new BorderLine());
   outerLayout->addLayout(faceAttribsLayout);
+  outerLayout->addWidget(new BorderLine());
+  outerLayout->addLayout(justifyAttribsLayout);
 
   setLayout(outerLayout);
 }
@@ -490,6 +534,28 @@ void FaceAttribsEditor::bindEvents() {
   connect(
     m_updateControlsSignalDelayer, &SignalDelayer::processSignal, this,
     &FaceAttribsEditor::updateControls);
+
+  connect(m_fitHTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_FitH);
+  });
+  connect(m_fitVTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_FitV);
+  });
+  connect(m_centerTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_Center);
+  });
+  connect(m_leftTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_Left);
+  });
+  connect(m_rightTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_Right);
+  });
+  connect(m_topTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_Top);
+  });
+  connect(m_bottomTextureButton, &QAbstractButton::clicked, this, [&] {
+    justifyPressed(Model::ChangeBrushFaceAttributesRequest::JustifyOp_Bottom);
+  });
 }
 
 void FaceAttribsEditor::connectObservers() {

--- a/common/src/View/FaceAttribsEditor.h
+++ b/common/src/View/FaceAttribsEditor.h
@@ -78,6 +78,15 @@ private:
   QLineEdit* m_colorEditor;
   QAbstractButton* m_colorUnsetButton;
 
+  QAbstractButton* m_fitHTextureButton;
+  QAbstractButton* m_fitVTextureButton;
+
+  QAbstractButton* m_centerTextureButton;
+  QAbstractButton* m_topTextureButton;
+  QAbstractButton* m_leftTextureButton;
+  QAbstractButton* m_rightTextureButton;
+  QAbstractButton* m_bottomTextureButton;
+
   SignalDelayer* m_updateControlsSignalDelayer;
 
   NotifierConnection m_notifierConnection;
@@ -99,6 +108,7 @@ private:
   void contentFlagChanged(size_t index, int value, int setFlag, int mixedFlag);
   void surfaceValueChanged(double value);
   void colorValueChanged(const QString& text);
+  void justifyPressed(int justifyOp);
   void surfaceFlagsUnset();
   void contentFlagsUnset();
   void surfaceValueUnset();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -572,6 +572,8 @@ public:
     const vm::vec3f& cameraUp, const vm::vec3f& cameraRight,
     vm::direction cameraRelativeFlipDirection);
 
+  bool justifySelectedFaces(int justifyOp, bool treatAsOne = false);
+
 public: // modifying vertices, declared in MapFacade interface
   bool snapVertices(FloatType snapTo) override;
 

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -325,6 +325,14 @@ QAbstractButton* createBitmapButton(const QIcon& icon, const QString& tooltip, Q
   return button;
 }
 
+QAbstractButton* createButton(const QString& text, const QString& tooltip, QWidget* parent) {
+  auto* button = new QToolButton(parent);
+  button->setText(text);
+  button->setToolTip(tooltip);
+
+  return button;
+}
+
 QAbstractButton* createBitmapToggleButton(
   const std::string& image, const QString& tooltip, QWidget* parent) {
   auto* button = createBitmapButton(image, tooltip, parent);

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -135,6 +135,9 @@ QAbstractButton* createBitmapButton(
 QAbstractButton* createBitmapToggleButton(
   const std::string& image, const QString& tooltip, QWidget* parent = nullptr);
 
+QAbstractButton* createButton(
+  const QString& text, const QString& tooltip, QWidget* parent = nullptr);
+
 QWidget* createDefaultPage(const QString& message, QWidget* parent = nullptr);
 QSlider* createSlider(int min, int max);
 


### PR DESCRIPTION
Basic implementations for justify texture coordinate system transformations.

- Learning Trenchbroom architecture.
- Need hardcore feedback.
- New with QT framework.
- Last time I touched C++ was 10 years ago.

- Want to create loosely coupled texture coordinate manipulations algorithms that are flexible to use in creative ways.
- Want to implement a switch between world and face texture coordinate projection.
- Want to be able to add checkbox "treat as one" when multiple faces are selected. (this allows multiple brush faces to be laid out over a single texture and aligned correctly)