### PR TITLE
Fix for parsing unrecognised FGD class properties

### DIFF
--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -396,6 +396,15 @@ Assets::ModelDefinition FgdParser::parseModel(ParserStatus& status) {
 }
 
 void FgdParser::skipClassProperty(ParserStatus& /* status */) {
+  // We have already consumed the property name.
+  // We assume that the next token we should encounter is
+  // an open parenthesis. If the next token is not a
+  // parenthesis, it forms part of the next property
+  // (which we should not skip).
+  if (m_tokenizer.peekToken().type() != FgdToken::OParenthesis) {
+    return;
+  }
+
   size_t depth = 0;
   Token token;
   do {

--- a/common/test/src/IO/FgdParserTest.cpp
+++ b/common/test/src/IO/FgdParserTest.cpp
@@ -254,6 +254,36 @@ TEST_CASE("FgdParserTest.parsePointClassWithBaseClasses", "[FgdParserTest]") {
   kdl::vec_clear_and_delete(definitions);
 }
 
+TEST_CASE("FgdParserTest.parsePointClassWithUnknownClassProperties", "[FgdParserTest]") {
+  const std::string file =
+    "@PointClass unknown1 unknown2(spaghetti) = info_notnull : \"Wildcard entity\" // I love you\n"
+    "[\n"
+    "	use(string) : \"self.use\"\n"
+    "	think(string) : \"self.think\"\n"
+    "	nextthink(integer) : \"nextthink\"\n"
+    "	noise(string) : \"noise\"\n"
+    "	touch(string) : \"self.touch\"\n"
+    "]\n";
+
+  const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
+  FgdParser parser(file, defaultColor);
+
+  TestParserStatus status;
+  auto definitions = parser.parseDefinitions(status);
+  CHECK(definitions.size() == 1u);
+
+  Assets::EntityDefinition* definition = definitions[0];
+  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition->name() == std::string("info_notnull"));
+  CHECK(definition->color() == defaultColor);
+  CHECK(definition->description() == std::string("Wildcard entity"));
+
+  const auto& propertyDefinitions = definition->propertyDefinitions();
+  CHECK(propertyDefinitions.size() == 5u);
+
+  kdl::vec_clear_and_delete(definitions);
+}
+
 TEST_CASE("FgdParserTest.parseType_TargetSourcePropertyDefinition", "[FgdParserTest]") {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"


### PR DESCRIPTION
This PR fixes the following corner case when parsing FGDs:

```
@PointClass unknownprop base(Targetname) = my_entity : 
```

In the above example, `unknownprop` is not recognised by TrenchBroom, so `FgdParser::skipClassProperty()` is called to skip any parentheses. However, since the `unknownprop` token has already been consumed and no parentheses are present, the token `base` is encountered and skipped, and then the function exits since the parentheses depth is 0. Parsing subsequently fails since the parenthesis that is read next is unexpected.

This was a corner case I encountered when parsing Source FGDs on my own branch. Many of the modifications I had to make to the parsing code at large aren't relevant to TrenchBroom, but I think this one might be if it's possible to specify class properties in an FGD with no parentheses. This situation occurred for me when I tried to parse a class with a `halfgridsnap` property.

If this fix isn't valid for old-school FGDs then I'm happy to disregard it.