### PR TITLE
Fix Neverball GameConfig obj backend reference

### DIFF
--- a/app/resources/games/Neverball/GameConfig.cfg
+++ b/app/resources/games/Neverball/GameConfig.cfg
@@ -18,7 +18,7 @@
     "entities": {
         "definitions": [ "neverball.fgd" ],
         "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "obj_neverball" ]
+        "modelformats": [ "obj" ]
     },
     "tags": {
         "brush": [


### PR DESCRIPTION
Someone changed the name of the OBJ backend, ignoring the Neverball-specific logic nature of it.

But whatever, using that transform with a 64-unit divisor seems common enough.

Still, the GameConfig needs to be updated.

(I'm also not sure what's up with Generic's model format list.)