### PR TITLE
4036: Fix CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,6 @@ jobs:
             build/*.md5
 
       # Create release
-
       # Official action upload-release-asset doesn't support uploading files
       # based on a glob, so use https://github.com/softprops/action-gh-release
       - name: Release


### PR DESCRIPTION
https://github.com/TrenchBroom/TrenchBroom/pull/4037 broke CI builds of pull requests (I think).