### PR TITLE
2957: Drop model format whitelist

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2384,8 +2384,7 @@ Game configuration files need to specify the following information.
 * **Entities**
 	* The builtin **entity definition files**
 	* The **default color** to use in the UI
-	* The supported **model formats**, e.g. mdl
-    * A default **model scale expression**
+  * A default **model scale expression**
 * **Tags** to attach additional information to faces or brushes in the editor, e.g. whether a face is detail or hint. (optional)
 * **Face attributes** to specify which additional attributes to allow on brush faces (optional)
 * **Map bounds** to be displayed in the 2D viewports (optional)
@@ -2414,7 +2413,6 @@ The game configuration is an [expression language](#expression_language) map wit
         "entities": { // the builtin entity definition files for this game
             "definitions": [ "Quake2.fgd" ],
             "defaultcolor": "0.6 0.6 0.6 1.0",
-            "modelformats": [ "md2" ],
             "scale": [ modelscale, modelscale_vec ]
         },
         "tags": { // "smart tags" select or modify a brush/face based on its characteristics
@@ -2626,27 +2624,15 @@ The optional `excludes` key specifies a list of patterns matched against texture
 
 #### Entity Configuration {#game_configuration_files_entities}
 
-In the entity configuration section, you can specify which entity definition files come with your game configuration, which model formats are supported for rendering the entity models in the editor, a default color for entities and an expression that yields a default scale when evaluated against an entities' properties.
+In the entity configuration section, you can specify which entity definition files come with your game configuration, a default color for entities and an expression that yields a default scale when evaluated against an entities' properties.
 
   	"entities": { // the builtin entity definition files for this game
 		"definitions": [ "Quake2/Quake2.fgd" ],
     	"defaultcolor": "0.6 0.6 0.6 1.0",
-		"modelformats": [ "md2" ],
-        "scale": [ modelscale, modelscale_vec ]
+      "scale": [ modelscale, modelscale_vec ]
     },
 
 The `definitions` key provides a list of entity definition files. These files are specified by a path that is relative to the `games` directory where TrenchBroom searches for the game configurations.
-
-The `modelformats` key has a list of model formats used by this game. The following model formats are supported.
-
-Format       Description
-------       -----------
-mdl          Quake model format
-md2          Quake 2 model format
-md3          Quake 3 model format
-bsp        	 Compiled brush model, used by Quake and Hexen 2
-dkm          Daikatana model format
-
 
 The `scale` key has an expression that is evaluated against an entities' properties to determine the model scale. This expression can refer to any of the entities' properties, or it can provide fixed values.
 

--- a/app/resources/games/DDayNormandy/GameConfig.cfg
+++ b/app/resources/games/DDayNormandy/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "D-Day Normandy",
     "icon": "Icon.png",
     "fileformats": [
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "dday.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "md2" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Daikatana/GameConfig.cfg
+++ b/app/resources/games/Daikatana/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Daikatana",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Daikatana" } ],
@@ -14,8 +14,7 @@
     },
     "entities": {
         "definitions": [ "Episode 1.fgd", "Episode 2.fgd", "Episode 3.fgd", "Episode 4.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "dkm" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/DigitalPaintball2/GameConfig.cfg
+++ b/app/resources/games/DigitalPaintball2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Digital Paintball2",
     "icon": "Icon.png",
     "fileformats": [
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "pball2.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "md2" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Generic/GameConfig.cfg
+++ b/app/resources/games/Generic/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    version: 4,
+    version: 5,
     name: "Generic",
     icon: "Icon.png",
     "fileformats": [
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "Generic.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "bsp, mdl, md2" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [],

--- a/app/resources/games/Halflife/GameConfig.cfg
+++ b/app/resources/games/Halflife/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Half-Life",
     "experimental": true,
     "icon": "Icon.png",
@@ -16,8 +16,7 @@
     },
     "entities": {
         "definitions": [ "HalfLife.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "assimp", "bsp" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Heretic2/GameConfig.cfg
+++ b/app/resources/games/Heretic2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Heretic 2",
     "icon": "Icon.png",
     "fileformats": [
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "heretic2.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "md2" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Hexen2/GameConfig.cfg
+++ b/app/resources/games/Hexen2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Hexen 2",
     "icon": "Icon.png",
     "fileformats": [
@@ -18,7 +18,6 @@
     },
     "entities": {
         "definitions": [ "Hexen2.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "mdl", "bsp" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     }
 }

--- a/app/resources/games/Kingpin/GameConfig.cfg
+++ b/app/resources/games/Kingpin/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Kingpin",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Quake2" } ],
@@ -15,8 +15,7 @@
     },
     "entities": {
         "definitions": [ "Kingpin.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "mdx", "md2" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Neverball/GameConfig.cfg
+++ b/app/resources/games/Neverball/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Neverball",
     "icon": "Icon.png",
     "experimental": true,
@@ -17,8 +17,7 @@
     },
     "entities": {
         "definitions": [ "neverball.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "obj" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Quake/GameConfig.cfg
+++ b/app/resources/games/Quake/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Quake",
     "icon": "Icon.png",
     "fileformats": [
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "Quake.fgd", "Quoth2.fgd", "Rubicon2.def", "Teamfortress.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "mdl", "bsp", "spr" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Quake2/GameConfig.cfg
+++ b/app/resources/games/Quake2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Quake 2",
     "icon": "Icon.png",
     "fileformats": [
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "Quake2.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "md2" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Quake 3",
     "icon": "Icon.png",
     "experimental": true,
@@ -22,7 +22,6 @@
     "entities": {
         "definitions": [ "entities.ent" ],
         "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "md3", "ase" ],
         "scale": [ modelscale, modelscale_vec ] // this is an expression that is evaluated at runtime
     },
     "tags": {

--- a/app/resources/games/Quetoo/GameConfig.cfg
+++ b/app/resources/games/Quetoo/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Quetoo",
     "icon": "Icon.png",
     "experimental": true,
@@ -18,8 +18,7 @@
     },
     "entities": {
         "definitions": [ "Quetoo.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": [ "md3", "obj_neverball" ]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/app/resources/games/Wrath/GameConfig.cfg
+++ b/app/resources/games/Wrath/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "name": "Wrath",
     "icon": "Icon.png",
     "experimental": true,
@@ -22,8 +22,7 @@
     },
     "entities": {
         "definitions": [ "wrath.fgd" ],
-        "defaultcolor": "0.6 0.6 0.6 1.0",
-        "modelformats": ["ase", "bsp", "mdl", "md2", "md3"]
+        "defaultcolor": "0.6 0.6 0.6 1.0"
     },
     "tags": {
         "brush": [

--- a/common/src/Assets/Palette.cpp
+++ b/common/src/Assets/Palette.cpp
@@ -130,7 +130,7 @@ bool Palette::initialized() const {
 }
 
 bool Palette::indexedToRgba(
-  IO::BufferedReader& reader, const size_t pixelCount, TextureBuffer& rgbaImage,
+  IO::Reader& reader, const size_t pixelCount, TextureBuffer& rgbaImage,
   const PaletteTransparency transparency, Color& averageColor) const {
   ensure(rgbaImage.size() == 4 * pixelCount, "incorrect destination buffer size");
   ensure(initialized(), "indexedToRgba called on uninitialized palette");
@@ -139,15 +139,10 @@ bool Palette::indexedToRgba(
                                        ? m_data->opaqueData.data()
                                        : m_data->index255TransparentData.data();
 
-  const unsigned char* indexedImage =
-    reinterpret_cast<const unsigned char*>(reader.begin() + reader.position());
-  reader.seekForward(
-    pixelCount); // throws ReaderException if there aren't pixelCount bytes available
-
   // Write rgba pixels
   unsigned char* const rgbaData = rgbaImage.data();
   for (size_t i = 0; i < pixelCount; ++i) {
-    const int index = static_cast<int>(indexedImage[i]);
+    const int index = reader.readInt<unsigned char>();
 
     std::memcpy(rgbaData + (i * 4), &paletteData[index * 4], 4);
   }

--- a/common/src/Assets/Palette.h
+++ b/common/src/Assets/Palette.h
@@ -82,7 +82,7 @@ public:
    * @throws ReaderException if reader doesn't have pixelCount bytes available
    */
   bool indexedToRgba(
-    IO::BufferedReader& reader, size_t pixelCount, TextureBuffer& rgbaImage,
+    IO::Reader& reader, size_t pixelCount, TextureBuffer& rgbaImage,
     const PaletteTransparency transparency, Color& averageColor) const;
 };
 } // namespace Assets

--- a/common/src/IO/AseParser.cpp
+++ b/common/src/IO/AseParser.cpp
@@ -113,6 +113,10 @@ AseParser::AseParser(const std::string& name, std::string_view str, const FileSy
   , m_tokenizer(std::move(str))
   , m_fs(fs) {}
 
+bool AseParser::canParse(const Path& path) {
+  return kdl::str_to_lower(path.extension()) == "ase";
+}
+
 std::unique_ptr<Assets::EntityModel> AseParser::doInitializeModel(Logger& logger) {
   Scene scene;
   parseAseFile(logger, scene);

--- a/common/src/IO/AseParser.h
+++ b/common/src/IO/AseParser.h
@@ -114,6 +114,8 @@ public:
    */
   AseParser(const std::string& name, std::string_view str, const FileSystem& fs);
 
+  static bool canParse(const Path& path);
+
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
 

--- a/common/src/IO/AssimpParser.cpp
+++ b/common/src/IO/AssimpParser.cpp
@@ -32,6 +32,7 @@
 #include "Renderer/TexturedIndexRangeMap.h"
 #include "Renderer/TexturedIndexRangeMapBuilder.h"
 
+#include <kdl/string_format.h>
 #include <kdl/vector_utils.h>
 
 #include <assimp/IOStream.hpp>
@@ -205,6 +206,23 @@ AssimpParser::AssimpParser(Path path, const FileSystem& fs)
   : m_path{std::move(path)}
   , m_fs{fs} {}
 
+bool AssimpParser::canParse(const Path& path) {
+  static const auto supportedExtensions = std::vector<std::string>{
+    // Quake model formats have been omitted since Trenchbroom's got its own parsers already.
+    "3mf",  "dae",      "xml",          "blend",    "bvh",       "3ds",  "ase",
+    "lwo",  "lws",      "md5mesh",      "md5anim",  "md5camera", // Lightwave and Doom 3 formats.
+    "gltf", "fbx",      "glb",          "ply",      "dxf",       "ifc",  "iqm",
+    "nff",  "smd",      "vta", // .smd and .vta are uncompiled Source engine models.
+    "mdc",  "x",        "q30",          "qrs",      "ter",       "raw",  "ac",
+    "ac3d", "stl",      "dxf",          "irrmesh",  "irr",       "off",
+    "obj", // .obj files will only be parsed by Assimp if the neverball importer isn't enabled.
+    "mdl", // 3D GameStudio Model. It requires a palette file to load.
+    "hmp",  "mesh.xml", "skeleton.xml", "material", "ogex",      "ms3d", "lxo",
+    "csm",  "ply",      "cob",          "scn",      "xgl"};
+
+  return kdl::vec_contains(supportedExtensions, kdl::str_to_lower(path.extension()));
+}
+
 void AssimpParser::processNode(
   const aiNode& node, const aiScene& scene, const aiMatrix4x4& transform,
   const aiMatrix4x4& axisTransform) {
@@ -339,19 +357,5 @@ void AssimpParser::processMaterials(const aiScene& scene, Logger& logger) {
   }
 }
 
-std::vector<std::string> AssimpParser::supportedExtensions() {
-  return std::vector<std::string>{
-    // Quake model formats have been omitted since Trenchbroom's got its own parsers already.
-    "3mf",  "dae",      "xml",          "blend",    "bvh",       "3ds",  "ase",
-    "lwo",  "lws",      "md5mesh",      "md5anim",  "md5camera", // Lightwave and Doom 3 formats.
-    "gltf", "fbx",      "glb",          "ply",      "dxf",       "ifc",  "iqm",
-    "nff",  "smd",      "vta", // .smd and .vta are uncompiled Source engine models.
-    "mdc",  "x",        "q30",          "qrs",      "ter",       "raw",  "ac",
-    "ac3d", "stl",      "dxf",          "irrmesh",  "irr",       "off",
-    "obj", // .obj files will only be parsed by Assimp if the neverball importer isn't enabled.
-    "mdl", // 3D GameStudio Model. It requires a palette file to load.
-    "hmp",  "mesh.xml", "skeleton.xml", "material", "ogex",      "ms3d", "lxo",
-    "csm",  "ply",      "cob",          "scn",      "xgl"};
-}
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/src/IO/AssimpParser.h
+++ b/common/src/IO/AssimpParser.h
@@ -69,7 +69,8 @@ private:
 
 public:
   AssimpParser(Path path, const FileSystem& fs);
-  static std::vector<std::string> supportedExtensions();
+
+  static bool canParse(const Path& path);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -72,16 +72,15 @@ static const size_t ModelFaceIndex = 0x38;
 } // namespace BspLayout
 
 Bsp29Parser::Bsp29Parser(
-  const std::string& name, const char* begin, const char* end, const Assets::Palette& palette,
+  const std::string& name, const Reader& reader, const Assets::Palette& palette,
   const FileSystem& fs)
   : m_name(name)
-  , m_begin(begin)
-  , m_end(end)
+  , m_reader(reader)
   , m_palette(palette)
   , m_fs(fs) {}
 
 std::unique_ptr<Assets::EntityModel> Bsp29Parser::doInitializeModel(Logger& logger) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const auto version = reader.readInt<int32_t>();
   if (version != 29) {
     throw AssetException("Unsupported BSP model version: " + std::to_string(version));
@@ -111,7 +110,7 @@ std::unique_ptr<Assets::EntityModel> Bsp29Parser::doInitializeModel(Logger& logg
 
 void Bsp29Parser::doLoadFrame(
   const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const auto version = reader.readInt<int32_t>();
   if (version != 29) {
     throw AssetException("Unsupported BSP model version: " + std::to_string(version));

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -27,15 +27,16 @@
 #include "IO/IdMipTextureReader.h"
 #include "IO/MipTextureReader.h"
 #include "IO/Reader.h"
+#include "IO/ResourceUtils.h"
 #include "Renderer/PrimType.h"
 #include "Renderer/TexturedIndexRangeMap.h"
 #include "Renderer/TexturedIndexRangeMapBuilder.h"
 
+#include <kdl/string_format.h>
+
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include "ResourceUtils.h"
 
 namespace TrenchBroom {
 namespace IO {
@@ -78,6 +79,15 @@ Bsp29Parser::Bsp29Parser(
   , m_reader(reader)
   , m_palette(palette)
   , m_fs(fs) {}
+
+bool Bsp29Parser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "bsp") {
+    return false;
+  }
+
+  const auto version = reader.readInt<int32_t>();
+  return version == 29;
+}
 
 std::unique_ptr<Assets::EntityModel> Bsp29Parser::doInitializeModel(Logger& logger) {
   auto reader = m_reader;

--- a/common/src/IO/Bsp29Parser.h
+++ b/common/src/IO/Bsp29Parser.h
@@ -74,6 +74,8 @@ public:
     const std::string& name, const Reader& reader, const Assets::Palette& palette,
     const FileSystem& fs);
 
+  static bool canParse(const Path& path, Reader reader);
+
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
   void doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) override;

--- a/common/src/IO/Bsp29Parser.h
+++ b/common/src/IO/Bsp29Parser.h
@@ -65,14 +65,13 @@ private:
   using FaceEdgeIndexList = std::vector<int>;
 
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const Assets::Palette& m_palette;
   const FileSystem& m_fs;
 
 public:
   Bsp29Parser(
-    const std::string& name, const char* begin, const char* end, const Assets::Palette& palette,
+    const std::string& name, const Reader& reader, const Assets::Palette& palette,
     const FileSystem& fs);
 
 private:

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -146,16 +146,14 @@ DkmParser::DkmMesh::DkmMesh(const int i_vertexCount)
   , vertexCount(static_cast<size_t>(i_vertexCount < 0 ? -i_vertexCount : i_vertexCount))
   , vertices(vertexCount) {}
 
-DkmParser::DkmParser(
-  const std::string& name, const char* begin, const char* end, const FileSystem& fs)
+DkmParser::DkmParser(const std::string& name, const Reader& reader, const FileSystem& fs)
   : m_name(name)
-  , m_begin(begin)
-  , m_end(end)
+  , m_reader(reader)
   , m_fs(fs) {}
 
 // http://tfc.duke.free.fr/old/models/md2.htm
 std::unique_ptr<Assets::EntityModel> DkmParser::doInitializeModel(Logger& logger) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
 
   const int ident = reader.readInt<int32_t>();
   const int version = reader.readInt<int32_t>();
@@ -196,7 +194,7 @@ std::unique_ptr<Assets::EntityModel> DkmParser::doInitializeModel(Logger& logger
 }
 
 void DkmParser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const int ident = reader.readInt<int32_t>();
   const int version = reader.readInt<int32_t>();
 

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -151,6 +151,18 @@ DkmParser::DkmParser(const std::string& name, const Reader& reader, const FileSy
   , m_reader(reader)
   , m_fs(fs) {}
 
+bool DkmParser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "dkm") {
+    return false;
+  }
+
+  const auto ident = reader.readInt<int32_t>();
+  const auto version = reader.readInt<int32_t>();
+
+  return ident == DkmLayout::Ident &&
+         (version == DkmLayout::Version1 || version == DkmLayout::Version2);
+}
+
 // http://tfc.duke.free.fr/old/models/md2.htm
 std::unique_ptr<Assets::EntityModel> DkmParser::doInitializeModel(Logger& logger) {
   auto reader = m_reader;

--- a/common/src/IO/DkmParser.h
+++ b/common/src/IO/DkmParser.h
@@ -94,6 +94,8 @@ private:
 public:
   DkmParser(const std::string& name, const Reader& reader, const FileSystem& fs);
 
+  static bool canParse(const Path& path, Reader reader);
+
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
   void doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) override;

--- a/common/src/IO/DkmParser.h
+++ b/common/src/IO/DkmParser.h
@@ -88,12 +88,11 @@ private:
   using DkmMeshList = std::vector<DkmMesh>;
 
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const FileSystem& m_fs;
 
 public:
-  DkmParser(const std::string& name, const char* begin, const char* end, const FileSystem& fs);
+  DkmParser(const std::string& name, const Reader& reader, const FileSystem& fs);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -44,7 +44,7 @@ GameConfigParser::GameConfigParser(std::string_view str, const Path& path)
   , m_version(0) {}
 
 static void checkVersion(const EL::Value& version) {
-  const std::vector<EL::IntegerType> validVsns({3, 4});
+  const std::vector<EL::IntegerType> validVsns({3, 4, 5});
   const bool isNumVersion = version.convertibleTo(EL::ValueType::Number);
   const bool isValidVersion =
     isNumVersion &&
@@ -187,12 +187,12 @@ Model::EntityConfig GameConfigParser::parseEntityConfig(const EL::Value& value) 
   expectStructure(
     value,
     "["
-    "{'definitions': 'Array', 'modelformats': 'Array', 'defaultcolor': 'String'},"
-    "{'scale': '*'}" // scale is an expression
+    "{'definitions': 'Array', 'defaultcolor': 'String'},"
+    "{'modelformats': 'Array', 'scale': '*'}" // scale is an expression
     "]");
 
   return Model::EntityConfig{
-    Path::asPaths(value["definitions"].asStringList()), value["modelformats"].asStringSet(),
+    Path::asPaths(value["definitions"].asStringList()),
     Color::parse(value["defaultcolor"].stringValue()).value_or(Color()),
     value["scale"].expression()};
 }

--- a/common/src/IO/ImageSpriteParser.cpp
+++ b/common/src/IO/ImageSpriteParser.cpp
@@ -30,6 +30,8 @@
 #include <vecmath/bbox.h>
 #include <vecmath/vec.h>
 
+#include <kdl/string_format.h>
+
 #include <vector>
 
 namespace TrenchBroom {
@@ -39,6 +41,10 @@ ImageSpriteParser::ImageSpriteParser(
   : m_name{std::move(name)}
   , m_file{std::move(file)}
   , m_fs{fs} {}
+
+bool ImageSpriteParser::canParse(const Path& path) {
+  return kdl::str_to_lower(path.extension()) == "png";
+}
 
 std::unique_ptr<Assets::EntityModel> ImageSpriteParser::doInitializeModel(Logger& logger) {
   auto textureReader =

--- a/common/src/IO/ImageSpriteParser.h
+++ b/common/src/IO/ImageSpriteParser.h
@@ -28,6 +28,7 @@ namespace TrenchBroom {
 namespace IO {
 class File;
 class FileSystem;
+class Path;
 
 class ImageSpriteParser : public EntityModelParser {
 private:
@@ -37,6 +38,8 @@ private:
 
 public:
   ImageSpriteParser(std::string name, std::shared_ptr<File> file, const FileSystem& fs);
+
+  static bool canParse(const Path& path);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -141,17 +141,16 @@ Md2Parser::Md2Mesh::Md2Mesh(const int i_vertexCount)
   , vertices(vertexCount) {}
 
 Md2Parser::Md2Parser(
-  const std::string& name, const char* begin, const char* end, const Assets::Palette& palette,
+  const std::string& name, const Reader& reader, const Assets::Palette& palette,
   const FileSystem& fs)
   : m_name(name)
-  , m_begin(begin)
-  , m_end(end)
+  , m_reader(reader)
   , m_palette(palette)
   , m_fs(fs) {}
 
 // http://tfc.duke.free.fr/old/models/md2.htm
 std::unique_ptr<Assets::EntityModel> Md2Parser::doInitializeModel(Logger& logger) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const int ident = reader.readInt<int32_t>();
   const int version = reader.readInt<int32_t>();
 
@@ -190,7 +189,7 @@ std::unique_ptr<Assets::EntityModel> Md2Parser::doInitializeModel(Logger& logger
 }
 
 void Md2Parser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const auto ident = reader.readInt<int32_t>();
   const auto version = reader.readInt<int32_t>();
 

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -32,6 +32,8 @@
 #include "Renderer/IndexRangeMapBuilder.h"
 #include "Renderer/PrimType.h"
 
+#include "kdl/string_format.h"
+
 #include <string>
 
 namespace TrenchBroom {
@@ -147,6 +149,17 @@ Md2Parser::Md2Parser(
   , m_reader(reader)
   , m_palette(palette)
   , m_fs(fs) {}
+
+bool Md2Parser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "md2") {
+    return false;
+  }
+
+  const auto ident = reader.readInt<int32_t>();
+  const auto version = reader.readInt<int32_t>();
+
+  return ident == Md2Layout::Ident && version == Md2Layout::Version;
+}
 
 // http://tfc.duke.free.fr/old/models/md2.htm
 std::unique_ptr<Assets::EntityModel> Md2Parser::doInitializeModel(Logger& logger) {

--- a/common/src/IO/Md2Parser.h
+++ b/common/src/IO/Md2Parser.h
@@ -35,6 +35,7 @@ class Palette;
 
 namespace IO {
 class FileSystem;
+class Path;
 class Reader;
 
 namespace Md2Layout {
@@ -97,6 +98,8 @@ public:
   Md2Parser(
     const std::string& name, const Reader& reader, const Assets::Palette& palette,
     const FileSystem& fs);
+
+  static bool canParse(const Path& path, Reader reader);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/Md2Parser.h
+++ b/common/src/IO/Md2Parser.h
@@ -89,14 +89,13 @@ private:
   using Md2MeshList = std::vector<Md2Mesh>;
 
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const Assets::Palette& m_palette;
   const FileSystem& m_fs;
 
 public:
   Md2Parser(
-    const std::string& name, const char* begin, const char* end, const Assets::Palette& palette,
+    const std::string& name, const Reader& reader, const Assets::Palette& palette,
     const FileSystem& fs);
 
 private:

--- a/common/src/IO/Md3Parser.cpp
+++ b/common/src/IO/Md3Parser.cpp
@@ -50,18 +50,13 @@ static const size_t VertexLength = 4 * sizeof(int16_t);
 static const float VertexScale = 1.0f / 64.0f;
 } // namespace Md3Layout
 
-Md3Parser::Md3Parser(
-  const std::string& name, const char* begin, const char* end, const FileSystem& fs)
+Md3Parser::Md3Parser(const std::string& name, const Reader& reader, const FileSystem& fs)
   : m_name(name)
-  , m_begin(begin)
-  , m_end(end)
-  , m_fs(fs) {
-  assert(m_begin < m_end);
-  unused(m_end);
-}
+  , m_reader(reader)
+  , m_fs(fs) {}
 
 std::unique_ptr<Assets::EntityModel> Md3Parser::doInitializeModel(Logger& logger) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
 
   const auto ident = reader.readInt<int32_t>();
   const auto version = reader.readInt<int32_t>();
@@ -98,7 +93,7 @@ std::unique_ptr<Assets::EntityModel> Md3Parser::doInitializeModel(Logger& logger
 
 void Md3Parser::doLoadFrame(
   const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
 
   const auto ident = reader.readInt<int32_t>();
   const auto version = reader.readInt<int32_t>();

--- a/common/src/IO/Md3Parser.cpp
+++ b/common/src/IO/Md3Parser.cpp
@@ -29,6 +29,8 @@
 #include "Renderer/IndexRangeMapBuilder.h"
 #include "Renderer/PrimType.h"
 
+#include "kdl/string_format.h"
+
 #include <string>
 
 namespace TrenchBroom {
@@ -54,6 +56,17 @@ Md3Parser::Md3Parser(const std::string& name, const Reader& reader, const FileSy
   : m_name(name)
   , m_reader(reader)
   , m_fs(fs) {}
+
+bool Md3Parser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "md3") {
+    return false;
+  }
+
+  const auto ident = reader.readInt<int32_t>();
+  const auto version = reader.readInt<int32_t>();
+
+  return ident == Md3Layout::Ident && version == Md3Layout::Version;
+}
 
 std::unique_ptr<Assets::EntityModel> Md3Parser::doInitializeModel(Logger& logger) {
   auto reader = m_reader;

--- a/common/src/IO/Md3Parser.h
+++ b/common/src/IO/Md3Parser.h
@@ -52,6 +52,8 @@ private:
 public:
   Md3Parser(const std::string& name, const Reader& reader, const FileSystem& fs);
 
+  static bool canParse(const Path& path, Reader reader);
+
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
   void doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) override;

--- a/common/src/IO/Md3Parser.h
+++ b/common/src/IO/Md3Parser.h
@@ -41,8 +41,7 @@ class Reader;
 class Md3Parser : public EntityModelParser {
 private:
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const FileSystem& m_fs;
 
 private:
@@ -51,7 +50,7 @@ private:
   };
 
 public:
-  Md3Parser(const std::string& name, const char* begin, const char* end, const FileSystem& fs);
+  Md3Parser(const std::string& name, const Reader& reader, const FileSystem& fs);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -133,18 +133,13 @@ const vm::vec3f MdlParser::Normals[] = {
 
 static const int MF_HOLEY = (1 << 14);
 
-MdlParser::MdlParser(
-  const std::string& name, const char* begin, const char* end, const Assets::Palette& palette)
-  : m_name(name)
-  , m_begin(begin)
-  , m_end(end)
-  , m_palette(palette) {
-  assert(m_begin < m_end);
-  unused(m_end);
-}
+MdlParser::MdlParser(const std::string& name, const Reader& reader, const Assets::Palette& palette)
+  : m_name{name}
+  , m_reader{reader}
+  , m_palette{palette} {}
 
 std::unique_ptr<Assets::EntityModel> MdlParser::doInitializeModel(Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end).buffer();
+  auto reader = m_reader;
 
   const auto ident = reader.readInt<int32_t>();
   const auto version = reader.readInt<int32_t>();
@@ -185,7 +180,7 @@ std::unique_ptr<Assets::EntityModel> MdlParser::doInitializeModel(Logger& /* log
 
 void MdlParser::doLoadFrame(
   const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end).buffer();
+  auto reader = m_reader;
 
   const auto ident = reader.readInt<int32_t>();
   const auto version = reader.readInt<int32_t>();
@@ -223,8 +218,8 @@ void MdlParser::doLoadFrame(
 }
 
 void MdlParser::parseSkins(
-  BufferedReader& reader, Assets::EntityModelSurface& surface, const size_t count,
-  const size_t width, const size_t height, const int flags) {
+  Reader& reader, Assets::EntityModelSurface& surface, const size_t count, const size_t width,
+  const size_t height, const int flags) {
   const auto size = width * height;
   const auto transparency = (flags & MF_HOLEY) ? Assets::PaletteTransparency::Index255Transparent
                                                : Assets::PaletteTransparency::Opaque;

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -138,6 +138,17 @@ MdlParser::MdlParser(const std::string& name, const Reader& reader, const Assets
   , m_reader{reader}
   , m_palette{palette} {}
 
+bool MdlParser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "mdl") {
+    return false;
+  }
+
+  const auto ident = reader.readInt<int32_t>();
+  const auto version = reader.readInt<int32_t>();
+
+  return ident == MdlLayout::Ident && version == MdlLayout::Version6;
+}
+
 std::unique_ptr<Assets::EntityModel> MdlParser::doInitializeModel(Logger& /* logger */) {
   auto reader = m_reader;
 

--- a/common/src/IO/MdlParser.h
+++ b/common/src/IO/MdlParser.h
@@ -35,6 +35,7 @@ class Palette;
 
 namespace IO {
 class Reader;
+class Path;
 
 class MdlParser : public EntityModelParser {
 private:
@@ -62,6 +63,8 @@ private:
 
 public:
   MdlParser(const std::string& name, const Reader& reader, const Assets::Palette& palette);
+
+  static bool canParse(const Path& path, Reader reader);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/MdlParser.h
+++ b/common/src/IO/MdlParser.h
@@ -34,7 +34,6 @@ class Palette;
 }
 
 namespace IO {
-class BufferedReader;
 class Reader;
 
 class MdlParser : public EntityModelParser {
@@ -58,21 +57,19 @@ private:
   using PackedFrameVertexList = std::vector<PackedFrameVertex>;
 
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const Assets::Palette& m_palette;
 
 public:
-  MdlParser(
-    const std::string& name, const char* begin, const char* end, const Assets::Palette& palette);
+  MdlParser(const std::string& name, const Reader& reader, const Assets::Palette& palette);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
   void doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) override;
 
   void parseSkins(
-    BufferedReader& reader, Assets::EntityModelSurface& surface, size_t count, size_t width,
-    size_t height, int flags);
+    Reader& reader, Assets::EntityModelSurface& surface, size_t count, size_t width, size_t height,
+    int flags);
   void skipSkins(Reader& reader, size_t count, size_t width, size_t height, int flags);
 
   MdlSkinVertexList parseVertices(Reader& reader, size_t count);

--- a/common/src/IO/MdxParser.cpp
+++ b/common/src/IO/MdxParser.cpp
@@ -139,16 +139,14 @@ MdxParser::MdxMesh::MdxMesh(const int i_vertexCount)
   , vertexCount(static_cast<size_t>(i_vertexCount < 0 ? -i_vertexCount : i_vertexCount))
   , vertices(vertexCount) {}
 
-MdxParser::MdxParser(
-  const std::string& name, const char* begin, const char* end, const FileSystem& fs)
+MdxParser::MdxParser(const std::string& name, const Reader& reader, const FileSystem& fs)
   : m_name(name)
-  , m_begin(begin)
-  , m_end(end)
+  , m_reader(reader)
   , m_fs(fs) {}
 
 // http://tfc.duke.free.fr/old/models/md2.htm
 std::unique_ptr<Assets::EntityModel> MdxParser::doInitializeModel(Logger& logger) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const int ident = reader.readInt<int32_t>();
   const int version = reader.readInt<int32_t>();
 
@@ -190,7 +188,7 @@ std::unique_ptr<Assets::EntityModel> MdxParser::doInitializeModel(Logger& logger
 }
 
 void MdxParser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
-  auto reader = Reader::from(m_begin, m_end);
+  auto reader = m_reader;
   const auto ident = reader.readInt<int32_t>();
   const auto version = reader.readInt<int32_t>();
 

--- a/common/src/IO/MdxParser.cpp
+++ b/common/src/IO/MdxParser.cpp
@@ -31,6 +31,8 @@
 #include "Renderer/IndexRangeMapBuilder.h"
 #include "Renderer/PrimType.h"
 
+#include "kdl/string_format.h"
+
 #include <string>
 
 namespace TrenchBroom {
@@ -143,6 +145,17 @@ MdxParser::MdxParser(const std::string& name, const Reader& reader, const FileSy
   : m_name(name)
   , m_reader(reader)
   , m_fs(fs) {}
+
+bool MdxParser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "mdx") {
+    return false;
+  }
+
+  const auto ident = reader.readInt<int32_t>();
+  const auto version = reader.readInt<int32_t>();
+
+  return ident == MdxLayout::Ident && version == MdxLayout::Version;
+}
 
 // http://tfc.duke.free.fr/old/models/md2.htm
 std::unique_ptr<Assets::EntityModel> MdxParser::doInitializeModel(Logger& logger) {

--- a/common/src/IO/MdxParser.h
+++ b/common/src/IO/MdxParser.h
@@ -33,6 +33,7 @@ class Logger;
 
 namespace IO {
 class FileSystem;
+class Path;
 class Reader;
 
 namespace MdxLayout {
@@ -92,6 +93,8 @@ private:
 
 public:
   MdxParser(const std::string& name, const Reader& reader, const FileSystem& fs);
+
+  static bool canParse(const Path& path, Reader reader);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/MdxParser.h
+++ b/common/src/IO/MdxParser.h
@@ -87,12 +87,11 @@ private:
   using MdxMeshList = std::vector<MdxMesh>;
 
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const FileSystem& m_fs;
 
 public:
-  MdxParser(const std::string& name, const char* begin, const char* end, const FileSystem& fs);
+  MdxParser(const std::string& name, const Reader& reader, const FileSystem& fs);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/ObjParser.cpp
+++ b/common/src/IO/ObjParser.cpp
@@ -80,9 +80,9 @@ struct ObjFace {
   std::vector<ObjVertexRef> m_vertices;
 };
 
-ObjParser::ObjParser(const std::string& name, const char* begin, const char* end)
+ObjParser::ObjParser(const std::string& name, const std::string_view text)
   : m_name(name)
-  , m_text(begin, end) {}
+  , m_text(text) {}
 
 std::unique_ptr<Assets::EntityModel> ObjParser::doInitializeModel(Logger& logger) {
   // Model construction prestart (skins are added to this mid-parse)
@@ -215,8 +215,8 @@ std::unique_ptr<Assets::EntityModel> ObjParser::doInitializeModel(Logger& logger
 
 // -- Neverball --
 
-NvObjParser::NvObjParser(const Path& path, const char* begin, const char* end, const FileSystem& fs)
-  : ObjParser(path.lastComponent().asString(), begin, end)
+NvObjParser::NvObjParser(const Path& path, const std::string_view text, const FileSystem& fs)
+  : ObjParser(path.lastComponent().asString(), text)
   , m_path(path)
   , m_fs(fs) {}
 

--- a/common/src/IO/ObjParser.cpp
+++ b/common/src/IO/ObjParser.cpp
@@ -220,6 +220,10 @@ NvObjParser::NvObjParser(const Path& path, const std::string_view text, const Fi
   , m_path(path)
   , m_fs(fs) {}
 
+bool NvObjParser::canParse(const Path& path) {
+  return kdl::str_to_lower(path.extension()) == "obj";
+}
+
 bool NvObjParser::transformObjCoordinateSet(
   std::vector<vm::vec3f>& positions, std::vector<vm::vec2f>& texcoords) {
   for (vm::vec3f& pos : positions) {

--- a/common/src/IO/ObjParser.h
+++ b/common/src/IO/ObjParser.h
@@ -101,6 +101,9 @@ public:
    */
   NvObjParser(const Path& path, std::string_view text, const FileSystem& fs);
 
+  static bool canParse(const Path& path);
+
+private:
   bool transformObjCoordinateSet(
     std::vector<vm::vec3f>& positions, std::vector<vm::vec2f>& texcoords) override;
   std::optional<Assets::Texture> loadMaterial(const std::string& name, Logger& logger) override;

--- a/common/src/IO/ObjParser.h
+++ b/common/src/IO/ObjParser.h
@@ -42,7 +42,7 @@ class FileSystem;
 class ObjParser : public EntityModelParser {
 private:
   std::string m_name;
-  std::string m_text;
+  std::string_view m_text;
 
 public:
   /**
@@ -52,7 +52,7 @@ public:
    * @param begin the start of the text
    * @param end the end of the text
    */
-  ObjParser(const std::string& name, const char* begin, const char* end);
+  ObjParser(const std::string& name, std::string_view text);
 
   /**
    * Transforms the various sets of coordinates.
@@ -99,7 +99,7 @@ public:
    * @param end the end of the text
    * @param fs the filesystem used to lookup textures
    */
-  NvObjParser(const Path& path, const char* begin, const char* end, const FileSystem& fs);
+  NvObjParser(const Path& path, std::string_view text, const FileSystem& fs);
 
   bool transformObjCoordinateSet(
     std::vector<vm::vec3f>& positions, std::vector<vm::vec2f>& texcoords) override;

--- a/common/src/IO/SprParser.cpp
+++ b/common/src/IO/SprParser.cpp
@@ -33,11 +33,9 @@
 
 namespace TrenchBroom {
 namespace IO {
-SprParser::SprParser(
-  std::string name, const char* begin, const char* end, const Assets::Palette& palette)
+SprParser::SprParser(std::string name, const Reader& reader, const Assets::Palette& palette)
   : m_name{std::move(name)}
-  , m_begin{begin}
-  , m_end{end}
+  , m_reader{reader}
   , m_palette{palette} {}
 
 struct SprPicture {
@@ -48,7 +46,7 @@ struct SprPicture {
   size_t height;
 };
 
-static SprPicture parsePicture(BufferedReader& reader, const Assets::Palette& palette) {
+static SprPicture parsePicture(Reader& reader, const Assets::Palette& palette) {
   const auto xOffset = reader.readInt<int32_t>();
   const auto yOffset = reader.readInt<int32_t>();
   const auto width = reader.readSize<int32_t>();
@@ -68,7 +66,7 @@ static SprPicture parsePicture(BufferedReader& reader, const Assets::Palette& pa
     height};
 }
 
-static void skipPicture(BufferedReader& reader) {
+static void skipPicture(Reader& reader) {
   /* const auto xOffset = */ reader.readInt<int32_t>();
   /* const auto yOffset = */ reader.readInt<int32_t>();
   const auto width = reader.readSize<int32_t>();
@@ -77,7 +75,7 @@ static void skipPicture(BufferedReader& reader) {
   reader.seekForward(width * height);
 }
 
-static SprPicture parsePictureFrame(BufferedReader& reader, const Assets::Palette& palette) {
+static SprPicture parsePictureFrame(Reader& reader, const Assets::Palette& palette) {
   const auto group = reader.readInt<int32_t>();
   if (group == 0) { // single picture frame
     return parsePicture(reader, palette);
@@ -95,7 +93,7 @@ static SprPicture parsePictureFrame(BufferedReader& reader, const Assets::Palett
   return picture;
 }
 
-static Assets::Orientation parseSpriteOrientationType(BufferedReader& reader) {
+static Assets::Orientation parseSpriteOrientationType(Reader& reader) {
   const auto type = reader.readInt<int32_t>();
   if (type < 0 || type > 4) {
     throw AssetException{"Unknown SPR type: " + std::to_string(type)};
@@ -107,7 +105,7 @@ static Assets::Orientation parseSpriteOrientationType(BufferedReader& reader) {
 std::unique_ptr<Assets::EntityModel> SprParser::doInitializeModel(Logger& /* logger */) {
   // see https://www.gamers.org/dEngine/quake/spec/quake-spec34/qkspec_6.htm#CSPRF
 
-  auto reader = Reader::from(m_begin, m_end).buffer();
+  auto reader = m_reader;
 
   const auto ident = reader.readString(4);
   if (ident != "IDSP") {

--- a/common/src/IO/SprParser.cpp
+++ b/common/src/IO/SprParser.cpp
@@ -28,6 +28,8 @@
 #include "Renderer/IndexRangeMapBuilder.h"
 #include "Renderer/PrimType.h"
 
+#include <kdl/string_format.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/vec.h>
 
@@ -37,6 +39,17 @@ SprParser::SprParser(std::string name, const Reader& reader, const Assets::Palet
   : m_name{std::move(name)}
   , m_reader{reader}
   , m_palette{palette} {}
+
+bool SprParser::canParse(const Path& path, Reader reader) {
+  if (kdl::str_to_lower(path.extension()) != "spr") {
+    return false;
+  }
+
+  const auto ident = reader.readString(4);
+  const auto version = reader.readInt<int32_t>();
+
+  return ident == "IDSP" && version == 1;
+}
 
 struct SprPicture {
   Assets::Texture texture;

--- a/common/src/IO/SprParser.h
+++ b/common/src/IO/SprParser.h
@@ -32,16 +32,16 @@ class Palette;
 namespace IO {
 class File;
 class FileSystem;
+class Reader;
 
 class SprParser : public EntityModelParser {
 private:
   std::string m_name;
-  const char* m_begin;
-  const char* m_end;
+  const Reader& m_reader;
   const Assets::Palette& m_palette;
 
 public:
-  SprParser(std::string name, const char* begin, const char* end, const Assets::Palette& palette);
+  SprParser(std::string name, const Reader& reader, const Assets::Palette& palette);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/IO/SprParser.h
+++ b/common/src/IO/SprParser.h
@@ -32,6 +32,7 @@ class Palette;
 namespace IO {
 class File;
 class FileSystem;
+class Path;
 class Reader;
 
 class SprParser : public EntityModelParser {
@@ -42,6 +43,8 @@ private:
 
 public:
   SprParser(std::string name, const Reader& reader, const Assets::Palette& palette);
+
+  static bool canParse(const Path& path, Reader reader);
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -91,11 +91,10 @@ struct TextureConfig {
 
 struct EntityConfig {
   std::vector<IO::Path> defFilePaths;
-  std::vector<std::string> modelFormats;
   Color defaultColor;
   std::optional<EL::Expression> scaleExpression;
 
-  kdl_reflect_decl(EntityConfig, defFilePaths, modelFormats, defaultColor, scaleExpression);
+  kdl_reflect_decl(EntityConfig, defFilePaths, defaultColor, scaleExpression);
 };
 
 struct FlagConfig {

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -527,7 +527,7 @@ static auto withEntityParser(
   } else if (extension == "spr") {
     const auto palette = getPalette();
     auto reader = file->reader().buffer();
-    auto parser = IO::SprParser{modelName, std::begin(reader), std::end(reader), palette};
+    auto parser = IO::SprParser{modelName, reader, palette};
     return fun(parser);
   } else if (kdl::vec_contains(IO::AssimpParser::supportedExtensions(), extension)) {
     auto parser = IO::AssimpParser{path, fs};

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -519,7 +519,7 @@ static auto withEntityParser(
   } else if (extension == "obj") {
     auto reader = file->reader().buffer();
     // has to be the whole path for implicit textures!
-    auto parser = IO::NvObjParser{path, std::begin(reader), std::end(reader), fs};
+    auto parser = IO::NvObjParser{path, reader.stringView(), fs};
     return fun(parser);
   } else if (extension == "png") {
     auto parser = IO::ImageSpriteParser{modelName, file, fs};

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -483,45 +483,44 @@ static auto withEntityParser(
   ensure(file != nullptr, "file is null");
 
   const auto modelName = path.lastComponent().asString();
-  const auto extension = kdl::str_to_lower(path.extension());
-
   auto reader = file->reader().buffer();
-  if (extension == "mdl") {
+
+  if (IO::MdlParser::canParse(path, reader)) {
     const auto palette = getPalette();
     auto parser = IO::MdlParser{modelName, reader, palette};
     return fun(parser);
-  } else if (extension == "md2") {
+  } else if (IO::Md2Parser::canParse(path, reader)) {
     const auto palette = getPalette();
     auto parser = IO::Md2Parser{modelName, reader, palette, fs};
     return fun(parser);
-  } else if (extension == "md3") {
+  } else if (IO::Md3Parser::canParse(path, reader)) {
     auto parser = IO::Md3Parser{modelName, reader, fs};
     return fun(parser);
-  } else if (extension == "mdx") {
+  } else if (IO::MdxParser::canParse(path, reader)) {
     auto parser = IO::MdxParser{modelName, reader, fs};
     return fun(parser);
-  } else if (extension == "bsp") {
+  } else if (IO::Bsp29Parser::canParse(path, reader)) {
     const auto palette = getPalette();
     auto parser = IO::Bsp29Parser{modelName, reader, palette, fs};
     return fun(parser);
-  } else if (extension == "dkm") {
+  } else if (IO::DkmParser::canParse(path, reader)) {
     auto parser = IO::DkmParser{modelName, reader, fs};
     return fun(parser);
-  } else if (extension == "ase") {
+  } else if (IO::AseParser::canParse(path)) {
     auto parser = IO::AseParser{modelName, reader.stringView(), fs};
     return fun(parser);
-  } else if (extension == "obj") {
+  } else if (IO::NvObjParser::canParse(path)) {
     // has to be the whole path for implicit textures!
     auto parser = IO::NvObjParser{path, reader.stringView(), fs};
     return fun(parser);
-  } else if (extension == "png") {
+  } else if (IO::ImageSpriteParser::canParse(path)) {
     auto parser = IO::ImageSpriteParser{modelName, file, fs};
     return fun(parser);
-  } else if (extension == "spr") {
+  } else if (IO::SprParser::canParse(path, reader)) {
     const auto palette = getPalette();
     auto parser = IO::SprParser{modelName, reader, palette};
     return fun(parser);
-  } else if (kdl::vec_contains(IO::AssimpParser::supportedExtensions(), extension)) {
+  } else if (IO::AssimpParser::canParse(path)) {
     auto parser = IO::AssimpParser{path, fs};
     return fun(parser);
   }

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -485,39 +485,32 @@ static auto withEntityParser(
   const auto modelName = path.lastComponent().asString();
   const auto extension = kdl::str_to_lower(path.extension());
 
+  auto reader = file->reader().buffer();
   if (extension == "mdl") {
     const auto palette = getPalette();
-    auto reader = file->reader().buffer();
     auto parser = IO::MdlParser{modelName, reader, palette};
     return fun(parser);
   } else if (extension == "md2") {
     const auto palette = getPalette();
-    auto reader = file->reader().buffer();
     auto parser = IO::Md2Parser{modelName, reader, palette, fs};
     return fun(parser);
   } else if (extension == "md3") {
-    auto reader = file->reader().buffer();
     auto parser = IO::Md3Parser{modelName, reader, fs};
     return fun(parser);
   } else if (extension == "mdx") {
-    auto reader = file->reader().buffer();
     auto parser = IO::MdxParser{modelName, reader, fs};
     return fun(parser);
   } else if (extension == "bsp") {
     const auto palette = getPalette();
-    auto reader = file->reader().buffer();
     auto parser = IO::Bsp29Parser{modelName, reader, palette, fs};
     return fun(parser);
   } else if (extension == "dkm") {
-    auto reader = file->reader().buffer();
     auto parser = IO::DkmParser{modelName, reader, fs};
     return fun(parser);
   } else if (extension == "ase") {
-    auto reader = file->reader().buffer();
     auto parser = IO::AseParser{modelName, reader.stringView(), fs};
     return fun(parser);
   } else if (extension == "obj") {
-    auto reader = file->reader().buffer();
     // has to be the whole path for implicit textures!
     auto parser = IO::NvObjParser{path, reader.stringView(), fs};
     return fun(parser);
@@ -526,7 +519,6 @@ static auto withEntityParser(
     return fun(parser);
   } else if (extension == "spr") {
     const auto palette = getPalette();
-    auto reader = file->reader().buffer();
     auto parser = IO::SprParser{modelName, reader, palette};
     return fun(parser);
   } else if (kdl::vec_contains(IO::AssimpParser::supportedExtensions(), extension)) {

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -506,7 +506,7 @@ static auto withEntityParser(
   } else if (extension == "bsp") {
     const auto palette = getPalette();
     auto reader = file->reader().buffer();
-    auto parser = IO::Bsp29Parser{modelName, std::begin(reader), std::end(reader), palette, fs};
+    auto parser = IO::Bsp29Parser{modelName, reader, palette, fs};
     return fun(parser);
   } else if (extension == "dkm") {
     auto reader = file->reader().buffer();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -407,17 +407,17 @@ std::vector<Assets::EntityDefinition*> GameImpl::doLoadEntityDefinitions(
   if (kdl::ci::str_is_equal("fgd", extension)) {
     auto file = IO::Disk::openFile(IO::Disk::fixPath(path));
     auto reader = file->reader().buffer();
-    IO::FgdParser parser(reader.stringView(), defaultColor, file->path());
+    auto parser = IO::FgdParser{reader.stringView(), defaultColor, file->path()};
     return parser.parseDefinitions(status);
   } else if (kdl::ci::str_is_equal("def", extension)) {
     auto file = IO::Disk::openFile(IO::Disk::fixPath(path));
     auto reader = file->reader().buffer();
-    IO::DefParser parser(reader.stringView(), defaultColor);
+    auto parser = IO::DefParser{reader.stringView(), defaultColor};
     return parser.parseDefinitions(status);
   } else if (kdl::ci::str_is_equal("ent", extension)) {
     auto file = IO::Disk::openFile(IO::Disk::fixPath(path));
     auto reader = file->reader().buffer();
-    IO::EntParser parser(reader.stringView(), defaultColor);
+    auto parser = IO::EntParser{reader.stringView(), defaultColor};
     return parser.parseDefinitions(status);
   } else {
     throw GameException("Unknown entity definition format: '" + path.asString() + "'");
@@ -494,46 +494,46 @@ std::unique_ptr<Assets::EntityModel> GameImpl::doInitializeModel(
     if (isModelFormat("mdl", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::MdlParser parser(modelName, std::begin(reader), std::end(reader), palette);
+      auto parser = IO::MdlParser{modelName, std::begin(reader), std::end(reader), palette};
       return parser.initializeModel(logger);
     } else if (isModelFormat("md2", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::Md2Parser parser(modelName, std::begin(reader), std::end(reader), palette, m_fs);
+      auto parser = IO::Md2Parser{modelName, std::begin(reader), std::end(reader), palette, m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("md3", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::Md3Parser parser(modelName, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::Md3Parser{modelName, std::begin(reader), std::end(reader), m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("mdx", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::MdxParser parser(modelName, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::MdxParser{modelName, std::begin(reader), std::end(reader), m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("bsp", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::Bsp29Parser parser(modelName, std::begin(reader), std::end(reader), palette, m_fs);
+      auto parser = IO::Bsp29Parser{modelName, std::begin(reader), std::end(reader), palette, m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("dkm", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::DkmParser parser(modelName, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::DkmParser{modelName, std::begin(reader), std::end(reader), m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("ase", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::AseParser parser(modelName, reader.stringView(), m_fs);
+      auto parser = IO::AseParser{modelName, reader.stringView(), m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("obj", extension, supported)) {
       auto reader = file->reader().buffer();
       // has to be the whole path for implicit textures!
-      IO::NvObjParser parser(path, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::NvObjParser{path, std::begin(reader), std::end(reader), m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("png", extension, supported)) {
-      IO::ImageSpriteParser parser{modelName, file, m_fs};
+      auto parser = IO::ImageSpriteParser{modelName, file, m_fs};
       return parser.initializeModel(logger);
     } else if (isModelFormat("spr", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::SprParser parser{modelName, std::begin(reader), std::end(reader), palette};
+      auto parser = IO::SprParser{modelName, std::begin(reader), std::end(reader), palette};
       return parser.initializeModel(logger);
     } else if (
       kdl::vec_contains(IO::AssimpParser::supportedExtensions(), extension) &&
@@ -568,41 +568,41 @@ void GameImpl::doLoadFrame(
     if (isModelFormat("mdl", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::MdlParser parser(modelName, std::begin(reader), std::end(reader), palette);
+      auto parser = IO::MdlParser{modelName, std::begin(reader), std::end(reader), palette};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("md2", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::Md2Parser parser(modelName, std::begin(reader), std::end(reader), palette, m_fs);
+      auto parser = IO::Md2Parser{modelName, std::begin(reader), std::end(reader), palette, m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("md3", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::Md3Parser parser(modelName, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::Md3Parser{modelName, std::begin(reader), std::end(reader), m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("mdx", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::MdxParser parser(modelName, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::MdxParser{modelName, std::begin(reader), std::end(reader), m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("bsp", extension, supported)) {
       const auto palette = loadTexturePalette();
       auto reader = file->reader().buffer();
-      IO::Bsp29Parser parser(modelName, std::begin(reader), std::end(reader), palette, m_fs);
+      auto parser = IO::Bsp29Parser{modelName, std::begin(reader), std::end(reader), palette, m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("dkm", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::DkmParser parser(modelName, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::DkmParser{modelName, std::begin(reader), std::end(reader), m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("ase", extension, supported)) {
       auto reader = file->reader().buffer();
-      IO::AseParser parser(modelName, reader.stringView(), m_fs);
+      auto parser = IO::AseParser{modelName, reader.stringView(), m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("obj", extension, supported)) {
       auto reader = file->reader().buffer();
       // has to be the whole path for implicit textures!
-      IO::NvObjParser parser(path, std::begin(reader), std::end(reader), m_fs);
+      auto parser = IO::NvObjParser{path, std::begin(reader), std::end(reader), m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else if (isModelFormat("png", extension, supported)) {
-      IO::ImageSpriteParser parser{modelName, file, m_fs};
+      auto parser = IO::ImageSpriteParser{modelName, file, m_fs};
       parser.loadFrame(frameIndex, model, logger);
     } else {
       throw GameException("Unsupported model format '" + path.asString() + "'");

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -497,7 +497,7 @@ static auto withEntityParser(
     return fun(parser);
   } else if (extension == "md3") {
     auto reader = file->reader().buffer();
-    auto parser = IO::Md3Parser{modelName, std::begin(reader), std::end(reader), fs};
+    auto parser = IO::Md3Parser{modelName, reader, fs};
     return fun(parser);
   } else if (extension == "mdx") {
     auto reader = file->reader().buffer();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -493,7 +493,7 @@ static auto withEntityParser(
   } else if (extension == "md2") {
     const auto palette = getPalette();
     auto reader = file->reader().buffer();
-    auto parser = IO::Md2Parser{modelName, std::begin(reader), std::end(reader), palette, fs};
+    auto parser = IO::Md2Parser{modelName, reader, palette, fs};
     return fun(parser);
   } else if (extension == "md3") {
     auto reader = file->reader().buffer();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -510,7 +510,7 @@ static auto withEntityParser(
     return fun(parser);
   } else if (extension == "dkm") {
     auto reader = file->reader().buffer();
-    auto parser = IO::DkmParser{modelName, std::begin(reader), std::end(reader), fs};
+    auto parser = IO::DkmParser{modelName, reader, fs};
     return fun(parser);
   } else if (extension == "ase") {
     auto reader = file->reader().buffer();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -501,7 +501,7 @@ static auto withEntityParser(
     return fun(parser);
   } else if (extension == "mdx") {
     auto reader = file->reader().buffer();
-    auto parser = IO::MdxParser{modelName, std::begin(reader), std::end(reader), fs};
+    auto parser = IO::MdxParser{modelName, reader, fs};
     return fun(parser);
   } else if (extension == "bsp") {
     const auto palette = getPalette();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -488,7 +488,7 @@ static auto withEntityParser(
   if (extension == "mdl") {
     const auto palette = getPalette();
     auto reader = file->reader().buffer();
-    auto parser = IO::MdlParser{modelName, std::begin(reader), std::end(reader), palette};
+    auto parser = IO::MdlParser{modelName, reader, palette};
     return fun(parser);
   } else if (extension == "md2") {
     const auto palette = getPalette();

--- a/common/test/src/IO/DefParserTest.cpp
+++ b/common/test/src/IO/DefParserTest.cpp
@@ -41,13 +41,14 @@ TEST_CASE("DefParserTest.parseIncludedDefFiles", "[DefParserTest]") {
     Disk::findItemsRecursively(basePath, IO::FileExtensionMatcher("def"));
 
   for (const Path& path : cfgFiles) {
+    CAPTURE(path);
+
     auto file = Disk::openFile(path);
     auto reader = file->reader().buffer();
     const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
     DefParser parser(reader.stringView(), defaultColor);
 
     TestParserStatus status;
-    UNSCOPED_INFO("Parsing DEF file " << path.asString() << " failed");
     CHECK_NOTHROW(parser.parseDefinitions(status));
 
     /* Disabled because our files are full of previously undetected problems

--- a/common/test/src/IO/EntParserTest.cpp
+++ b/common/test/src/IO/EntParserTest.cpp
@@ -53,6 +53,8 @@ TEST_CASE("EntParserTest.parseIncludedEntFiles", "[EntParserTest]") {
     Disk::findItemsRecursively(basePath, IO::FileExtensionMatcher("ent"));
 
   for (const Path& path : cfgFiles) {
+    CAPTURE(path);
+
     auto file = Disk::openFile(path);
     auto reader = file->reader().buffer();
 
@@ -60,7 +62,6 @@ TEST_CASE("EntParserTest.parseIncludedEntFiles", "[EntParserTest]") {
     EntParser parser(reader.stringView(), defaultColor);
 
     TestParserStatus status;
-    UNSCOPED_INFO("Parsing ENT file " << path.asString() << " failed");
     CHECK_NOTHROW(parser.parseDefinitions(status));
 
     /* Disabled because our files are full of previously undetected problems

--- a/common/test/src/IO/FgdParserTest.cpp
+++ b/common/test/src/IO/FgdParserTest.cpp
@@ -43,6 +43,8 @@ TEST_CASE("FgdParserTest.parseIncludedFgdFiles", "[FgdParserTest]") {
     Disk::findItemsRecursively(basePath, IO::FileExtensionMatcher("fgd"));
 
   for (const Path& path : cfgFiles) {
+    CAPTURE(path);
+
     auto file = Disk::openFile(path);
     auto reader = file->reader().buffer();
 
@@ -50,7 +52,6 @@ TEST_CASE("FgdParserTest.parseIncludedFgdFiles", "[FgdParserTest]") {
     FgdParser parser(reader.stringView(), defaultColor, path);
 
     TestParserStatus status;
-    UNSCOPED_INFO("Parsing FGD file " << path.asString() << " failed");
     CHECK_NOTHROW(parser.parseDefinitions(status));
 
     /* Disabled because our files are full of previously undetected problems

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -40,6 +40,8 @@ TEST_CASE("GameConfigParserTest.parseIncludedGameConfigs", "[GameConfigParserTes
     Disk::findItemsRecursively(basePath, IO::FileExtensionMatcher("cfg"));
 
   for (const Path& path : cfgFiles) {
+    CAPTURE(path);
+
     auto file = Disk::openFile(path);
     auto reader = file->reader().buffer();
 

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -145,7 +145,6 @@ TEST_CASE("GameConfigParserTest.parseQuakeConfig", "[GameConfigParserTest]") {
         {}},
       Model::EntityConfig{
         {Path{"Quake.fgd"}, Path{"Quoth2.fgd"}, Path{"Rubicon2.def"}, Path{"Teamfortress.fgd"}},
-        {"bsp", "mdl"},
         Color{0.6f, 0.6f, 0.6f, 1.0f},
         {}},
       Model::FaceAttribsConfig{},
@@ -400,7 +399,7 @@ TEST_CASE("GameConfigParserTest.parseQuake2Config", "[GameConfigParserTest]") {
         "_tb_textures",
         Path{},
         {}},
-      Model::EntityConfig{{Path{"Quake2.fgd"}}, {"md2"}, Color{0.6f, 0.6f, 0.6f, 1.0f}, {}},
+      Model::EntityConfig{{Path{"Quake2.fgd"}}, Color{0.6f, 0.6f, 0.6f, 1.0f}, {}},
       Model::FaceAttribsConfig{
         {{{"light", "Emit light from the surface, brightness is specified in the 'value' field",
            1 << 0},
@@ -718,7 +717,6 @@ TEST_CASE("GameConfigParserTest.parseExtrasConfig", "[GameConfigParserTest]") {
         {"*_norm", "*_gloss"}},
       Model::EntityConfig{
         {Path{"Extras.ent"}},
-        {"md3"},
         Color{0.6f, 0.6f, 0.6f, 1.0f},
         EL::Expression{
           EL::ArrayExpression{{

--- a/common/test/src/IO/Md3ParserRegressionTest.cpp
+++ b/common/test/src/IO/Md3ParserRegressionTest.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Md3ParserTest.loadFailure_2659", "[Md3ParserTest]") {
   REQUIRE(md3File != nullptr);
 
   auto reader = md3File->reader().buffer();
-  auto parser = Md3Parser("armor_red", std::begin(reader), std::end(reader), *fs);
+  auto parser = Md3Parser("armor_red", reader, *fs);
   auto model = std::unique_ptr<Assets::EntityModel>(parser.initializeModel(logger));
 
   CHECK(model != nullptr);

--- a/common/test/src/IO/Md3ParserTest.cpp
+++ b/common/test/src/IO/Md3ParserTest.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Md3ParserTest.loadValidMd3", "[Md3ParserTest]") {
   REQUIRE(md3File != nullptr);
 
   auto reader = md3File->reader().buffer();
-  auto parser = Md3Parser("bfg", std::begin(reader), std::end(reader), *fs);
+  auto parser = Md3Parser("bfg", reader, *fs);
   auto model = std::unique_ptr<Assets::EntityModel>(parser.initializeModel(logger));
   parser.loadFrame(0, *model, logger);
 

--- a/common/test/src/IO/MdlParserTest.cpp
+++ b/common/test/src/IO/MdlParserTest.cpp
@@ -42,7 +42,7 @@ TEST_CASE("MdlParserTest.loadValidMdl", "[MdlParserTest]") {
   REQUIRE(mdlFile != nullptr);
 
   auto reader = mdlFile->reader().buffer();
-  auto parser = MdlParser("armor", std::begin(reader), std::end(reader), palette);
+  auto parser = MdlParser("armor", reader, palette);
   auto model = parser.initializeModel(logger);
   parser.loadFrame(0, *model, logger);
 
@@ -68,7 +68,7 @@ TEST_CASE("MdlParserTest.loadInvalidMdl", "[MdlParserTest]") {
   REQUIRE(mdlFile != nullptr);
 
   auto reader = mdlFile->reader().buffer();
-  auto parser = MdlParser("armor", std::begin(reader), std::end(reader), palette);
+  auto parser = MdlParser("armor", reader, palette);
   CHECK_THROWS_AS(parser.initializeModel(logger), AssetException);
 }
 } // namespace IO

--- a/common/test/src/IO/ObjParserTest.cpp
+++ b/common/test/src/IO/ObjParserTest.cpp
@@ -40,7 +40,7 @@ TEST_CASE("ObjParserTest.loadValidObj", "[ObjParserTest]") {
   REQUIRE(mdlFile != nullptr);
 
   auto reader = mdlFile->reader().buffer();
-  auto parser = NvObjParser(mdlPath, std::begin(reader), std::end(reader), fs);
+  auto parser = NvObjParser(mdlPath, reader.stringView(), fs);
   auto model = parser.initializeModel(logger);
   parser.loadFrame(0, *model, logger);
 


### PR DESCRIPTION
This PR drops the model format whitelist. Every game can now load any model format. Some model formats require a palette to be available, so loading a model in a game that doesn't have a palette configured for it will result in an error. For example, it is not possible to load a Quake model in the Quake 3 game config.