### PR TITLE
4023: Disallow selection via hidden face

### DIFF
--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -29,12 +29,22 @@
 #include "Model/WorldNode.h"
 
 #include <kdl/overload.h>
+#include <kdl/reflection_impl.h>
 
 #include <algorithm>
 #include <vector>
 
 namespace TrenchBroom {
 namespace Model {
+
+kdl_reflect_impl(NodeCollection);
+
+NodeCollection::NodeCollection() = default;
+
+NodeCollection::NodeCollection(const std::vector<Node*>& nodes) {
+  addNodes(nodes);
+}
+
 bool NodeCollection::empty() const {
   return m_nodes.empty();
 }

--- a/common/src/Model/NodeCollection.h
+++ b/common/src/Model/NodeCollection.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <kdl/reflection_decl.h>
+
 #include <cstddef>
 #include <vector>
 
@@ -41,6 +43,11 @@ private:
   std::vector<PatchNode*> m_patches;
 
 public:
+  kdl_reflect_decl(NodeCollection, m_nodes, m_layers, m_groups, m_entities, m_brushes, m_patches);
+
+  NodeCollection();
+  explicit NodeCollection(const std::vector<Node*>& nodes);
+
   bool empty() const;
   size_t nodeCount() const;
   size_t layerCount() const;

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -135,7 +135,6 @@ bool SelectionTool::mouseClick(const InputState& inputState) {
     if (const auto faceHandle = Model::hitToFaceHandle(hit)) {
       const auto* brush = faceHandle->node();
       const auto& face = faceHandle->face();
-      ;
       if (editorContext.selectable(brush, face)) {
         if (isMultiClick(inputState)) {
           const auto objects = document->hasSelectedNodes();
@@ -223,7 +222,7 @@ bool SelectionTool::mouseDoubleClick(const InputState& inputState) {
     const auto& hit = firstHit(inputState, Model::nodeHitType());
     if (hit.isMatch()) {
       const auto hitInGroup =
-        inGroup && hit.isMatch() && Model::hitToNode(hit)->isDescendantOf(document->currentGroup());
+        inGroup && Model::hitToNode(hit)->isDescendantOf(document->currentGroup());
       if (!inGroup || hitInGroup) {
         // If the hit node is inside a closed group, treat it as a hit on the group insted
         auto* group = findOutermostClosedGroup(Model::hitToNode(hit));

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -53,7 +53,6 @@ private:
 public:
   explicit SelectionTool(std::weak_ptr<MapDocument> document);
 
-private:
   Tool& tool() override;
   const Tool& tool() const override;
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/PickingTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/ScaleObjectsToolTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SelectionTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/SelectionToolTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SetEntityPropertiesTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SetLockStateTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SetVisibilityStateTest.cpp"

--- a/common/test/src/View/SelectionToolTest.cpp
+++ b/common/test/src/View/SelectionToolTest.cpp
@@ -325,11 +325,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking") {
 
           THEN("Nothing happens") {
             CHECK(document->selectedBrushFaces().empty());
-            /* EXPECTED:
             CHECK(document->selectedNodes().empty());
-            ACTUAL:
-            */
-            CHECK_FALSE(document->selectedNodes().empty());
           }
         }
       }

--- a/common/test/src/View/SelectionToolTest.cpp
+++ b/common/test/src/View/SelectionToolTest.cpp
@@ -1,0 +1,340 @@
+/*
+ Copyright (C) 2022 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Model/BrushBuilder.h"
+
+#include "FloatType.h"
+#include "Model/Brush.h"
+#include "Model/BrushFace.h"
+#include "Model/BrushNode.h"
+#include "Model/EditorContext.h"
+#include "Model/Entity.h"
+#include "Model/EntityNode.h"
+#include "Model/PickResult.h"
+#include "Model/WorldNode.h"
+#include "Renderer/OrthographicCamera.h"
+#include "View/InputState.h"
+#include "View/MapDocumentTest.h"
+#include "View/PickRequest.h"
+#include "View/SelectionTool.h"
+
+#include <vecmath/ray.h>
+
+#include <kdl/result.h>
+#include <kdl/vector_utils.h>
+
+#include "Catch2.h"
+
+namespace TrenchBroom {
+namespace View {
+TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking") {
+  const auto* world = document->world();
+  auto builder = Model::BrushBuilder{
+    world->mapFormat(), document->worldBounds(), document->game()->defaultFaceAttribs()};
+
+  auto tool = SelectionTool{document};
+
+  GIVEN("A brush node and an entity node") {
+    auto brush =
+      builder
+        .createCube(
+          32.0, "left_face", "right_face", "front_face", "back_face", "top_face", "bottom_face")
+        .value();
+    auto* brushNode = new Model::BrushNode{std::move(brush)};
+
+    const auto topFaceIndex = brushNode->brush().findFace("top_face").value();
+    const auto frontFaceIndex = brushNode->brush().findFace("front_face").value();
+
+    auto* entityNode = new Model::EntityNode{{}, {{"origin", "64 0 0"}}};
+
+    document->addNodes({{document->parentForNodes(), {brushNode, entityNode}}});
+
+    auto camera = Renderer::OrthographicCamera{};
+
+    AND_GIVEN("A pick ray that points at the top face of the brush") {
+      camera.moveTo({0, 0, 32});
+      camera.setDirection({0, 0, -1}, {0, 1, 0});
+
+      const auto pickRay = vm::ray3{camera.pickRay({0, 0, 0})};
+
+      auto pickResult = Model::PickResult{};
+      document->pick(pickRay, pickResult);
+      REQUIRE(pickResult.all().size() == 1);
+
+      REQUIRE(document->selectedBrushFaces().empty());
+
+      auto inputState = InputState{};
+      inputState.setPickRequest({pickRay, camera});
+      inputState.setPickResult(std::move(pickResult));
+
+      WHEN("I shift click once") {
+        inputState.setModifierKeys(ModifierKeys::MKShift);
+        inputState.mouseDown(MouseButtons::MBLeft);
+        tool.mouseClick(inputState);
+        inputState.mouseUp(MouseButtons::MBLeft);
+
+        THEN("The top face get selected") {
+          CHECK(
+            document->selectedBrushFaces() ==
+            std::vector<Model::BrushFaceHandle>{{brushNode, topFaceIndex}});
+          CHECK(document->selectedNodes().empty());
+        }
+
+        AND_WHEN("I shift click on the selected face again") {
+          inputState.setModifierKeys(ModifierKeys::MKShift);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The top face remains selected") {
+            CHECK(
+              document->selectedBrushFaces() ==
+              std::vector<Model::BrushFaceHandle>{{brushNode, topFaceIndex}});
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+
+        AND_WHEN("I shift+ctrl click on the selected face again") {
+          inputState.setModifierKeys(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The top face gets deselected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+      }
+
+      WHEN("I click once") {
+        inputState.mouseDown(MouseButtons::MBLeft);
+        tool.mouseClick(inputState);
+        inputState.mouseUp(MouseButtons::MBLeft);
+
+        THEN("The brush gets selected") {
+          CHECK(document->selectedBrushFaces().empty());
+          CHECK(document->selectedNodes() == Model::NodeCollection{{brushNode}});
+        }
+
+        AND_WHEN("I click on the selected brushagain") {
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The brush remains selected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes() == Model::NodeCollection{{brushNode}});
+          }
+        }
+
+        AND_WHEN("I ctrl click on the selected brush again") {
+          inputState.setModifierKeys(ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The brush gets deselected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+      }
+
+      WHEN("I shift double click") {
+        inputState.setModifierKeys(ModifierKeys::MKShift);
+        inputState.mouseDown(MouseButtons::MBLeft);
+        tool.mouseDoubleClick(inputState);
+        inputState.mouseUp(MouseButtons::MBLeft);
+
+        THEN("All brush faces are selected") {
+          CHECK(document->selectedBrushFaces().size() == 6);
+          CHECK(document->selectedNodes().empty());
+        }
+      }
+
+      WHEN("I double click") {
+        inputState.mouseDown(MouseButtons::MBLeft);
+        tool.mouseDoubleClick(inputState);
+        inputState.mouseUp(MouseButtons::MBLeft);
+
+        THEN("All nodes are selected") {
+          CHECK(document->selectedBrushFaces().empty());
+          CHECK(document->selectedNodes() == Model::NodeCollection{{brushNode, entityNode}});
+        }
+      }
+
+      AND_GIVEN("The front face of the brush is selected") {
+        document->selectBrushFaces({{brushNode, frontFaceIndex}});
+
+        WHEN("I shift click once") {
+          inputState.setModifierKeys(ModifierKeys::MKShift);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The top face get selected") {
+            CHECK(
+              document->selectedBrushFaces() ==
+              std::vector<Model::BrushFaceHandle>{{brushNode, topFaceIndex}});
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+
+        WHEN("I shift+ctrl click once") {
+          inputState.setModifierKeys(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("Both the front and the top faces are selected") {
+            CHECK_THAT(
+              document->selectedBrushFaces(),
+              Catch::Matchers::UnorderedEquals(std::vector<Model::BrushFaceHandle>{
+                {brushNode, topFaceIndex}, {brushNode, frontFaceIndex}}));
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+
+        WHEN("I click once") {
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The brush gets selected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes() == Model::NodeCollection{{brushNode}});
+          }
+        }
+
+        WHEN("I ctrl click once") {
+          inputState.setModifierKeys(ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The brush gets selected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes() == Model::NodeCollection{{brushNode}});
+          }
+        }
+      }
+
+      AND_GIVEN("The entity is selected") {
+        document->selectNodes({entityNode});
+
+        WHEN("I shift click once") {
+          inputState.setModifierKeys(ModifierKeys::MKShift);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The top face get selected") {
+            CHECK(
+              document->selectedBrushFaces() ==
+              std::vector<Model::BrushFaceHandle>{{brushNode, topFaceIndex}});
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+
+        WHEN("I shift+ctrl click once") {
+          inputState.setModifierKeys(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The top face get selected") {
+            CHECK(
+              document->selectedBrushFaces() ==
+              std::vector<Model::BrushFaceHandle>{{brushNode, topFaceIndex}});
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+
+        WHEN("I click once") {
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The brush gets selected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes() == Model::NodeCollection{{brushNode}});
+          }
+        }
+
+        WHEN("I ctrl click once") {
+          inputState.setModifierKeys(ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("The brush and entity both get selected") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes() == Model::NodeCollection{{entityNode, brushNode}});
+          }
+        }
+      }
+
+      AND_GIVEN("The top face is hidden") {
+
+        auto hiddenTag = Model::Tag{"hidden", {}};
+
+        auto newBrush = brushNode->brush();
+        newBrush.face(topFaceIndex).addTag(hiddenTag);
+        document->swapNodeContents(
+          "Set Tag", {{brushNode, Model::NodeContents{std::move(newBrush)}}});
+
+        REQUIRE(brushNode->brush().face(topFaceIndex).hasTag(hiddenTag));
+
+        document->editorContext().setHiddenTags(hiddenTag.type());
+        REQUIRE_FALSE(
+          document->editorContext().visible(brushNode, brushNode->brush().face(topFaceIndex)));
+
+        WHEN("I shift click once") {
+          inputState.setModifierKeys(ModifierKeys::MKShift);
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("Nothing happens") {
+            CHECK(document->selectedBrushFaces().empty());
+            CHECK(document->selectedNodes().empty());
+          }
+        }
+
+        WHEN("I click once") {
+          inputState.mouseDown(MouseButtons::MBLeft);
+          tool.mouseClick(inputState);
+          inputState.mouseUp(MouseButtons::MBLeft);
+
+          THEN("Nothing happens") {
+            CHECK(document->selectedBrushFaces().empty());
+            /* EXPECTED:
+            CHECK(document->selectedNodes().empty());
+            ACTUAL:
+            */
+            CHECK_FALSE(document->selectedNodes().empty());
+          }
+        }
+      }
+    }
+  }
+}
+} // namespace View
+} // namespace TrenchBroom


### PR DESCRIPTION
Closes #4023.

If a face is hidden via a tag, it should not be possible to select the owning brush by click the selected face. This PR fixes this behavior by filtering out hits on brush nodes where the hit face is invisible.