### PR TITLE
3984: Snap vertices to grid planes when extruding

### DIFF
--- a/common/src/View/ExtrudeToolController.cpp
+++ b/common/src/View/ExtrudeToolController.cpp
@@ -140,9 +140,14 @@ struct ExtrudeDragDelegate : public HandleDragTrackerDelegate {
           return proposedHandlePosition;
         }
 
-        const auto totalHandleDelta = proposedHandlePosition - dragState.initialHandlePosition;
-        const auto snappedHandleDelta = grid.snap(totalHandleDelta);
-        return dragState.initialHandlePosition + snappedHandleDelta;
+        if (m_extrudeDragState.currentDragFaces.empty()) {
+          return proposedHandlePosition;
+        }
+
+        const auto moveDelta = proposedHandlePosition - dragState.currentHandlePosition;
+        const auto& face = m_extrudeDragState.currentDragFaces.front().face();
+        const auto snappedMoveDelta = grid.snapMoveDeltaForFace(face, moveDelta);
+        return dragState.currentHandlePosition + snappedMoveDelta;
       };
 
     return makeHandlePositionProposer(std::move(picker), std::move(snapper));

--- a/common/src/View/Grid.cpp
+++ b/common/src/View/Grid.cpp
@@ -204,14 +204,6 @@ vm::vec3 Grid::moveDeltaForBounds(
   return newMinPos - bounds.min;
 }
 
-vm::vec3 Grid::combineDeltas(const vm::vec3& delta1, const vm::vec3& delta2) const {
-  if (vm::squared_length(delta1) < vm::squared_length(delta2)) {
-    return delta1;
-  } else {
-    return delta2;
-  }
-}
-
 vm::vec3 Grid::referencePoint(const vm::bbox3& bounds) const {
   return snap(bounds.center());
 }

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -388,7 +388,6 @@ public:
     const vm::plane3& targetPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds,
     const vm::ray3& ray) const;
 
-  vm::vec3 combineDeltas(const vm::vec3& delta1, const vm::vec3& delta2) const;
   vm::vec3 referencePoint(const vm::bbox3& bounds) const;
 };
 } // namespace View

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -388,6 +388,15 @@ public:
     const vm::plane3& targetPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds,
     const vm::ray3& ray) const;
 
+  /**
+   * Given a line and a point X on the line (via the distance from the line's origin), returns the
+   * distance to a point Y on the line such that Y is on the intersection of the line with a grid
+   * plane, and the distance between X and Y is minimal among all such points.
+   */
+  FloatType snapToGridPlane(const vm::line3& line, FloatType distance) const;
+
+  vm::vec3 snapMoveDeltaForFace(const Model::BrushFace& face, const vm::vec3& delta) const;
+
   vm::vec3 referencePoint(const vm::bbox3& bounds) const;
 };
 } // namespace View

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -387,11 +387,7 @@ public:
   vm::vec3 moveDeltaForBounds(
     const vm::plane3& targetPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds,
     const vm::ray3& ray) const;
-  /**
-   * Given `delta`, a vector in the direction of the face's normal,
-   * returns a copy of it, also in the direction of the face's normal, that will try to keep the
-   * face on-grid.
-   */
+
   vm::vec3 combineDeltas(const vm::vec3& delta1, const vm::vec3& delta2) const;
   vm::vec3 referencePoint(const vm::bbox3& bounds) const;
 };


### PR DESCRIPTION
Closes #3984.

This PR restores the old way of snapping vertices to grid planes when extruding. This allows for better precision when extruding brushes along non-axial face normals.