### PR TITLE
Put all conditions for uploading releases in one line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,7 @@ jobs:
       # based on a glob, so use https://github.com/softprops/action-gh-release
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: >
-          ${{ startsWith(github.ref, 'refs/tags/')
-          && (matrix.os == 'windows-2019' || matrix.os == 'ubuntu-18.04' || matrix.os == 'macos-10.15')
-          && matrix.tb-build-type != 'asan' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && (matrix.os == 'windows-2019' || matrix.os == 'ubuntu-18.04' || matrix.os == 'macos-10.15') && matrix.tb-build-type != 'asan' }}
         with:
           draft: true
           files: |


### PR DESCRIPTION
This hopefully fixes the problem that every CI run tries to upload release builds.