### PR TITLE
Add reflective facility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Version.h
 Thumbs.db
 *.sublime-workspace
 .vscode
+.cache
 
 /cmake-build-*
 /build*

--- a/common/src/Assets/AssetReference.h
+++ b/common/src/Assets/AssetReference.h
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <kdl/reflection_impl.h>
+
 #include <utility>
 
 #pragma once
@@ -62,13 +64,7 @@ public:
 
   const T* get() const { return m_asset; }
 
-  friend bool operator==(const AssetReference& lhs, const AssetReference& rhs) {
-    return lhs.m_asset == rhs.m_asset;
-  }
-
-  friend bool operator!=(const AssetReference& lhs, const AssetReference& rhs) {
-    return !(lhs == rhs);
-  }
+  kdl_reflect_inline(AssetReference<T>, m_asset);
 };
 } // namespace Assets
 } // namespace TrenchBroom

--- a/common/src/Assets/ModelDefinition.cpp
+++ b/common/src/Assets/ModelDefinition.cpp
@@ -26,6 +26,7 @@
 #include "EL/Value.h"
 #include "EL/VariableStore.h"
 
+#include <kdl/reflection_impl.h>
 #include <kdl/string_compare.h>
 
 #include <vecmath/scalar.h>
@@ -46,49 +47,7 @@ ModelSpecification::ModelSpecification(
   , skinIndex{i_skinIndex}
   , frameIndex{i_frameIndex} {}
 
-bool ModelSpecification::operator<(const ModelSpecification& rhs) const {
-  return compare(rhs) < 0;
-}
-
-bool ModelSpecification::operator>(const ModelSpecification& rhs) const {
-  return compare(rhs) > 0;
-}
-
-bool ModelSpecification::operator<=(const ModelSpecification& rhs) const {
-  return compare(rhs) <= 0;
-}
-
-bool ModelSpecification::operator>=(const ModelSpecification& rhs) const {
-  return compare(rhs) >= 0;
-}
-
-bool ModelSpecification::operator==(const ModelSpecification& rhs) const {
-  return compare(rhs) == 0;
-}
-
-bool ModelSpecification::operator!=(const ModelSpecification& rhs) const {
-  return compare(rhs) != 0;
-}
-
-int ModelSpecification::compare(const ModelSpecification& other) const {
-  const int pathCmp = path.compare(other.path);
-  if (pathCmp != 0) {
-    return pathCmp;
-  }
-  if (skinIndex != other.skinIndex) {
-    return static_cast<int>(skinIndex) - static_cast<int>(other.skinIndex);
-  }
-  if (frameIndex != other.frameIndex) {
-    return static_cast<int>(frameIndex) - static_cast<int>(other.frameIndex);
-  }
-  return 0;
-}
-
-std::ostream& operator<<(std::ostream& stream, const ModelSpecification& spec) {
-  stream << "ModelSpecification{path: " << spec.path << ", skinIndex: " << spec.skinIndex
-         << ", frameIndex: " << spec.frameIndex << "}";
-  return stream;
-}
+kdl_reflect_impl(ModelSpecification);
 
 ModelDefinition::ModelDefinition()
   : m_expression{EL::LiteralExpression{EL::Value::Undefined}, 0, 0} {}
@@ -98,19 +57,6 @@ ModelDefinition::ModelDefinition(const size_t line, const size_t column)
 
 ModelDefinition::ModelDefinition(const EL::Expression& expression)
   : m_expression{expression} {}
-
-bool operator==(const ModelDefinition& lhs, const ModelDefinition& rhs) {
-  return lhs.m_expression.asString() == rhs.m_expression.asString();
-}
-
-bool operator!=(const ModelDefinition& lhs, const ModelDefinition& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const ModelDefinition& def) {
-  str << "ModelDefinition{ " << def.m_expression << " }";
-  return str;
-}
 
 void ModelDefinition::append(const ModelDefinition& other) {
   const size_t line = m_expression.line();
@@ -230,6 +176,8 @@ vm::vec3 ModelDefinition::scale(
 
   return vm::vec3{1, 1, 1};
 }
+
+kdl_reflect_impl(ModelDefinition);
 
 vm::vec3 safeGetModelScale(
   const ModelDefinition& definition, const EL::VariableStore& variableStore,

--- a/common/src/Assets/ModelDefinition.h
+++ b/common/src/Assets/ModelDefinition.h
@@ -23,6 +23,7 @@
 #include "FloatType.h"
 #include "IO/Path.h"
 
+#include <kdl/reflection_decl.h>
 #include <vecmath/vec.h>
 
 #include <iosfwd>
@@ -38,16 +39,8 @@ struct ModelSpecification {
   ModelSpecification();
   ModelSpecification(const IO::Path& path, size_t skinIndex, size_t frameIndex);
 
-  bool operator<(const ModelSpecification& rhs) const;
-  bool operator>(const ModelSpecification& rhs) const;
-  bool operator<=(const ModelSpecification& rhs) const;
-  bool operator>=(const ModelSpecification& rhs) const;
-  bool operator==(const ModelSpecification& rhs) const;
-  bool operator!=(const ModelSpecification& rhs) const;
-  int compare(const ModelSpecification& other) const;
+  kdl_reflect_decl(ModelSpecification, path, skinIndex, frameIndex);
 };
-
-std::ostream& operator<<(std::ostream& stream, const ModelSpecification& spec);
 
 class ModelDefinition {
 private:
@@ -57,10 +50,6 @@ public:
   ModelDefinition();
   ModelDefinition(size_t line, size_t column);
   explicit ModelDefinition(const EL::Expression& expression);
-
-  friend bool operator==(const ModelDefinition& lhs, const ModelDefinition& rhs);
-  friend bool operator!=(const ModelDefinition& lhs, const ModelDefinition& rhs);
-  friend std::ostream& operator<<(std::ostream& str, const ModelDefinition& def);
 
   void append(const ModelDefinition& other);
 
@@ -93,6 +82,8 @@ public:
   vm::vec3 scale(
     const EL::VariableStore& variableStore,
     const std::optional<EL::Expression>& defaultScaleExpression) const;
+
+  kdl_reflect_decl(ModelDefinition, m_expression);
 };
 
 /**

--- a/common/src/Assets/PropertyDefinition.cpp
+++ b/common/src/Assets/PropertyDefinition.cpp
@@ -21,6 +21,8 @@
 
 #include "Macros.h"
 
+#include <kdl/reflection_impl.h>
+
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -205,6 +207,8 @@ const std::string& ChoicePropertyOption::description() const {
   return m_description;
 }
 
+kdl_reflect_impl(ChoicePropertyOption);
+
 ChoicePropertyDefinition::ChoicePropertyDefinition(
   const std::string& key, const std::string& shortDescription, const std::string& longDescription,
   const ChoicePropertyOption::List& options, const bool readOnly,
@@ -216,21 +220,6 @@ ChoicePropertyDefinition::ChoicePropertyDefinition(
 
 const ChoicePropertyOption::List& ChoicePropertyDefinition::options() const {
   return m_options;
-}
-
-bool operator==(const ChoicePropertyOption& lhs, const ChoicePropertyOption& rhs) {
-  return lhs.value() == rhs.value() && lhs.description() == rhs.description();
-}
-
-bool operator!=(const ChoicePropertyOption& lhs, const ChoicePropertyOption& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const ChoicePropertyOption& opt) {
-  str << "ChoicePropertyOption{"
-      << "value: " << opt.value() << ", "
-      << "description: '" << opt.description() << "}";
-  return str;
 }
 
 bool ChoicePropertyDefinition::doEquals(const PropertyDefinition* other) const {
@@ -268,23 +257,7 @@ bool FlagsPropertyOption::isDefault() const {
   return m_isDefault;
 }
 
-bool operator==(const FlagsPropertyOption& lhs, const FlagsPropertyOption& rhs) {
-  return lhs.value() == rhs.value() && lhs.shortDescription() == rhs.shortDescription() &&
-         lhs.longDescription() == rhs.longDescription() && lhs.isDefault() == rhs.isDefault();
-}
-
-bool operator!=(const FlagsPropertyOption& lhs, const FlagsPropertyOption& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const FlagsPropertyOption& opt) {
-  str << "FlagPropertyOption{"
-      << "value: " << opt.value() << ", "
-      << "shortDescription: '" << opt.shortDescription() << "', "
-      << "longDescription: '" << opt.longDescription() << "', "
-      << "isDefault: " << opt.isDefault() << "}";
-  return str;
-}
+kdl_reflect_impl(FlagsPropertyOption);
 
 FlagsPropertyDefinition::FlagsPropertyDefinition(const std::string& key)
   : PropertyDefinition(key, PropertyDefinitionType::FlagsProperty, "", "", false) {}

--- a/common/src/Assets/PropertyDefinition.h
+++ b/common/src/Assets/PropertyDefinition.h
@@ -21,7 +21,8 @@
 
 #include "Ensure.h"
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -156,11 +157,9 @@ public:
   ChoicePropertyOption(const std::string& value, const std::string& description);
   const std::string& value() const;
   const std::string& description() const;
-};
 
-bool operator==(const ChoicePropertyOption& lhs, const ChoicePropertyOption& rhs);
-bool operator!=(const ChoicePropertyOption& lhs, const ChoicePropertyOption& rhs);
-std::ostream& operator<<(std::ostream& str, const ChoicePropertyOption& opt);
+  kdl_reflect_decl(ChoicePropertyOption, m_value, m_description);
+};
 
 class ChoicePropertyDefinition : public PropertyDefinitionWithDefaultValue<std::string> {
 private:
@@ -198,11 +197,9 @@ public:
   const std::string& shortDescription() const;
   const std::string& longDescription() const;
   bool isDefault() const;
-};
 
-bool operator==(const FlagsPropertyOption& lhs, const FlagsPropertyOption& rhs);
-bool operator!=(const FlagsPropertyOption& lhs, const FlagsPropertyOption& rhs);
-std::ostream& operator<<(std::ostream& str, const FlagsPropertyOption& opt);
+  kdl_reflect_decl(FlagsPropertyOption, m_shortDescription, m_longDescription, m_isDefault);
+};
 
 class FlagsPropertyDefinition : public PropertyDefinition {
 private:

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -23,25 +23,16 @@
 #include "Macros.h"
 #include "Renderer/GL.h"
 
+#include <kdl/reflection_impl.h>
+
 #include <algorithm> // for std::max
 #include <cassert>
 #include <ostream>
 
 namespace TrenchBroom {
 namespace Assets {
-bool Q2Data::operator==(const Q2Data& other) const {
-  return flags == other.flags && contents == other.contents && value == other.value;
-}
 
-bool Q2Data::operator!=(const Q2Data& other) const {
-  return !(*this == other);
-}
-
-std::ostream& operator<<(std::ostream& str, const Q2Data& data) {
-  str << "{flags: " << data.flags << ", contents: " << data.contents << ", value: " << data.value
-      << "}";
-  return str;
-}
+kdl_reflect_impl(Q2Data);
 
 Texture::Texture(
   const std::string& name, const size_t width, const size_t height, const Color& averageColor,

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -26,6 +26,8 @@
 
 #include <vecmath/forward.h>
 
+#include <kdl/reflection_decl.h>
+
 #include <atomic>
 #include <iosfwd>
 #include <set>
@@ -79,10 +81,8 @@ struct Q2Data {
   int contents;
   int value;
 
-  bool operator==(const Q2Data& other) const;
-  bool operator!=(const Q2Data& other) const;
+  kdl_reflect_decl(Q2Data, flags, contents, value);
 };
-std::ostream& operator<<(std::ostream& str, const Q2Data& data);
 
 using GameData = std::variant<std::monostate, Q2Data>;
 

--- a/common/src/IO/EntityDefinitionClassInfo.cpp
+++ b/common/src/IO/EntityDefinitionClassInfo.cpp
@@ -23,7 +23,7 @@
 #include "Macros.h"
 #include "Model/EntityProperties.h"
 
-#include <kdl/optional_io.h>
+#include <kdl/reflection_impl.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/bbox_io.h>
@@ -51,6 +51,8 @@ std::ostream& operator<<(std::ostream& str, const EntityDefinitionClassType type
   return str;
 }
 
+kdl_reflect_impl(EntityDefinitionClassInfo);
+
 bool addPropertyDefinition(
   std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDefinitions,
   std::shared_ptr<Assets::PropertyDefinition> propertyDefinition) {
@@ -65,40 +67,5 @@ bool addPropertyDefinition(
   return true;
 }
 
-bool operator==(const EntityDefinitionClassInfo& lhs, const EntityDefinitionClassInfo& rhs) {
-  return lhs.type == rhs.type && lhs.line == rhs.line && lhs.column == rhs.column &&
-         lhs.name == rhs.name && lhs.description == rhs.description && lhs.color == rhs.color &&
-         lhs.size == rhs.size && lhs.modelDefinition == rhs.modelDefinition &&
-         lhs.propertyDefinitions == rhs.propertyDefinitions && lhs.superClasses == rhs.superClasses;
-}
-
-bool operator!=(const EntityDefinitionClassInfo& lhs, const EntityDefinitionClassInfo& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const EntityDefinitionClassInfo& classInfo) {
-  str << "EntityDefinitionClassInfo{ "
-      << "type: " << classInfo.type << ", "
-      << "line: " << classInfo.line << ", "
-      << "column: " << classInfo.column << ", "
-      << "name: " << classInfo.name << ", "
-      << "description: " << kdl::make_streamable(classInfo.description) << ", "
-      << "color: " << kdl::make_streamable(classInfo.color) << ", "
-      << "size: " << kdl::make_streamable(classInfo.size) << ", "
-      << "modelDefinition: " << kdl::make_streamable(classInfo.modelDefinition) << ", "
-      << "propertyDefinnitions: {";
-  for (const auto& propertyDefinition : classInfo.propertyDefinitions) {
-    str << "'" << propertyDefinition->key() << "', ";
-  }
-  str << "}, "
-      << "superClasses: { ";
-  for (const auto& superClass : classInfo.superClasses) {
-    str << superClass << ", ";
-  }
-  str << " } "
-      << " }";
-
-  return str;
-}
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/src/IO/EntityDefinitionClassInfo.cpp
+++ b/common/src/IO/EntityDefinitionClassInfo.cpp
@@ -23,7 +23,7 @@
 #include "Macros.h"
 #include "Model/EntityProperties.h"
 
-#include <kdl/opt_utils.h>
+#include <kdl/optional_io.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/bbox_io.h>
@@ -82,10 +82,10 @@ std::ostream& operator<<(std::ostream& str, const EntityDefinitionClassInfo& cla
       << "line: " << classInfo.line << ", "
       << "column: " << classInfo.column << ", "
       << "name: " << classInfo.name << ", "
-      << "description: " << kdl::opt_to_string(classInfo.description) << ", "
-      << "color: " << kdl::opt_to_string(classInfo.color) << ", "
-      << "size: " << kdl::opt_to_string(classInfo.size) << ", "
-      << "modelDefinition: " << kdl::opt_to_string(classInfo.modelDefinition) << ", "
+      << "description: " << kdl::make_streamable(classInfo.description) << ", "
+      << "color: " << kdl::make_streamable(classInfo.color) << ", "
+      << "size: " << kdl::make_streamable(classInfo.size) << ", "
+      << "modelDefinition: " << kdl::make_streamable(classInfo.modelDefinition) << ", "
       << "propertyDefinnitions: {";
   for (const auto& propertyDefinition : classInfo.propertyDefinitions) {
     str << "'" << propertyDefinition->key() << "', ";

--- a/common/src/IO/EntityDefinitionClassInfo.h
+++ b/common/src/IO/EntityDefinitionClassInfo.h
@@ -25,6 +25,8 @@
 
 #include <vecmath/bbox.h>
 
+#include <kdl/reflection_decl.h>
+
 #include <iosfwd>
 #include <memory>
 #include <optional>
@@ -58,15 +60,15 @@ struct EntityDefinitionClassInfo {
 
   std::vector<std::shared_ptr<Assets::PropertyDefinition>> propertyDefinitions;
   std::vector<std::string> superClasses;
+
+  kdl_reflect_decl(
+    EntityDefinitionClassInfo, type, line, column, name, description, color, size, modelDefinition,
+    propertyDefinitions, superClasses);
 };
 
 bool addPropertyDefinition(
   std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDefinitions,
   std::shared_ptr<Assets::PropertyDefinition> propertyDefinition);
 
-bool operator==(const EntityDefinitionClassInfo& lhs, const EntityDefinitionClassInfo& rhs);
-bool operator!=(const EntityDefinitionClassInfo& lhs, const EntityDefinitionClassInfo& rhs);
-
-std::ostream& operator<<(std::ostream& str, const EntityDefinitionClassInfo& classInfo);
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/src/IO/ExportOptions.cpp
+++ b/common/src/IO/ExportOptions.cpp
@@ -22,25 +22,14 @@
 #include "Macros.h"
 
 #include <kdl/overload.h>
+#include <kdl/reflection_impl.h>
 
 #include <ostream>
 
 namespace TrenchBroom {
 namespace IO {
-bool operator==(const MapExportOptions& lhs, const MapExportOptions& rhs) {
-  return lhs.exportPath == rhs.exportPath;
-}
 
-bool operator!=(const MapExportOptions& lhs, const MapExportOptions& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& lhs, const MapExportOptions& rhs) {
-  lhs << "MapExportOptions{";
-  lhs << "exportPath: " << rhs.exportPath;
-  lhs << "}";
-  return lhs;
-}
+kdl_reflect_impl(MapExportOptions);
 
 std::ostream& operator<<(std::ostream& lhs, const ObjMtlPathMode rhs) {
   switch (rhs) {
@@ -55,21 +44,7 @@ std::ostream& operator<<(std::ostream& lhs, const ObjMtlPathMode rhs) {
   return lhs;
 }
 
-bool operator==(const ObjExportOptions& lhs, const ObjExportOptions& rhs) {
-  return lhs.exportPath == rhs.exportPath && lhs.mtlPathMode == rhs.mtlPathMode;
-}
-
-bool operator!=(const ObjExportOptions& lhs, const ObjExportOptions& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& lhs, const ObjExportOptions& rhs) {
-  lhs << "ObjExportOptions{";
-  lhs << "exportPath: " << rhs.exportPath << ", ";
-  lhs << "mtlPathMode: " << rhs.mtlPathMode;
-  lhs << "}";
-  return lhs;
-}
+kdl_reflect_impl(ObjExportOptions);
 
 std::ostream& operator<<(std::ostream& lhs, const ExportOptions& rhs) {
   std::visit(

--- a/common/src/IO/ExportOptions.h
+++ b/common/src/IO/ExportOptions.h
@@ -22,18 +22,17 @@
 
 #include "IO/Path.h"
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <variant>
 
 namespace TrenchBroom {
 namespace IO {
 struct MapExportOptions {
   Path exportPath;
-};
 
-bool operator==(const MapExportOptions& lhs, const MapExportOptions& rhs);
-bool operator!=(const MapExportOptions& lhs, const MapExportOptions& rhs);
-std::ostream& operator<<(std::ostream& lhs, const MapExportOptions& rhs);
+  kdl_reflect_decl(MapExportOptions, exportPath);
+};
 
 enum class ObjMtlPathMode {
   RelativeToGamePath,
@@ -45,11 +44,9 @@ std::ostream& operator<<(std::ostream& lhs, ObjMtlPathMode rhs);
 struct ObjExportOptions {
   Path exportPath;
   ObjMtlPathMode mtlPathMode;
-};
 
-bool operator==(const ObjExportOptions& lhs, const ObjExportOptions& rhs);
-bool operator!=(const ObjExportOptions& lhs, const ObjExportOptions& rhs);
-std::ostream& operator<<(std::ostream& lhs, const ObjExportOptions& rhs);
+  kdl_reflect_decl(ObjExportOptions, exportPath, mtlPathMode);
+};
 
 using ExportOptions = std::variant<MapExportOptions, ObjExportOptions>;
 

--- a/common/src/Model/BezierPatch.cpp
+++ b/common/src/Model/BezierPatch.cpp
@@ -22,11 +22,13 @@
 #include "Assets/Texture.h"
 #include "Ensure.h"
 
+#include <vecmath/bbox_io.h>
 #include <vecmath/bezier_surface.h>
 #include <vecmath/vec_io.h>
 
+#include <kdl/reflection_impl.h>
+
 #include <cassert>
-#include <iostream>
 
 namespace TrenchBroom {
 namespace Model {
@@ -275,29 +277,7 @@ std::vector<BezierPatch::Point> BezierPatch::evaluate(const size_t subdivisionsP
   return grid;
 }
 
-std::ostream& operator<<(std::ostream& str, const BezierPatch& patch) {
-  str << "BezierPatch{rowCount: " << patch.pointRowCount()
-      << ", columnCount: " << patch.pointColumnCount() << ", controlPoints: {";
+kdl_reflect_impl(BezierPatch);
 
-  const auto& controlPoints = patch.controlPoints();
-  for (size_t i = 0; i < controlPoints.size(); ++i) {
-    str << "{" << controlPoints[i] << "}";
-    if (i < controlPoints.size() - 1u) {
-      str << ", ";
-    }
-  }
-  str << "}}";
-  return str;
-}
-
-bool operator==(const BezierPatch& lhs, const BezierPatch& rhs) {
-  return lhs.pointRowCount() == rhs.pointRowCount() &&
-         lhs.pointColumnCount() == rhs.pointColumnCount() &&
-         lhs.controlPoints() == rhs.controlPoints();
-}
-
-bool operator!=(const BezierPatch& lhs, const BezierPatch& rhs) {
-  return !(lhs == rhs);
-}
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/BezierPatch.h
+++ b/common/src/Model/BezierPatch.h
@@ -26,7 +26,8 @@
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <string>
 #include <vector>
 
@@ -85,11 +86,10 @@ public:
   void transform(const vm::mat4x4& transformation);
 
   std::vector<Point> evaluate(size_t subdivisionsPerSurface) const;
+
+  kdl_reflect_decl(
+    BezierPatch, m_pointRowCount, m_pointColumnCount, m_bounds, m_controlPoints, m_textureName);
 };
 
-std::ostream& operator<<(std::ostream& str, const BezierPatch& patch);
-
-bool operator==(const BezierPatch& lhs, const BezierPatch& rhs);
-bool operator!=(const BezierPatch& lhs, const BezierPatch& rhs);
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -33,6 +33,7 @@
 #include "Polyhedron.h"
 
 #include <kdl/overload.h>
+#include <kdl/reflection_impl.h>
 #include <kdl/result.h>
 #include <kdl/string_utils.h>
 
@@ -40,6 +41,7 @@
 #include <vecmath/intersection.h>
 #include <vecmath/mat.h>
 #include <vecmath/plane.h>
+#include <vecmath/plane_io.h>
 #include <vecmath/polygon.h>
 #include <vecmath/scalar.h>
 #include <vecmath/util.h>
@@ -109,6 +111,8 @@ void swap(BrushFace& lhs, BrushFace& rhs) noexcept {
 }
 
 BrushFace::~BrushFace() = default;
+
+kdl_reflect_impl(BrushFace);
 
 kdl::result<BrushFace, BrushError> BrushFace::create(
   const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2,
@@ -190,22 +194,6 @@ BrushFace::BrushFace(
   , m_selected(false)
   , m_markedToRenderFace(false) {
   ensure(m_texCoordSystem != nullptr, "texCoordSystem is null");
-}
-
-bool operator==(const BrushFace& lhs, const BrushFace& rhs) {
-  return lhs.m_points == rhs.m_points && lhs.m_boundary == rhs.m_boundary &&
-         lhs.m_attributes == rhs.m_attributes && *lhs.m_texCoordSystem == *rhs.m_texCoordSystem &&
-         lhs.m_lineNumber == rhs.m_lineNumber && lhs.m_lineCount == rhs.m_lineCount &&
-         lhs.m_selected == rhs.m_selected;
-}
-
-bool operator!=(const BrushFace& lhs, const BrushFace& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const BrushFace& face) {
-  str << "{ " << face.m_points[0] << ", " << face.m_points[1] << ", " << face.m_points[2] << " }";
-  return str;
 }
 
 void BrushFace::sortFaces(std::vector<BrushFace>& faces) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -26,6 +26,7 @@
 #include "Model/BrushGeometry.h"
 #include "Model/Tag.h" // BrushFace inherits from Taggable
 
+#include <kdl/reflection_decl.h>
 #include <kdl/result_forward.h>
 #include <kdl/transform_range.h>
 
@@ -34,7 +35,6 @@
 #include <vecmath/vec.h>
 
 #include <array>
-#include <iosfwd>
 #include <memory>
 #include <string>
 #include <vector>
@@ -109,13 +109,15 @@ public:
 
   ~BrushFace();
 
+  kdl_reflect_decl(BrushFace, m_points, m_boundary, m_attributes, m_textureReference);
+
   /**
    * Creates a face using TB's default texture projection for the given map format and the given
    * plane.
    *
    * Used when creating new faces when we don't have a particular texture alignment to request.
-   * On Valve format maps, this differs from createFromStandard() by creating a face-aligned texture
-   * projection, whereas createFromStandard() creates an axis-aligned texture projection.
+   * On Valve format maps, this differs from createFromStandard() by creating a face-aligned
+   * texture projection, whereas createFromStandard() creates an axis-aligned texture projection.
    *
    * The returned face has a TexCoordSystem matching the given format.
    */
@@ -153,10 +155,6 @@ public:
   BrushFace(
     const BrushFace::Points& points, const vm::plane3& boundary,
     const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
-
-  friend bool operator==(const BrushFace& lhs, const BrushFace& rhs);
-  friend bool operator!=(const BrushFace& lhs, const BrushFace& rhs);
-  friend std::ostream& operator<<(std::ostream& str, const BrushFace& face);
 
   static void sortFaces(std::vector<BrushFace>& faces);
 
@@ -263,5 +261,6 @@ private: // implement Taggable interface
   void doAcceptTagVisitor(TagVisitor& visitor) override;
   void doAcceptTagVisitor(ConstTagVisitor& visitor) const override;
 };
+
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -23,7 +23,7 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
-#include <kdl/opt_utils.h>
+#include <kdl/optional_io.h>
 
 #include <ostream>
 #include <string>
@@ -83,10 +83,10 @@ std::ostream& operator<<(std::ostream& str, const BrushFaceAttributes& attrs) {
       << "offset: " << attrs.m_offset << ", "
       << "scale: " << attrs.m_scale << ", "
       << "rotation: " << attrs.m_rotation << ", "
-      << "surfaceContents: " << kdl::opt_to_string(attrs.m_surfaceContents) << ", "
-      << "surfaceFlags: " << kdl::opt_to_string(attrs.m_surfaceFlags) << ", "
-      << "surfaceValue: " << kdl::opt_to_string(attrs.m_surfaceValue) << ", "
-      << "color: " << kdl::opt_to_string(attrs.m_color) << "}";
+      << "surfaceContents: " << kdl::make_streamable(attrs.m_surfaceContents) << ", "
+      << "surfaceFlags: " << kdl::make_streamable(attrs.m_surfaceFlags) << ", "
+      << "surfaceValue: " << kdl::make_streamable(attrs.m_surfaceValue) << ", "
+      << "color: " << kdl::make_streamable(attrs.m_color) << "}";
   return str;
 }
 

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -23,9 +23,8 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
-#include <kdl/optional_io.h>
+#include <kdl/reflection_impl.h>
 
-#include <ostream>
 #include <string>
 
 namespace TrenchBroom {
@@ -65,30 +64,7 @@ BrushFaceAttributes& BrushFaceAttributes::operator=(BrushFaceAttributes other) {
   return *this;
 }
 
-bool operator==(const BrushFaceAttributes& lhs, const BrushFaceAttributes& rhs) {
-  return (
-    lhs.m_textureName == rhs.m_textureName && lhs.m_offset == rhs.m_offset &&
-    lhs.m_scale == rhs.m_scale && lhs.m_rotation == rhs.m_rotation &&
-    lhs.m_surfaceContents == rhs.m_surfaceContents && lhs.m_surfaceFlags == rhs.m_surfaceFlags &&
-    lhs.m_surfaceValue == rhs.m_surfaceValue && lhs.m_color == rhs.m_color);
-}
-
-bool operator!=(const BrushFaceAttributes& lhs, const BrushFaceAttributes& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const BrushFaceAttributes& attrs) {
-  str << "BrushFaceAttributes{"
-      << "textureName: " << attrs.m_textureName << ", "
-      << "offset: " << attrs.m_offset << ", "
-      << "scale: " << attrs.m_scale << ", "
-      << "rotation: " << attrs.m_rotation << ", "
-      << "surfaceContents: " << kdl::make_streamable(attrs.m_surfaceContents) << ", "
-      << "surfaceFlags: " << kdl::make_streamable(attrs.m_surfaceFlags) << ", "
-      << "surfaceValue: " << kdl::make_streamable(attrs.m_surfaceValue) << ", "
-      << "color: " << kdl::make_streamable(attrs.m_color) << "}";
-  return str;
-}
+kdl_reflect_impl(BrushFaceAttributes);
 
 void swap(BrushFaceAttributes& lhs, BrushFaceAttributes& rhs) {
   using std::swap;

--- a/common/src/Model/BrushFaceAttributes.h
+++ b/common/src/Model/BrushFaceAttributes.h
@@ -23,7 +23,8 @@
 
 #include <vecmath/forward.h>
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <optional>
 #include <string>
 #include <string_view>
@@ -34,6 +35,7 @@ class Texture;
 }
 
 namespace Model {
+
 class BrushFaceAttributes {
 public:
   static const std::string NoTextureName;
@@ -58,9 +60,10 @@ public:
 
   BrushFaceAttributes& operator=(BrushFaceAttributes other);
 
-  friend bool operator==(const BrushFaceAttributes& lhs, const BrushFaceAttributes& rhs);
-  friend bool operator!=(const BrushFaceAttributes& lhs, const BrushFaceAttributes& rhs);
-  friend std::ostream& operator<<(std::ostream& str, const BrushFaceAttributes& attrs);
+  kdl_reflect_decl(
+    BrushFaceAttributes, m_textureName, m_offset, m_scale, m_rotation, m_surfaceContents,
+    m_surfaceFlags, m_surfaceValue, m_color);
+
   friend void swap(BrushFaceAttributes& lhs, BrushFaceAttributes& rhs);
 
   const std::string& textureName() const;
@@ -99,5 +102,6 @@ public:
   bool setSurfaceValue(const std::optional<float>& surfaceValue);
   bool setColor(const std::optional<Color>& color);
 };
+
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/BrushFaceHandle.cpp
+++ b/common/src/Model/BrushFaceHandle.cpp
@@ -23,9 +23,8 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include "Model/Brush.h"
 #include "Model/BrushNode.h"
 
+#include <kdl/reflection_impl.h>
 #include <kdl/vector_utils.h>
-
-#include <ostream>
 
 namespace TrenchBroom {
 namespace Model {
@@ -48,20 +47,7 @@ const BrushFace& BrushFaceHandle::face() const {
   return m_node->brush().face(m_faceIndex);
 }
 
-bool operator==(const BrushFaceHandle& lhs, const BrushFaceHandle& rhs) {
-  return lhs.m_node == rhs.m_node && lhs.m_faceIndex == rhs.m_faceIndex;
-}
-
-bool operator!=(const BrushFaceHandle& lhs, const BrushFaceHandle& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& lhs, const BrushFaceHandle& rhs) {
-  lhs << "BrushFaceHandle{";
-  lhs << "node: " << rhs.m_node << ", ";
-  lhs << "faceIndex: " << rhs.m_faceIndex << ";";
-  return lhs;
-}
+kdl_reflect_impl(BrushFaceHandle);
 
 std::vector<BrushNode*> toNodes(const std::vector<BrushFaceHandle>& handles) {
   return kdl::vec_transform(handles, [](const auto& handle) {

--- a/common/src/Model/BrushFaceHandle.h
+++ b/common/src/Model/BrushFaceHandle.h
@@ -19,7 +19,8 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <vector>
 
 namespace TrenchBroom {
@@ -63,17 +64,7 @@ public:
    */
   const BrushFace& face() const;
 
-  /**
-   * Returns true if the given handles represent the same face.
-   */
-  friend bool operator==(const BrushFaceHandle& lhs, const BrushFaceHandle& rhs);
-
-  /**
-   * Returns true if the given handles do not represent the same face.
-   */
-  friend bool operator!=(const BrushFaceHandle& lhs, const BrushFaceHandle& rhs);
-
-  friend std::ostream& operator<<(std::ostream& lhs, const BrushFaceHandle& rhs);
+  kdl_reflect_decl(BrushFaceHandle, m_node, m_faceIndex);
 };
 
 /**

--- a/common/src/Model/CompilationConfig.cpp
+++ b/common/src/Model/CompilationConfig.cpp
@@ -23,7 +23,8 @@
 #include "Model/CompilationProfile.h"
 
 #include <kdl/deref_iterator.h>
-#include <kdl/string_utils.h>
+#include <kdl/reflection_impl.h>
+#include <kdl/struct_io.h>
 #include <kdl/vector_utils.h>
 
 #include <ostream>
@@ -57,15 +58,7 @@ void swap(CompilationConfig& lhs, CompilationConfig& rhs) {
 }
 
 bool operator==(const CompilationConfig& lhs, const CompilationConfig& rhs) {
-  if (lhs.m_profiles.size() != rhs.m_profiles.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < lhs.m_profiles.size(); ++i) {
-    if (*lhs.m_profiles[i] != *rhs.m_profiles[i]) {
-      return false;
-    }
-  }
-  return true;
+  return kdl::const_deref_range{lhs.m_profiles} == kdl::const_deref_range{rhs.m_profiles};
 }
 
 bool operator!=(const CompilationConfig& lhs, const CompilationConfig& rhs) {
@@ -73,8 +66,8 @@ bool operator!=(const CompilationConfig& lhs, const CompilationConfig& rhs) {
 }
 
 std::ostream& operator<<(std::ostream& str, const CompilationConfig& config) {
-  str << "CompilationConfig{"
-      << "profiles: [" << kdl::str_join(kdl::const_deref_range{config.m_profiles}) << "]}";
+  kdl::struct_stream{str} << "CompilationConfig"
+                          << "m_profiles" << kdl::const_deref_range{config.m_profiles};
   return str;
 }
 

--- a/common/src/Model/CompilationProfile.cpp
+++ b/common/src/Model/CompilationProfile.cpp
@@ -23,7 +23,7 @@
 #include "Model/CompilationTask.h"
 
 #include <kdl/deref_iterator.h>
-#include <kdl/string_utils.h>
+#include <kdl/struct_io.h>
 #include <kdl/vector_utils.h>
 
 #include <ostream>
@@ -62,15 +62,7 @@ bool operator==(const CompilationProfile& lhs, const CompilationProfile& rhs) {
   if (lhs.m_workDirSpec != rhs.m_workDirSpec) {
     return false;
   }
-  if (lhs.m_tasks.size() != rhs.m_tasks.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < lhs.m_tasks.size(); ++i) {
-    if (*lhs.m_tasks[i] != *rhs.m_tasks[i]) {
-      return false;
-    }
-  }
-  return true;
+  return kdl::const_deref_range{lhs.m_tasks} == kdl::const_deref_range{rhs.m_tasks};
 }
 
 bool operator!=(const CompilationProfile& lhs, const CompilationProfile& rhs) {
@@ -78,10 +70,9 @@ bool operator!=(const CompilationProfile& lhs, const CompilationProfile& rhs) {
 }
 
 std::ostream& operator<<(std::ostream& str, const CompilationProfile& profile) {
-  str << "CompilationProfile{"
-      << "name: " << profile.m_name << ", "
-      << "workDirSpec: " << profile.m_workDirSpec << ", "
-      << "tasks: [" << kdl::str_join(kdl::const_deref_range{profile.m_tasks}) << "]}";
+  kdl::struct_stream{str} << "CompilationProfile"
+                          << "m_name" << profile.m_name << "m_workDirSpec" << profile.m_workDirSpec
+                          << "m_tasks" << kdl::const_deref_range{profile.m_tasks};
   return str;
 }
 

--- a/common/src/Model/CompilationTask.cpp
+++ b/common/src/Model/CompilationTask.cpp
@@ -19,7 +19,8 @@
 
 #include "CompilationTask.h"
 
-#include <ostream>
+#include <kdl/struct_io.h>
+
 #include <string>
 
 namespace TrenchBroom {
@@ -97,9 +98,8 @@ bool CompilationExportMap::operator==(const CompilationTask& other) const {
 }
 
 void CompilationExportMap::appendToStream(std::ostream& str) const {
-  str << "CompilationExportMap{"
-      << "enabled: " << m_enabled << ", "
-      << "targetSpec: " << m_targetSpec << "}";
+  kdl::struct_stream{str} << "CompilationExportMap"
+                          << "m_enabled" << m_enabled << "m_targetSpec" << m_targetSpec;
 }
 
 // CompilationCopyFiles
@@ -164,10 +164,9 @@ bool CompilationCopyFiles::operator==(const CompilationTask& other) const {
 }
 
 void CompilationCopyFiles::appendToStream(std::ostream& str) const {
-  str << "CompilationCopyFiles{"
-      << "enabled: " << m_enabled << ", "
-      << "sourceSpec: " << m_sourceSpec << ", "
-      << "targetSpec: " << m_targetSpec << "}";
+  kdl::struct_stream{str} << "CompilationCopyFiles"
+                          << "m_enabled" << m_enabled << "m_sourceSpec" << m_sourceSpec
+                          << "m_targetSpec" << m_targetSpec;
 }
 
 // CompilationRunTool
@@ -232,10 +231,9 @@ bool CompilationRunTool::operator==(const CompilationTask& other) const {
 }
 
 void CompilationRunTool::appendToStream(std::ostream& str) const {
-  str << "CompilationRunTool{"
-      << "enabled: " << m_enabled << ", "
-      << "toolSpec: " << m_toolSpec << ", "
-      << "parameterSpec: << " << m_parameterSpec << "}";
+  kdl::struct_stream{str} << "CompilationRunTool"
+                          << "m_enabled" << m_enabled << "m_toolSpec" << m_toolSpec
+                          << "m_parameterSpec" << m_parameterSpec;
 }
 
 CompilationTaskVisitor::~CompilationTaskVisitor() = default;

--- a/common/src/Model/EntityNodeBase.cpp
+++ b/common/src/Model/EntityNodeBase.cpp
@@ -163,11 +163,10 @@ void EntityNodeBase::updatePropertyIndex(
     const EntityProperty& oldProp = *oldIt;
     const EntityProperty& newProp = *newIt;
 
-    const int cmp = oldProp.compare(newProp);
-    if (cmp < 0) {
+    if (oldProp < newProp) {
       removePropertyFromIndex(oldProp.key(), oldProp.value());
       ++oldIt;
-    } else if (cmp > 0) {
+    } else if (oldProp > newProp) {
       addPropertyToIndex(newProp.key(), newProp.value());
       ++newIt;
     } else {
@@ -202,11 +201,10 @@ void EntityNodeBase::updateLinks(
     const EntityProperty& oldProp = *oldIt;
     const EntityProperty& newProp = *newIt;
 
-    const int cmp = oldProp.compare(newProp);
-    if (cmp < 0) {
+    if (oldProp < newProp) {
       removeLinks(oldProp.key(), oldProp.value());
       ++oldIt;
-    } else if (cmp > 0) {
+    } else if (oldProp > newProp) {
       addLinks(newProp.key(), newProp.value());
       ++newIt;
     } else {

--- a/common/src/Model/EntityProperties.cpp
+++ b/common/src/Model/EntityProperties.cpp
@@ -21,7 +21,7 @@
 
 #include "Assets/EntityDefinition.h"
 
-#include <kdl/opt_utils.h>
+#include <kdl/optional_io.h>
 #include <kdl/string_compare.h>
 #include <kdl/vector_set.h>
 
@@ -89,7 +89,7 @@ bool operator!=(const EntityPropertyConfig& lhs, const EntityPropertyConfig& rhs
 
 std::ostream& operator<<(std::ostream& lhs, const EntityPropertyConfig& rhs) {
   lhs << "EntityPropertyConfig{";
-  lhs << "defaultModelScaleExpression=" << kdl::opt_to_string(rhs.defaultModelScaleExpression);
+  lhs << "defaultModelScaleExpression=" << kdl::make_streamable(rhs.defaultModelScaleExpression);
   lhs << "}";
   return lhs;
 }

--- a/common/src/Model/EntityProperties.cpp
+++ b/common/src/Model/EntityProperties.cpp
@@ -21,11 +21,10 @@
 
 #include "Assets/EntityDefinition.h"
 
-#include <kdl/optional_io.h>
+#include <kdl/reflection_impl.h>
 #include <kdl/string_compare.h>
 #include <kdl/vector_set.h>
 
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -79,20 +78,7 @@ const std::string LayerHiddenValue = "1";
 const std::string LayerOmitFromExportValue = "1";
 } // namespace EntityPropertyValues
 
-bool operator==(const EntityPropertyConfig& lhs, const EntityPropertyConfig& rhs) {
-  return lhs.defaultModelScaleExpression == rhs.defaultModelScaleExpression;
-}
-
-bool operator!=(const EntityPropertyConfig& lhs, const EntityPropertyConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& lhs, const EntityPropertyConfig& rhs) {
-  lhs << "EntityPropertyConfig{";
-  lhs << "defaultModelScaleExpression=" << kdl::make_streamable(rhs.defaultModelScaleExpression);
-  lhs << "}";
-  return lhs;
-}
+kdl_reflect_impl(EntityPropertyConfig);
 
 bool isNumberedProperty(std::string_view prefix, std::string_view key) {
   // %* matches 0 or more digits
@@ -106,12 +92,7 @@ EntityProperty::EntityProperty(const std::string& key, const std::string& value)
   : m_key(key)
   , m_value(value) {}
 
-int EntityProperty::compare(const EntityProperty& rhs) const {
-  const int keyCmp = m_key.compare(rhs.m_key);
-  if (keyCmp != 0)
-    return keyCmp;
-  return m_value.compare(rhs.m_value);
-}
+kdl_reflect_impl(EntityProperty);
 
 const std::string& EntityProperty::key() const {
   return m_key;
@@ -157,35 +138,6 @@ void EntityProperty::setKey(const std::string& key) {
 
 void EntityProperty::setValue(const std::string& value) {
   m_value = value;
-}
-
-bool operator<(const EntityProperty& lhs, const EntityProperty& rhs) {
-  return lhs.compare(rhs) < 0;
-}
-
-bool operator<=(const EntityProperty& lhs, const EntityProperty& rhs) {
-  return lhs.compare(rhs) <= 0;
-}
-
-bool operator>(const EntityProperty& lhs, const EntityProperty& rhs) {
-  return lhs.compare(rhs) > 0;
-}
-
-bool operator>=(const EntityProperty& lhs, const EntityProperty& rhs) {
-  return lhs.compare(rhs) >= 0;
-}
-
-bool operator==(const EntityProperty& lhs, const EntityProperty& rhs) {
-  return lhs.compare(rhs) == 0;
-}
-
-bool operator!=(const EntityProperty& lhs, const EntityProperty& rhs) {
-  return lhs.compare(rhs) != 0;
-}
-
-std::ostream& operator<<(std::ostream& str, const EntityProperty& prop) {
-  str << "{ key: " << prop.key() << ", value: " << prop.value() << " }";
-  return str;
 }
 
 bool isLayer(const std::string& classname, const std::vector<EntityProperty>& properties) {

--- a/common/src/Model/EntityProperties.h
+++ b/common/src/Model/EntityProperties.h
@@ -21,7 +21,8 @@
 
 #include "EL/Expression.h"
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -78,12 +79,9 @@ extern const std::string LayerOmitFromExportValue;
 
 struct EntityPropertyConfig {
   std::optional<EL::Expression> defaultModelScaleExpression;
+
+  kdl_reflect_decl(EntityPropertyConfig, defaultModelScaleExpression);
 };
-
-bool operator==(const EntityPropertyConfig& lhs, const EntityPropertyConfig& rhs);
-bool operator!=(const EntityPropertyConfig& lhs, const EntityPropertyConfig& rhs);
-
-std::ostream& operator<<(std::ostream& lhs, const EntityPropertyConfig& rhs);
 
 bool isNumberedProperty(std::string_view prefix, std::string_view key);
 
@@ -96,7 +94,7 @@ public:
   EntityProperty();
   EntityProperty(const std::string& key, const std::string& value);
 
-  int compare(const EntityProperty& rhs) const;
+  kdl_reflect_decl(EntityProperty, m_key, m_value);
 
   const std::string& key() const;
   const std::string& value() const;
@@ -112,14 +110,6 @@ public:
   void setKey(const std::string& key);
   void setValue(const std::string& value);
 };
-
-bool operator<(const EntityProperty& lhs, const EntityProperty& rhs);
-bool operator<=(const EntityProperty& lhs, const EntityProperty& rhs);
-bool operator>(const EntityProperty& lhs, const EntityProperty& rhs);
-bool operator>=(const EntityProperty& lhs, const EntityProperty& rhs);
-bool operator==(const EntityProperty& lhs, const EntityProperty& rhs);
-bool operator!=(const EntityProperty& lhs, const EntityProperty& rhs);
-std::ostream& operator<<(std::ostream& str, const EntityProperty& prop);
 
 bool isLayer(const std::string& classname, const std::vector<EntityProperty>& properties);
 bool isGroup(const std::string& classname, const std::vector<EntityProperty>& properties);

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -22,7 +22,7 @@
 #include "Ensure.h"
 #include "IO/DiskFileSystem.h"
 
-#include <kdl/opt_utils.h>
+#include <kdl/optional_io.h>
 #include <kdl/overload.h>
 #include <kdl/string_utils.h>
 
@@ -167,7 +167,7 @@ std::ostream& operator<<(std::ostream& str, const EntityConfig& config) {
       << "defFilePaths: [" << kdl::str_join(config.defFilePaths) << "], "
       << "modelFormats: [" << kdl::str_join(config.modelFormats) << "], "
       << "defaultColor: " << config.defaultColor << ", "
-      << "scaleExpression: " << kdl::opt_to_string(config.scaleExpression) << "}";
+      << "scaleExpression: " << kdl::make_streamable(config.scaleExpression) << "}";
   return str;
 }
 
@@ -310,7 +310,7 @@ std::ostream& operator<<(std::ostream& str, const GameConfig& config) {
       << "  compilationConfig: " << config.compilationConfig << ",\n"
       << "  gameEngineConfig: " << config.gameEngineConfig << ",\n"
       << "  maxPropertyLength: " << config.maxPropertyLength << ",\n"
-      << "  softMapBounds: " << kdl::opt_to_string(config.softMapBounds) << ",\n"
+      << "  softMapBounds: " << kdl::make_streamable(config.softMapBounds) << ",\n"
       << "  compilationTools: [" << kdl::str_join(config.compilationTools) << "]}\n";
   return str;
 }

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -22,8 +22,8 @@
 #include "Ensure.h"
 #include "IO/DiskFileSystem.h"
 
-#include <kdl/optional_io.h>
 #include <kdl/overload.h>
+#include <kdl/reflection_impl.h>
 #include <kdl/string_utils.h>
 
 #include <vecmath/bbox_io.h>
@@ -36,80 +36,16 @@
 
 namespace TrenchBroom {
 namespace Model {
-bool operator==(const MapFormatConfig& lhs, const MapFormatConfig& rhs) {
-  return lhs.format == rhs.format && lhs.initialMap == rhs.initialMap;
-}
 
-bool operator!=(const MapFormatConfig& lhs, const MapFormatConfig& rhs) {
-  return !(lhs == rhs);
-}
+kdl_reflect_impl(MapFormatConfig);
 
-std::ostream& operator<<(std::ostream& str, const MapFormatConfig& config) {
-  str << "MapFormatConfig{"
-      << "format: " << config.format << ", "
-      << "initialMap: " << config.initialMap << "}";
-  return str;
-}
+kdl_reflect_impl(PackageFormatConfig);
 
-bool operator==(const PackageFormatConfig& lhs, const PackageFormatConfig& rhs) {
-  return lhs.extensions == rhs.extensions && lhs.format == rhs.format;
-}
+kdl_reflect_impl(FileSystemConfig);
 
-bool operator!=(const PackageFormatConfig& lhs, const PackageFormatConfig& rhs) {
-  return !(lhs == rhs);
-}
+kdl_reflect_impl(TextureFilePackageConfig);
 
-std::ostream& operator<<(std::ostream& str, const PackageFormatConfig& config) {
-  str << "PackageFormatConfig{"
-      << "extensions: [" << kdl::str_join(config.extensions) << "], "
-      << "format: " << config.format << "}";
-  return str;
-}
-
-bool operator==(const FileSystemConfig& lhs, const FileSystemConfig& rhs) {
-  return lhs.searchPath == rhs.searchPath && lhs.packageFormat == rhs.packageFormat;
-}
-
-bool operator!=(const FileSystemConfig& lhs, const FileSystemConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const FileSystemConfig& config) {
-  str << "FileSystemConfig{"
-      << "searchPath: " << config.searchPath << ", "
-      << "packageFormat: " << config.packageFormat << "}";
-  return str;
-}
-
-bool operator==(const TextureFilePackageConfig& lhs, const TextureFilePackageConfig& rhs) {
-  return lhs.fileFormat == rhs.fileFormat;
-}
-
-bool operator!=(const TextureFilePackageConfig& lhs, const TextureFilePackageConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const TextureFilePackageConfig& config) {
-  str << "TextureFilePackageConfig{"
-      << "fileFormat: " << config.fileFormat << "}";
-  return str;
-}
-
-bool operator==(
-  const TextureDirectoryPackageConfig& lhs, const TextureDirectoryPackageConfig& rhs) {
-  return lhs.rootDirectory == rhs.rootDirectory;
-}
-
-bool operator!=(
-  const TextureDirectoryPackageConfig& lhs, const TextureDirectoryPackageConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const TextureDirectoryPackageConfig& config) {
-  str << "TextureDirectoryPackageConfig{"
-      << "rootDirectory: " << config.rootDirectory << "}";
-  return str;
-}
+kdl_reflect_impl(TextureDirectoryPackageConfig);
 
 std::ostream& operator<<(std::ostream& str, const TexturePackageConfig& config) {
   std::visit(
@@ -132,60 +68,13 @@ IO::Path getRootDirectory(const TexturePackageConfig& texturePackageConfig) {
     texturePackageConfig);
 }
 
-bool operator==(const TextureConfig& lhs, const TextureConfig& rhs) {
-  return lhs.package == rhs.package && lhs.format == rhs.format && lhs.palette == rhs.palette &&
-         lhs.property == rhs.property && lhs.shaderSearchPath == rhs.shaderSearchPath &&
-         lhs.excludes == rhs.excludes;
-}
+kdl_reflect_impl(TextureConfig);
 
-bool operator!=(const TextureConfig& lhs, const TextureConfig& rhs) {
-  return !(lhs == rhs);
-}
+kdl_reflect_impl(EntityConfig);
 
-std::ostream& operator<<(std::ostream& str, const TextureConfig& config) {
-  str << "TextureConfig{"
-      << "package: " << config.package << ", "
-      << "format: " << config.format << ", "
-      << "palette: " << config.palette << ", "
-      << "property: " << config.property << ", "
-      << "shaderSearchPath: " << config.shaderSearchPath << ", "
-      << "excludes: [" << kdl::str_join(config.excludes) << "]}";
-  return str;
-}
+kdl_reflect_impl(FlagConfig);
 
-bool operator==(const EntityConfig& lhs, const EntityConfig& rhs) {
-  return lhs.defFilePaths == rhs.defFilePaths && lhs.modelFormats == rhs.modelFormats &&
-         lhs.defaultColor == rhs.defaultColor && lhs.scaleExpression == rhs.scaleExpression;
-}
-
-bool operator!=(const EntityConfig& lhs, const EntityConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const EntityConfig& config) {
-  str << "EntityConfig{"
-      << "defFilePaths: [" << kdl::str_join(config.defFilePaths) << "], "
-      << "modelFormats: [" << kdl::str_join(config.modelFormats) << "], "
-      << "defaultColor: " << config.defaultColor << ", "
-      << "scaleExpression: " << kdl::make_streamable(config.scaleExpression) << "}";
-  return str;
-}
-
-bool operator==(const FlagConfig& lhs, const FlagConfig& rhs) {
-  return lhs.name == rhs.name && lhs.description == rhs.description && lhs.value == rhs.value;
-}
-
-bool operator!=(const FlagConfig& lhs, const FlagConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const FlagConfig& config) {
-  str << "FlagConfig{"
-      << "name: " << config.name << ", "
-      << "description: " << config.description << ", "
-      << "value: " << config.value << "}";
-  return str;
-}
+kdl_reflect_impl(FlagsConfig);
 
 int FlagsConfig::flagValue(const std::string& flagName) const {
   for (size_t i = 0; i < flags.size(); ++i) {
@@ -215,51 +104,11 @@ std::vector<std::string> FlagsConfig::flagNames(const int mask) const {
   return names;
 }
 
-bool operator==(const FlagsConfig& lhs, const FlagsConfig& rhs) {
-  return lhs.flags == rhs.flags;
-}
+kdl_reflect_impl(FaceAttribsConfig);
 
-bool operator!=(const FlagsConfig& lhs, const FlagsConfig& rhs) {
-  return !(lhs == rhs);
-}
+kdl_reflect_impl(CompilationTool);
 
-std::ostream& operator<<(std::ostream& str, const FlagsConfig& config) {
-  str << "FlagsConfig{"
-      << "flags: [" << kdl::str_join(config.flags) << "]}";
-  return str;
-}
-
-bool operator==(const FaceAttribsConfig& lhs, const FaceAttribsConfig& rhs) {
-  return lhs.surfaceFlags == rhs.surfaceFlags && lhs.contentFlags == rhs.contentFlags &&
-         lhs.defaults == rhs.defaults;
-}
-
-bool operator!=(const FaceAttribsConfig& lhs, const FaceAttribsConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const FaceAttribsConfig& config) {
-  str << "FaceAttribsConfig{"
-      << "surfaceFlags: " << config.surfaceFlags << ", "
-      << "contentFlags: " << config.contentFlags << ", "
-      << "defaults: " << config.defaults << "}";
-  return str;
-}
-
-bool operator==(const CompilationTool& lhs, const CompilationTool& rhs) {
-  return lhs.name == rhs.name && lhs.description == rhs.description;
-}
-
-bool operator!=(const CompilationTool& lhs, const CompilationTool& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const CompilationTool& tool) {
-  str << "CompilationTool{"
-      << "name: " << tool.name << ", "
-      << "description: " << tool.description.value_or("") << "}";
-  return str;
-}
+kdl_reflect_impl(GameConfig);
 
 IO::Path GameConfig::findInitialMap(const std::string& formatName) const {
   for (const auto& format : fileFormats) {
@@ -276,43 +125,6 @@ IO::Path GameConfig::findInitialMap(const std::string& formatName) const {
 
 IO::Path GameConfig::findConfigFile(const IO::Path& filePath) const {
   return path.deleteLastComponent() + filePath;
-}
-
-bool operator==(const GameConfig& lhs, const GameConfig& rhs) {
-  return lhs.name == rhs.name && lhs.path == rhs.path && lhs.icon == rhs.icon &&
-         lhs.experimental == rhs.experimental && lhs.fileFormats == rhs.fileFormats &&
-         lhs.fileSystemConfig == rhs.fileSystemConfig && lhs.textureConfig == rhs.textureConfig &&
-         lhs.entityConfig == rhs.entityConfig && lhs.faceAttribsConfig == rhs.faceAttribsConfig &&
-         lhs.smartTags == rhs.smartTags && lhs.compilationConfig == rhs.compilationConfig &&
-         lhs.gameEngineConfig == rhs.gameEngineConfig &&
-         lhs.maxPropertyLength == rhs.maxPropertyLength && lhs.softMapBounds == rhs.softMapBounds &&
-         lhs.compilationConfigParseFailed == rhs.compilationConfigParseFailed &&
-         lhs.gameEngineConfigParseFailed == rhs.gameEngineConfigParseFailed &&
-         lhs.compilationTools == rhs.compilationTools;
-}
-
-bool operator!=(const GameConfig& lhs, const GameConfig& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const GameConfig& config) {
-  str << "GameConfig{\n"
-      << "  name: " << config.name << ",\n"
-      << "  path: " << config.path << ",\n"
-      << "  icon: " << config.icon << ",\n"
-      << "  experimental: " << config.experimental << ",\n"
-      << "  fileFormats: [" << kdl::str_join(config.fileFormats) << "],\n"
-      << "  fileSystemConfig: " << config.fileSystemConfig << ",\n"
-      << "  textureConfig: " << config.textureConfig << ",\n"
-      << "  entityConfig: " << config.entityConfig << ",\n"
-      << "  faceAttribsConfig: " << config.faceAttribsConfig << ",\n"
-      << "  smartTags: [" << kdl::str_join(config.smartTags) << "],\n"
-      << "  compilationConfig: " << config.compilationConfig << ",\n"
-      << "  gameEngineConfig: " << config.gameEngineConfig << ",\n"
-      << "  maxPropertyLength: " << config.maxPropertyLength << ",\n"
-      << "  softMapBounds: " << kdl::make_streamable(config.softMapBounds) << ",\n"
-      << "  compilationTools: [" << kdl::str_join(config.compilationTools) << "]}\n";
-  return str;
 }
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -30,7 +30,8 @@
 
 #include <vecmath/bbox.h>
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <optional>
 #include <set>
 #include <string>
@@ -42,45 +43,35 @@ namespace Model {
 struct MapFormatConfig {
   std::string format;
   IO::Path initialMap;
-};
 
-bool operator==(const MapFormatConfig& lhs, const MapFormatConfig& rhs);
-bool operator!=(const MapFormatConfig& lhs, const MapFormatConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const MapFormatConfig& config);
+  kdl_reflect_decl(MapFormatConfig, format, initialMap);
+};
 
 struct PackageFormatConfig {
   std::vector<std::string> extensions;
   std::string format;
-};
 
-bool operator==(const PackageFormatConfig& lhs, const PackageFormatConfig& rhs);
-bool operator!=(const PackageFormatConfig& lhs, const PackageFormatConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const PackageFormatConfig& config);
+  kdl_reflect_decl(PackageFormatConfig, extensions, format);
+};
 
 struct FileSystemConfig {
   IO::Path searchPath;
   PackageFormatConfig packageFormat;
-};
 
-bool operator==(const FileSystemConfig& lhs, const FileSystemConfig& rhs);
-bool operator!=(const FileSystemConfig& lhs, const FileSystemConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const FileSystemConfig& config);
+  kdl_reflect_decl(FileSystemConfig, searchPath, packageFormat);
+};
 
 struct TextureFilePackageConfig {
   PackageFormatConfig fileFormat;
-};
 
-bool operator==(const TextureFilePackageConfig& lhs, const TextureFilePackageConfig& rhs);
-bool operator!=(const TextureFilePackageConfig& lhs, const TextureFilePackageConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const TextureFilePackageConfig& config);
+  kdl_reflect_decl(TextureFilePackageConfig, fileFormat);
+};
 
 struct TextureDirectoryPackageConfig {
   IO::Path rootDirectory;
-};
 
-bool operator==(const TextureDirectoryPackageConfig& lhs, const TextureDirectoryPackageConfig& rhs);
-bool operator!=(const TextureDirectoryPackageConfig& lhs, const TextureDirectoryPackageConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const TextureDirectoryPackageConfig& config);
+  kdl_reflect_decl(TextureDirectoryPackageConfig, rootDirectory);
+};
 
 using TexturePackageConfig = std::variant<TextureFilePackageConfig, TextureDirectoryPackageConfig>;
 std::ostream& operator<<(std::ostream& str, const TexturePackageConfig& config);
@@ -94,63 +85,52 @@ struct TextureConfig {
   std::string property;
   IO::Path shaderSearchPath;
   std::vector<std::string> excludes; // Glob patterns used to match texture names for exclusion
-};
 
-bool operator==(const TextureConfig& lhs, const TextureConfig& rhs);
-bool operator!=(const TextureConfig& lhs, const TextureConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const TextureConfig& config);
+  kdl_reflect_decl(TextureConfig, package, format, palette, property, shaderSearchPath, excludes);
+};
 
 struct EntityConfig {
   std::vector<IO::Path> defFilePaths;
   std::vector<std::string> modelFormats;
   Color defaultColor;
   std::optional<EL::Expression> scaleExpression;
-};
 
-bool operator==(const EntityConfig& lhs, const EntityConfig& rhs);
-bool operator!=(const EntityConfig& lhs, const EntityConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const EntityConfig& config);
+  kdl_reflect_decl(EntityConfig, defFilePaths, modelFormats, defaultColor, scaleExpression);
+};
 
 struct FlagConfig {
   std::string name;
   std::string description;
   int value;
-};
 
-bool operator==(const FlagConfig& lhs, const FlagConfig& rhs);
-bool operator!=(const FlagConfig& lhs, const FlagConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const FlagConfig& config);
+  kdl_reflect_decl(FlagConfig, name, description, value);
+};
 
 struct FlagsConfig {
   std::vector<FlagConfig> flags;
+
+  kdl_reflect_decl(FlagsConfig, flags);
 
   int flagValue(const std::string& flagName) const;
   std::string flagName(size_t index) const;
   std::vector<std::string> flagNames(int mask = ~0) const;
 };
 
-bool operator==(const FlagsConfig& lhs, const FlagsConfig& rhs);
-bool operator!=(const FlagsConfig& lhs, const FlagsConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const FlagsConfig& config);
-
 struct FaceAttribsConfig {
   FlagsConfig surfaceFlags;
   FlagsConfig contentFlags;
+
+  kdl_reflect_decl(FaceAttribsConfig, surfaceFlags, contentFlags);
+
   BrushFaceAttributes defaults{BrushFaceAttributes::NoTextureName};
 };
-
-bool operator==(const FaceAttribsConfig& lhs, const FaceAttribsConfig& rhs);
-bool operator!=(const FaceAttribsConfig& lhs, const FaceAttribsConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const FaceAttribsConfig& config);
 
 struct CompilationTool {
   std::string name;
   std::optional<std::string> description;
-};
 
-bool operator==(const CompilationTool& lhs, const CompilationTool& rhs);
-bool operator!=(const CompilationTool& lhs, const CompilationTool& rhs);
-std::ostream& operator<<(std::ostream& str, const CompilationTool& tool);
+  kdl_reflect_decl(CompilationTool, name, description);
+};
 
 struct GameConfig {
   std::string name;
@@ -173,12 +153,13 @@ struct GameConfig {
 
   size_t maxPropertyLength{1023};
 
+  kdl_reflect_decl(
+    GameConfig, name, path, icon, experimental, fileFormats, fileSystemConfig, textureConfig,
+    entityConfig, faceAttribsConfig, smartTags, softMapBounds, compilationTools, compilationConfig,
+    gameEngineConfig, compilationConfigParseFailed, gameEngineConfigParseFailed, maxPropertyLength);
+
   IO::Path findInitialMap(const std::string& formatName) const;
   IO::Path findConfigFile(const IO::Path& filePath) const;
 };
-
-bool operator==(const GameConfig& lhs, const GameConfig& rhs);
-bool operator!=(const GameConfig& lhs, const GameConfig& rhs);
-std::ostream& operator<<(std::ostream& str, const GameConfig& config);
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/GameEngineConfig.cpp
+++ b/common/src/Model/GameEngineConfig.cpp
@@ -23,7 +23,7 @@
 #include "Model/GameEngineProfile.h"
 
 #include <kdl/deref_iterator.h>
-#include <kdl/string_utils.h>
+#include <kdl/struct_io.h>
 #include <kdl/vector_utils.h>
 
 #include <ostream>
@@ -87,15 +87,7 @@ void GameEngineConfig::removeProfile(const size_t index) {
 }
 
 bool operator==(const GameEngineConfig& lhs, const GameEngineConfig& rhs) {
-  if (lhs.m_profiles.size() != rhs.m_profiles.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < lhs.m_profiles.size(); ++i) {
-    if (*lhs.m_profiles[i] != *rhs.m_profiles[i]) {
-      return false;
-    }
-  }
-  return true;
+  return kdl::const_deref_range{lhs.m_profiles} == kdl::const_deref_range{rhs.m_profiles};
 }
 
 bool operator!=(const GameEngineConfig& lhs, const GameEngineConfig& rhs) {
@@ -103,8 +95,8 @@ bool operator!=(const GameEngineConfig& lhs, const GameEngineConfig& rhs) {
 }
 
 std::ostream& operator<<(std::ostream& str, const GameEngineConfig& config) {
-  str << "GameEngineConfig{"
-      << "profiles: [" << kdl::str_join(kdl::const_deref_range{config.m_profiles}) << "]};";
+  kdl::struct_stream{str} << "GameEngineConfig"
+                          << "m_tasks" << kdl::const_deref_range{config.m_profiles};
   return str;
 }
 } // namespace Model

--- a/common/src/Model/GameEngineProfile.cpp
+++ b/common/src/Model/GameEngineProfile.cpp
@@ -19,6 +19,8 @@
 
 #include "GameEngineProfile.h"
 
+#include <kdl/reflection_impl.h>
+
 #include <memory>
 #include <ostream>
 #include <string>
@@ -59,21 +61,7 @@ void GameEngineProfile::setParameterSpec(const std::string& parameterSpec) {
   m_parameterSpec = parameterSpec;
 }
 
-bool operator==(const GameEngineProfile& lhs, const GameEngineProfile& rhs) {
-  return lhs.m_name == rhs.m_name && lhs.m_path == rhs.m_path &&
-         lhs.m_parameterSpec == rhs.m_parameterSpec;
-}
+kdl_reflect_impl(GameEngineProfile);
 
-bool operator!=(const GameEngineProfile& lhs, const GameEngineProfile& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const GameEngineProfile& profile) {
-  str << "GameEngineProfile{"
-      << "name: " << profile.m_name << ", "
-      << "path: " << profile.m_path << ", "
-      << "parameterSpec: " << profile.m_parameterSpec << "}";
-  return str;
-}
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/GameEngineProfile.h
+++ b/common/src/Model/GameEngineProfile.h
@@ -22,7 +22,8 @@
 #include "IO/Path.h"
 #include "Macros.h"
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <memory>
 #include <string>
 
@@ -48,9 +49,7 @@ public:
   void setPath(const IO::Path& path);
   void setParameterSpec(const std::string& parameterSpec);
 
-  friend bool operator==(const GameEngineProfile& lhs, const GameEngineProfile& rhs);
-  friend bool operator!=(const GameEngineProfile& lhs, const GameEngineProfile& rhs);
-  friend std::ostream& operator<<(std::ostream& str, const GameEngineProfile& profile);
+  kdl_reflect_decl(GameEngineProfile, m_name, m_path, m_parameterSpec);
 
   deleteCopyAndMove(GameEngineProfile);
 };

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -27,6 +27,7 @@
 #include "Model/LockState.h"
 #include "Model/VisibilityState.h"
 
+#include <kdl/reflection_impl.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/bbox.h>
@@ -39,25 +40,8 @@
 
 namespace TrenchBroom {
 namespace Model {
-bool operator==(const NodePath& lhs, const NodePath& rhs) {
-  return lhs.indices == rhs.indices;
-}
 
-bool operator!=(const NodePath& lhs, const NodePath& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const NodePath& path) {
-  str << "NodePath{";
-  for (size_t i = 0u; i < path.indices.size(); ++i) {
-    str << i;
-    if (i < path.indices.size() - 1u) {
-      str << ", ";
-    }
-  }
-  str << "}";
-  return str;
-}
+kdl_reflect_impl(NodePath);
 
 Node::Node()
   : m_parent{nullptr}

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -28,7 +28,8 @@
 #include <vecmath/forward.h>
 #include <vecmath/util.h>
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -48,11 +49,9 @@ enum class VisibilityState;
 
 struct NodePath {
   std::vector<std::size_t> indices;
-};
 
-bool operator==(const NodePath& lhs, const NodePath& rhs);
-bool operator!=(const NodePath& lhs, const NodePath& rhs);
-std::ostream& operator<<(std::ostream& str, const NodePath& path);
+  kdl_reflect_decl(NodePath, indices);
+};
 
 class Node : public Taggable {
 private:

--- a/common/src/Model/PatchNode.cpp
+++ b/common/src/Model/PatchNode.cpp
@@ -32,8 +32,10 @@
 #include "Model/WorldNode.h"
 
 #include <kdl/overload.h>
+#include <kdl/reflection_impl.h>
 #include <kdl/zip_iterator.h>
 
+#include <vecmath/bbox_io.h>
 #include <vecmath/intersection.h>
 #include <vecmath/vec_io.h>
 
@@ -45,24 +47,12 @@ namespace TrenchBroom {
 namespace Model {
 constexpr static size_t DefaultSubdivisionsPerSurface = 3u;
 
+kdl_reflect_impl(PatchGrid::Point);
+
 const PatchGrid::Point& PatchGrid::point(const size_t row, const size_t col) const {
   const auto index = row * pointColumnCount + col;
   assert(index < points.size());
   return points[index];
-}
-
-bool operator==(const PatchGrid::Point& lhs, const PatchGrid::Point& rhs) {
-  return lhs.position == rhs.position && lhs.texCoords == rhs.texCoords && lhs.normal == rhs.normal;
-}
-
-bool operator!=(const PatchGrid::Point& lhs, const PatchGrid::Point& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const PatchGrid::Point& p) {
-  str << "{ position: {" << p.position << "}, texCoords: {" << p.texCoords << "}, normal: {"
-      << p.normal << "} }";
-  return str;
 }
 
 size_t PatchGrid::quadRowCount() const {
@@ -72,6 +62,8 @@ size_t PatchGrid::quadRowCount() const {
 size_t PatchGrid::quadColumnCount() const {
   return pointColumnCount - 1u;
 }
+
+kdl_reflect_impl(PatchGrid);
 
 /**
  * Compute the normals for the given patch grid points.

--- a/common/src/Model/PatchNode.h
+++ b/common/src/Model/PatchNode.h
@@ -24,7 +24,11 @@
 #include "Model/Node.h"
 #include "Model/Object.h"
 
-#include <iosfwd>
+#include <vecmath/bbox.h>
+#include <vecmath/vec.h>
+
+#include <kdl/reflection_decl.h>
+
 #include <optional>
 
 namespace TrenchBroom {
@@ -40,6 +44,8 @@ struct PatchGrid {
     vm::vec3 position;
     vm::vec2 texCoords;
     vm::vec3 normal;
+
+    kdl_reflect_decl(Point, position, texCoords, normal);
   };
 
   size_t pointRowCount;
@@ -51,6 +57,8 @@ struct PatchGrid {
 
   size_t quadRowCount() const;
   size_t quadColumnCount() const;
+
+  kdl_reflect_decl(PatchGrid, pointRowCount, pointColumnCount, points, bounds);
 };
 
 // public for testing
@@ -60,10 +68,6 @@ std::vector<vm::vec3> computeGridNormals(
 
 // public for testing
 PatchGrid makePatchGrid(const BezierPatch& patch, size_t subdivisionsPerSurface);
-
-bool operator==(const PatchGrid::Point& lhs, const PatchGrid::Point& rhs);
-bool operator!=(const PatchGrid::Point& lhs, const PatchGrid::Point& rhs);
-std::ostream& operator<<(std::ostream& str, const PatchGrid::Point& p);
 
 class PatchNode : public Node, public Object {
 public:

--- a/common/src/Model/PointTrace.cpp
+++ b/common/src/Model/PointTrace.cpp
@@ -21,6 +21,7 @@
 
 #include "Ensure.h"
 
+#include <kdl/reflection_impl.h>
 #include <kdl/string_utils.h>
 
 #include <vecmath/distance.h>
@@ -129,21 +130,7 @@ static std::vector<vm::vec3f> segmentizePoints(const std::vector<vm::vec3f>& poi
   return segmentizedPoints;
 }
 
-bool operator==(const PointTrace& lhs, const PointTrace& rhs) {
-  return lhs.m_points == rhs.m_points && lhs.m_current == rhs.m_current;
-}
-
-bool operator!=(const PointTrace& lhs, const PointTrace& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& lhs, const PointTrace& rhs) {
-  lhs << "PointTrace{";
-  lhs << "points: [" << kdl::str_join(rhs.m_points) << "], ";
-  lhs << "current: " << rhs.m_current;
-  lhs << "}";
-  return lhs;
-}
+kdl_reflect_impl(PointTrace);
 
 std::optional<PointTrace> loadPointFile(std::istream& stream) {
   const auto str = std::string{std::istreambuf_iterator<char>{stream}, {}};

--- a/common/src/Model/PointTrace.h
+++ b/common/src/Model/PointTrace.h
@@ -22,7 +22,8 @@
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
 
-#include <iosfwd>
+#include <kdl/reflection_decl.h>
+
 #include <optional>
 #include <vector>
 
@@ -45,10 +46,7 @@ public:
   void advance();
   void retreat();
 
-  friend bool operator==(const PointTrace& lhs, const PointTrace& rhs);
-  friend bool operator!=(const PointTrace& lhs, const PointTrace& rhs);
-
-  friend std::ostream& operator<<(std::ostream& lhs, const PointTrace& rhs);
+  kdl_reflect_decl(PointTrace, m_points, m_current);
 };
 
 std::optional<PointTrace> loadPointFile(std::istream& stream);

--- a/common/src/Model/Tag.cpp
+++ b/common/src/Model/Tag.cpp
@@ -23,6 +23,7 @@
 #include "Model/TagManager.h"
 
 #include <kdl/string_utils.h>
+#include <kdl/struct_io.h>
 
 #include <cassert>
 #include <ostream>
@@ -56,7 +57,9 @@ bool operator<(const TagAttribute& lhs, const TagAttribute& rhs) {
 }
 
 std::ostream& operator<<(std::ostream& str, const TagAttribute& attr) {
-  return str << "TagAttribute{type: " << attr.m_type << ", name: " << attr.m_name << "}";
+  kdl::struct_stream{str} << "TagAttribute"
+                          << "m_type" << attr.m_type << "m_name" << attr.m_name;
+  return str;
 }
 
 Tag::Tag(const size_t index, const std::string& name, std::vector<TagAttribute> attributes)
@@ -108,10 +111,9 @@ bool operator<(const Tag& lhs, const Tag& rhs) {
 }
 
 void Tag::appendToStream(std::ostream& str) const {
-  str << "Tag{"
-      << "index: " << m_index << ", "
-      << "name: " << m_name << ", "
-      << "attributes: " << kdl::str_join(m_attributes) << "}";
+  kdl::struct_stream{str} << "Tag"
+                          << "m_index" << m_index << "m_name" << m_name << "m_attributes"
+                          << m_attributes;
 }
 
 std::ostream& operator<<(std::ostream& str, const Tag& tag) {
@@ -302,11 +304,9 @@ bool SmartTag::canDisable() const {
 }
 
 void SmartTag::appendToStream(std::ostream& str) const {
-  str << "SmartTag{"
-      << "index: " << m_index << ", "
-      << "name: " << m_name << ", "
-      << "attributes: " << kdl::str_join(m_attributes) << ", "
-      << "matcher: " << *m_matcher << "}";
+  kdl::struct_stream{str} << "SmartTag"
+                          << "m_index" << m_index << "m_name" << m_name << "m_attributes"
+                          << m_attributes << "m_matcher" << *m_matcher;
 }
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/src/Model/TagMatcher.cpp
+++ b/common/src/Model/TagMatcher.cpp
@@ -36,6 +36,7 @@
 
 #include <kdl/string_compare.h>
 #include <kdl/string_utils.h>
+#include <kdl/struct_io.h>
 #include <kdl/vector_utils.h>
 
 #include <ostream>
@@ -110,7 +111,7 @@ bool TextureTagMatcher::canEnable() const {
 }
 
 void TextureTagMatcher::appendToStream(std::ostream& str) const {
-  str << "TextureTagMatcher{}";
+  kdl::struct_stream{str} << "TextureTagMatcher";
 }
 
 TextureNameTagMatcher::TextureNameTagMatcher(const std::string& pattern)
@@ -130,7 +131,8 @@ bool TextureNameTagMatcher::matches(const Taggable& taggable) const {
 }
 
 void TextureNameTagMatcher::appendToStream(std::ostream& str) const {
-  str << "TextureNameTagMatcher{pattern: " << m_pattern << "}";
+  kdl::struct_stream{str} << "TextureNameTagMatcher"
+                          << "m_pattern" << m_pattern;
 }
 
 bool TextureNameTagMatcher::matchesTexture(const Assets::Texture* texture) const {
@@ -173,7 +175,8 @@ bool SurfaceParmTagMatcher::matches(const Taggable& taggable) const {
 }
 
 void SurfaceParmTagMatcher::appendToStream(std::ostream& str) const {
-  str << "SurfaceParmTagMatcher{parameters: [" << kdl::str_join(m_parameters) << "]}";
+  kdl::struct_stream{str} << "SurfaceParmTagMatcher"
+                          << "m_parameters" << m_parameters;
 }
 
 bool SurfaceParmTagMatcher::matchesTexture(const Assets::Texture* texture) const {
@@ -272,7 +275,8 @@ bool FlagsTagMatcher::canDisable() const {
 }
 
 void FlagsTagMatcher::appendToStream(std::ostream& str) const {
-  str << "FlagsTagMatcher{flags: " << m_flags << "}";
+  kdl::struct_stream{str} << "FlagsTagMatcher"
+                          << "m_flags" << m_flags;
 }
 
 ContentFlagsTagMatcher::ContentFlagsTagMatcher(const int i_flags)
@@ -414,9 +418,8 @@ bool EntityClassNameTagMatcher::canDisable() const {
 }
 
 void EntityClassNameTagMatcher::appendToStream(std::ostream& str) const {
-  str << "EntityClassNameMatcher{"
-      << "pattern: " << m_pattern << ", "
-      << "texture: " << m_texture << "}";
+  kdl::struct_stream{str} << "EntityClassNameMatcher"
+                          << "m_pattern" << m_pattern << "m_texture" << m_texture;
 }
 
 bool EntityClassNameTagMatcher::matchesClassname(const std::string& classname) const {

--- a/common/src/View/HandleDragTracker.cpp
+++ b/common/src/View/HandleDragTracker.cpp
@@ -34,26 +34,14 @@
 #include <vecmath/quat.h>
 #include <vecmath/vec_io.h>
 
+#include <kdl/reflection_impl.h>
+
 #include <ostream>
 
 namespace TrenchBroom {
 namespace View {
-bool operator==(const DragState& lhs, const DragState& rhs) {
-  return lhs.initialHandlePosition == rhs.initialHandlePosition &&
-         lhs.currentHandlePosition == rhs.currentHandlePosition &&
-         lhs.handleOffset == rhs.handleOffset;
-}
 
-bool operator!=(const DragState& lhs, const DragState& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& str, const DragState& dragState) {
-  str << "DragState{initialHandlePosition: " << dragState.initialHandlePosition
-      << ", currentHandlePosition: " << dragState.currentHandlePosition
-      << ", handleOffset: " << dragState.handleOffset << "}";
-  return str;
-}
+kdl_reflect_impl(DragState);
 
 std::optional<UpdateDragConfig> HandleDragTrackerDelegate::modifierKeyChange(
   const InputState&, const DragState&) {

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -28,8 +28,9 @@
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
 
+#include <kdl/reflection_decl.h>
+
 #include <functional>
-#include <iosfwd>
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -45,11 +46,9 @@ struct DragState {
   vm::vec3 initialHandlePosition;
   vm::vec3 currentHandlePosition;
   vm::vec3 handleOffset;
-};
 
-bool operator==(const DragState& lhs, const DragState& rhs);
-bool operator!=(const DragState& lhs, const DragState& rhs);
-std::ostream& operator<<(std::ostream& str, const DragState& dragState);
+  kdl_reflect_decl(DragState, initialHandlePosition, currentHandlePosition, handleOffset);
+};
 
 /**
  * Maps the input state and the drag state to a new proposed handle position.

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -21,6 +21,8 @@
 
 #include <QApplication>
 
+#include <kdl/reflection_impl.h>
+
 #include <iostream>
 #include <string_view>
 
@@ -47,20 +49,18 @@ void KeyEvent::processWith(InputEventProcessor& processor) const {
   processor.processEvent(*this);
 }
 
-bool operator==(const KeyEvent& lhs, const KeyEvent& rhs) {
-  return lhs.type == rhs.type;
-}
+kdl_reflect_impl(KeyEvent);
 
-std::ostream& operator<<(std::ostream& out, const KeyEvent& event) {
-  switch (event.type) {
+std::ostream& operator<<(std::ostream& lhs, const KeyEvent::Type& rhs) {
+  switch (rhs) {
     case KeyEvent::Type::Down:
-      out << "KeyEvent { type=Down }";
+      lhs << "KeyEvent { type=Down }";
       break;
     case KeyEvent::Type::Up:
-      out << "KeyEVent { type=Up }";
+      lhs << "KeyEVent { type=Up }";
       break;
   }
-  return out;
+  return lhs;
 }
 
 MouseEvent::MouseEvent(
@@ -96,101 +96,85 @@ void MouseEvent::processWith(InputEventProcessor& processor) const {
   processor.processEvent(*this);
 }
 
-bool operator==(const MouseEvent& lhs, const MouseEvent& rhs) {
-  return lhs.type == rhs.type && lhs.button == rhs.button && lhs.wheelAxis == rhs.wheelAxis &&
-         lhs.posX == rhs.posX && lhs.posY == rhs.posY && lhs.scrollDistance == rhs.scrollDistance;
-}
+kdl_reflect_impl(MouseEvent);
 
-std::ostream& operator<<(std::ostream& out, const MouseEvent& event) {
-  std::string_view typeName;
-  switch (event.type) {
+std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Type& rhs) {
+  switch (rhs) {
     case MouseEvent::Type::Down:
-      typeName = "Down";
+      lhs << "Down";
       break;
     case MouseEvent::Type::Up:
-      typeName = "Up";
+      lhs << "Up";
       break;
     case MouseEvent::Type::Click:
-      typeName = "Click";
+      lhs << "Click";
       break;
     case MouseEvent::Type::DoubleClick:
-      typeName = "DoubleClick";
+      lhs << "DoubleClick";
       break;
     case MouseEvent::Type::Motion:
-      typeName = "Motion";
+      lhs << "Motion";
       break;
     case MouseEvent::Type::Scroll:
-      typeName = "Scroll";
+      lhs << "Scroll";
       break;
     case MouseEvent::Type::DragStart:
-      typeName = "DragStart";
+      lhs << "DragStart";
       break;
     case MouseEvent::Type::Drag:
-      typeName = "Drag";
+      lhs << "Drag";
       break;
     case MouseEvent::Type::DragEnd:
-      typeName = "DragEnd";
+      lhs << "DragEnd";
       break;
   }
+  return lhs;
+}
 
-  std::string_view buttonName;
-  switch (event.button) {
+std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs) {
+  switch (rhs) {
     case MouseEvent::Button::None:
-      buttonName = "None";
+      lhs << "None";
       break;
     case MouseEvent::Button::Left:
-      buttonName = "Left";
+      lhs << "Left";
       break;
     case MouseEvent::Button::Middle:
-      buttonName = "Middle";
+      lhs << "Middle";
       break;
     case MouseEvent::Button::Right:
-      buttonName = "Right";
+      lhs << "Right";
       break;
     case MouseEvent::Button::Aux1:
-      buttonName = "Aux1";
+      lhs << "Aux1";
       break;
     case MouseEvent::Button::Aux2:
-      buttonName = "Aux2";
+      lhs << "Aux2";
       break;
   }
+  return lhs;
+}
 
-  std::string_view wheelAxisName;
-  switch (event.wheelAxis) {
+std::ostream& operator<<(std::ostream& lhs, const MouseEvent::WheelAxis& rhs) {
+  switch (rhs) {
     case MouseEvent::WheelAxis::None:
-      wheelAxisName = "None";
+      lhs << "None";
       break;
     case MouseEvent::WheelAxis::Horizontal:
-      wheelAxisName = "Horizontal";
+      lhs << "Horizontal";
       break;
     case MouseEvent::WheelAxis::Vertical:
-      wheelAxisName = "Vertical";
+      lhs << "Vertical";
       break;
   }
-
-  out << "MouseEvent { ";
-  out << " type=" << typeName;
-  out << ", button=" << buttonName;
-  out << ", wheelAxis=" << wheelAxisName;
-  out << ", posX=" << event.posX;
-  out << ", posY=" << event.posY;
-  out << ", scrollDistance=" << event.scrollDistance;
-  out << " }";
-
-  return out;
+  return lhs;
 }
 
 void CancelEvent::processWith(InputEventProcessor& processor) const {
   processor.processEvent(*this);
 }
 
-bool operator==(const CancelEvent&, const CancelEvent&) {
-  return true;
-}
-
-std::ostream& operator<<(std::ostream& out, const CancelEvent&) {
-  return out << "CancelEvent {}";
-}
+kdl_reflect_impl(CancelEvent);
 
 void InputEventQueue::processEvents(InputEventProcessor& processor) {
   // Swap out the queue before processing it, because if processing an event blocks (e.g. a popup

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -21,8 +21,9 @@
 
 #include <QKeyEvent>
 
+#include <kdl/reflection_decl.h>
+
 #include <chrono>
-#include <iosfwd>
 #include <memory>
 #include <vector>
 
@@ -110,16 +111,10 @@ public:
    */
   void processWith(InputEventProcessor& processor) const override;
 
-  /**
-   * Indicates whether the given two key events are equal.
-   */
-  friend bool operator==(const KeyEvent& lhs, const KeyEvent& rhs);
-
-  /**
-   * Prints a textual representation of the given event to the given output stream.
-   */
-  friend std::ostream& operator<<(std::ostream& out, const KeyEvent& event);
+  kdl_reflect_decl(KeyEvent, type);
 };
+
+std::ostream& operator<<(std::ostream& lhs, const KeyEvent::Type& rhs);
 
 /**
  * A mouse event. Supports several event types such as button down and button up, up to five mouse
@@ -220,16 +215,12 @@ public:
    */
   void processWith(InputEventProcessor& processor) const override;
 
-  /**
-   * Indicates whether the given two mouse events are equal.
-   */
-  friend bool operator==(const MouseEvent& lhs, const MouseEvent& rhs);
-
-  /**
-   * Prints a textual representation of the given event to the given output stream.
-   */
-  friend std::ostream& operator<<(std::ostream& out, const MouseEvent& event);
+  kdl_reflect_decl(MouseEvent, type, button, wheelAxis, posX, posY, scrollDistance);
 };
+
+std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Type& rhs);
+std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs);
+std::ostream& operator<<(std::ostream& lhs, const MouseEvent::WheelAxis& rhs);
 
 /**
  * Event to signal that a mouse drag was cancelled by the windowing system, e.g. when the window
@@ -244,15 +235,7 @@ public:
    */
   void processWith(InputEventProcessor& processor) const override;
 
-  /**
-   * Indicates whether the given two cancel events are equal.
-   */
-  friend bool operator==(const CancelEvent&, const CancelEvent&);
-
-  /**
-   * Prints a textual representation of the given event to the given output stream.
-   */
-  friend std::ostream& operator<<(std::ostream& out, const CancelEvent& event);
+  kdl_reflect_decl_empty(CancelEvent);
 };
 
 /**

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -42,6 +42,7 @@
 #include <kdl/map_utils.h>
 #include <kdl/memory_utils.h>
 #include <kdl/overload.h>
+#include <kdl/reflection_impl.h>
 #include <kdl/result.h>
 #include <kdl/result_for_each.h>
 #include <kdl/vector_utils.h>
@@ -77,20 +78,7 @@ vm::vec3 DragHandle::faceNormal() const {
   return faceAtDragStart().normal();
 }
 
-bool operator==(const DragHandle& lhs, const DragHandle& rhs) {
-  return lhs.node == rhs.node && lhs.faceIndex == rhs.faceIndex;
-}
-
-bool operator!=(const DragHandle& lhs, const DragHandle& rhs) {
-  return !(lhs == rhs);
-}
-
-std::ostream& operator<<(std::ostream& lhs, const DragHandle& rhs) {
-  lhs << "DragHandle{";
-  lhs << "node: " << rhs.node << ", ";
-  lhs << "faceIndex: " << rhs.faceIndex << "}";
-  return lhs;
-}
+kdl_reflect_impl(DragHandle);
 
 // ResizeBrushesTool
 

--- a/common/src/View/ResizeBrushesTool.h
+++ b/common/src/View/ResizeBrushesTool.h
@@ -29,6 +29,8 @@
 #include <vecmath/polygon.h>
 #include <vecmath/vec.h>
 
+#include <kdl/reflection_decl.h>
+
 #include <memory>
 #include <tuple>
 #include <vector>
@@ -65,11 +67,9 @@ struct DragHandle {
 
   const Model::BrushFace& faceAtDragStart() const;
   vm::vec3 faceNormal() const;
-};
 
-bool operator==(const DragHandle& lhs, const DragHandle& rhs);
-bool operator!=(const DragHandle& lhs, const DragHandle& rhs);
-std::ostream& operator<<(std::ostream& lhs, const DragHandle& rhs);
+  kdl_reflect_decl(DragHandle, node, faceIndex);
+};
 
 /**
  * Tool for extruding faces along their normals (Shift+LMB Drag).

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -38,7 +38,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/map_utils.h"
     "${KDL_INCLUDE_DIR}/kdl/memory_utils.h"
     "${KDL_INCLUDE_DIR}/kdl/meta_utils.h"
-    "${KDL_INCLUDE_DIR}/kdl/opt_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/optional_io.h"
     "${KDL_INCLUDE_DIR}/kdl/overload.h"
     "${KDL_INCLUDE_DIR}/kdl/parallel.h"
     "${KDL_INCLUDE_DIR}/kdl/set_adapter.h"

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/string_compare.h"
     "${KDL_INCLUDE_DIR}/kdl/string_format.h"
     "${KDL_INCLUDE_DIR}/kdl/string_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/traits.h"
     "${KDL_INCLUDE_DIR}/kdl/transform_range.h"
     "${KDL_INCLUDE_DIR}/kdl/tuple_io.h"
     "${KDL_INCLUDE_DIR}/kdl/tuple_utils.h"

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/optional_io.h"
     "${KDL_INCLUDE_DIR}/kdl/overload.h"
     "${KDL_INCLUDE_DIR}/kdl/parallel.h"
+    "${KDL_INCLUDE_DIR}/kdl/range_io.h"
     "${KDL_INCLUDE_DIR}/kdl/set_adapter.h"
     "${KDL_INCLUDE_DIR}/kdl/set_temp.h"
     "${KDL_INCLUDE_DIR}/kdl/skip_iterator.h"

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -42,6 +42,8 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/overload.h"
     "${KDL_INCLUDE_DIR}/kdl/parallel.h"
     "${KDL_INCLUDE_DIR}/kdl/range_io.h"
+    "${KDL_INCLUDE_DIR}/kdl/reflection_decl.h"
+    "${KDL_INCLUDE_DIR}/kdl/reflection_impl.h"
     "${KDL_INCLUDE_DIR}/kdl/set_adapter.h"
     "${KDL_INCLUDE_DIR}/kdl/set_temp.h"
     "${KDL_INCLUDE_DIR}/kdl/skip_iterator.h"

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/string_compare.h"
     "${KDL_INCLUDE_DIR}/kdl/string_format.h"
     "${KDL_INCLUDE_DIR}/kdl/string_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/struct_io.h"
     "${KDL_INCLUDE_DIR}/kdl/traits.h"
     "${KDL_INCLUDE_DIR}/kdl/transform_range.h"
     "${KDL_INCLUDE_DIR}/kdl/tuple_io.h"

--- a/lib/kdl/include/kdl/deref_iterator.h
+++ b/lib/kdl/include/kdl/deref_iterator.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <iterator>
 
 namespace kdl {
@@ -141,6 +142,14 @@ public:
 
 template <typename R> deref_range(R) -> deref_range<R>;
 
+template <typename R> bool operator==(const deref_range<R>& lhs, const deref_range<R>& rhs) {
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+template <typename R> bool operator!=(const deref_range<R>& lhs, const deref_range<R>& rhs) {
+  return !(lhs == rhs);
+}
+
 template <typename R> class const_deref_range {
 private:
   const R& m_range;
@@ -175,4 +184,14 @@ public:
 };
 
 template <typename R> const_deref_range(R) -> const_deref_range<R>;
+
+template <typename R>
+bool operator==(const const_deref_range<R>& lhs, const const_deref_range<R>& rhs) {
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+template <typename R>
+bool operator!=(const const_deref_range<R>& lhs, const const_deref_range<R>& rhs) {
+  return !(lhs == rhs);
+}
 } // namespace kdl

--- a/lib/kdl/include/kdl/deref_iterator.h
+++ b/lib/kdl/include/kdl/deref_iterator.h
@@ -61,6 +61,34 @@ public:
   friend bool operator!=(const deref_iterator& lhs, const I& rhs) { return lhs.m_it != rhs; }
   friend bool operator!=(const I& lhs, const deref_iterator& rhs) { return lhs != rhs.m_it; }
 
+  friend deref_iterator operator+(const deref_iterator& lhs, const difference_type rhs) {
+    return deref_iterator{lhs.m_it + rhs};
+  }
+
+  friend deref_iterator operator+(const difference_type& lhs, const deref_iterator rhs) {
+    return rhs + lhs;
+  }
+
+  friend deref_iterator& operator+=(deref_iterator& lhs, const difference_type rhs) {
+    lhs.m_it += rhs;
+    return lhs;
+  }
+
+  friend difference_type operator-(const deref_iterator& lhs, const deref_iterator& rhs) {
+    return lhs.m_it - rhs.m_it;
+  }
+
+  friend deref_iterator operator-(const deref_iterator& lhs, const difference_type rhs) {
+    return deref_iterator{lhs.m_it - rhs};
+  }
+
+  friend deref_iterator& operator-=(deref_iterator& lhs, const difference_type rhs) {
+    lhs.m_it -= rhs;
+    return lhs;
+  }
+
+  reference operator[](const difference_type n) const { return *m_it[n]; }
+
   deref_iterator& operator++() {
     m_it++;
     return *this;

--- a/lib/kdl/include/kdl/optional_io.h
+++ b/lib/kdl/include/kdl/optional_io.h
@@ -1,0 +1,43 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <optional>
+#include <ostream>
+
+namespace kdl {
+
+template <typename T> struct streamable_optional_wrapper { const std::optional<T>& opt; };
+
+template <typename T> streamable_optional_wrapper<T> make_streamable(const std::optional<T>& opt) {
+  return streamable_optional_wrapper<T>{opt};
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& lhs, const streamable_optional_wrapper<T>& rhs) {
+  if (rhs.opt.has_value()) {
+    lhs << *rhs.opt;
+  } else {
+    lhs << "nullopt";
+  }
+  return lhs;
+}
+
+} // namespace kdl

--- a/lib/kdl/include/kdl/range_io.h
+++ b/lib/kdl/include/kdl/range_io.h
@@ -1,0 +1,47 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <ostream>
+
+namespace kdl {
+template <typename R> struct streamable_range_wrapper { const R& range; };
+
+template <typename R> auto make_streamable(R&& range) {
+  return streamable_range_wrapper<R>{std::forward<R>(range)};
+}
+
+template <typename R>
+std::ostream& operator<<(std::ostream& lhs, const streamable_range_wrapper<R>& adapter) {
+  using std::begin;
+  using std::end;
+
+  auto cur = begin(adapter.range);
+  if (cur != end(adapter.range)) {
+    lhs << "[";
+    lhs << *cur++;
+    while (cur != end(adapter.range)) {
+      lhs << "," << *cur++;
+    }
+    lhs << "]";
+  }
+  return lhs;
+}
+} // namespace kdl

--- a/lib/kdl/include/kdl/reflection_decl.h
+++ b/lib/kdl/include/kdl/reflection_decl.h
@@ -1,0 +1,151 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <array>
+#include <iosfwd>
+#include <string_view>
+#include <tuple>
+
+namespace kdl {
+
+namespace detail {
+constexpr size_t reflection_count_tokens(const std::string_view str) {
+  constexpr auto ws = std::string_view{" \n\t\r"};
+
+  const auto s = str.find_first_not_of(ws);
+  if (s == std::string_view::npos) {
+    return 0;
+  }
+
+  auto c = 0u;
+  auto has_non_ws = false;
+  for (auto i = s; i < str.size(); ++i) {
+    if (str[i] == ',') {
+      if (has_non_ws) {
+        ++c;
+      }
+      has_non_ws = false;
+    } else if (ws.find_first_of(str[i]) == std::string_view::npos) {
+      has_non_ws = true;
+    }
+  }
+
+  return has_non_ws ? c + 1 : c;
+}
+
+template <size_t C> constexpr auto reflection_split_tokens(std::string_view str) {
+  constexpr auto ws = std::string_view{" \n\t\r"};
+
+  auto result = std::array<std::string_view, C>{};
+  if constexpr (C == 0) {
+    return result;
+  }
+
+  str = str.substr(str.find_first_not_of(ws));
+  for (auto i = 0u; i < C - 1; ++i) {
+    const auto c = str.find_first_of(",");
+    const auto e = str.substr(0, c).find_last_not_of(ws);
+
+    result[i] = str.substr(0, e + 1);
+    str = str.substr(str.find_first_not_of(ws, c + 1));
+  }
+
+  auto e = str.find_last_not_of(ws);
+  if (e == std::string_view::npos) {
+    e = str.size() - 1;
+  }
+  result[C - 1] = str.substr(0, e + 1);
+  return result;
+}
+} // namespace detail
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-macros"
+#endif
+
+#define kdl_reflect_members_n(...)                                                                 \
+  template <size_t C = kdl::detail::reflection_count_tokens(#__VA_ARGS__)>                         \
+  [[maybe_unused]] constexpr static auto member_names() {                                          \
+    return kdl::detail::reflection_split_tokens<C>(#__VA_ARGS__);                                  \
+  }                                                                                                \
+  [[maybe_unused]] auto members() const { return std::forward_as_tuple(__VA_ARGS__); }
+
+#define kdl_reflect_members_0()                                                                    \
+  [[maybe_unused]] constexpr static auto member_names() {                                          \
+    return std::array<std::string_view, 0>{};                                                      \
+  }                                                                                                \
+  [[maybe_unused]] auto members() const { return std::tuple<>{}; }
+
+#define kdl_reflect_relational_operators(type_name)                                                \
+  template <                                                                                       \
+    typename KDL_T, typename std::enable_if<std::is_same_v<type_name, KDL_T>, bool>::type = true>  \
+  friend auto operator==(const KDL_T& lhs, const KDL_T& rhs)                                       \
+    ->decltype(lhs.members() == rhs.members()) {                                                   \
+    return lhs.members() == rhs.members();                                                         \
+  }                                                                                                \
+  template <                                                                                       \
+    typename KDL_T, typename std::enable_if<std::is_same_v<type_name, KDL_T>, bool>::type = true>  \
+  friend auto operator!=(const KDL_T& lhs, const KDL_T& rhs)                                       \
+    ->decltype(lhs.members() != rhs.members()) {                                                   \
+    return lhs.members() != rhs.members();                                                         \
+  }                                                                                                \
+  template <                                                                                       \
+    typename KDL_T, typename std::enable_if<std::is_same_v<type_name, KDL_T>, bool>::type = true>  \
+  friend auto operator<(const KDL_T& lhs, const KDL_T& rhs)                                        \
+    ->decltype(lhs.members() < rhs.members()) {                                                    \
+    return lhs.members() < rhs.members();                                                          \
+  }                                                                                                \
+  template <                                                                                       \
+    typename KDL_T, typename std::enable_if<std::is_same_v<type_name, KDL_T>, bool>::type = true>  \
+  friend auto operator<=(const KDL_T& lhs, const KDL_T& rhs)                                       \
+    ->decltype(lhs.members() <= rhs.members()) {                                                   \
+    return lhs.members() <= rhs.members();                                                         \
+  }                                                                                                \
+  template <                                                                                       \
+    typename KDL_T, typename std::enable_if<std::is_same_v<type_name, KDL_T>, bool>::type = true>  \
+  friend auto operator>(const KDL_T& lhs, const KDL_T& rhs)                                        \
+    ->decltype(lhs.members() > rhs.members()) {                                                    \
+    return lhs.members() > rhs.members();                                                          \
+  }                                                                                                \
+  template <                                                                                       \
+    typename KDL_T, typename std::enable_if<std::is_same_v<type_name, KDL_T>, bool>::type = true>  \
+  friend auto operator>=(const KDL_T& lhs, const KDL_T& rhs)                                       \
+    ->decltype(lhs.members() >= rhs.members()) {                                                   \
+    return lhs.members() >= rhs.members();                                                         \
+  }
+
+#define kdl_stream_operator_decl(type_name)                                                        \
+  friend std::ostream& operator<<(std::ostream& lhs, const type_name& rhs);
+
+#define kdl_reflect_decl(type_name, ...)                                                           \
+  kdl_reflect_members_n(__VA_ARGS__) kdl_reflect_relational_operators(type_name)                   \
+    kdl_stream_operator_decl(type_name) struct dummy
+
+#define kdl_reflect_decl_empty(type_name)                                                          \
+  kdl_reflect_members_0() kdl_reflect_relational_operators(type_name)                              \
+    kdl_stream_operator_decl(type_name) struct dummy
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+} // namespace kdl

--- a/lib/kdl/include/kdl/reflection_impl.h
+++ b/lib/kdl/include/kdl/reflection_impl.h
@@ -1,0 +1,80 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <kdl/reflection_decl.h>
+#include <kdl/struct_io.h>
+
+#include <ostream>
+
+namespace kdl {
+namespace detail {
+
+template <size_t C, size_t I, typename... V>
+void print_reflective_member(
+  [[maybe_unused]] struct_stream& sstr,
+  [[maybe_unused]] const std::array<std::string_view, C>& member_names,
+  [[maybe_unused]] const std::tuple<V...>& member_values) {
+  if constexpr (I < C) {
+    sstr << member_names[I] << std::get<I>(member_values);
+    print_reflective_member<C, I + 1, V...>(sstr, member_names, member_values);
+  }
+}
+
+template <size_t C, typename... V>
+void print_reflective(
+  std::ostream& str, const std::string_view type_name,
+  const std::array<std::string_view, C>& member_names, const std::tuple<V...>& member_values) {
+  using kdl::detail::print_reflective_member;
+
+  auto sstr = struct_stream{str};
+  sstr << type_name;
+  print_reflective_member<std::tuple_size_v<std::tuple<V...>>, 0, V...>(
+    sstr, member_names, member_values);
+}
+} // namespace detail
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-macros"
+#endif
+
+#define kdl_stream_operator_impl(type_name)                                                        \
+  std::ostream& operator<<(std::ostream& lhs, const type_name& rhs) {                              \
+    kdl::detail::print_reflective<std::tuple_size_v<decltype(rhs.members())>>(                     \
+      lhs, #type_name, rhs.member_names(), rhs.members());                                         \
+    return lhs;                                                                                    \
+  }
+
+#define kdl_reflect_impl(type_name) kdl_stream_operator_impl(type_name) struct dummy
+
+#define kdl_reflect_inline(type_name, ...)                                                         \
+  kdl_reflect_members_n(__VA_ARGS__) kdl_reflect_relational_operators(                             \
+    type_name) friend kdl_stream_operator_impl(type_name) struct dummy
+
+#define kdl_reflect_inline_empty(type_name)                                                        \
+  kdl_reflect_members_0() kdl_reflect_relational_operators(                                        \
+    type_name) friend kdl_stream_operator_impl(type_name) struct dummy
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+} // namespace kdl

--- a/lib/kdl/include/kdl/struct_io.h
+++ b/lib/kdl/include/kdl/struct_io.h
@@ -1,0 +1,94 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <kdl/optional_io.h>
+#include <kdl/range_io.h>
+#include <kdl/traits.h>
+#include <kdl/tuple_io.h>
+
+#include <ostream>
+#include <string_view>
+
+namespace kdl {
+class struct_stream {
+private:
+  enum class expected {
+    type_name,
+    attr_name,
+    attr_value
+  };
+
+  std::ostream& m_str;
+  expected m_expected = expected::type_name;
+  bool m_first_attr = true;
+
+public:
+  explicit struct_stream(std::ostream& str)
+    : m_str{str} {}
+
+  ~struct_stream() { m_str << "}"; }
+
+  template <typename T> friend struct_stream& operator<<(struct_stream& lhs, const T& rhs) {
+    append_to_stream(lhs, rhs);
+    return lhs;
+  }
+
+  template <typename T> friend struct_stream& operator<<(struct_stream&& lhs, const T& rhs) {
+    append_to_stream(lhs, rhs);
+    return lhs;
+  }
+
+private:
+  template <typename T, typename std::enable_if<can_print_v<T>, bool>::type = true>
+  static void append_to_stream(std::ostream& lhs, const T& rhs) {
+    lhs << rhs;
+  }
+
+  template <typename T, typename std::enable_if<!can_print_v<T>, bool>::type = true>
+  static void append_to_stream(std::ostream& lhs, const T& rhs) {
+    lhs << make_streamable(rhs);
+  }
+
+  template <typename T> static void append_to_stream(struct_stream& lhs, const T& rhs) {
+    switch (lhs.m_expected) {
+      case expected::type_name:
+        append_to_stream(lhs.m_str, rhs);
+        lhs.m_str << "{";
+        lhs.m_expected = expected::attr_name;
+        break;
+      case expected::attr_name:
+        if (!lhs.m_first_attr) {
+          lhs.m_str << ", ";
+        }
+        lhs.m_first_attr = false;
+        append_to_stream(lhs.m_str, rhs);
+        lhs.m_str << ": ";
+        lhs.m_expected = expected::attr_value;
+        break;
+      case expected::attr_value:
+        append_to_stream(lhs.m_str, rhs);
+        lhs.m_expected = expected::attr_name;
+        break;
+    }
+  }
+};
+
+} // namespace kdl

--- a/lib/kdl/include/kdl/traits.h
+++ b/lib/kdl/include/kdl/traits.h
@@ -1,0 +1,61 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <iterator>
+
+namespace kdl {
+namespace detail {
+// To allow ADL with custom begin/end
+using std::begin;
+using std::end;
+
+template <typename T>
+auto is_iterable(int) -> decltype(
+  begin(std::declval<T&>()) != end(std::declval<T&>()),   // begin/end and operator !=
+  void(),                                                 // Handle evil operator ,
+  ++std::declval<decltype(begin(std::declval<T&>()))&>(), // operator ++
+  void(*begin(std::declval<T&>())),                       // operator*
+  std::true_type{});
+
+template <typename T> std::false_type is_iterable(...);
+
+} // namespace detail
+
+template <typename T> using is_iterable = decltype(detail::is_iterable<T>(0));
+template <typename T> inline constexpr bool is_iterable_v = is_iterable<T>::value;
+
+namespace detail {
+template <typename...> using void_t = void;
+
+template <typename T, typename S, typename = void> struct can_print : std::false_type {};
+
+template <typename T, typename S>
+struct can_print<T, S, void_t<decltype(std::declval<S&>() << std::declval<const T&>())>>
+  : std::true_type {};
+
+} // namespace detail
+
+template <typename T, typename S = std::ostream> using can_print = detail::can_print<T, S>;
+
+template <typename T, typename S = std::ostream>
+inline constexpr bool can_print_v = can_print<T, S>::value;
+
+} // namespace kdl

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/map_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/meta_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/optional_io_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/range_io_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/result_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/run_all.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_adapter_test.cpp"

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/meta_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/optional_io_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/range_io_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/reflection_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/result_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/run_all.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_adapter_test.cpp"

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/string_compare_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/string_format_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/string_utils_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/struct_io_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_temp_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/test_utils.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_range_test.cpp"

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/parallel_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/map_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/meta_utils_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/optional_io_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/result_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/run_all.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_adapter_test.cpp"

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_temp_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/test_utils.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_range_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/tuple_io_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tuple_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/vector_set_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/vector_utils_test.cpp"

--- a/lib/kdl/test/src/deref_iterator_test.cpp
+++ b/lib/kdl/test/src/deref_iterator_test.cpp
@@ -60,6 +60,35 @@ TEST_CASE("deref_iterator type members") {
   }
 }
 
+TEST_CASE("deref_iterator.operator+/-") {
+  const int a = 1;
+  const int b = 2;
+  const int c = 3;
+
+  const auto v = std::vector<const int*>{&a, &b, &c};
+
+  const auto d = GENERATE(0, 1, 2, 3);
+  SECTION("operator+") {
+    CHECK(deref_iterator{v.begin()} + d == deref_iterator{v.begin() + d});
+    CHECK(d + deref_iterator{v.begin()} == deref_iterator{v.begin()} + d);
+  }
+
+  SECTION("operator+=") {
+    auto i = deref_iterator{v.begin()};
+    CHECK((i += d) == deref_iterator{v.begin()} + d);
+  }
+
+  SECTION("operator-") {
+    CHECK(deref_iterator{v.end()} - d == deref_iterator{v.end() - d});
+    CHECK(deref_iterator{v.begin()} + d - deref_iterator{v.begin()} == d);
+  }
+
+  SECTION("operator-=") {
+    auto i = deref_iterator{v.end()};
+    CHECK((i -= d) == deref_iterator{v.end()} - d);
+  }
+}
+
 TEST_CASE("deref_iterator.operator*") {
   int a = 1;
   int b = 2;

--- a/lib/kdl/test/src/optional_io_test.cpp
+++ b/lib/kdl/test/src/optional_io_test.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright 2010-2019 Kristian Duske
+ Copyright 2022 Kristian Duske
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -16,20 +16,29 @@
  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
  OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-#pragma once
+
+#include "kdl/optional_io.h"
+#include <kdl/string_utils.h>
 
 #include <optional>
 #include <sstream>
-#include <string>
+
+#include <catch2/catch.hpp>
 
 namespace kdl {
-template <typename T> std::string opt_to_string(const std::optional<T>& opt) {
-  std::stringstream str;
-  if (opt.has_value()) {
-    str << *opt;
-  } else {
-    str << "nullopt";
-  }
-  return str.str();
+
+TEST_CASE("optional IO") {
+  CHECK(str_to_string(make_streamable(std::optional<int>{})) == "nullopt");
+  CHECK(str_to_string(make_streamable(std::optional<int>{0})) == "0");
 }
+
 } // namespace kdl
+
+namespace sibling {
+
+TEST_CASE("optional IO - ADL from sibling namespace") {
+  auto str = std::stringstream{};
+  str << kdl::make_streamable(std::optional<int>{0});
+}
+
+} // namespace sibling

--- a/lib/kdl/test/src/range_io_test.cpp
+++ b/lib/kdl/test/src/range_io_test.cpp
@@ -1,0 +1,53 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "kdl/range_io.h"
+#include "kdl/string_utils.h"
+
+#include <ostream>
+
+#include <catch2/catch.hpp>
+
+namespace kdl {
+
+namespace some_ns {
+struct test {};
+
+inline std::ostream& operator<<(std::ostream& lhs, const test&) {
+  return lhs << "test";
+}
+} // namespace some_ns
+
+TEST_CASE("range IO") {
+  CHECK(str_to_string(make_streamable(std::vector<int>{})) == "");
+  CHECK(str_to_string(make_streamable(std::vector<int>{1})) == "[1]");
+  CHECK(str_to_string(make_streamable(std::vector<int>{1, 2})) == "[1,2]");
+  CHECK(str_to_string(make_streamable(std::vector<some_ns::test>{{}, {}})) == "[test,test]");
+}
+
+} // namespace kdl
+
+namespace sibling {
+
+TEST_CASE("range IO - ADL from sibling namespace") {
+  auto str = std::stringstream{};
+  str << kdl::make_streamable(std::vector<int>{1});
+}
+
+} // namespace sibling

--- a/lib/kdl/test/src/reflection_test.cpp
+++ b/lib/kdl/test/src/reflection_test.cpp
@@ -1,0 +1,122 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "kdl/range_io.h"
+#include "kdl/reflection_decl.h"
+#include "kdl/reflection_impl.h"
+#include "kdl/string_utils.h"
+
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+namespace kdl {
+namespace detail {
+TEST_CASE("reflection_count_tokens") {
+  static_assert(reflection_count_tokens("") == 0);
+  static_assert(reflection_count_tokens("  ") == 0);
+  static_assert(reflection_count_tokens(",") == 0);
+  static_assert(reflection_count_tokens(" ,  ") == 0);
+  static_assert(reflection_count_tokens("asdf") == 1);
+  static_assert(reflection_count_tokens("asdf,blah") == 2);
+  static_assert(reflection_count_tokens(" asdf ,  blah ") == 2);
+}
+
+TEST_CASE("reflection_split_tokens") {
+  CHECK(reflection_split_tokens<0>("") == std::array<std::string_view, 0>{});
+  CHECK(reflection_split_tokens<0>("   ") == std::array<std::string_view, 0>{});
+  CHECK(reflection_split_tokens<0>(",") == std::array<std::string_view, 0>{});
+  CHECK(reflection_split_tokens<0>(" ,  ") == std::array<std::string_view, 0>{});
+  CHECK(reflection_split_tokens<1>("asdf") == std::array<std::string_view, 1>{"asdf"});
+  CHECK(reflection_split_tokens<2>("asdf,blah") == std::array<std::string_view, 2>{"asdf", "blah"});
+  CHECK(
+    reflection_split_tokens<2>(" asdf ,  blah ") ==
+    std::array<std::string_view, 2>{"asdf", "blah"});
+}
+} // namespace detail
+
+struct empty {
+  kdl_reflect_inline_empty(empty);
+};
+
+struct test {
+  int someName;
+  std::string otherName;
+
+  kdl_reflect_inline(test, someName, otherName);
+};
+
+TEST_CASE("member_names") {
+  CHECK(empty::member_names() == std::array<std::string_view, 0>{});
+  CHECK(test::member_names() == std::array<std::string_view, 2>{"someName", "otherName"});
+}
+
+TEST_CASE("members") {
+  CHECK(empty{}.members() == std::make_tuple());
+  CHECK(test{2, "asdf"}.members() == std::make_tuple(2, "asdf"));
+}
+
+TEST_CASE("operator==") {
+  CHECK(test{2, "asdf"} == test{2, "asdf"});
+  CHECK_FALSE(test{2, "asdf"} == test{3, "asdf"});
+  CHECK_FALSE(test{2, "asdf"} == test{2, "x"});
+}
+
+TEST_CASE("operator!=") {
+  CHECK(test{2, "asdf"} != test{3, "asdf"});
+  CHECK(test{2, "asdf"} != test{2, "x"});
+  CHECK_FALSE(test{2, "asdf"} != test{2, "asdf"});
+}
+
+TEST_CASE("operator<") {
+  CHECK(test{1, "asdf"} < test{2, "asdf"});
+  CHECK_FALSE(test{2, "asdf"} < test{2, "asdf"});
+  CHECK_FALSE(test{3, "asdf"} < test{2, "asdf"});
+
+  CHECK(test{2, "asdf"} < test{2, "bsdf"});
+  CHECK_FALSE(test{2, "asdf"} < test{2, "abdf"});
+}
+
+struct incomparable {};
+
+[[maybe_unused]] static std::ostream& operator<<(std::ostream& lhs, const incomparable&) {
+  return lhs << "incomparable";
+}
+
+struct test_incomparable_member {
+  incomparable x;
+
+  kdl_reflect_inline(test_incomparable_member, x);
+};
+
+namespace test_ns {
+struct custom {
+  std::vector<int> v;
+
+  kdl_reflect_inline(custom, v);
+};
+
+} // namespace test_ns
+
+TEST_CASE("operator<<") {
+  CHECK(str_to_string(empty{}) == "empty{}");
+  CHECK(str_to_string(test{1, "asdf"}) == "test{someName: 1, otherName: asdf}");
+  CHECK(str_to_string(test_ns::custom{{1, 2, 3}}) == "custom{v: [1,2,3]}");
+}
+} // namespace kdl

--- a/lib/kdl/test/src/struct_io_test.cpp
+++ b/lib/kdl/test/src/struct_io_test.cpp
@@ -1,0 +1,47 @@
+/*
+ Copyright 2022 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ associated documentation files (the "Software"), to deal in the Software without restriction,
+ including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "kdl/struct_io.h"
+#include <kdl/string_utils.h>
+
+#include <optional>
+#include <sstream>
+#include <tuple>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+namespace kdl {
+
+template <typename... Args> std::string build_string(const Args&... args) {
+  auto str = std::stringstream{};
+  (struct_stream{str} << ... << args);
+  return str.str();
+}
+
+TEST_CASE("streamable_struct") {
+  CHECK(build_string("type") == "type{}");
+  CHECK(build_string("type", "a", "x") == "type{a: x}");
+  CHECK(build_string("type", "a", "x", "b", "y") == "type{a: x, b: y}");
+
+  CHECK(build_string("type", "a", std::vector<int>{1, 2, 3}) == "type{a: [1,2,3]}");
+  CHECK(build_string("type", "a", std::optional<int>{1}) == "type{a: 1}");
+  CHECK(build_string("type", "a", std::tuple<int, std::string>{1, "asdf"}) == "type{a: {1, asdf}}");
+}
+} // namespace kdl

--- a/lib/kdl/test/src/tuple_io_test.cpp
+++ b/lib/kdl/test/src/tuple_io_test.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright 2020 Kristian Duske
+ Copyright 2022 Kristian Duske
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -17,40 +17,28 @@
  OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#pragma once
+#include "kdl/tuple_io.h"
+#include <kdl/string_utils.h>
 
-#include <iostream>
+#include <sstream>
 #include <tuple>
+
+#include <catch2/catch.hpp>
 
 namespace kdl {
 
-namespace detail {
-template <typename T, size_t Idx> void print_tuple_element(std::ostream& str, const T& t) {
-  str << std::get<Idx>(t) << ", ";
+TEST_CASE("tuple IO") {
+  CHECK(str_to_string(make_streamable(std::tuple<int>{0})) == "{0}");
+  CHECK(str_to_string(make_streamable(std::tuple<int, std::string>{0, "asdf"})) == "{0, asdf}");
 }
 
-template <typename T, size_t... Idx>
-void print_tuple(std::ostream& str, const T& t, std::index_sequence<Idx...>) {
-  (..., print_tuple_element<T, Idx>(str, t));
-}
-} // namespace detail
-
-template <typename... T> struct streamable_tuple_wrapper { const std::tuple<T...>& tuple; };
-
-template <typename... T>
-streamable_tuple_wrapper<T...> make_streamable(const std::tuple<T...>& tuple) {
-  return streamable_tuple_wrapper<T...>{tuple};
-}
-
-template <typename... T>
-std::ostream& operator<<(std::ostream& lhs, const streamable_tuple_wrapper<T...>& rhs) {
-  lhs << "{";
-  constexpr auto size = std::tuple_size_v<std::tuple<T...>>;
-  if constexpr (size > 0u) {
-    kdl::detail::print_tuple(lhs, rhs.tuple, std::make_index_sequence<size - 1u>{});
-    lhs << std::get<size - 1u>(rhs.tuple);
-  }
-  lhs << "}";
-  return lhs;
-}
 } // namespace kdl
+
+namespace sibling {
+
+TEST_CASE("tuple IO - ADL from sibling namespace") {
+  auto str = std::stringstream{};
+  str << kdl::make_streamable(std::tuple<int>{0});
+}
+
+} // namespace sibling


### PR DESCRIPTION
We add a new set of macros that are useful for making a type reflective. The macros provide member functions that return the names of all reflective members, their values as a tuple, member wise relational operators and a member wise stream operator.

This saves a lot of code and it makes all classes serializable in the same way.