### PR TITLE
3992: Set C++ standard version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Set TrenchBroom item as default single startup project (NOTE: CMake 3.6 and newer)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT TrenchBroom)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Using C and CXX because GLEW is C
 project(TrenchBroom C CXX)
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1009,7 +1009,6 @@ set(COMMON_HEADER
 
 add_library(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})
 set_target_properties(common PROPERTIES AUTOMOC TRUE)
-target_compile_features(common PRIVATE cxx_std_17)
 target_include_directories(common PUBLIC ${COMMON_SOURCE_DIR})
 target_link_libraries(common PUBLIC tinyxml2::tinyxml2 kdl vecmath GLEW::GLEW miniz::miniz freeimage::FreeImage freetype OpenGL::GL Qt5::Widgets Qt5::Svg fmt::fmt)
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -158,7 +158,6 @@ set(TEST_FIXTURE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/fixture")
 
 add_library(common-test-utils OBJECT ${COMMON_TEST_UTILS_SOURCE})
 set_compiler_config(common-test-utils)
-target_compile_features(common-test-utils PRIVATE cxx_std_17)
 target_include_directories(common-test-utils PUBLIC ${COMMON_TEST_SOURCE_DIR})
 target_link_libraries(common-test-utils PRIVATE common Catch2::Catch2)
 

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -10,7 +10,6 @@ endif()
 set(KDL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_library(kdl INTERFACE)
-target_compile_features(kdl INTERFACE cxx_std_17)
 target_include_directories(kdl INTERFACE
         $<BUILD_INTERFACE:${KDL_INCLUDE_DIR}>
         $<INSTALL_INTERFACE:kdl/include/kdl>)
@@ -63,7 +62,6 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/zip_iterator.h"
 )
 
-target_compile_features(kdl INTERFACE cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(kdl INTERFACE -Wall -Wextra -Wconversion -Wshadow-all -pedantic -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-exit-time-destructors)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
Closes #3992

Setting CMAKE_CXX_STANDARD globally sets the default and lets cmake choose whatever flags are appropriate for us.