### PR TITLE
3989: Set CMAKE_OSX_DEPLOYMENT_TARGET only when building on CI

### DIFF
--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -22,7 +22,7 @@ echo "TB_ENABLE_ASAN: $TB_ENABLE_ASAN_VALUE"
 
 mkdir build
 cd build
-cmake .. -GNinja -DCMAKE_BUILD_TYPE="$BUILD_TYPE_VALUE" -DCMAKE_CXX_FLAGS="-Werror" -DTB_ENABLE_ASAN="$TB_ENABLE_ASAN_VALUE" -DTB_RUN_MACDEPLOYQT=1 -DTB_SUPPRESS_PCH=1 -DCMAKE_PREFIX_PATH="$(brew --prefix qt5)" -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake || exit 1
+cmake .. -GNinja -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" -DCMAKE_BUILD_TYPE="$BUILD_TYPE_VALUE" -DCMAKE_CXX_FLAGS="-Werror" -DTB_ENABLE_ASAN="$TB_ENABLE_ASAN_VALUE" -DTB_RUN_MACDEPLOYQT=1 -DTB_SUPPRESS_PCH=1 -DCMAKE_PREFIX_PATH="$(brew --prefix qt5)" -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake || exit 1
 
 cmake --build . --config "$BUILD_TYPE_VALUE" || exit 1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,6 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Set TrenchBroom item as default single startup project (NOTE: CMake 3.6 and newer)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT TrenchBroom)
 
-# Mac OS X specific configuration. These settings are ignored on other platforms.
-# We are using deployment target 10.14 because C++17 is only fully supported on that version and up.
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
-
 # Using C and CXX because GLEW is C
 project(TrenchBroom C CXX)
 


### PR DESCRIPTION
Closes #3989.