### PR TITLE
4059: Don't crash when linked group updates of an intermediate state exceed world bounds

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1538,10 +1538,10 @@ Model::EntityNode* MapDocument::createPointEntity(
   auto* entityNode = new Model::EntityNode{Model::Entity{
     m_world->entityPropertyConfig(), {{Model::EntityPropertyKeys::Classname, definition->name()}}}};
 
-  std::stringstream name;
+  auto name = std::stringstream{};
   name << "Create " << definition->name();
 
-  const Transaction transaction(this, name.str());
+  const auto transaction = Transaction{this, name.str()};
   deselectAll();
   addNodes({{parentForNodes(), {entityNode}}});
   selectNodes({entityNode});
@@ -1576,14 +1576,14 @@ Model::EntityNode* MapDocument::createBrushEntity(const Assets::BrushEntityDefin
 
   entity.addOrUpdateProperty(
     m_world->entityPropertyConfig(), Model::EntityPropertyKeys::Classname, definition->name());
-  auto* entityNode = new Model::EntityNode(std::move(entity));
+  auto* entityNode = new Model::EntityNode{std::move(entity)};
 
-  std::stringstream name;
+  auto name = std::stringstream{};
   name << "Create " << definition->name();
 
-  const std::vector<Model::Node*> nodes(std::begin(brushes), std::end(brushes));
+  const auto nodes = kdl::vec_element_cast<Model::Node*>(brushes);
 
-  const Transaction transaction(this, name.str());
+  const auto transaction = Transaction{this, name.str()};
   deselectAll();
   addNodes({{parentForNodes(), {entityNode}}});
   reparentNodes({{entityNode, nodes}});

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1542,10 +1542,13 @@ Model::EntityNode* MapDocument::createPointEntity(
   name << "Create " << definition->name();
 
   const auto transaction = Transaction{this, name.str()};
-  deselectAll();
-  addNodes({{parentForNodes(), {entityNode}}});
+  if (addNodes({{parentForNodes(), {entityNode}}}).empty()) {
+    return nullptr;
+  }
   selectNodes({entityNode});
-  translateObjects(delta);
+  if (!translateObjects(delta)) {
+    return nullptr;
+  }
 
   return entityNode;
 }
@@ -1585,8 +1588,12 @@ Model::EntityNode* MapDocument::createBrushEntity(const Assets::BrushEntityDefin
 
   const auto transaction = Transaction{this, name.str()};
   deselectAll();
-  addNodes({{parentForNodes(), {entityNode}}});
-  reparentNodes({{entityNode, nodes}});
+  if (addNodes({{parentForNodes(), {entityNode}}}).empty()) {
+    return nullptr;
+  }
+  if (!reparentNodes({{entityNode, nodes}})) {
+    return nullptr;
+  }
   selectNodes(nodes);
 
   return entityNode;

--- a/lib/kdl/test/src/compact_trie_test.cpp
+++ b/lib/kdl/test/src/compact_trie_test.cpp
@@ -29,7 +29,6 @@ using test_index = compact_trie<std::string>;
 
 static void assertMatches(
   const test_index& index, const std::string& pattern, std::vector<std::string> expectedMatches) {
-  ;
   std::vector<std::string> matches;
   index.find_matches(pattern, std::back_inserter(matches));
 


### PR DESCRIPTION
See #4059.

This PR only fixes the crash, it doesn't fix the underlying issue. That will be done in a separate PR.