### PR TITLE
1140: Add sprite and iconsprite as model fgd header properties

### DIFF
--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -297,7 +297,8 @@ EntityDefinitionClassInfo FgdParser::parseClassInfo(
       classInfo.size = parseSize(status);
     } else if (
       kdl::ci::str_is_equal(typeName, "model") || kdl::ci::str_is_equal(typeName, "studio") ||
-      kdl::ci::str_is_equal(typeName, "studioprop")) {
+      kdl::ci::str_is_equal(typeName, "studioprop") || kdl::ci::str_is_equal(typeName, "sprite") ||
+      kdl::ci::str_is_equal(typeName, "iconsprite")) {
       if (classInfo.modelDefinition) {
         status.warn(token.line(), token.column(), "Found multiple model properties");
       }


### PR DESCRIPTION
Part of the work required for #1140
Won't work for HL format sprites until #3938 has been merged

Both `sprite` and `iconsprite` are used in Half-Life FGDs to indicate a sprite model, this change simply adds them to the list.