### PR TITLE
Fix enum formatting

### DIFF
--- a/common/src/Assets/EntityDefinition.h
+++ b/common/src/Assets/EntityDefinition.h
@@ -36,14 +36,12 @@ class PropertyDefinition;
 class FlagsPropertyDefinition;
 class FlagsPropertyOption;
 
-enum class EntityDefinitionType
-{
+enum class EntityDefinitionType {
   PointEntity,
   BrushEntity
 };
 
-enum class EntityDefinitionSortOrder
-{
+enum class EntityDefinitionSortOrder {
   Name,
   Usage
 };

--- a/common/src/Assets/EntityDefinitionFileSpec.h
+++ b/common/src/Assets/EntityDefinitionFileSpec.h
@@ -30,8 +30,7 @@ namespace TrenchBroom {
 namespace Assets {
 class EntityDefinitionFileSpec {
 private:
-  enum class Type
-  {
+  enum class Type {
     Builtin,
     External,
     Unset

--- a/common/src/Assets/EntityModel.h
+++ b/common/src/Assets/EntityModel.h
@@ -41,8 +41,7 @@ namespace Assets {
 class Texture;
 class TextureCollection;
 
-enum class PitchType
-{
+enum class PitchType {
   Normal,
   MdlInverted
 };
@@ -53,8 +52,7 @@ enum class PitchType
  * See
  * https://github.com/ericwa/Quakespasm/blob/7e7e13f9335697f8e94d1631fdf60ecdddb7498f/quakespasm/Quake/r_sprite.c#L82
  */
-enum class Orientation
-{
+enum class Orientation {
   /** Faces view plane, up is towards the heavens. */
   ViewPlaneParallelUpright,
   /** Faces camera origin, up is towards the heavens. */

--- a/common/src/Assets/Palette.h
+++ b/common/src/Assets/Palette.h
@@ -37,8 +37,7 @@ namespace Assets {
 struct PaletteData;
 class TextureBuffer;
 
-enum class PaletteTransparency
-{
+enum class PaletteTransparency {
   Opaque,
   Index255Transparent
 };

--- a/common/src/Assets/PropertyDefinition.h
+++ b/common/src/Assets/PropertyDefinition.h
@@ -28,8 +28,7 @@
 
 namespace TrenchBroom {
 namespace Assets {
-enum class PropertyDefinitionType
-{
+enum class PropertyDefinitionType {
   TargetSourceProperty,
   TargetDestinationProperty,
   StringProperty,

--- a/common/src/Assets/Quake3Shader.h
+++ b/common/src/Assets/Quake3Shader.h
@@ -64,8 +64,7 @@ bool operator!=(const Quake3ShaderStage& lhs, const Quake3ShaderStage& rhs);
 
 class Quake3Shader {
 public:
-  enum class Culling
-  {
+  enum class Culling {
     Front,
     Back,
     None

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -37,8 +37,7 @@ namespace TrenchBroom {
 namespace Assets {
 class TextureCollection;
 
-enum class TextureType
-{
+enum class TextureType {
   Opaque,
   /**
    * Modifies texture uploading to support mask textures.
@@ -46,8 +45,7 @@ enum class TextureType
   Masked
 };
 
-enum class TextureCulling
-{
+enum class TextureCulling {
   CullDefault,
   CullNone,
   CullFront,
@@ -56,8 +54,7 @@ enum class TextureCulling
 };
 
 struct TextureBlendFunc {
-  enum class Enable
-  {
+  enum class Enable {
     /**
      * Don't change GL_BLEND and don't change the blend function.
      */

--- a/common/src/EL/Expressions.h
+++ b/common/src/EL/Expressions.h
@@ -125,8 +125,7 @@ private:
   void appendToStream(std::ostream& str) const override;
 };
 
-enum class UnaryOperator
-{
+enum class UnaryOperator {
   Plus,
   Minus,
   LogicalNegation,
@@ -152,8 +151,7 @@ private:
   void appendToStream(std::ostream& str) const override;
 };
 
-enum class BinaryOperator
-{
+enum class BinaryOperator {
   Addition,
   Subtraction,
   Multiplication,

--- a/common/src/EL/Types.h
+++ b/common/src/EL/Types.h
@@ -35,8 +35,7 @@ using ArrayType = std::vector<Value>;
 using MapType = std::map<std::string, Value>;
 using RangeType = std::vector<long>;
 
-enum class ValueType
-{
+enum class ValueType {
   Boolean,
   String,
   Number,

--- a/common/src/IO/DkmParser.h
+++ b/common/src/IO/DkmParser.h
@@ -74,8 +74,7 @@ private:
   using DkmMeshVertexList = std::vector<DkmMeshVertex>;
 
   struct DkmMesh {
-    enum Type
-    {
+    enum Type {
       Fan,
       Strip
     };

--- a/common/src/IO/ELParser.h
+++ b/common/src/IO/ELParser.h
@@ -100,8 +100,7 @@ private:
 
 class ELParser : public Parser<ELToken::Type> {
 public:
-  enum class Mode
-  {
+  enum class Mode {
     Strict,
     Lenient
   };

--- a/common/src/IO/EntityDefinitionClassInfo.h
+++ b/common/src/IO/EntityDefinitionClassInfo.h
@@ -37,8 +37,7 @@ class PropertyDefinition;
 }
 
 namespace IO {
-enum class EntityDefinitionClassType
-{
+enum class EntityDefinitionClassType {
   PointClass,
   BrushClass,
   BaseClass

--- a/common/src/IO/ExportOptions.h
+++ b/common/src/IO/ExportOptions.h
@@ -35,8 +35,7 @@ bool operator==(const MapExportOptions& lhs, const MapExportOptions& rhs);
 bool operator!=(const MapExportOptions& lhs, const MapExportOptions& rhs);
 std::ostream& operator<<(std::ostream& lhs, const MapExportOptions& rhs);
 
-enum class ObjMtlPathMode
-{
+enum class ObjMtlPathMode {
   RelativeToGamePath,
   RelativeToExportPath
 };

--- a/common/src/IO/ImageLoader.h
+++ b/common/src/IO/ImageLoader.h
@@ -29,14 +29,12 @@ class Path;
 
 class ImageLoader {
 public:
-  enum Format
-  {
+  enum Format {
     PCX,
     BMP
   };
 
-  enum PixelFormat
-  {
+  enum PixelFormat {
     RGB,
     RGBA
   };

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -152,8 +152,7 @@ void MapReader::onPatch(
 
 namespace {
 /** The type of a node's container. */
-enum class ContainerType
-{
+enum class ContainerType {
   Layer,
   Group,
 };

--- a/common/src/IO/Md2Parser.h
+++ b/common/src/IO/Md2Parser.h
@@ -75,8 +75,7 @@ private:
   using Md2MeshVertexList = std::vector<Md2MeshVertex>;
 
   struct Md2Mesh {
-    enum Type
-    {
+    enum Type {
       Fan,
       Strip
     };

--- a/common/src/IO/MdxParser.h
+++ b/common/src/IO/MdxParser.h
@@ -73,8 +73,7 @@ private:
   using MdxMeshVertexList = std::vector<MdxMeshVertex>;
 
   struct MdxMesh {
-    enum Type
-    {
+    enum Type {
       Fan,
       Strip
     };

--- a/common/src/Logger.h
+++ b/common/src/Logger.h
@@ -25,8 +25,7 @@
 class QString;
 
 namespace TrenchBroom {
-enum class LogLevel
-{
+enum class LogLevel {
   Debug,
   Info,
   Warn,

--- a/common/src/Model/BrushError.h
+++ b/common/src/Model/BrushError.h
@@ -23,8 +23,7 @@
 
 namespace TrenchBroom {
 namespace Model {
-enum class BrushError
-{
+enum class BrushError {
   EmptyBrush,
   IncompleteBrush,
   InvalidBrush,

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.h
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.h
@@ -36,8 +36,7 @@ class BrushFaceAttributes;
 class ChangeBrushFaceAttributesRequest {
 public:
   // TODO: replace with class based enum
-  typedef enum
-  {
+  typedef enum {
     AxisOp_None,
     AxisOp_Reset,
     AxisOp_ToParaxial,
@@ -45,8 +44,7 @@ public:
   } AxisOp;
 
   // TODO: replace with class based enum
-  typedef enum
-  {
+  typedef enum {
     ValueOp_None,
     ValueOp_Set,
     ValueOp_Add,
@@ -54,8 +52,7 @@ public:
   } ValueOp;
 
   // TODO: replace with class based enum
-  typedef enum
-  {
+  typedef enum {
     FlagOp_None,
     FlagOp_Replace,
     FlagOp_Set,   // TODO: rename to SetBits
@@ -63,8 +60,7 @@ public:
   } FlagOp;
 
   // TODO: replace with class based enum
-  typedef enum
-  {
+  typedef enum {
     TextureOp_None,
     TextureOp_Set
   } TextureOp;

--- a/common/src/Model/EntityNodeIndex.h
+++ b/common/src/Model/EntityNodeIndex.h
@@ -35,8 +35,7 @@ using EntityNodeStringIndex = kdl::compact_trie<EntityNodeBase*>;
 
 class EntityNodeIndexQuery {
 public:
-  typedef enum
-  {
+  typedef enum {
     Type_Exact,
     Type_Prefix,
     Type_Numbered,

--- a/common/src/Model/EntityRotationPolicy.h
+++ b/common/src/Model/EntityRotationPolicy.h
@@ -36,8 +36,7 @@ struct EntityPropertyConfig;
 
 class EntityRotationPolicy {
 private:
-  enum class RotationType
-  {
+  enum class RotationType {
     None,
     Angle,
     AngleUpDown,
@@ -45,8 +44,7 @@ private:
     Euler_PositivePitchDown,
     Mangle
   };
-  enum class RotationUsage
-  {
+  enum class RotationUsage {
     Allowed,
     BlockRotation
   };

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -57,8 +57,7 @@ class WorldNode;
 
 class Game : public IO::EntityDefinitionLoader, public IO::EntityModelLoader {
 public:
-  enum class TexturePackageType
-  {
+  enum class TexturePackageType {
     File,
     Directory
   };
@@ -80,8 +79,7 @@ public:
 
   const std::vector<SmartTag>& smartTags() const;
 
-  enum class SoftMapBoundsType
-  {
+  enum class SoftMapBoundsType {
     Game,
     Map
   };

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -78,8 +78,7 @@ kdl::result<UpdateLinkedGroupsResult, UpdateLinkedGroupsError> updateLinkedGroup
  */
 class GroupNode : public Node, public Object {
 private:
-  enum class EditState
-  {
+  enum class EditState {
     Open,
     Closed,
     DescendantOpen

--- a/common/src/Model/LockState.h
+++ b/common/src/Model/LockState.h
@@ -23,8 +23,7 @@
 
 namespace TrenchBroom {
 namespace Model {
-enum class LockState
-{
+enum class LockState {
   Inherited = 1,
   Locked = 2,
   Unlocked = 4

--- a/common/src/Model/MapFormat.h
+++ b/common/src/Model/MapFormat.h
@@ -24,8 +24,7 @@
 
 namespace TrenchBroom {
 namespace Model {
-enum class MapFormat
-{
+enum class MapFormat {
   /**
    * Unknown map format.
    */

--- a/common/src/Model/PatchNode.cpp
+++ b/common/src/Model/PatchNode.cpp
@@ -103,13 +103,11 @@ std::vector<vm::vec3> computeGridNormals(
     return patchGrid[index(row, col)].xyz();
   };
 
-  enum class RowOffset
-  {
+  enum class RowOffset {
     Above,
     Below
   };
-  enum class ColOffset
-  {
+  enum class ColOffset {
     Left,
     Right
   };

--- a/common/src/Model/Polyhedron.h
+++ b/common/src/Model/Polyhedron.h
@@ -1929,8 +1929,7 @@ public: // Clipping
    */
   class ClipResult {
   public:
-    enum class FailureReason
-    {
+    enum class FailureReason {
       /**
        * Clipping did not change this polyhedron.
        */

--- a/common/src/Model/Polyhedron_Face.h
+++ b/common/src/Model/Polyhedron_Face.h
@@ -421,8 +421,7 @@ size_t Polyhedron_Face<T, FP, VP>::countSharedVertices(const Face* other) const 
 
 template <typename T, typename FP, typename VP> class Polyhedron_Face<T, FP, VP>::RayIntersection {
 private:
-  typedef enum
-  {
+  typedef enum {
     Type_Front = 1,
     Type_Back = 2,
     Type_None = 3

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -50,8 +50,7 @@ private:
   friend class ParaxialTexCoordSystem;
 };
 
-enum class WrapStyle
-{
+enum class WrapStyle {
   Projection,
   Rotation
 };

--- a/common/src/Model/UpdateLinkedGroupsError.h
+++ b/common/src/Model/UpdateLinkedGroupsError.h
@@ -23,8 +23,7 @@
 
 namespace TrenchBroom {
 namespace Model {
-enum class UpdateLinkedGroupsError
-{
+enum class UpdateLinkedGroupsError {
   TransformIsNotInvertible,
   TransformFailed,
   UpdateExceedsWorldBounds,

--- a/common/src/Model/VisibilityState.h
+++ b/common/src/Model/VisibilityState.h
@@ -23,8 +23,7 @@
 
 namespace TrenchBroom {
 namespace Model {
-enum class VisibilityState
-{
+enum class VisibilityState {
   Inherited = 1,
   Hidden = 2,
   Shown = 4

--- a/common/src/Renderer/AttrString.h
+++ b/common/src/Renderer/AttrString.h
@@ -26,8 +26,7 @@ namespace TrenchBroom {
 namespace Renderer {
 class AttrString {
 private:
-  enum class Justify
-  {
+  enum class Justify {
     Left,
     Right,
     Center

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -43,14 +43,12 @@ class BrushRenderer {
 public:
   class Filter {
   public:
-    enum class FaceRenderPolicy
-    {
+    enum class FaceRenderPolicy {
       RenderMarked,
       RenderNone
     };
 
-    enum class EdgeRenderPolicy
-    {
+    enum class EdgeRenderPolicy {
       RenderAll,
       RenderIfEitherFaceMarked,
       RenderIfBothFacesMarked,

--- a/common/src/Renderer/Camera.h
+++ b/common/src/Renderer/Camera.h
@@ -80,8 +80,7 @@ private:
   mutable vm::mat4x4f m_inverseMatrix;
 
 protected:
-  typedef enum
-  {
+  typedef enum {
     Projection_Orthographic,
     Projection_Perspective
   } ProjectionType;

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -68,8 +68,7 @@ private:
   std::unique_ptr<EntityLinkRenderer> m_entityLinkRenderer;
   std::unique_ptr<GroupLinkRenderer> m_groupLinkRenderer;
 
-  typedef enum
-  {
+  typedef enum {
     Renderer_Default = 1,
     Renderer_Selection = 2,
     Renderer_Locked = 4,

--- a/common/src/Renderer/PrimType.h
+++ b/common/src/Renderer/PrimType.h
@@ -23,8 +23,7 @@
 
 namespace TrenchBroom {
 namespace Renderer {
-enum class PrimType
-{
+enum class PrimType {
   Points,
   Lines,
   Triangles,

--- a/common/src/Renderer/PrimitiveRenderer.h
+++ b/common/src/Renderer/PrimitiveRenderer.h
@@ -32,15 +32,13 @@ class ActiveShader;
 template <typename VertexSpec> class IndexRangeMapBuilder;
 class IndexRangeRenderer;
 
-enum class PrimitiveRendererOcclusionPolicy
-{
+enum class PrimitiveRendererOcclusionPolicy {
   Hide,
   Show,
   Transparent
 };
 
-enum class PrimitiveRendererCullingPolicy
-{
+enum class PrimitiveRendererCullingPolicy {
   CullBackfaces,
   ShowBackfaces
 };

--- a/common/src/Renderer/RenderContext.h
+++ b/common/src/Renderer/RenderContext.h
@@ -30,16 +30,14 @@ class Camera;
 class FontManager;
 class ShaderManager;
 
-enum class RenderMode
-{
+enum class RenderMode {
   Render3D,
   Render2D
 };
 
 class RenderContext {
 private:
-  enum class ShowSelectionGuide
-  {
+  enum class ShowSelectionGuide {
     Show,
     Hide,
     ForceShow,

--- a/common/src/Renderer/VboManager.h
+++ b/common/src/Renderer/VboManager.h
@@ -28,14 +28,12 @@ namespace Renderer {
 class Vbo;
 class ShaderManager;
 
-enum class VboType
-{
+enum class VboType {
   ArrayBuffer,
   ElementArrayBuffer
 };
 
-enum class VboUsage
-{
+enum class VboUsage {
   StaticDraw,
   DynamicDraw
 };

--- a/common/src/View/ActionContext.h
+++ b/common/src/View/ActionContext.h
@@ -48,8 +48,7 @@ bool actionContextMatches(
 
 std::string actionContextName(ActionContext::Type actionContext);
 
-typedef enum
-{
+typedef enum {
   ActionView_Map2D = 0,
   ActionView_Map3D = 1
 } ActionView;

--- a/common/src/View/Actions.h
+++ b/common/src/View/Actions.h
@@ -156,8 +156,7 @@ public:
   virtual void visit(const MenuActionItem& item) = 0;
 };
 
-enum class MenuEntryType
-{
+enum class MenuEntryType {
   Menu_RecentDocuments,
   Menu_Undo,
   Menu_Redo,

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -39,8 +39,7 @@ public:
   static const CommandType Type;
 
 private:
-  enum class Action
-  {
+  enum class Action {
     Add,
     Remove
   };

--- a/common/src/View/Animation.h
+++ b/common/src/View/Animation.h
@@ -58,8 +58,7 @@ public:
   using Type = int;
   static const Type NoType = -1;
 
-  enum class Curve
-  {
+  enum class Curve {
     Flat,
     EaseInEaseOut
   };

--- a/common/src/View/BorderLine.h
+++ b/common/src/View/BorderLine.h
@@ -26,8 +26,7 @@ namespace View {
 class BorderLine : public QFrame {
   Q_OBJECT
 public:
-  enum class Direction
-  {
+  enum class Direction {
     Horizontal,
     Vertical
   };

--- a/common/src/View/BorderPanel.h
+++ b/common/src/View/BorderPanel.h
@@ -26,8 +26,7 @@ namespace View {
 class BorderPanel : public QWidget {
   Q_OBJECT
 public:
-  enum Sides
-  {
+  enum Sides {
     TopSide = 1,
     RightSide = 2,
     BottomSide = 4,

--- a/common/src/View/ClipTool.h
+++ b/common/src/View/ClipTool.h
@@ -54,8 +54,7 @@ public:
   static const Model::HitType::Type PointHitType;
 
 private:
-  enum ClipSide
-  {
+  enum ClipSide {
     ClipSide_Front,
     ClipSide_Both,
     ClipSide_Back

--- a/common/src/View/Command.h
+++ b/common/src/View/Command.h
@@ -43,8 +43,7 @@ class Command {
 public:
   using CommandType = size_t;
 
-  enum class CommandState
-  {
+  enum class CommandState {
     Default,
     Doing,
     Done,

--- a/common/src/View/CyclingMapView.h
+++ b/common/src/View/CyclingMapView.h
@@ -43,8 +43,7 @@ class MapViewToolBox;
 class CyclingMapView : public MapViewContainer, public CameraLinkableView {
   Q_OBJECT
 public:
-  typedef enum
-  {
+  typedef enum {
     View_3D = 1,
     View_XY = 2,
     View_XZ = 4,

--- a/common/src/View/EntityPropertyModel.h
+++ b/common/src/View/EntityPropertyModel.h
@@ -35,8 +35,7 @@ class EntityNodeBase;
 namespace View {
 class MapDocument;
 
-enum class ValueType
-{
+enum class ValueType {
   /**
    * No entities have this key set; the provided value is the default from the entity definition
    */
@@ -55,8 +54,7 @@ enum class ValueType
   MultipleValues
 };
 
-enum class PropertyProtection
-{
+enum class PropertyProtection {
   NotProtectable,
   Protected,
   NotProtected,

--- a/common/src/View/GameDialog.h
+++ b/common/src/View/GameDialog.h
@@ -41,8 +41,7 @@ class GameListBox;
 class GameDialog : public QDialog {
   Q_OBJECT
 private:
-  enum class DialogType
-  {
+  enum class DialogType {
     Open,
     New
   };

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -106,8 +106,7 @@ public: // Snap scalars.
   }
 
 private:
-  typedef enum
-  {
+  typedef enum {
     /**
      * Snap to nearest grid increment (rounding away from 0 if the input is half way between two
      * multiples of the grid size).

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -63,8 +63,7 @@ using HandlePositionProposer =
 /**
  * Controls whether the initial handle position should be updated to the current handle position.
  */
-enum class ResetInitialHandlePosition
-{
+enum class ResetInitialHandlePosition {
   Keep,
   Reset
 };
@@ -83,8 +82,7 @@ struct UpdateDragConfig {
  * The status of a drag. This is returned from a handle drag tracker's delegate when it reacts to a
  * drag event.
  */
-enum class DragStatus
-{
+enum class DragStatus {
   /** The drag should continue. */
   Continue,
   /** The drag should continue, but the current event could not be applied to the object being
@@ -226,8 +224,7 @@ struct HandleDragTrackerDelegate {
  */
 template <typename Delegate> class HandleDragTracker : public DragTracker {
 private:
-  enum class IdenticalPositionPolicy
-  {
+  enum class IdenticalPositionPolicy {
     SkipDrag,
     ForceDrag
   };

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -80,8 +80,7 @@ public:
  */
 class KeyEvent : public InputEvent {
 public:
-  enum class Type
-  {
+  enum class Type {
     /**
      * A key was pressed.
      */
@@ -128,8 +127,7 @@ public:
  */
 class MouseEvent : public InputEvent {
 public:
-  enum class Type
-  {
+  enum class Type {
     /**
      * A button was pressed.
      */
@@ -167,8 +165,7 @@ public:
      */
     DragEnd
   };
-  enum class Button
-  {
+  enum class Button {
     None,
     Left,
     Middle,
@@ -176,8 +173,7 @@ public:
     Aux1,
     Aux2
   };
-  enum class WheelAxis
-  {
+  enum class WheelAxis {
     None,
     Vertical,
     Horizontal

--- a/common/src/View/InputState.h
+++ b/common/src/View/InputState.h
@@ -38,8 +38,7 @@ static const ModifierKeyState MKAlt = 1 << 2;
 static const ModifierKeyState MKDontCare = 1 << 3;
 } // namespace ModifierKeys
 
-typedef enum
-{
+typedef enum {
   MK_Yes,
   MK_No,
   MK_DontCare

--- a/common/src/View/Inspector.h
+++ b/common/src/View/Inspector.h
@@ -34,8 +34,7 @@ class MapViewBar;
 class SyncHeightEventFilter;
 class TabBook;
 
-enum class InspectorPage
-{
+enum class InspectorPage {
   Map = 0,
   Entity = 1,
   Face = 2

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -473,8 +473,7 @@ public: // layer management
   void renameLayer(Model::LayerNode* layer, const std::string& name);
 
 private:
-  enum class MoveDirection
-  {
+  enum class MoveDirection {
     Up,
     Down
   };

--- a/common/src/View/MapTextEncoding.h
+++ b/common/src/View/MapTextEncoding.h
@@ -21,8 +21,7 @@
 
 namespace TrenchBroom {
 namespace View {
-enum class MapTextEncoding
-{
+enum class MapTextEncoding {
   Quake,
   Iso88591,
   Utf8

--- a/common/src/View/MapView2D.h
+++ b/common/src/View/MapView2D.h
@@ -45,8 +45,7 @@ namespace View {
 class MapView2D : public MapViewBase {
   Q_OBJECT
 public:
-  typedef enum
-  {
+  typedef enum {
     ViewPlane_XY,
     ViewPlane_XZ,
     ViewPlane_YZ

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -183,8 +183,7 @@ public: // move, rotate, flip actions
   bool canFlipObjects() const;
 
 public: // texture actions
-  enum class TextureActionMode
-  {
+  enum class TextureActionMode {
     Normal,
     Coarse,
     Fine

--- a/common/src/View/MapViewLayout.h
+++ b/common/src/View/MapViewLayout.h
@@ -21,8 +21,7 @@
 
 namespace TrenchBroom {
 namespace View {
-enum class MapViewLayout
-{
+enum class MapViewLayout {
   OnePane,
   TwoPanes,
   ThreePanes,

--- a/common/src/View/MoveHandleDragTracker.h
+++ b/common/src/View/MoveHandleDragTracker.h
@@ -39,8 +39,7 @@
 
 namespace TrenchBroom {
 namespace View {
-enum class SnapMode
-{
+enum class SnapMode {
   /** Snap the delta between a previous and the proposed handle position. */
   Relative,
   /** Snap the proposed handle position to absolute values. */
@@ -182,8 +181,7 @@ private:
     "Delegate must extend MoveHandleDragTrackerDelegate");
 
   /** The different modes of moving. */
-  enum class MoveMode
-  {
+  enum class MoveMode {
     /** A vertical move (3D views only) */
     Vertical,
     /** A constricted move (move along only one axis of a horizontal plane) */

--- a/common/src/View/MoveObjectsTool.h
+++ b/common/src/View/MoveObjectsTool.h
@@ -32,8 +32,7 @@ class MapDocument;
 
 class MoveObjectsTool : public Tool {
 public:
-  typedef enum
-  {
+  typedef enum {
     MR_Continue,
     MR_Deny,
     MR_Cancel

--- a/common/src/View/PasteType.h
+++ b/common/src/View/PasteType.h
@@ -21,8 +21,7 @@
 
 namespace TrenchBroom {
 namespace View {
-enum class PasteType
-{
+enum class PasteType {
   Node,
   BrushFace,
   Failed

--- a/common/src/View/PreferenceDialog.h
+++ b/common/src/View/PreferenceDialog.h
@@ -36,8 +36,7 @@ class PreferencePane;
 class PreferenceDialog : public QDialog {
   Q_OBJECT
 private:
-  typedef enum
-  {
+  typedef enum {
     PrefPane_First = 0,
     PrefPane_Games = 0,
     PrefPane_View = 1,

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -80,8 +80,7 @@ public:
   bool eventFilter(QObject* target, QEvent* event) override;
 };
 
-enum class FileDialogDir
-{
+enum class FileDialogDir {
   Map,
   TextureCollection,
   CompileTool,

--- a/common/src/View/ResizeBrushesToolController.h
+++ b/common/src/View/ResizeBrushesToolController.h
@@ -38,8 +38,7 @@ protected:
   ResizeBrushesTool& m_tool;
 
 private:
-  enum class Mode
-  {
+  enum class Mode {
     Resize,
     MoveFace
   };

--- a/common/src/View/RotateObjectsHandle.h
+++ b/common/src/View/RotateObjectsHandle.h
@@ -41,8 +41,7 @@ class RotateObjectsHandle {
 public:
   static const Model::HitType::Type HandleHitType;
 
-  enum class HitArea
-  {
+  enum class HitArea {
     None = 0,
     Center = 1,
     XAxis = 2,

--- a/common/src/View/ScaleObjectsTool.h
+++ b/common/src/View/ScaleObjectsTool.h
@@ -87,8 +87,7 @@ public:
   bool operator==(const BBoxEdge& other) const;
 };
 
-enum class AnchorPos
-{
+enum class AnchorPos {
   Opposite,
   Center
 };

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -43,8 +43,7 @@ public:
   static const CommandType Type;
 
 private:
-  enum class Action
-  {
+  enum class Action {
     SelectNodes,
     SelectFaces,
     SelectAllNodes,

--- a/common/src/View/SetVisibilityCommand.h
+++ b/common/src/View/SetVisibilityCommand.h
@@ -39,8 +39,7 @@ public:
   static const CommandType Type;
 
 private:
-  enum class Action
-  {
+  enum class Action {
     Reset,
     Hide,
     Show,

--- a/common/src/View/TextureBrowserView.h
+++ b/common/src/View/TextureBrowserView.h
@@ -52,8 +52,7 @@ struct TextureCellData {
   Renderer::FontDescriptor subTitleFont;
 };
 
-enum class TextureSortOrder
-{
+enum class TextureSortOrder {
   Name,
   Usage
 };

--- a/common/src/View/VertexTool.h
+++ b/common/src/View/VertexTool.h
@@ -47,8 +47,7 @@ class Selection;
 
 class VertexTool : public VertexToolBase<vm::vec3> {
 private:
-  enum class Mode
-  {
+  enum class Mode {
     Move,
     SplitEdge,
     SplitFace

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -75,8 +75,7 @@ class MapDocument;
 
 template <typename H> class VertexToolBase : public Tool {
 public:
-  enum class MoveResult
-  {
+  enum class MoveResult {
     Continue,
     Deny,
     Cancel

--- a/common/test/src/Model/NodeTest.cpp
+++ b/common/test/src/Model/NodeTest.cpp
@@ -506,8 +506,7 @@ TEST_CASE("NodeTest.isDescendantOf", "[NodeTest]") {
     std::vector<Node*>{&root, child1, child2, grandChild1_1, grandChild1_2}));
 }
 
-enum class Visited
-{
+enum class Visited {
   World,
   Layer,
   Group,

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -125,16 +125,14 @@ DocumentGameConfig loadMapDocument(
 DocumentGameConfig newMapDocument(const std::string& gameName, Model::MapFormat mapFormat);
 } // namespace View
 
-enum class Component
-{
+enum class Component {
   R,
   G,
   B,
   A
 };
 
-enum class ColorMatch
-{
+enum class ColorMatch {
   Exact,
   Approximate
 };

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -34,8 +34,7 @@
 
 namespace TrenchBroom {
 namespace View {
-enum class CommandNotif
-{
+enum class CommandNotif {
   CommandDo,
   CommandDone,
   CommandDoFailed,


### PR DESCRIPTION
clang-format 13.0.1 fixes enum formatting. Previously, the `BraceWrapping` setting `AfterEnum: false` would have no effect and hence our enums were wrongly formatted. This commit fixes this formatting.

This means that the code must be formatting with clang-format 13.0.1 from now on to make our checks pass. The binaries in our [dev-tools](https://github.com/TrenchBroom/dev-tools) repo have been updated to 13.0.1.