### PR TITLE
3986: Update angle of brush entity when it is transformed while all children are selected

### DIFF
--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -308,14 +308,14 @@ void Entity::transform(
     if (origin() != newOrigin) {
       setOrigin(propertyConfig, transformedCenter - offset);
     }
+  }
 
-    // applying rotation has side effects (e.g. normalizing "angles")
-    // so only do it if there is actually some rotation.
-    const auto rotation = vm::strip_translation(transformation);
-    if (rotation != vm::mat4x4::identity()) {
-      // applyRotation does not read the origin, so it's ok that it's already updated now
-      applyRotation(propertyConfig, rotation);
-    }
+  // applying rotation has side effects (e.g. normalizing "angles")
+  // so only do it if there is actually some rotation.
+  const auto rotation = vm::strip_translation(transformation);
+  if (rotation != vm::mat4x4::identity()) {
+    // applyRotation does not read the origin, so it's ok that it's already updated now
+    applyRotation(propertyConfig, rotation);
   }
 }
 


### PR DESCRIPTION
Closes #3986.

When transforming all brushes of a brush entity, we now update the entities' rotation properties, e.g. "angle", if present (or defined via an entity definition). This does not apply if some, but not all brushes of the entity are rotated.