### PR TITLE
4002: Update build instructions for Linux

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -120,7 +120,7 @@ cd <path/to/TrenchBroom>/build
 Then, execute this command to configure the project:
 
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake"
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="cmake/packages" -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake"
 cmake --build . --target TrenchBroom
 ```
 


### PR DESCRIPTION
On Linux, we must pass DCMAKE_PREFIX_PATH to cmake so that it can find our config scripts for some external libraries.