### PR TITLE
4033: Prefer entity properties over definitions when determining rotation type

### DIFF
--- a/common/test/src/Model/EntityRotationTest.cpp
+++ b/common/test/src/Model/EntityRotationTest.cpp
@@ -151,6 +151,11 @@ TEST_CASE("entityRotationInfo") {
   {{{"classname", "other"}},      true,  {{EntityDefinitionType::PointEntity,
                                            {manglePropertyDef}}},         nullptr,        {EntityRotationType::Euler_PositivePitchDown, "mangle", EntityRotationUsage::Allowed}},
 
+  // prefer actual existing properties over definitions when determining the rotation type
+  {{{"classname", "other"},
+    {"angle", "45"}},             true,  {{EntityDefinitionType::PointEntity,
+                                           {manglePropertyDef}}},         nullptr,        {EntityRotationType::AngleUpDown, "angle", EntityRotationUsage::Allowed}},
+
   // but not for light entities
   {{{"classname", "light"}},      true,  {{EntityDefinitionType::PointEntity,
                                            {manglePropertyDef}}},         nullptr,        {EntityRotationType::None, "", EntityRotationUsage::Allowed}},


### PR DESCRIPTION
Closes #4033

When determining the rotation type, we look at both the actual entity
properties and the entity property definitions from the FGD file with
equal priorities. This commit changes this behavior to prefer the actual
properties over the property definitions so that entities with more than
one defined angle-related properties (e.g. misc_model for Quake 3, which
has both a defined angle and a defined angles property) are still
displayed correctly. Before this change, the definition for the angles
property would override an actual angle property and so the entity
rotation would be computed wrongly.