### PR TITLE
3827: Check for property definitions when determining the rotation info

### DIFF
--- a/common/src/Model/EntityRotationPolicy.cpp
+++ b/common/src/Model/EntityRotationPolicy.cpp
@@ -115,9 +115,11 @@ EntityRotationInfo entityRotationInfo(const Entity& entity) {
         if (entity.hasProperty(EntityPropertyKeys::Angles)) {
           type = eulerType;
           propertyKey = EntityPropertyKeys::Angles;
-        } else {
+        } else if (entity.hasProperty(EntityPropertyKeys::Angle)) {
           type = EntityRotationType::Angle;
           propertyKey = EntityPropertyKeys::Angle;
+        } else {
+          // not a spotlight, don't modify
         }
       } else {
         // spotlight with target, don't modify

--- a/common/src/Model/EntityRotationPolicy.cpp
+++ b/common/src/Model/EntityRotationPolicy.cpp
@@ -19,6 +19,7 @@
 
 #include "EntityRotationPolicy.h"
 
+#include "Assets/EntityDefinition.h"
 #include "Assets/EntityModel.h"
 #include "Macros.h"
 #include "Model/Entity.h"
@@ -79,6 +80,17 @@ std::ostream& operator<<(std::ostream& lhs, const EntityRotationUsage& rhs) {
 
 kdl_reflect_impl(EntityRotationInfo);
 
+namespace {
+bool hasPropertyOrDefinition(const Entity& entity, const std::string& propertyKey) {
+  if (entity.hasProperty(propertyKey)) {
+    return true;
+  }
+
+  const auto* definition = entity.definition();
+  return definition != nullptr && definition->propertyDefinition(propertyKey) != nullptr;
+}
+} // namespace
+
 EntityRotationInfo entityRotationInfo(const Entity& entity) {
   auto type = EntityRotationType::None;
   std::string propertyKey;
@@ -115,13 +127,13 @@ EntityRotationInfo entityRotationInfo(const Entity& entity) {
 
       if (!entity.pointEntity()) {
         // brush entity
-        if (entity.hasProperty(EntityPropertyKeys::Angles)) {
+        if (hasPropertyOrDefinition(entity, EntityPropertyKeys::Angles)) {
           type = eulerType;
           propertyKey = EntityPropertyKeys::Angles;
-        } else if (entity.hasProperty(EntityPropertyKeys::Mangle)) {
+        } else if (hasPropertyOrDefinition(entity, EntityPropertyKeys::Mangle)) {
           type = eulerType;
           propertyKey = EntityPropertyKeys::Mangle;
-        } else if (entity.hasProperty(EntityPropertyKeys::Angle)) {
+        } else if (hasPropertyOrDefinition(entity, EntityPropertyKeys::Angle)) {
           type = EntityRotationType::AngleUpDown;
           propertyKey = EntityPropertyKeys::Angle;
         }
@@ -136,10 +148,10 @@ EntityRotationInfo entityRotationInfo(const Entity& entity) {
           usage = EntityRotationUsage::BlockRotation;
         }
 
-        if (entity.hasProperty(EntityPropertyKeys::Angles)) {
+        if (hasPropertyOrDefinition(entity, EntityPropertyKeys::Angles)) {
           type = eulerType;
           propertyKey = EntityPropertyKeys::Angles;
-        } else if (entity.hasProperty(EntityPropertyKeys::Mangle)) {
+        } else if (hasPropertyOrDefinition(entity, EntityPropertyKeys::Mangle)) {
           type = eulerType;
           propertyKey = EntityPropertyKeys::Mangle;
         } else {

--- a/common/src/Model/EntityRotationPolicy.cpp
+++ b/common/src/Model/EntityRotationPolicy.cpp
@@ -24,6 +24,7 @@
 #include "Model/Entity.h"
 #include "Model/EntityNode.h"
 
+#include <kdl/reflection_impl.h>
 #include <kdl/string_compare.h>
 #include <kdl/string_utils.h>
 
@@ -33,8 +34,50 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
+#include <ostream>
+
 namespace TrenchBroom {
 namespace Model {
+
+std::ostream& operator<<(std::ostream& lhs, const EntityRotationType& rhs) {
+  switch (rhs) {
+    case EntityRotationType::None:
+      lhs << "None";
+      break;
+    case EntityRotationType::Angle:
+      lhs << "Angle";
+      break;
+    case EntityRotationType::AngleUpDown:
+      lhs << "AngleUpDown";
+      break;
+    case EntityRotationType::Euler:
+      lhs << "Euler";
+      break;
+    case EntityRotationType::Euler_PositivePitchDown:
+      lhs << "Euler_PositivePitchDown";
+      break;
+    case EntityRotationType::Mangle:
+      lhs << "Mangle";
+      break;
+      switchDefault();
+  }
+  return lhs;
+}
+
+std::ostream& operator<<(std::ostream& lhs, const EntityRotationUsage& rhs) {
+  switch (rhs) {
+    case EntityRotationUsage::Allowed:
+      lhs << "Allowed";
+      break;
+    case EntityRotationUsage::BlockRotation:
+      lhs << "BlockRotation";
+      break;
+      switchDefault();
+  }
+  return lhs;
+}
+
+kdl_reflect_impl(EntityRotationInfo);
 
 EntityRotationInfo entityRotationInfo(const Entity& entity) {
   auto type = EntityRotationType::None;

--- a/common/src/Model/EntityRotationPolicy.h
+++ b/common/src/Model/EntityRotationPolicy.h
@@ -34,42 +34,36 @@ namespace Model {
 class Entity;
 struct EntityPropertyConfig;
 
+enum class EntityRotationType {
+  None,
+  Angle,
+  AngleUpDown,
+  Euler,
+  Euler_PositivePitchDown,
+  Mangle
+};
+
+enum class EntityRotationUsage {
+  Allowed,
+  BlockRotation
+};
+
+struct EntityRotationInfo {
+  const EntityRotationType type;
+  const std::string propertyKey;
+  const EntityRotationUsage usage;
+};
+
+EntityRotationInfo entityRotationInfo(const Entity& entity);
+
 class EntityRotationPolicy {
 private:
-  enum class RotationType {
-    None,
-    Angle,
-    AngleUpDown,
-    Euler,
-    Euler_PositivePitchDown,
-    Mangle
-  };
-  enum class RotationUsage {
-    Allowed,
-    BlockRotation
-  };
-
-  struct RotationInfo {
-    const RotationType type;
-    const std::string propertyKey;
-    const RotationUsage usage;
-  };
-
 public:
   static vm::mat4x4 getRotation(const Entity& entity);
   static void applyRotation(
     Entity& entity, const EntityPropertyConfig& propertyConfig, const vm::mat4x4& transformation);
   static std::string getPropertyKey(const Entity& entity);
 
-private:
-  static RotationInfo rotationInfo(const Entity& entity);
-  static void setAngle(
-    Entity& entity, const EntityPropertyConfig& propertyConfig, const std::string& propertyKey,
-    const vm::vec3& direction);
-
-  static FloatType getAngle(vm::vec3 direction);
-
-public:
   /**
    * Given an arbitrary transform and a rotation matrix, applies the transformation to the
    * rotation matrix and returns the result as euler angles in degrees.

--- a/common/src/Model/EntityRotationPolicy.h
+++ b/common/src/Model/EntityRotationPolicy.h
@@ -23,6 +23,9 @@
 
 #include <vecmath/forward.h>
 
+#include <kdl/reflection_decl.h>
+
+#include <iosfwd>
 #include <string>
 
 namespace TrenchBroom {
@@ -43,15 +46,21 @@ enum class EntityRotationType {
   Mangle
 };
 
+std::ostream& operator<<(std::ostream& lhs, const EntityRotationType& rhs);
+
 enum class EntityRotationUsage {
   Allowed,
   BlockRotation
 };
 
+std::ostream& operator<<(std::ostream& lhs, const EntityRotationUsage& rhs);
+
 struct EntityRotationInfo {
   const EntityRotationType type;
   const std::string propertyKey;
   const EntityRotationUsage usage;
+
+  kdl_reflect_decl(EntityRotationInfo, type, propertyKey, usage);
 };
 
 EntityRotationInfo entityRotationInfo(const Entity& entity);

--- a/common/test/src/Model/EntityRotationPolicyTest.cpp
+++ b/common/test/src/Model/EntityRotationPolicyTest.cpp
@@ -151,7 +151,7 @@ TEST_CASE("EntityRotationPolicy.entityRotationInfo") {
     {"angles",    "0 0 0"}},      true,  std::nullopt,                    &invertedPitch, {EntityRotationType::Euler, "angles", EntityRotationUsage::Allowed}},
 
   // a light without a target key and without an angles key
-  {{{"classname", "light"}},      true,  std::nullopt,                    nullptr,        {EntityRotationType::Angle, "angle", EntityRotationUsage::Allowed}},
+  {{{"classname", "light"}},      true,  std::nullopt,                    nullptr,        {EntityRotationType::None, "", EntityRotationUsage::Allowed}},
 
   // a light with a target key
   {{{"classname", "light"},
@@ -203,7 +203,7 @@ TEST_CASE("EntityRotationPolicy.entityRotationInfo") {
 
   // but not for light entities
   {{{"classname", "light"}},      true,  {{EntityDefinitionType::PointEntity, 
-                                           {manglePropertyDef}}},         nullptr,        {EntityRotationType::Angle, "angle", EntityRotationUsage::Allowed}},
+                                           {manglePropertyDef}}},         nullptr,        {EntityRotationType::None, "", EntityRotationUsage::Allowed}},
   }));
   // clang-format on
 

--- a/common/test/src/Model/EntityRotationPolicyTest.cpp
+++ b/common/test/src/Model/EntityRotationPolicyTest.cpp
@@ -17,8 +17,15 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Model/EntityRotationPolicy.h"
 #include "FloatType.h"
+#include "Macros.h"
+
+#include "Assets/EntityDefinition.h"
+#include "Assets/EntityModel.h"
+#include "Assets/PropertyDefinition.h"
+#include "Model/Entity.h"
+#include "Model/EntityProperties.h"
+#include "Model/EntityRotationPolicy.h"
 
 #include <vecmath/approx.h>
 #include <vecmath/mat.h>
@@ -80,6 +87,120 @@ TEST_CASE("EntityRotationPolicy.getYawPitchRoll_flip") {
   const auto yawPitchRoll = EntityRotationPolicy::getYawPitchRoll(scaleMat, rotMat);
 
   CHECK(yawPitchRoll == vm::approx(vm::vec3(180, 45, -10)));
+}
+
+namespace {
+struct EntityDefinitionInfo {
+  Assets::EntityDefinitionType type;
+  vm::bbox3 bounds = vm::bbox3{16.0};
+};
+
+std::unique_ptr<Assets::EntityDefinition> createEntityDefinition(
+  const std::optional<EntityDefinitionInfo>& info) {
+  if (!info.has_value()) {
+    return nullptr;
+  }
+
+  switch (info->type) {
+    case Assets::EntityDefinitionType::PointEntity:
+      return std::make_unique<Assets::PointEntityDefinition>(
+        "", Color{}, info->bounds, "", std::vector<std::shared_ptr<Assets::PropertyDefinition>>{},
+        Assets::ModelDefinition{});
+    case Assets::EntityDefinitionType::BrushEntity:
+      return std::make_unique<Assets::BrushEntityDefinition>(
+        "", Color{}, "", std::vector<std::shared_ptr<Assets::PropertyDefinition>>{});
+      switchDefault();
+  }
+}
+} // namespace
+
+TEST_CASE("EntityRotationPolicy.entityRotationInfo") {
+  using namespace Assets;
+
+  auto normalPitch = EntityModelLoadedFrame{0, "", {}, PitchType::Normal, Orientation::Oriented};
+  auto invertedPitch =
+    EntityModelLoadedFrame{0, "", {}, PitchType::MdlInverted, Orientation::Oriented};
+
+  using T = std::tuple<
+    std::vector<EntityProperty>, bool, std::optional<EntityDefinitionInfo>, EntityModelFrame*,
+    EntityRotationInfo>;
+
+  // clang-format off
+  const auto
+  [entityProperties,              point, entityDefinitionInfo,            entityModel,    expectedRotationInfo] = GENERATE_REF(values<T>({
+  {{},                            false, std::nullopt,                    nullptr,        {EntityRotationType::None, "", EntityRotationUsage::Allowed}},
+  // a light with a mangle key
+  {{{"classname", "light"},
+    {"mangle",    "0 0 0"}},      true,  std::nullopt,                    nullptr,        {EntityRotationType::Mangle, "mangle", EntityRotationUsage::Allowed}},
+
+  // a light without a target key and with an angles key, type is controlled by the model's pitch type (default is normal)
+  {{{"classname", "light"},
+    {"angles",    "0 0 0"}},      true,  std::nullopt,                    nullptr,        {EntityRotationType::Euler_PositivePitchDown, "angles", EntityRotationUsage::Allowed}},
+
+  // a light without a target key and with an angle key
+  {{{"classname", "light"},
+    {"angle",    "0"}},           true,  std::nullopt,                    nullptr,        {EntityRotationType::Angle, "angle", EntityRotationUsage::Allowed}},
+
+  // a light without a target key and with an angles key, type is controlled by the model's pitch type (normal)
+  {{{"classname", "light"},
+    {"angles",    "0 0 0"}},      true,  std::nullopt,                    &normalPitch,   {EntityRotationType::Euler_PositivePitchDown, "angles", EntityRotationUsage::Allowed}},
+
+  // a light without a target key and with an angles key, type is controlled by the model's pitch type (inverted)
+  {{{"classname", "light"},
+    {"angles",    "0 0 0"}},      true,  std::nullopt,                    &invertedPitch, {EntityRotationType::Euler, "angles", EntityRotationUsage::Allowed}},
+
+  // a light without a target key and without an angles key
+  {{{"classname", "light"}},      true,  std::nullopt,                    nullptr,        {EntityRotationType::Angle, "angle", EntityRotationUsage::Allowed}},
+
+  // a light with a target key
+  {{{"classname", "light"},
+    {"target", "xyz"}},           true,  std::nullopt,                    nullptr,        {EntityRotationType::None, "", EntityRotationUsage::Allowed}},
+
+  // non-light brush entity without additional keys
+  {{{"classname", "other"}},      false, std::nullopt,                    nullptr,        {EntityRotationType::None, "", EntityRotationUsage::Allowed}},
+
+  // non-light brush entity with angles key
+  {{{"classname", "other"},
+    {"angles", "0 0 0"}},         false, std::nullopt,                    nullptr,        {EntityRotationType::Euler_PositivePitchDown, "angles", EntityRotationUsage::Allowed}},
+
+  // non-light brush entity with mangle key
+  {{{"classname", "other"},
+    {"mangle", "0 0 0"}},         false, std::nullopt,                    &invertedPitch, {EntityRotationType::Euler, "mangle", EntityRotationUsage::Allowed}},
+
+  // non-light brush entity with mangle key (model controls the euler type)
+  {{{"classname", "other"},
+    {"mangle", "0 0 0"}},         false, std::nullopt,                    nullptr,        {EntityRotationType::Euler_PositivePitchDown, "mangle", EntityRotationUsage::Allowed}},
+
+  // non-light brush entity with angle key
+  {{{"classname", "other"},
+    {"angle", "0"}},              false, std::nullopt,                    nullptr,        {EntityRotationType::AngleUpDown, "angle", EntityRotationUsage::Allowed}},
+
+  // non-light point entity without additional keys
+  {{{"classname", "other"}},      true,  std::nullopt,                    nullptr,        {EntityRotationType::AngleUpDown, "angle", EntityRotationUsage::Allowed}},
+
+  // non-light point entity with angles key
+  {{{"classname", "other"},
+    {"angles", "0 0 0"}},         true,  std::nullopt,                    nullptr,        {EntityRotationType::Euler_PositivePitchDown, "angles", EntityRotationUsage::Allowed}},
+
+  // non-light point entity with angles key (model controls the euler type)
+  {{{"classname", "other"},
+    {"angles", "0 0 0"}},         true,  std::nullopt,                    &invertedPitch, {EntityRotationType::Euler, "angles", EntityRotationUsage::Allowed}},
+
+  // non-light point entity with mangle key
+  {{{"classname", "other"},
+    {"mangle", "0 0 0"}},         true,  std::nullopt,                    nullptr,        {EntityRotationType::Euler_PositivePitchDown, "mangle", EntityRotationUsage::Allowed}},
+  }));
+  // clang-format on
+
+  CAPTURE(entityProperties, point, entityDefinitionInfo, entityModel);
+
+  auto entityDefinition = createEntityDefinition(entityDefinitionInfo);
+  auto entity = Entity{{}, entityProperties};
+  entity.setDefinition({}, entityDefinition.get());
+  entity.setModel({}, entityModel);
+  entity.setPointEntity({}, point);
+
+  CHECK(entityRotationInfo(entity) == expectedRotationInfo);
 }
 } // namespace Model
 } // namespace TrenchBroom


### PR DESCRIPTION
Closes #3827.

The rotation of an entity should be determined by its entity properties, but in absence of such properties, we must inspect the property definitions instead. The effect is that users can apply rotations to entities that don't have corresponding entity properties such as "angles" can still be rotated without adding such a property if the entity has a property definition for an "angles" property.
