### PR TITLE
4007: Scale entity models in browser

### DIFF
--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -279,7 +279,7 @@ void EntityBrowserView::renderBounds(Layout& layout, const float y, const float 
             auto* modelRenderer = cellData(cell).modelRenderer;
 
             if (modelRenderer == nullptr) {
-              const auto itemTrans = itemTransformation(cell, y, height);
+              const auto itemTrans = itemTransformation(cell, y, height, false);
               const auto& color = definition->color();
               CollectBoundsVertices<BoundsVertex> collect(itemTrans, color, vertices);
               vm::bbox3f(definition->bounds()).for_each_edge(collect);
@@ -324,7 +324,7 @@ void EntityBrowserView::renderModels(
             if (modelRenderer != nullptr) {
               shader.set("Orientation", static_cast<int>(cellData(cell).modelOrientation));
 
-              const auto itemTrans = itemTransformation(cell, y, height);
+              const auto itemTrans = itemTransformation(cell, y, height, true);
               shader.set("ModelMatrix", itemTrans);
 
               Renderer::MultiplyModelMatrix multMatrix(transformation, itemTrans);
@@ -452,7 +452,7 @@ EntityBrowserView::StringMap EntityBrowserView::collectStringVertices(
 }
 
 vm::mat4x4f EntityBrowserView::itemTransformation(
-  const Cell& cell, const float y, const float height) const {
+  const Cell& cell, const float y, const float height, const bool applyModelScale) const {
   const auto& cellData = this->cellData(cell);
   const auto* definition = cellData.entityDefinition;
 
@@ -460,7 +460,7 @@ vm::mat4x4f EntityBrowserView::itemTransformation(
     vm::vec3f(0.0f, cell.itemBounds().left(), height - (cell.itemBounds().bottom() - y));
   const auto scaling = cell.scale();
   const auto& rotatedBounds = cellData.bounds;
-  const auto& modelScale = cellData.modelScale;
+  const auto modelScale = applyModelScale ? cellData.modelScale : vm::vec3f{1, 1, 1};
   const auto rotationOffset = vm::vec3f(0.0f, -rotatedBounds.min.y(), -rotatedBounds.min.z());
   const auto boundsCenter = vm::vec3f(definition->bounds().center());
 

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -202,7 +202,7 @@ void EntityBrowserView::addEntityToLayout(
       const auto bounds = frame->bounds();
       const auto center = bounds.center();
       const auto transform = vm::translation_matrix(center) * vm::rotation_matrix(m_rotation) *
-                             vm::translation_matrix(-center);
+                             vm::scaling_matrix(modelScale) * vm::translation_matrix(-center);
       rotatedBounds = bounds.transform(transform);
       modelRenderer = m_entityModelManager.renderer(spec);
       modelOrientation = frame->orientation();

--- a/common/src/View/EntityBrowserView.h
+++ b/common/src/View/EntityBrowserView.h
@@ -60,6 +60,7 @@ struct EntityCellData {
   Assets::Orientation modelOrientation;
   Renderer::FontDescriptor fontDescriptor;
   vm::bbox3f bounds;
+  vm::vec3f modelScale;
 };
 
 class EntityBrowserView : public CellView {

--- a/common/src/View/EntityBrowserView.h
+++ b/common/src/View/EntityBrowserView.h
@@ -130,7 +130,8 @@ private:
   void renderStrings(Layout& layout, float y, float height);
   StringMap collectStringVertices(Layout& layout, float y, float height);
 
-  vm::mat4x4f itemTransformation(const Cell& cell, float y, float height) const;
+  vm::mat4x4f itemTransformation(
+    const Cell& cell, float y, float height, bool applyModelScale) const;
 
   QString tooltip(const Cell& cell) override;
 


### PR DESCRIPTION
Closes #4007.

First we revert #3978 because it turns out we do want to apply model scale in the browser. The original problem wasn't the scale per se, but that we failed to correctly scale down models if they were too large to fit a cell of the browser view. This PR fixes the problem by considering the model scale when computing the scale factor for the browser cells.