### PR TITLE
1140: Add support for Goldsource (Half-Life) Sprite format

### DIFF
--- a/common/src/IO/SprParser.cpp
+++ b/common/src/IO/SprParser.cpp
@@ -119,8 +119,7 @@ static Assets::Orientation parseSpriteOrientationType(Reader& reader) {
  * Specifies the render mode for a Goldsource sprite.
  * Affects the palette data.
  */
-enum class RenderMode : int32_t
-{
+enum class RenderMode : int32_t {
   /** No alpha channel, just plain RGB */
   Normal = 0,
   /** Normal but also R+G+B/3 is the alpha channel */

--- a/common/src/IO/SprParser.cpp
+++ b/common/src/IO/SprParser.cpp
@@ -181,7 +181,7 @@ static std::vector<unsigned char> processGoldsourcePalette(
   return processed;
 }
 
-static Assets::Palette readEmbeddedPalette(Reader& reader, const RenderMode renderMode) {
+static Assets::Palette parseEmbeddedPalette(Reader& reader, const RenderMode renderMode) {
   const auto paletteSize = reader.readSize<int16_t>();
   if (paletteSize != 256) {
     throw AssetException{
@@ -230,7 +230,7 @@ std::unique_ptr<Assets::EntityModel> SprParser::doInitializeModel(Logger& /* log
 
   Assets::Palette palette = m_palette;
   if (version == 2) {
-    palette = readEmbeddedPalette(reader, renderMode);
+    palette = parseEmbeddedPalette(reader, renderMode);
   }
 
   auto model =


### PR DESCRIPTION
Part of the work required for #1140

The Half-Life sprite format is very similar to the Quake format - the two differences are:
- Render mode added to sprite header
- Palette data embedded after sprite header

The render mode has 4 options which change the behaviour of the alpha channel. This allows sprites to have an 8-bit alpha channel at the expense of RGB data. Since this logic is specific to sprites, the processing code does not need to be abstracted away for re-use, so the conversion to an RGBA palette is done inside the SPR parser. In order to load a 1024 byte RGBA palette without it altering the alpha channel I have also made a small change to the Palette class.

Please let me know if I have done anything wrong or broken any style guidelines - I am not very familiar with C++.

---

TrenchBroom does not render any sprite pixels with an opacity of less than 0.5, so currently the sprites with an alpha-channel render incorrectly. I have not changed this because I don't know how the change would impact other parts of the application.

![image](https://user-images.githubusercontent.com/3071180/150663987-f8895905-dd4f-4daf-b520-63e06a3a9d8b.png)

This is what it looks like if I were to remove these lines in the fragment shader:
https://github.com/TrenchBroom/TrenchBroom/blob/30abfc2db657ab0a25655cc5671538d17978c583/app/resources/shader/EntityModel.fragsh#L35-L39

![image](https://user-images.githubusercontent.com/3071180/150663989-597d15fb-c99b-4ac6-b3b6-8331e65f6fe9.png)
