### PR TITLE
Improve Linux desktop integration

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -346,6 +346,9 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LINUX_RESOURCE_LOCATION "share/TrenchBroom")
     set(LINUX_TARGET_RESOURCE_DIRECTORY ${CPACK_PACKAGING_INSTALL_PREFIX}/${LINUX_RESOURCE_LOCATION})
 
+    # add mime type definitions
+    install(FILES "${APP_DIR}/resources/linux/trenchbroom.xml" DESTINATION "${CPACK_PACKAGING_INSTALL_PREFIX}/share/mime/packages/" COMPONENT TrenchBroom)
+
     # configure install scripts
     configure_file(${APP_DIR}/resources/linux/postinst ${CMAKE_CURRENT_BINARY_DIR}/linux/postinst @ONLY)
     configure_file(${APP_DIR}/resources/linux/prerm ${CMAKE_CURRENT_BINARY_DIR}/linux/prerm @ONLY)

--- a/app/resources/linux/trenchbroom.desktop
+++ b/app/resources/linux/trenchbroom.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=trenchbroom
+Exec=trenchbroom %F
 GenericName=Level Editor
 Comment=Level Editor
 Icon=trenchbroom
@@ -8,4 +8,4 @@ Terminal=0
 Type=Application
 Categories=Game
 Keywords=quake;level;editor;
-
+MimeType=text/x-quakemap;

--- a/app/resources/linux/trenchbroom.xml
+++ b/app/resources/linux/trenchbroom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+	<mime-type type="text/x-quakemap">
+		<comment>Quake map source file</comment>
+		<sub-class-of type="test/plain"/>
+		<magic>
+			<match offset="0" type="string" value="// Game: Quake"/>
+		</magic>
+		<glob pattern="*.map"/>
+	</mime-type>
+</mime-info>

--- a/app/resources/linux/trenchbroom.xml
+++ b/app/resources/linux/trenchbroom.xml
@@ -2,7 +2,7 @@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
 	<mime-type type="text/x-quakemap">
 		<comment>Quake map source file</comment>
-		<sub-class-of type="test/plain"/>
+		<sub-class-of type="text/plain"/>
 		<magic>
 			<match offset="0" type="string" value="// Game: Quake"/>
 		</magic>


### PR DESCRIPTION
- Adds a new `text/x-quakemap` MIME type definition with a shared mime info file.
- Updates the `Exec` line in the desktop file so that TrenchBroom is listed in the "Open with" application list.
- Adds `MimeType` line to desktop file to associate TrenchBroom with `text/x-quakemap` files.

In my test the built package has the new XML file in the correct location:
![image](https://user-images.githubusercontent.com/424218/183279795-5cd44760-359f-4995-a892-91130ec24b72.png)
