### PR TITLE
Remove Command Types

### DIFF
--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -125,7 +125,7 @@ void AddRemoveNodesCommand::doAction(MapDocumentCommandFacade* document) {
   }
 
   using std::swap;
-  std::swap(m_nodesToAdd, m_nodesToRemove);
+  swap(m_nodesToAdd, m_nodesToRemove);
 }
 
 void AddRemoveNodesCommand::undoAction(MapDocumentCommandFacade* document) {
@@ -139,7 +139,7 @@ void AddRemoveNodesCommand::undoAction(MapDocumentCommandFacade* document) {
   }
 
   using std::swap;
-  std::swap(m_nodesToAdd, m_nodesToRemove);
+  swap(m_nodesToAdd, m_nodesToRemove);
 }
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -33,8 +33,6 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType AddRemoveNodesCommand::Type = Command::freeType();
-
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   Model::Node* parent, const std::vector<Model::Node*>& children,
   std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
@@ -70,7 +68,7 @@ AddRemoveNodesCommand::AddRemoveNodesCommand(
   const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
   std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
     linkedGroupsToUpdate)
-  : UndoableCommand(Type, makeName(action), true)
+  : UndoableCommand(makeName(action), true)
   , m_action(action)
   , m_updateLinkedGroupsHelper(std::move(linkedGroupsToUpdate)) {
   switch (m_action) {

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -141,9 +141,5 @@ void AddRemoveNodesCommand::undoAction(MapDocumentCommandFacade* document) {
   using std::swap;
   std::swap(m_nodesToAdd, m_nodesToRemove);
 }
-
-bool AddRemoveNodesCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -142,7 +142,7 @@ void AddRemoveNodesCommand::undoAction(MapDocumentCommandFacade* document) {
   std::swap(m_nodesToAdd, m_nodesToRemove);
 }
 
-bool AddRemoveNodesCommand::doCollateWith(UndoableCommand*) {
+bool AddRemoveNodesCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -35,9 +35,6 @@ class Node;
 
 namespace View {
 class AddRemoveNodesCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   enum class Action {
     Add,

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -78,8 +78,6 @@ private:
   void doAction(MapDocumentCommandFacade* document);
   void undoAction(MapDocumentCommandFacade* document);
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(AddRemoveNodesCommand);
 };
 } // namespace View

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -78,7 +78,7 @@ private:
   void doAction(MapDocumentCommandFacade* document);
   void undoAction(MapDocumentCommandFacade* document);
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(AddRemoveNodesCommand);
 };

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -100,10 +100,10 @@ std::unique_ptr<CommandResult> BrushVertexCommand::createCommandResult(
     swapResult->success(), !m_newVertexPositions.empty());
 }
 
-bool BrushVertexCommand::doCollateWith(UndoableCommand* command) {
-  BrushVertexCommand* other = static_cast<BrushVertexCommand*>(command);
+bool BrushVertexCommand::doCollateWith(UndoableCommand& command) {
+  auto& other = static_cast<BrushVertexCommand&>(command);
 
-  if (m_newVertexPositions != other->m_oldVertexPositions) {
+  if (m_newVertexPositions != other.m_oldVertexPositions) {
     return false;
   }
 
@@ -111,7 +111,7 @@ bool BrushVertexCommand::doCollateWith(UndoableCommand* command) {
     return false;
   }
 
-  m_newVertexPositions = std::move(other->m_newVertexPositions);
+  m_newVertexPositions = std::move(other.m_newVertexPositions);
 
   return true;
 }
@@ -137,10 +137,10 @@ BrushEdgeCommand::BrushEdgeCommand(
   , m_oldEdgePositions(std::move(oldEdgePositions))
   , m_newEdgePositions(std::move(newEdgePositions)) {}
 
-bool BrushEdgeCommand::doCollateWith(UndoableCommand* command) {
-  BrushEdgeCommand* other = static_cast<BrushEdgeCommand*>(command);
+bool BrushEdgeCommand::doCollateWith(UndoableCommand& command) {
+  auto& other = static_cast<BrushEdgeCommand&>(command);
 
-  if (m_newEdgePositions != other->m_oldEdgePositions) {
+  if (m_newEdgePositions != other.m_oldEdgePositions) {
     return false;
   }
 
@@ -148,7 +148,7 @@ bool BrushEdgeCommand::doCollateWith(UndoableCommand* command) {
     return false;
   }
 
-  m_newEdgePositions = std::move(other->m_newEdgePositions);
+  m_newEdgePositions = std::move(other.m_newEdgePositions);
 
   return true;
 }
@@ -174,10 +174,10 @@ BrushFaceCommand::BrushFaceCommand(
   , m_oldFacePositions(std::move(oldFacePositions))
   , m_newFacePositions(std::move(newFacePositions)) {}
 
-bool BrushFaceCommand::doCollateWith(UndoableCommand* command) {
-  BrushFaceCommand* other = static_cast<BrushFaceCommand*>(command);
+bool BrushFaceCommand::doCollateWith(UndoableCommand& command) {
+  auto& other = static_cast<BrushFaceCommand&>(command);
 
-  if (m_newFacePositions != other->m_oldFacePositions) {
+  if (m_newFacePositions != other.m_oldFacePositions) {
     return false;
   }
 
@@ -185,7 +185,7 @@ bool BrushFaceCommand::doCollateWith(UndoableCommand* command) {
     return false;
   }
 
-  m_newFacePositions = std::move(other->m_newFacePositions);
+  m_newFacePositions = std::move(other.m_newFacePositions);
 
   return true;
 }

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -83,8 +83,6 @@ bool BrushVertexCommandResult::hasRemainingVertices() const {
   return m_hasRemainingVertices;
 }
 
-const Command::CommandType BrushVertexCommand::Type = Command::freeType();
-
 BrushVertexCommand::BrushVertexCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
@@ -101,9 +99,12 @@ std::unique_ptr<CommandResult> BrushVertexCommand::createCommandResult(
 }
 
 bool BrushVertexCommand::doCollateWith(UndoableCommand& command) {
-  auto& other = static_cast<BrushVertexCommand&>(command);
+  auto* other = dynamic_cast<BrushVertexCommand*>(&command);
+  if (other == nullptr) {
+    return false;
+  }
 
-  if (m_newVertexPositions != other.m_oldVertexPositions) {
+  if (m_newVertexPositions != other->m_oldVertexPositions) {
     return false;
   }
 
@@ -111,7 +112,7 @@ bool BrushVertexCommand::doCollateWith(UndoableCommand& command) {
     return false;
   }
 
-  m_newVertexPositions = std::move(other.m_newVertexPositions);
+  m_newVertexPositions = std::move(other->m_newVertexPositions);
 
   return true;
 }
@@ -126,8 +127,6 @@ void BrushVertexCommand::selectOldHandlePositions(
   manager.select(std::begin(m_oldVertexPositions), std::end(m_oldVertexPositions));
 }
 
-const Command::CommandType BrushEdgeCommand::Type = Command::freeType();
-
 BrushEdgeCommand::BrushEdgeCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
@@ -138,9 +137,12 @@ BrushEdgeCommand::BrushEdgeCommand(
   , m_newEdgePositions(std::move(newEdgePositions)) {}
 
 bool BrushEdgeCommand::doCollateWith(UndoableCommand& command) {
-  auto& other = static_cast<BrushEdgeCommand&>(command);
+  auto* other = dynamic_cast<BrushEdgeCommand*>(&command);
+  if (other == nullptr) {
+    return false;
+  }
 
-  if (m_newEdgePositions != other.m_oldEdgePositions) {
+  if (m_newEdgePositions != other->m_oldEdgePositions) {
     return false;
   }
 
@@ -148,7 +150,7 @@ bool BrushEdgeCommand::doCollateWith(UndoableCommand& command) {
     return false;
   }
 
-  m_newEdgePositions = std::move(other.m_newEdgePositions);
+  m_newEdgePositions = std::move(other->m_newEdgePositions);
 
   return true;
 }
@@ -163,8 +165,6 @@ void BrushEdgeCommand::selectOldHandlePositions(
   manager.select(std::begin(m_oldEdgePositions), std::end(m_oldEdgePositions));
 }
 
-const Command::CommandType BrushFaceCommand::Type = Command::freeType();
-
 BrushFaceCommand::BrushFaceCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
@@ -175,9 +175,12 @@ BrushFaceCommand::BrushFaceCommand(
   , m_newFacePositions(std::move(newFacePositions)) {}
 
 bool BrushFaceCommand::doCollateWith(UndoableCommand& command) {
-  auto& other = static_cast<BrushFaceCommand&>(command);
+  auto* other = dynamic_cast<BrushFaceCommand*>(&command);
+  if (other == nullptr) {
+    return false;
+  }
 
-  if (m_newFacePositions != other.m_oldFacePositions) {
+  if (m_newFacePositions != other->m_oldFacePositions) {
     return false;
   }
 
@@ -185,7 +188,7 @@ bool BrushFaceCommand::doCollateWith(UndoableCommand& command) {
     return false;
   }
 
-  m_newFacePositions = std::move(other.m_newFacePositions);
+  m_newFacePositions = std::move(other->m_newFacePositions);
 
   return true;
 }

--- a/common/src/View/BrushVertexCommands.h
+++ b/common/src/View/BrushVertexCommands.h
@@ -92,7 +92,7 @@ private:
   std::unique_ptr<CommandResult> createCommandResult(
     std::unique_ptr<CommandResult> swapResult) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   void selectNewHandlePositions(VertexHandleManagerBaseT<vm::vec3>& manager) const override;
   void selectOldHandlePositions(VertexHandleManagerBaseT<vm::vec3>& manager) const override;
@@ -116,7 +116,7 @@ public:
       linkedGroupsToUpdate);
 
 private:
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   void selectNewHandlePositions(VertexHandleManagerBaseT<vm::segment3>& manager) const override;
   void selectOldHandlePositions(VertexHandleManagerBaseT<vm::segment3>& manager) const override;
@@ -140,7 +140,7 @@ public:
       linkedGroupsToUpdate);
 
 private:
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   void selectNewHandlePositions(VertexHandleManagerBaseT<vm::polygon3>& manager) const override;
   void selectOldHandlePositions(VertexHandleManagerBaseT<vm::polygon3>& manager) const override;

--- a/common/src/View/BrushVertexCommands.h
+++ b/common/src/View/BrushVertexCommands.h
@@ -74,9 +74,6 @@ public:
 };
 
 class BrushVertexCommand : public BrushVertexCommandBase {
-public:
-  static const CommandType Type;
-
 private:
   std::vector<vm::vec3> m_oldVertexPositions;
   std::vector<vm::vec3> m_newVertexPositions;
@@ -101,9 +98,6 @@ private:
 };
 
 class BrushEdgeCommand : public BrushVertexCommandBase {
-public:
-  static const CommandType Type;
-
 private:
   std::vector<vm::segment3> m_oldEdgePositions;
   std::vector<vm::segment3> m_newEdgePositions;
@@ -125,9 +119,6 @@ private:
 };
 
 class BrushFaceCommand : public BrushVertexCommandBase {
-public:
-  static const CommandType Type;
-
 private:
   std::vector<vm::polygon3> m_oldFacePositions;
   std::vector<vm::polygon3> m_newFacePositions;

--- a/common/src/View/Command.cpp
+++ b/common/src/View/Command.cpp
@@ -32,25 +32,11 @@ bool CommandResult::success() const {
   return m_success;
 }
 
-Command::CommandType Command::freeType() {
-  static CommandType type = 1;
-  return type++;
-}
-
-Command::Command(const CommandType type, const std::string& name)
-  : m_type(type)
-  , m_state(CommandState::Default)
+Command::Command(const std::string& name)
+  : m_state(CommandState::Default)
   , m_name(name) {}
 
 Command::~Command() {}
-
-Command::CommandType Command::type() const {
-  return m_type;
-}
-
-bool Command::isType(CommandType type) const {
-  return m_type == type;
-}
 
 Command::CommandState Command::state() const {
   return m_state;

--- a/common/src/View/Command.h
+++ b/common/src/View/Command.h
@@ -41,8 +41,6 @@ public:
 
 class Command {
 public:
-  using CommandType = size_t;
-
   enum class CommandState {
     Default,
     Doing,
@@ -51,24 +49,14 @@ public:
   };
 
 protected:
-  CommandType m_type;
   CommandState m_state;
   std::string m_name;
 
 public:
-  static CommandType freeType();
-
-  Command(CommandType type, const std::string& name);
+  Command(const std::string& name);
   virtual ~Command();
 
-  CommandType type() const;
-
-  bool isType(CommandType type) const;
-
-  template <typename... C> bool isType(CommandType type, C... types) const {
-    return isType(type) || isType(types...);
-  }
-
+public:
   CommandState state() const;
   const std::string& name() const;
 

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -144,8 +144,8 @@ const std::string& CommandProcessor::redoCommandName() const {
   }
 }
 
-void CommandProcessor::startTransaction(const std::string& name) {
-  m_transactionStack.emplace_back(name);
+void CommandProcessor::startTransaction(std::string name) {
+  m_transactionStack.emplace_back(std::move(name));
 }
 
 void CommandProcessor::commitTransaction() {

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -107,7 +107,7 @@ private:
     return std::make_unique<CommandResult>(true);
   }
 
-  bool doCollateWith(UndoableCommand*) override { return false; }
+  bool doCollateWith(UndoableCommand&) override { return false; }
 };
 
 const Command::CommandType CommandProcessor::TransactionCommand::Type = Command::freeType();
@@ -274,7 +274,7 @@ bool CommandProcessor::pushTransactionCommand(
   auto& transaction = m_transactionStack.back();
   if (!transaction.commands.empty()) {
     auto& lastCommand = transaction.commands.back();
-    if (collate && lastCommand->collateWith(command.get())) {
+    if (collate && lastCommand->collateWith(*command)) {
       // the command is not stored because it was collated with its predecessor
       return false;
     }
@@ -318,7 +318,7 @@ bool CommandProcessor::pushToUndoStack(
 
   if (collatable(collate, timestamp)) {
     auto& lastCommand = m_undoStack.back();
-    if (lastCommand->collateWith(command.get())) {
+    if (lastCommand->collateWith(*command)) {
       return false;
     }
   }

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -106,8 +106,6 @@ private:
     }
     return std::make_unique<CommandResult>(true);
   }
-
-  bool doCollateWith(UndoableCommand&) override { return false; }
 };
 
 const Command::CommandType CommandProcessor::TransactionCommand::Type = Command::freeType();

--- a/common/src/View/CommandProcessor.h
+++ b/common/src/View/CommandProcessor.h
@@ -168,7 +168,7 @@ public:
    *
    * @param name the name of the transaction to start
    */
-  void startTransaction(const std::string& name = "");
+  void startTransaction(const std::string& name);
 
   /**
    * Commits the currently executing transaction. If it is a nested transaction, then its commands

--- a/common/src/View/CommandProcessor.h
+++ b/common/src/View/CommandProcessor.h
@@ -103,32 +103,32 @@ public:
   /**
    * Notifies observers when a command is going to be executed.
    */
-  Notifier<Command*> commandDoNotifier;
+  Notifier<Command&> commandDoNotifier;
 
   /**
    * Notifies observers when a command was successfully executed.
    */
-  Notifier<Command*> commandDoneNotifier;
+  Notifier<Command&> commandDoneNotifier;
 
   /**
    * Notifies observers when a command failed to execute.
    */
-  Notifier<Command*> commandDoFailedNotifier;
+  Notifier<Command&> commandDoFailedNotifier;
 
   /**
    * Notifies observers when an undoable command is going to be undone.
    */
-  Notifier<UndoableCommand*> commandUndoNotifier;
+  Notifier<UndoableCommand&> commandUndoNotifier;
 
   /**
    * Notifies observers when an undoable command was successfully undone.
    */
-  Notifier<UndoableCommand*> commandUndoneNotifier;
+  Notifier<UndoableCommand&> commandUndoneNotifier;
 
   /**
    * Notifies observers when an undoable command failed to undo.
    */
-  Notifier<UndoableCommand*> commandUndoFailedNotifier;
+  Notifier<UndoableCommand&> commandUndoFailedNotifier;
 
   /**
    * Notifies observers when a transaction completed successfully.

--- a/common/src/View/CommandProcessor.h
+++ b/common/src/View/CommandProcessor.h
@@ -168,7 +168,7 @@ public:
    *
    * @param name the name of the transaction to start
    */
-  void startTransaction(const std::string& name);
+  void startTransaction(std::string name);
 
   /**
    * Commits the currently executing transaction. If it is a nested transaction, then its commands

--- a/common/src/View/CommandProcessor.h
+++ b/common/src/View/CommandProcessor.h
@@ -96,7 +96,7 @@ public:
    */
   explicit CommandProcessor(
     MapDocumentCommandFacade* document,
-    std::chrono::milliseconds collationInterval = std::chrono::milliseconds(1000));
+    std::chrono::milliseconds collationInterval = std::chrono::milliseconds{1000});
 
   ~CommandProcessor();
 
@@ -275,7 +275,7 @@ private:
    * @param command the command to execute
    * @return the result of executing the given command
    */
-  std::unique_ptr<CommandResult> executeCommand(Command* command);
+  std::unique_ptr<CommandResult> executeCommand(Command& command);
 
   /**
    * Undoes the given command by calling its `performUndo` method and triggers the corresponding
@@ -284,7 +284,7 @@ private:
    * @param command the command to undo
    * @return the result of undoing the given command
    */
-  std::unique_ptr<CommandResult> undoCommand(UndoableCommand* command);
+  std::unique_ptr<CommandResult> undoCommand(UndoableCommand& command);
 
   /**
    * Stores the given command or collates it with the topmost command on the undo stack.
@@ -329,7 +329,7 @@ private:
    * @return the newly created command
    */
   std::unique_ptr<UndoableCommand> createTransaction(
-    const std::string& name, std::vector<std::unique_ptr<UndoableCommand>> commands);
+    std::string name, std::vector<std::unique_ptr<UndoableCommand>> commands);
 
   /**
    * Pushes the given command onto the undo stack, unless it can be collated with the topmost

--- a/common/src/View/CurrentGroupCommand.cpp
+++ b/common/src/View/CurrentGroupCommand.cpp
@@ -60,9 +60,5 @@ std::unique_ptr<CommandResult> CurrentGroupCommand::doPerformUndo(
   }
   return std::make_unique<CommandResult>(true);
 }
-
-bool CurrentGroupCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/CurrentGroupCommand.cpp
+++ b/common/src/View/CurrentGroupCommand.cpp
@@ -23,8 +23,6 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType CurrentGroupCommand::Type = Command::freeType();
-
 std::unique_ptr<CurrentGroupCommand> CurrentGroupCommand::push(Model::GroupNode* group) {
   return std::make_unique<CurrentGroupCommand>(group);
 }
@@ -34,7 +32,7 @@ std::unique_ptr<CurrentGroupCommand> CurrentGroupCommand::pop() {
 }
 
 CurrentGroupCommand::CurrentGroupCommand(Model::GroupNode* group)
-  : UndoableCommand(Type, group != nullptr ? "Push Group" : "Pop Group", false)
+  : UndoableCommand(group != nullptr ? "Push Group" : "Pop Group", false)
   , m_group(group) {}
 
 std::unique_ptr<CommandResult> CurrentGroupCommand::doPerformDo(

--- a/common/src/View/CurrentGroupCommand.cpp
+++ b/common/src/View/CurrentGroupCommand.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<CommandResult> CurrentGroupCommand::doPerformUndo(
   return std::make_unique<CommandResult>(true);
 }
 
-bool CurrentGroupCommand::doCollateWith(UndoableCommand*) {
+bool CurrentGroupCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/CurrentGroupCommand.h
+++ b/common/src/View/CurrentGroupCommand.h
@@ -47,7 +47,7 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(CurrentGroupCommand);
 };

--- a/common/src/View/CurrentGroupCommand.h
+++ b/common/src/View/CurrentGroupCommand.h
@@ -47,8 +47,6 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(CurrentGroupCommand);
 };
 } // namespace View

--- a/common/src/View/CurrentGroupCommand.h
+++ b/common/src/View/CurrentGroupCommand.h
@@ -31,9 +31,6 @@ class GroupNode;
 
 namespace View {
 class CurrentGroupCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   Model::GroupNode* m_group;
 

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -123,7 +123,7 @@ bool DuplicateNodesCommand::shouldCloneParentWhenCloningNode(const Model::Node* 
     }));
 }
 
-bool DuplicateNodesCommand::doCollateWith(UndoableCommand*) {
+bool DuplicateNodesCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -122,9 +122,5 @@ bool DuplicateNodesCommand::shouldCloneParentWhenCloningNode(const Model::Node* 
       return false;
     }));
 }
-
-bool DuplicateNodesCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/DuplicateNodesCommand.h
+++ b/common/src/View/DuplicateNodesCommand.h
@@ -54,8 +54,6 @@ private:
 
   bool shouldCloneParentWhenCloningNode(const Model::Node* node) const;
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(DuplicateNodesCommand);
 };
 } // namespace View

--- a/common/src/View/DuplicateNodesCommand.h
+++ b/common/src/View/DuplicateNodesCommand.h
@@ -54,7 +54,7 @@ private:
 
   bool shouldCloneParentWhenCloningNode(const Model::Node* node) const;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(DuplicateNodesCommand);
 };

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3440,12 +3440,11 @@ void MapDocument::printVertices() {
 
 class ThrowExceptionCommand : public UndoableCommand {
 public:
-  static const CommandType Type;
   using Ptr = std::shared_ptr<ThrowExceptionCommand>;
 
 public:
   ThrowExceptionCommand()
-    : UndoableCommand(Type, "Throw Exception", false) {}
+    : UndoableCommand("Throw Exception", false) {}
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade*) override {
@@ -3456,8 +3455,6 @@ private:
     return std::make_unique<CommandResult>(true);
   }
 };
-
-const ThrowExceptionCommand::CommandType ThrowExceptionCommand::Type = Command::freeType();
 
 bool MapDocument::throwExceptionDuringCommand() {
   const auto result = executeAndStore(std::make_unique<ThrowExceptionCommand>());

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3455,8 +3455,6 @@ private:
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade*) override {
     return std::make_unique<CommandResult>(true);
   }
-
-  bool doCollateWith(UndoableCommand&) override { return false; }
 };
 
 const ThrowExceptionCommand::CommandType ThrowExceptionCommand::Type = Command::freeType();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -4286,12 +4286,12 @@ void MapDocument::preferenceDidChange(const IO::Path& path) {
   }
 }
 
-void MapDocument::commandDone(Command* command) {
-  debug() << "Command '" << command->name() << "' executed";
+void MapDocument::commandDone(Command& command) {
+  debug() << "Command '" << command.name() << "' executed";
 }
 
-void MapDocument::commandUndone(UndoableCommand* command) {
-  debug() << "Command '" << command->name() << "' undone";
+void MapDocument::commandUndone(UndoableCommand& command) {
+  debug() << "Command '" << command.name() << "' undone";
 }
 
 void MapDocument::transactionDone(const std::string& name) {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3505,9 +3505,9 @@ void MapDocument::clearRepeatableCommands() {
   m_repeatStack->clear();
 }
 
-void MapDocument::startTransaction(const std::string& name) {
+void MapDocument::startTransaction(std::string name) {
   debug("Starting transaction '" + name + "'");
-  doStartTransaction(name);
+  doStartTransaction(std::move(name));
   m_repeatStack->startTransaction();
 }
 
@@ -4302,22 +4302,22 @@ void MapDocument::transactionUndone(const std::string& name) {
   debug() << "Transaction '" << name << "' undone";
 }
 
-Transaction::Transaction(std::weak_ptr<MapDocument> document, const std::string& name)
+Transaction::Transaction(std::weak_ptr<MapDocument> document, std::string name)
   : m_document(kdl::mem_lock(document).get())
   , m_cancelled(false) {
-  begin(name);
+  begin(std::move(name));
 }
 
-Transaction::Transaction(std::shared_ptr<MapDocument> document, const std::string& name)
+Transaction::Transaction(std::shared_ptr<MapDocument> document, std::string name)
   : m_document(document.get())
   , m_cancelled(false) {
-  begin(name);
+  begin(std::move(name));
 }
 
-Transaction::Transaction(MapDocument* document, const std::string& name)
+Transaction::Transaction(MapDocument* document, std::string name)
   : m_document(document)
   , m_cancelled(false) {
-  begin(name);
+  begin(std::move(name));
 }
 
 Transaction::~Transaction() {
@@ -4334,8 +4334,8 @@ void Transaction::cancel() {
   m_cancelled = true;
 }
 
-void Transaction::begin(const std::string& name) {
-  m_document->startTransaction(name);
+void Transaction::begin(std::string name) {
+  m_document->startTransaction(std::move(name));
 }
 
 void Transaction::commit() {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3456,7 +3456,7 @@ private:
     return std::make_unique<CommandResult>(true);
   }
 
-  bool doCollateWith(UndoableCommand*) override { return false; }
+  bool doCollateWith(UndoableCommand&) override { return false; }
 };
 
 const ThrowExceptionCommand::CommandType ThrowExceptionCommand::Type = Command::freeType();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -141,12 +141,12 @@ protected:
   std::unique_ptr<RepeatStack> m_repeatStack;
 
 public: // notification
-  Notifier<Command*> commandDoNotifier;
-  Notifier<Command*> commandDoneNotifier;
-  Notifier<Command*> commandDoFailedNotifier;
-  Notifier<UndoableCommand*> commandUndoNotifier;
-  Notifier<UndoableCommand*> commandUndoneNotifier;
-  Notifier<UndoableCommand*> commandUndoFailedNotifier;
+  Notifier<Command&> commandDoNotifier;
+  Notifier<Command&> commandDoneNotifier;
+  Notifier<Command&> commandDoFailedNotifier;
+  Notifier<UndoableCommand&> commandUndoNotifier;
+  Notifier<UndoableCommand&> commandUndoneNotifier;
+  Notifier<UndoableCommand&> commandUndoFailedNotifier;
   Notifier<const std::string&> transactionDoneNotifier;
   Notifier<const std::string&> transactionUndoneNotifier;
 
@@ -751,8 +751,8 @@ private: // observers
   void modsWillChange();
   void modsDidChange();
   void preferenceDidChange(const IO::Path& path);
-  void commandDone(Command* command);
-  void commandUndone(UndoableCommand* command);
+  void commandDone(Command& command);
+  void commandUndone(UndoableCommand& command);
   void transactionDone(const std::string& name);
   void transactionUndone(const std::string& name);
 };

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -597,7 +597,7 @@ public: // command processing
   void clearRepeatableCommands();
 
 public: // transactions
-  void startTransaction(const std::string& name = "");
+  void startTransaction(const std::string& name);
   void rollbackTransaction();
   void commitTransaction();
   void cancelTransaction();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -597,7 +597,7 @@ public: // command processing
   void clearRepeatableCommands();
 
 public: // transactions
-  void startTransaction(const std::string& name);
+  void startTransaction(std::string name);
   void rollbackTransaction();
   void commitTransaction();
   void cancelTransaction();
@@ -615,7 +615,7 @@ private: // subclassing interface for command processing
   virtual void doRedoCommand() = 0;
 
   virtual void doClearCommandProcessor() = 0;
-  virtual void doStartTransaction(const std::string& name) = 0;
+  virtual void doStartTransaction(std::string name) = 0;
   virtual void doCommitTransaction() = 0;
   virtual void doRollbackTransaction() = 0;
 
@@ -763,16 +763,16 @@ private:
   bool m_cancelled;
 
 public:
-  explicit Transaction(std::weak_ptr<MapDocument> document, const std::string& name = "");
-  explicit Transaction(std::shared_ptr<MapDocument> document, const std::string& name = "");
-  explicit Transaction(MapDocument* document, const std::string& name = "");
+  explicit Transaction(std::weak_ptr<MapDocument> document, std::string name = "");
+  explicit Transaction(std::shared_ptr<MapDocument> document, std::string name = "");
+  explicit Transaction(MapDocument* document, std::string name = "");
   ~Transaction();
 
   void rollback();
   void cancel();
 
 private:
-  void begin(const std::string& name);
+  void begin(std::string name);
   void commit();
 };
 } // namespace View

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -568,8 +568,8 @@ void MapDocumentCommandFacade::doClearCommandProcessor() {
   m_commandProcessor->clear();
 }
 
-void MapDocumentCommandFacade::doStartTransaction(const std::string& name) {
-  m_commandProcessor->startTransaction(name);
+void MapDocumentCommandFacade::doStartTransaction(std::string name) {
+  m_commandProcessor->startTransaction(std::move(name));
 }
 
 void MapDocumentCommandFacade::doCommitTransaction() {

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -142,7 +142,7 @@ private: // implement MapDocument interface
   void doRedoCommand() override;
 
   void doClearCommandProcessor() override;
-  void doStartTransaction(const std::string& name) override;
+  void doStartTransaction(std::string name) override;
   void doCommitTransaction() override;
   void doRollbackTransaction() override;
 

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -204,13 +204,13 @@ void MapViewBase::toolChanged(Tool&) {
   update();
 }
 
-void MapViewBase::commandDone(Command*) {
+void MapViewBase::commandDone(Command&) {
   updateActionStatesDelayed();
   updatePickResult();
   update();
 }
 
-void MapViewBase::commandUndone(UndoableCommand*) {
+void MapViewBase::commandUndone(UndoableCommand&) {
   updateActionStatesDelayed();
   updatePickResult();
   update();

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -143,8 +143,8 @@ private:
 
   void nodesDidChange(const std::vector<Model::Node*>& nodes);
   void toolChanged(Tool& tool);
-  void commandDone(Command* command);
-  void commandUndone(UndoableCommand* command);
+  void commandDone(Command& command);
+  void commandUndone(UndoableCommand& command);
   void selectionDidChange(const Selection& selection);
   void textureCollectionsDidChange();
   void entityDefinitionsDidChange();

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -26,8 +26,6 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType ReparentNodesCommand::Type = Command::freeType();
-
 std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
@@ -42,7 +40,7 @@ ReparentNodesCommand::ReparentNodesCommand(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
   std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
     linkedGroupsToUpdate)
-  : UndoableCommand(Type, "Reparent Objects", true)
+  : UndoableCommand("Reparent Objects", true)
   , m_nodesToAdd(std::move(nodesToAdd))
   , m_nodesToRemove(std::move(nodesToRemove))
   , m_updateLinkedGroupsHelper(std::move(linkedGroupsToUpdate)) {}

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -77,7 +77,7 @@ void ReparentNodesCommand::undoAction(MapDocumentCommandFacade* document) {
   document->performAddNodes(m_nodesToRemove);
 }
 
-bool ReparentNodesCommand::doCollateWith(UndoableCommand*) {
+bool ReparentNodesCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -76,9 +76,5 @@ void ReparentNodesCommand::undoAction(MapDocumentCommandFacade* document) {
   document->performRemoveNodes(m_nodesToAdd);
   document->performAddNodes(m_nodesToRemove);
 }
-
-bool ReparentNodesCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -63,7 +63,7 @@ private:
   void doAction(MapDocumentCommandFacade* document);
   void undoAction(MapDocumentCommandFacade* document);
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(ReparentNodesCommand);
 };

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -63,8 +63,6 @@ private:
   void doAction(MapDocumentCommandFacade* document);
   void undoAction(MapDocumentCommandFacade* document);
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(ReparentNodesCommand);
 };
 } // namespace View

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -35,9 +35,6 @@ class Node;
 
 namespace View {
 class ReparentNodesCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   std::map<Model::Node*, std::vector<Model::Node*>> m_nodesToAdd;
   std::map<Model::Node*, std::vector<Model::Node*>> m_nodesToRemove;

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -169,9 +169,5 @@ std::unique_ptr<CommandResult> SelectionCommand::doPerformUndo(MapDocumentComman
   }
   return std::make_unique<CommandResult>(true);
 }
-
-bool SelectionCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -37,8 +37,6 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType SelectionCommand::Type = Command::freeType();
-
 std::unique_ptr<SelectionCommand> SelectionCommand::select(const std::vector<Model::Node*>& nodes) {
   return std::make_unique<SelectionCommand>(
     Action::SelectNodes, nodes, std::vector<Model::BrushFaceHandle>{});
@@ -85,7 +83,7 @@ std::unique_ptr<SelectionCommand> SelectionCommand::deselectAll() {
 SelectionCommand::SelectionCommand(
   const Action action, const std::vector<Model::Node*>& nodes,
   const std::vector<Model::BrushFaceHandle>& faces)
-  : UndoableCommand(Type, makeName(action, nodes.size(), faces.size()), false)
+  : UndoableCommand(makeName(action, nodes.size(), faces.size()), false)
   , m_action(action)
   , m_nodes(nodes)
   , m_faceRefs(Model::createRefs(faces)) {}

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<CommandResult> SelectionCommand::doPerformUndo(MapDocumentComman
   return std::make_unique<CommandResult>(true);
 }
 
-bool SelectionCommand::doCollateWith(UndoableCommand*) {
+bool SelectionCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -39,9 +39,6 @@ class Node;
 
 namespace View {
 class SelectionCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   enum class Action {
     SelectNodes,

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -86,8 +86,6 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(SelectionCommand);
 };
 } // namespace View

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -86,7 +86,7 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(SelectionCommand);
 };

--- a/common/src/View/SetCurrentLayerCommand.cpp
+++ b/common/src/View/SetCurrentLayerCommand.cpp
@@ -22,14 +22,12 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType SetCurrentLayerCommand::Type = Command::freeType();
-
 std::unique_ptr<SetCurrentLayerCommand> SetCurrentLayerCommand::set(Model::LayerNode* layer) {
   return std::make_unique<SetCurrentLayerCommand>(layer);
 }
 
 SetCurrentLayerCommand::SetCurrentLayerCommand(Model::LayerNode* layer)
-  : UndoableCommand(Type, "Set Current Layer", false)
+  : UndoableCommand("Set Current Layer", false)
   , m_currentLayer(layer)
   , m_oldCurrentLayer(nullptr) {}
 
@@ -46,9 +44,11 @@ std::unique_ptr<CommandResult> SetCurrentLayerCommand::doPerformUndo(
 }
 
 bool SetCurrentLayerCommand::doCollateWith(UndoableCommand& command) {
-  auto& other = static_cast<SetCurrentLayerCommand&>(command);
-  m_currentLayer = other.m_currentLayer;
-  return true;
+  if (auto* other = dynamic_cast<SetCurrentLayerCommand*>(&command)) {
+    m_currentLayer = other->m_currentLayer;
+    return true;
+  }
+  return false;
 }
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/SetCurrentLayerCommand.cpp
+++ b/common/src/View/SetCurrentLayerCommand.cpp
@@ -45,9 +45,9 @@ std::unique_ptr<CommandResult> SetCurrentLayerCommand::doPerformUndo(
   return std::make_unique<CommandResult>(true);
 }
 
-bool SetCurrentLayerCommand::doCollateWith(UndoableCommand* command) {
-  SetCurrentLayerCommand* other = static_cast<SetCurrentLayerCommand*>(command);
-  m_currentLayer = other->m_currentLayer;
+bool SetCurrentLayerCommand::doCollateWith(UndoableCommand& command) {
+  auto& other = static_cast<SetCurrentLayerCommand&>(command);
+  m_currentLayer = other.m_currentLayer;
   return true;
 }
 } // namespace View

--- a/common/src/View/SetCurrentLayerCommand.h
+++ b/common/src/View/SetCurrentLayerCommand.h
@@ -31,9 +31,6 @@ class LayerNode;
 
 namespace View {
 class SetCurrentLayerCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   Model::LayerNode* m_currentLayer;
   Model::LayerNode* m_oldCurrentLayer;

--- a/common/src/View/SetCurrentLayerCommand.h
+++ b/common/src/View/SetCurrentLayerCommand.h
@@ -47,7 +47,7 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(SetCurrentLayerCommand);
 };

--- a/common/src/View/SetLockStateCommand.cpp
+++ b/common/src/View/SetLockStateCommand.cpp
@@ -34,8 +34,6 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType SetLockStateCommand::Type = Command::freeType();
-
 std::unique_ptr<SetLockStateCommand> SetLockStateCommand::lock(
   const std::vector<Model::Node*>& nodes) {
   return std::make_unique<SetLockStateCommand>(nodes, Model::LockState::Locked);
@@ -81,7 +79,7 @@ static bool shouldUpdateModificationCount(const std::vector<Model::Node*>& nodes
 
 SetLockStateCommand::SetLockStateCommand(
   const std::vector<Model::Node*>& nodes, const Model::LockState lockState)
-  : UndoableCommand(Type, makeName(lockState), shouldUpdateModificationCount(nodes))
+  : UndoableCommand(makeName(lockState), shouldUpdateModificationCount(nodes))
   , m_nodes(nodes)
   , m_lockState(lockState) {}
 

--- a/common/src/View/SetLockStateCommand.cpp
+++ b/common/src/View/SetLockStateCommand.cpp
@@ -108,9 +108,5 @@ std::unique_ptr<CommandResult> SetLockStateCommand::doPerformUndo(
   document->restoreLockState(m_oldLockState);
   return std::make_unique<CommandResult>(true);
 }
-
-bool SetLockStateCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/SetLockStateCommand.cpp
+++ b/common/src/View/SetLockStateCommand.cpp
@@ -109,7 +109,7 @@ std::unique_ptr<CommandResult> SetLockStateCommand::doPerformUndo(
   return std::make_unique<CommandResult>(true);
 }
 
-bool SetLockStateCommand::doCollateWith(UndoableCommand*) {
+bool SetLockStateCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/SetLockStateCommand.h
+++ b/common/src/View/SetLockStateCommand.h
@@ -35,9 +35,6 @@ class Node;
 
 namespace View {
 class SetLockStateCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   std::vector<Model::Node*> m_nodes;
   Model::LockState m_lockState;

--- a/common/src/View/SetLockStateCommand.h
+++ b/common/src/View/SetLockStateCommand.h
@@ -56,8 +56,6 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(SetLockStateCommand);
 };
 } // namespace View

--- a/common/src/View/SetLockStateCommand.h
+++ b/common/src/View/SetLockStateCommand.h
@@ -56,7 +56,7 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(SetLockStateCommand);
 };

--- a/common/src/View/SetVisibilityCommand.cpp
+++ b/common/src/View/SetVisibilityCommand.cpp
@@ -93,9 +93,5 @@ std::unique_ptr<CommandResult> SetVisibilityCommand::doPerformUndo(
   document->restoreVisibilityState(m_oldState);
   return std::make_unique<CommandResult>(true);
 }
-
-bool SetVisibilityCommand::doCollateWith(UndoableCommand&) {
-  return false;
-}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/SetVisibilityCommand.cpp
+++ b/common/src/View/SetVisibilityCommand.cpp
@@ -26,8 +26,6 @@
 
 namespace TrenchBroom {
 namespace View {
-const Command::CommandType SetVisibilityCommand::Type = Command::freeType();
-
 std::unique_ptr<SetVisibilityCommand> SetVisibilityCommand::show(
   const std::vector<Model::Node*>& nodes) {
   return std::make_unique<SetVisibilityCommand>(nodes, Action::Show);
@@ -50,7 +48,7 @@ std::unique_ptr<SetVisibilityCommand> SetVisibilityCommand::reset(
 
 SetVisibilityCommand::SetVisibilityCommand(
   const std::vector<Model::Node*>& nodes, const Action action)
-  : UndoableCommand(Type, makeName(action), false)
+  : UndoableCommand(makeName(action), false)
   , m_nodes(nodes)
   , m_action(action) {}
 

--- a/common/src/View/SetVisibilityCommand.cpp
+++ b/common/src/View/SetVisibilityCommand.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<CommandResult> SetVisibilityCommand::doPerformUndo(
   return std::make_unique<CommandResult>(true);
 }
 
-bool SetVisibilityCommand::doCollateWith(UndoableCommand*) {
+bool SetVisibilityCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
 } // namespace View

--- a/common/src/View/SetVisibilityCommand.h
+++ b/common/src/View/SetVisibilityCommand.h
@@ -35,9 +35,6 @@ enum class VisibilityState;
 
 namespace View {
 class SetVisibilityCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 private:
   enum class Action {
     Reset,

--- a/common/src/View/SetVisibilityCommand.h
+++ b/common/src/View/SetVisibilityCommand.h
@@ -65,7 +65,7 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(SetVisibilityCommand);
 };

--- a/common/src/View/SetVisibilityCommand.h
+++ b/common/src/View/SetVisibilityCommand.h
@@ -65,8 +65,6 @@ private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand& command) override;
-
   deleteCopyAndMove(SetVisibilityCommand);
 };
 } // namespace View

--- a/common/src/View/SwapNodeContentsCommand.cpp
+++ b/common/src/View/SwapNodeContentsCommand.cpp
@@ -62,13 +62,13 @@ std::unique_ptr<CommandResult> SwapNodeContentsCommand::doPerformUndo(
   return std::make_unique<CommandResult>(true);
 }
 
-bool SwapNodeContentsCommand::doCollateWith(UndoableCommand* command) {
-  auto* other = static_cast<SwapNodeContentsCommand*>(command);
+bool SwapNodeContentsCommand::doCollateWith(UndoableCommand& command) {
+  auto& other = static_cast<SwapNodeContentsCommand&>(command);
 
   auto myNodes = kdl::vec_transform(m_nodes, [](const auto& pair) {
     return pair.first;
   });
-  auto theirNodes = kdl::vec_transform(other->m_nodes, [](const auto& pair) {
+  auto theirNodes = kdl::vec_transform(other.m_nodes, [](const auto& pair) {
     return pair.first;
   });
 
@@ -76,7 +76,7 @@ bool SwapNodeContentsCommand::doCollateWith(UndoableCommand* command) {
   kdl::vec_sort(theirNodes);
 
   if (myNodes == theirNodes) {
-    m_updateLinkedGroupsHelper.collateWith(other->m_updateLinkedGroupsHelper);
+    m_updateLinkedGroupsHelper.collateWith(other.m_updateLinkedGroupsHelper);
     return true;
   }
 

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -39,9 +39,6 @@ class Node;
 
 namespace View {
 class SwapNodeContentsCommand : public UndoableCommand {
-public:
-  static const CommandType Type;
-
 protected:
   std::vector<std::pair<Model::Node*, Model::NodeContents>> m_nodes;
   UpdateLinkedGroupsHelper m_updateLinkedGroupsHelper;

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -56,7 +56,7 @@ public:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
-  bool doCollateWith(UndoableCommand* command) override;
+  bool doCollateWith(UndoableCommand& command) override;
 
   deleteCopyAndMove(SwapNodeContentsCommand);
 };

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -65,5 +65,9 @@ bool UndoableCommand::collateWith(UndoableCommand& command) {
   }
   return false;
 }
+
+bool UndoableCommand::doCollateWith(UndoableCommand&) {
+  return false;
+}
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -57,10 +57,10 @@ std::unique_ptr<CommandResult> UndoableCommand::performUndo(MapDocumentCommandFa
   return result;
 }
 
-bool UndoableCommand::collateWith(UndoableCommand* command) {
-  assert(command != this);
-  if (command->type() == m_type && doCollateWith(command)) {
-    m_modificationCount += command->m_modificationCount;
+bool UndoableCommand::collateWith(UndoableCommand& command) {
+  assert(&command != this);
+  if (command.type() == m_type && doCollateWith(command)) {
+    m_modificationCount += command.m_modificationCount;
     return true;
   }
   return false;

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -26,9 +26,8 @@
 
 namespace TrenchBroom {
 namespace View {
-UndoableCommand::UndoableCommand(
-  const CommandType type, const std::string& name, const bool updateModificationCount)
-  : Command(type, name)
+UndoableCommand::UndoableCommand(const std::string& name, const bool updateModificationCount)
+  : Command(name)
   , m_modificationCount(updateModificationCount ? 1u : 0u) {}
 
 UndoableCommand::~UndoableCommand() {}
@@ -59,7 +58,7 @@ std::unique_ptr<CommandResult> UndoableCommand::performUndo(MapDocumentCommandFa
 
 bool UndoableCommand::collateWith(UndoableCommand& command) {
   assert(&command != this);
-  if (command.type() == m_type && doCollateWith(command)) {
+  if (doCollateWith(command)) {
     m_modificationCount += command.m_modificationCount;
     return true;
   }

--- a/common/src/View/UndoableCommand.h
+++ b/common/src/View/UndoableCommand.h
@@ -34,7 +34,7 @@ private:
   size_t m_modificationCount;
 
 protected:
-  UndoableCommand(CommandType type, const std::string& name, bool updateModificationCount);
+  UndoableCommand(const std::string& name, bool updateModificationCount);
 
 public:
   virtual ~UndoableCommand();

--- a/common/src/View/UndoableCommand.h
+++ b/common/src/View/UndoableCommand.h
@@ -42,12 +42,12 @@ public:
   std::unique_ptr<CommandResult> performDo(MapDocumentCommandFacade* document) override;
   virtual std::unique_ptr<CommandResult> performUndo(MapDocumentCommandFacade* document);
 
-  virtual bool collateWith(UndoableCommand* command);
+  virtual bool collateWith(UndoableCommand& command);
 
 private:
   virtual std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) = 0;
 
-  virtual bool doCollateWith(UndoableCommand* command) = 0;
+  virtual bool doCollateWith(UndoableCommand& command) = 0;
 
   deleteCopyAndMove(UndoableCommand);
 };

--- a/common/src/View/UndoableCommand.h
+++ b/common/src/View/UndoableCommand.h
@@ -47,7 +47,7 @@ public:
 private:
   virtual std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) = 0;
 
-  virtual bool doCollateWith(UndoableCommand& command) = 0;
+  virtual bool doCollateWith(UndoableCommand& command);
 
   deleteCopyAndMove(UndoableCommand);
 };

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -446,36 +446,36 @@ private: // Observers and state management
       document->commandUndoFailedNotifier.connect(this, &VertexToolBase::commandUndoFailed);
   }
 
-  void commandDo(Command* command) { commandDoOrUndo(command); }
+  void commandDo(Command& command) { commandDoOrUndo(command); }
 
-  void commandDone(Command* command) { commandDoneOrUndoFailed(command); }
+  void commandDone(Command& command) { commandDoneOrUndoFailed(command); }
 
-  void commandDoFailed(Command* command) { commandDoFailedOrUndone(command); }
+  void commandDoFailed(Command& command) { commandDoFailedOrUndone(command); }
 
-  void commandUndo(UndoableCommand* command) { commandDoOrUndo(command); }
+  void commandUndo(UndoableCommand& command) { commandDoOrUndo(command); }
 
-  void commandUndone(UndoableCommand* command) { commandDoFailedOrUndone(command); }
+  void commandUndone(UndoableCommand& command) { commandDoFailedOrUndone(command); }
 
-  void commandUndoFailed(UndoableCommand* command) { commandDoneOrUndoFailed(command); }
+  void commandUndoFailed(UndoableCommand& command) { commandDoneOrUndoFailed(command); }
 
-  void commandDoOrUndo(Command* command) {
-    if (auto* vertexCommand = dynamic_cast<BrushVertexCommandBase*>(command)) {
+  void commandDoOrUndo(Command& command) {
+    if (auto* vertexCommand = dynamic_cast<BrushVertexCommandBase*>(&command)) {
       deselectHandles();
       removeHandles(vertexCommand);
       ++m_ignoreChangeNotifications;
     }
   }
 
-  void commandDoneOrUndoFailed(Command* command) {
-    if (auto* vertexCommand = dynamic_cast<BrushVertexCommandBase*>(command)) {
+  void commandDoneOrUndoFailed(Command& command) {
+    if (auto* vertexCommand = dynamic_cast<BrushVertexCommandBase*>(&command)) {
       addHandles(vertexCommand);
       selectNewHandlePositions(vertexCommand);
       --m_ignoreChangeNotifications;
     }
   }
 
-  void commandDoFailedOrUndone(Command* command) {
-    if (auto* vertexCommand = dynamic_cast<BrushVertexCommandBase*>(command)) {
+  void commandDoFailedOrUndone(Command& command) {
+    if (auto* vertexCommand = dynamic_cast<BrushVertexCommandBase*>(&command)) {
       addHandles(vertexCommand);
       selectOldHandlePositions(vertexCommand);
       --m_ignoreChangeNotifications;

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -133,14 +133,12 @@ private:
   mutable std::vector<TestCommandCall> m_expectedCalls;
 
 public:
-  static const CommandType Type;
-
   static std::unique_ptr<TestCommand> create(const std::string& name) {
     return std::make_unique<TestCommand>(name);
   }
 
   explicit TestCommand(const std::string& name)
-    : UndoableCommand(Type, name, false) {}
+    : UndoableCommand(name, false) {}
 
   ~TestCommand() { CHECK(m_expectedCalls.empty()); }
 
@@ -197,8 +195,6 @@ public:
 
   deleteCopyAndMove(TestCommand);
 };
-
-const Command::CommandType TestCommand::Type = Command::freeType();
 
 TEST_CASE("CommandProcessorTest.doAndUndoSuccessfulCommand", "[CommandProcessorTest]") {
   /*

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -162,10 +162,10 @@ private:
     return std::make_unique<CommandResult>(expectedCall.returnSuccess);
   }
 
-  bool doCollateWith(UndoableCommand* otherCommand) override {
+  bool doCollateWith(UndoableCommand& otherCommand) override {
     const auto expectedCall = popCall<DoCollateWith>();
 
-    REQUIRE(otherCommand == expectedCall.expectedOtherCommand);
+    REQUIRE(&otherCommand == expectedCall.expectedOtherCommand);
 
     return expectedCall.returnCanCollate;
   }

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -89,23 +89,23 @@ public:
 
 private:
   // these would be tidier as lambdas in the TestObserver() constructor
-  void commandDo(Command* command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDo, command->name()));
+  void commandDo(Command& command) {
+    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDo, command.name()));
   }
-  void commandDone(Command* command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDone, command->name()));
+  void commandDone(Command& command) {
+    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDone, command.name()));
   }
-  void commandDoFailed(Command* command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDoFailed, command->name()));
+  void commandDoFailed(Command& command) {
+    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDoFailed, command.name()));
   }
-  void commandUndo(UndoableCommand* command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndo, command->name()));
+  void commandUndo(UndoableCommand& command) {
+    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndo, command.name()));
   }
-  void commandUndone(UndoableCommand* command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndone, command->name()));
+  void commandUndone(UndoableCommand& command) {
+    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndone, command.name()));
   }
-  void commandUndoFailed(UndoableCommand* command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndoFailed, command->name()));
+  void commandUndoFailed(UndoableCommand& command) {
+    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndoFailed, command.name()));
   }
   void transactionDone(const std::string& transactionName) {
     m_notifications.push_back(std::make_tuple(CommandNotif::TransactionDone, transactionName));

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -217,7 +217,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTransaction") {
   document->selectNodes({entityNode1});
   CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
 
-  document->startTransaction();
+  document->startTransaction("");
   document->translateObjects(vm::vec3(0, 0, 10));
   document->rollbackTransaction();
   document->translateObjects(vm::vec3(10, 0, 0));
@@ -257,7 +257,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatDuplicateAndTrans
   SECTION("transaction containing a rollback") {
     document->duplicateObjects();
 
-    document->startTransaction();
+    document->startTransaction("");
     document->translateObjects(vm::vec3(0, 0, 10));
     document->rollbackTransaction();
     document->translateObjects(vm::vec3(10, 0, 0));
@@ -270,7 +270,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatDuplicateAndTrans
     document->translateObjects(vm::vec3(5, 0, 0));
   }
   SECTION("duplicate inside transaction, then standalone movements") {
-    document->startTransaction();
+    document->startTransaction("");
     document->duplicateObjects();
     document->translateObjects(vm::vec3(2, 0, 0));
     document->translateObjects(vm::vec3(2, 0, 0));


### PR DESCRIPTION
This PR contains mostly cleanups and a change to remove command types. We can use `dynamic_cast` to achieve the same effect and remove some code along with it.