### PR TITLE
4025: Retain the skin index when loading an entity frame

### DIFF
--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -480,6 +480,8 @@ EntityModelLoadedFrame& EntityModel::loadFrame(
 
   auto frame =
     std::make_unique<EntityModelLoadedFrame>(frameIndex, name, bounds, m_pitchType, m_orientation);
+  frame->setSkinOffset(m_frames[frameIndex]->skinOffset());
+
   auto& result = *frame;
   m_frames[frameIndex] = std::move(frame);
   return result;


### PR DESCRIPTION
Closes #4025.