### PR TITLE
Simplify linked group updates

### DIFF
--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -35,26 +35,26 @@ namespace TrenchBroom {
 namespace View {
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   Model::Node* parent, const std::vector<Model::Node*>& children,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> changedLinkedGroups) {
   ensure(parent != nullptr, "parent is null");
   auto nodes = std::map<Model::Node*, std::vector<Model::Node*>>{};
   nodes[parent] = children;
 
-  return add(nodes, std::move(linkedGroupsToUpdate));
+  return add(nodes, std::move(changedLinkedGroups));
 }
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> changedLinkedGroups) {
   return std::make_unique<AddRemoveNodesCommand>(
-    Action::Add, nodes, std::move(linkedGroupsToUpdate));
+    Action::Add, nodes, std::move(changedLinkedGroups));
 }
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::remove(
   const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> changedLinkedGroups) {
   return std::make_unique<AddRemoveNodesCommand>(
-    Action::Remove, nodes, std::move(linkedGroupsToUpdate));
+    Action::Remove, nodes, std::move(changedLinkedGroups));
 }
 
 AddRemoveNodesCommand::~AddRemoveNodesCommand() {
@@ -63,10 +63,10 @@ AddRemoveNodesCommand::~AddRemoveNodesCommand() {
 
 AddRemoveNodesCommand::AddRemoveNodesCommand(
   const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
   : UndoableCommand{makeName(action), true}
   , m_action{action}
-  , m_updateLinkedGroupsHelper{std::move(linkedGroupsToUpdate)} {
+  , m_updateLinkedGroupsHelper{std::move(changedLinkedGroups)} {
   switch (m_action) {
     case Action::Add:
       m_nodesToAdd = nodes;

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
     linkedGroupsToUpdate) {
   ensure(parent != nullptr, "parent is null");
-  std::map<Model::Node*, std::vector<Model::Node*>> nodes;
+  auto nodes = std::map<Model::Node*, std::vector<Model::Node*>>{};
   nodes[parent] = children;
 
   return add(nodes, std::move(linkedGroupsToUpdate));
@@ -68,9 +68,9 @@ AddRemoveNodesCommand::AddRemoveNodesCommand(
   const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
   std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
     linkedGroupsToUpdate)
-  : UndoableCommand(makeName(action), true)
-  , m_action(action)
-  , m_updateLinkedGroupsHelper(std::move(linkedGroupsToUpdate)) {
+  : UndoableCommand{makeName(action), true}
+  , m_action{action}
+  , m_updateLinkedGroupsHelper{std::move(linkedGroupsToUpdate)} {
   switch (m_action) {
     case Action::Add:
       m_nodesToAdd = nodes;

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -35,8 +35,7 @@ namespace TrenchBroom {
 namespace View {
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   Model::Node* parent, const std::vector<Model::Node*>& children,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
   ensure(parent != nullptr, "parent is null");
   auto nodes = std::map<Model::Node*, std::vector<Model::Node*>>{};
   nodes[parent] = children;
@@ -46,16 +45,14 @@ std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
   return std::make_unique<AddRemoveNodesCommand>(
     Action::Add, nodes, std::move(linkedGroupsToUpdate));
 }
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::remove(
   const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
   return std::make_unique<AddRemoveNodesCommand>(
     Action::Remove, nodes, std::move(linkedGroupsToUpdate));
 }
@@ -66,8 +63,7 @@ AddRemoveNodesCommand::~AddRemoveNodesCommand() {
 
 AddRemoveNodesCommand::AddRemoveNodesCommand(
   const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : UndoableCommand{makeName(action), true}
   , m_action{action}
   , m_updateLinkedGroupsHelper{std::move(linkedGroupsToUpdate)} {

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -49,17 +49,17 @@ private:
 public:
   static std::unique_ptr<AddRemoveNodesCommand> add(
     Model::Node* parent, const std::vector<Model::Node*>& children,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
   static std::unique_ptr<AddRemoveNodesCommand> add(
     const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
   static std::unique_ptr<AddRemoveNodesCommand> remove(
     const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
   AddRemoveNodesCommand(
     Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
   ~AddRemoveNodesCommand() override;
 
 private:

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -49,21 +49,17 @@ private:
 public:
   static std::unique_ptr<AddRemoveNodesCommand> add(
     Model::Node* parent, const std::vector<Model::Node*>& children,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
   static std::unique_ptr<AddRemoveNodesCommand> add(
     const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
   static std::unique_ptr<AddRemoveNodesCommand> remove(
     const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
   AddRemoveNodesCommand(
     Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
   ~AddRemoveNodesCommand() override;
 
 private:

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -28,8 +28,7 @@ namespace TrenchBroom {
 namespace View {
 BrushVertexCommandBase::BrushVertexCommandBase(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : SwapNodeContentsCommand(name, std::move(nodes), std::move(linkedGroupsToUpdate)) {}
 
 std::unique_ptr<CommandResult> BrushVertexCommandBase::doPerformDo(
@@ -86,8 +85,7 @@ bool BrushVertexCommandResult::hasRemainingVertices() const {
 BrushVertexCommand::BrushVertexCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : BrushVertexCommandBase(name, std::move(nodes), std::move(linkedGroupsToUpdate))
   , m_oldVertexPositions(std::move(oldVertexPositions))
   , m_newVertexPositions(std::move(newVertexPositions)) {}
@@ -130,8 +128,7 @@ void BrushVertexCommand::selectOldHandlePositions(
 BrushEdgeCommand::BrushEdgeCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : BrushVertexCommandBase(name, std::move(nodes), std::move(linkedGroupsToUpdate))
   , m_oldEdgePositions(std::move(oldEdgePositions))
   , m_newEdgePositions(std::move(newEdgePositions)) {}
@@ -168,8 +165,7 @@ void BrushEdgeCommand::selectOldHandlePositions(
 BrushFaceCommand::BrushFaceCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : BrushVertexCommandBase(name, std::move(nodes), std::move(linkedGroupsToUpdate))
   , m_oldFacePositions(std::move(oldFacePositions))
   , m_newFacePositions(std::move(newFacePositions)) {}

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -28,8 +28,8 @@ namespace TrenchBroom {
 namespace View {
 BrushVertexCommandBase::BrushVertexCommandBase(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
-  : SwapNodeContentsCommand(name, std::move(nodes), std::move(linkedGroupsToUpdate)) {}
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  : SwapNodeContentsCommand(name, std::move(nodes), std::move(changedLinkedGroups)) {}
 
 std::unique_ptr<CommandResult> BrushVertexCommandBase::doPerformDo(
   MapDocumentCommandFacade* document) {
@@ -85,8 +85,8 @@ bool BrushVertexCommandResult::hasRemainingVertices() const {
 BrushVertexCommand::BrushVertexCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
-  : BrushVertexCommandBase(name, std::move(nodes), std::move(linkedGroupsToUpdate))
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  : BrushVertexCommandBase(name, std::move(nodes), std::move(changedLinkedGroups))
   , m_oldVertexPositions(std::move(oldVertexPositions))
   , m_newVertexPositions(std::move(newVertexPositions)) {}
 
@@ -128,8 +128,8 @@ void BrushVertexCommand::selectOldHandlePositions(
 BrushEdgeCommand::BrushEdgeCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
-  : BrushVertexCommandBase(name, std::move(nodes), std::move(linkedGroupsToUpdate))
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  : BrushVertexCommandBase(name, std::move(nodes), std::move(changedLinkedGroups))
   , m_oldEdgePositions(std::move(oldEdgePositions))
   , m_newEdgePositions(std::move(newEdgePositions)) {}
 
@@ -165,8 +165,8 @@ void BrushEdgeCommand::selectOldHandlePositions(
 BrushFaceCommand::BrushFaceCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
-  : BrushVertexCommandBase(name, std::move(nodes), std::move(linkedGroupsToUpdate))
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  : BrushVertexCommandBase(name, std::move(nodes), std::move(changedLinkedGroups))
   , m_oldFacePositions(std::move(oldFacePositions))
   , m_newFacePositions(std::move(newFacePositions)) {}
 

--- a/common/src/View/BrushVertexCommands.h
+++ b/common/src/View/BrushVertexCommands.h
@@ -40,7 +40,7 @@ class BrushVertexCommandBase : public SwapNodeContentsCommand {
 protected:
   BrushVertexCommandBase(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
@@ -81,7 +81,7 @@ public:
   BrushVertexCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
 private:
   std::unique_ptr<CommandResult> createCommandResult(
@@ -104,7 +104,7 @@ public:
   BrushEdgeCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;
@@ -124,7 +124,7 @@ public:
   BrushFaceCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;

--- a/common/src/View/BrushVertexCommands.h
+++ b/common/src/View/BrushVertexCommands.h
@@ -40,8 +40,7 @@ class BrushVertexCommandBase : public SwapNodeContentsCommand {
 protected:
   BrushVertexCommandBase(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
@@ -82,8 +81,7 @@ public:
   BrushVertexCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
 private:
   std::unique_ptr<CommandResult> createCommandResult(
@@ -106,8 +104,7 @@ public:
   BrushEdgeCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;
@@ -127,8 +124,7 @@ public:
   BrushFaceCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -132,7 +132,7 @@
 namespace TrenchBroom {
 namespace View {
 template <typename T>
-static auto findLinkedGroupsToUpdate(
+static auto findLinkedGroupsRecursively(
   Model::WorldNode& worldNode, const std::vector<T*>& nodes, const bool includeGivenNodes) {
   auto result = std::vector<const Model::GroupNode*>{};
 
@@ -172,14 +172,13 @@ static auto findLinkedGroupsToUpdate(
 }
 
 template <typename T>
-static auto findContainingLinkedGroupsToUpdate(
-  Model::WorldNode& worldNode, const std::vector<T*>& nodes) {
-  return findLinkedGroupsToUpdate(worldNode, nodes, false);
+static auto findContainingLinkedGroups(Model::WorldNode& worldNode, const std::vector<T*>& nodes) {
+  return findLinkedGroupsRecursively(worldNode, nodes, false);
 }
 
 template <typename T>
-static auto findAllLinkedGroupsToUpdate(Model::WorldNode& worldNode, const std::vector<T*>& nodes) {
-  return findLinkedGroupsToUpdate(worldNode, nodes, true);
+static auto findAllLinkedGroups(Model::WorldNode& worldNode, const std::vector<T*>& nodes) {
+  return findLinkedGroupsRecursively(worldNode, nodes, true);
 }
 
 /**
@@ -257,14 +256,14 @@ static std::optional<std::vector<std::pair<Model::Node*, Model::NodeContents>>> 
 template <typename N, typename L>
 static bool applyAndSwap(
   MapDocument& document, const std::string& commandName, const std::vector<N*>& nodes,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate, L lambda) {
+  std::vector<const Model::GroupNode*> changedLinkedGroups, L lambda) {
   if (nodes.empty()) {
     return true;
   }
 
   if (auto newNodes = applyToNodeContents(nodes, std::move(lambda))) {
     return document.swapNodeContents(
-      commandName, std::move(*newNodes), std::move(linkedGroupsToUpdate));
+      commandName, std::move(*newNodes), std::move(changedLinkedGroups));
   }
 
   return false;
@@ -320,11 +319,11 @@ static bool applyAndSwap(
       newNodes.emplace_back(brushNode, Model::NodeContents(std::move(brush)));
     }
 
-    auto linkedGroupsToUpdate = findContainingLinkedGroupsToUpdate(
-      *document.world(), kdl::vec_transform(newNodes, [](const auto& p) {
+    auto changedLinkedGroups =
+      findContainingLinkedGroups(*document.world(), kdl::vec_transform(newNodes, [](const auto& p) {
         return p.first;
       }));
-    document.swapNodeContents(commandName, std::move(newNodes), std::move(linkedGroupsToUpdate));
+    document.swapNodeContents(commandName, std::move(newNodes), std::move(changedLinkedGroups));
   }
 
   return success;
@@ -1245,7 +1244,7 @@ std::vector<Model::Node*> MapDocument::addNodes(
 
   Transaction transaction(this, "Add Objects");
   const auto result = executeAndStore(
-    AddRemoveNodesCommand::add(nodes, findAllLinkedGroupsToUpdate(*m_world, kdl::map_keys(nodes))));
+    AddRemoveNodesCommand::add(nodes, findAllLinkedGroups(*m_world, kdl::map_keys(nodes))));
   if (!result->success()) {
     return {};
   }
@@ -1299,7 +1298,7 @@ void MapDocument::removeNodes(const std::vector<Model::Node*>& nodes) {
 
     closeRemovedGroups(removableNodes);
     executeAndStore(AddRemoveNodesCommand::remove(
-      removableNodes, findAllLinkedGroupsToUpdate(*m_world, kdl::map_keys(removableNodes))));
+      removableNodes, findAllLinkedGroups(*m_world, kdl::map_keys(removableNodes))));
 
     removableNodes = collectRemovableParents(removableNodes);
   }
@@ -1314,7 +1313,7 @@ void MapDocument::removeNodes(const std::vector<Model::Node*>& nodes) {
 
   applyAndSwap(
     *this, "Reset Linked Group ID", singletonLinkSetsAfterRemoval,
-    findContainingLinkedGroupsToUpdate(*m_world, singletonLinkSetsAfterRemoval),
+    findContainingLinkedGroups(*m_world, singletonLinkSetsAfterRemoval),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -1413,11 +1412,11 @@ bool MapDocument::reparentNodes(
     downgradeShownToInherit(nodesToDowngrade);
   }
 
-  auto linkedGroupsToUpdate = findAllLinkedGroupsToUpdate(
+  auto changedLinkedGroups = findAllLinkedGroups(
     *m_world, kdl::vec_concat(kdl::map_keys(nodesToAdd), kdl::map_keys(nodesToRemove)));
   const auto success =
     executeAndStore(ReparentNodesCommand::reparent(
-                      std::move(nodesToAdd), nodesToRemove, std::move(linkedGroupsToUpdate)))
+                      std::move(nodesToAdd), nodesToRemove, std::move(changedLinkedGroups)))
       ->success();
   if (success) {
     std::map<Model::Node*, std::vector<Model::Node*>> removableNodes =
@@ -1425,7 +1424,7 @@ bool MapDocument::reparentNodes(
     while (!removableNodes.empty()) {
       closeRemovedGroups(removableNodes);
       executeAndStore(AddRemoveNodesCommand::remove(
-        removableNodes, findAllLinkedGroupsToUpdate(*m_world, kdl::map_keys(removableNodes))));
+        removableNodes, findAllLinkedGroups(*m_world, kdl::map_keys(removableNodes))));
 
       removableNodes = collectRemovableParents(removableNodes);
     }
@@ -1763,7 +1762,7 @@ Model::GroupNode* MapDocument::createLinkedDuplicate() {
   if (!groupNode->group().linkedGroupId()) {
     applyAndSwap(
       *this, "Set Linked Group ID", m_selectedNodes.groups(),
-      findContainingLinkedGroupsToUpdate(*m_world, m_selectedNodes.groups()),
+      findContainingLinkedGroups(*m_world, m_selectedNodes.groups()),
       kdl::overload(
         [](Model::Layer&) {
           return true;
@@ -1839,8 +1838,7 @@ bool MapDocument::canSelectLinkedGroups() const {
 void MapDocument::linkGroups(const std::vector<Model::GroupNode*>& groupNodes) {
   const auto newLinkedGroupId = generateUuid();
   applyAndSwap(
-    *this, "Set Linked Group ID", groupNodes,
-    findContainingLinkedGroupsToUpdate(*m_world, groupNodes),
+    *this, "Set Linked Group ID", groupNodes, findContainingLinkedGroups(*m_world, groupNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -1862,8 +1860,7 @@ void MapDocument::linkGroups(const std::vector<Model::GroupNode*>& groupNodes) {
 
 void MapDocument::unlinkGroups(const std::vector<Model::GroupNode*>& groupNodes) {
   applyAndSwap(
-    *this, "Reset Linked Group ID", groupNodes,
-    findContainingLinkedGroupsToUpdate(*m_world, groupNodes),
+    *this, "Reset Linked Group ID", groupNodes, findContainingLinkedGroups(*m_world, groupNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -1909,8 +1906,8 @@ bool MapDocument::canUpdateLinkedGroups(const std::vector<Model::Node*>& nodes) 
     return false;
   }
 
-  const auto linkedGroupsToUpdate = findContainingLinkedGroupsToUpdate(*m_world, nodes);
-  return checkLinkedGroupsToUpdate(linkedGroupsToUpdate);
+  const auto changedLinkedGroups = findContainingLinkedGroups(*m_world, nodes);
+  return checkLinkedGroupsToUpdate(changedLinkedGroups);
 }
 
 void MapDocument::separateSelectedLinkedGroups(const bool relinkGroups) {
@@ -2323,21 +2320,21 @@ void MapDocument::downgradeUnlockedToInherit(const std::vector<Model::Node*>& no
 bool MapDocument::swapNodeContents(
   const std::string& commandName,
   std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> changedLinkedGroups) {
   return executeAndStore(std::make_unique<SwapNodeContentsCommand>(
-                           commandName, std::move(nodesToSwap), std::move(linkedGroupsToUpdate)))
+                           commandName, std::move(nodesToSwap), std::move(changedLinkedGroups)))
     ->success();
 }
 
 bool MapDocument::swapNodeContents(
   const std::string& commandName,
   std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap) {
-  auto linkedGroupsToUpdate =
-    findContainingLinkedGroupsToUpdate(*m_world, kdl::vec_transform(nodesToSwap, [](const auto& p) {
+  auto changedLinkedGroups =
+    findContainingLinkedGroups(*m_world, kdl::vec_transform(nodesToSwap, [](const auto& p) {
       return p.first;
     }));
 
-  return swapNodeContents(commandName, std::move(nodesToSwap), std::move(linkedGroupsToUpdate));
+  return swapNodeContents(commandName, std::move(nodesToSwap), std::move(changedLinkedGroups));
 }
 
 bool MapDocument::transformObjects(
@@ -2437,7 +2434,7 @@ bool MapDocument::transformObjects(
 
   const auto success = swapNodeContents(
     commandName, std::move(nodesToUpdate),
-    findContainingLinkedGroupsToUpdate(*m_world, m_selectedNodes.nodes()));
+    findContainingLinkedGroups(*m_world, m_selectedNodes.nodes()));
 
   if (success) {
     m_repeatStack->push([=]() {
@@ -2738,7 +2735,7 @@ bool MapDocument::setProperty(
   const std::string& key, const std::string& value, const bool defaultToProtected) {
   const auto entityNodes = allSelectedEntityNodes();
   return applyAndSwap(
-    *this, "Set Property", entityNodes, findContainingLinkedGroupsToUpdate(*m_world, entityNodes),
+    *this, "Set Property", entityNodes, findContainingLinkedGroups(*m_world, entityNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -2761,8 +2758,7 @@ bool MapDocument::setProperty(
 bool MapDocument::renameProperty(const std::string& oldKey, const std::string& newKey) {
   const auto entityNodes = allSelectedEntityNodes();
   return applyAndSwap(
-    *this, "Rename Property", entityNodes,
-    findContainingLinkedGroupsToUpdate(*m_world, entityNodes),
+    *this, "Rename Property", entityNodes, findContainingLinkedGroups(*m_world, entityNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -2785,8 +2781,7 @@ bool MapDocument::renameProperty(const std::string& oldKey, const std::string& n
 bool MapDocument::removeProperty(const std::string& key) {
   const auto entityNodes = allSelectedEntityNodes();
   return applyAndSwap(
-    *this, "Remove Property", entityNodes,
-    findContainingLinkedGroupsToUpdate(*m_world, entityNodes),
+    *this, "Remove Property", entityNodes, findContainingLinkedGroups(*m_world, entityNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -2809,7 +2804,7 @@ bool MapDocument::removeProperty(const std::string& key) {
 bool MapDocument::convertEntityColorRange(const std::string& key, Assets::ColorRange::Type range) {
   const auto entityNodes = allSelectedEntityNodes();
   return applyAndSwap(
-    *this, "Convert Color", entityNodes, findContainingLinkedGroupsToUpdate(*m_world, entityNodes),
+    *this, "Convert Color", entityNodes, findContainingLinkedGroups(*m_world, entityNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -2837,7 +2832,7 @@ bool MapDocument::updateSpawnflag(
   const auto entityNodes = allSelectedEntityNodes();
   return applyAndSwap(
     *this, setFlag ? "Set Spawnflag" : "Unset Spawnflag", entityNodes,
-    findContainingLinkedGroupsToUpdate(*m_world, entityNodes),
+    findContainingLinkedGroups(*m_world, entityNodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -2927,8 +2922,7 @@ bool MapDocument::setProtectedProperty(const std::string& key, const bool value)
   }
 
   return swapNodeContents(
-    "Set Protected Property", nodesToUpdate,
-    findContainingLinkedGroupsToUpdate(*m_world, entityNodes));
+    "Set Protected Property", nodesToUpdate, findContainingLinkedGroups(*m_world, entityNodes));
 }
 
 bool MapDocument::clearProtectedProperties() {
@@ -2967,8 +2961,7 @@ bool MapDocument::clearProtectedProperties() {
   }
 
   return swapNodeContents(
-    "Clear Protected Properties", nodesToUpdate,
-    findContainingLinkedGroupsToUpdate(*m_world, entityNodes));
+    "Clear Protected Properties", nodesToUpdate, findContainingLinkedGroups(*m_world, entityNodes));
 }
 
 bool MapDocument::canClearProtectedProperties() const {
@@ -2983,7 +2976,7 @@ bool MapDocument::canClearProtectedProperties() const {
 bool MapDocument::extrudeBrushes(const std::vector<vm::polygon3>& faces, const vm::vec3& delta) {
   const auto nodes = m_selectedNodes.nodes();
   return applyAndSwap(
-    *this, "Resize Brushes", nodes, findContainingLinkedGroupsToUpdate(*m_world, nodes),
+    *this, "Resize Brushes", nodes, findContainingLinkedGroups(*m_world, nodes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -3091,7 +3084,7 @@ bool MapDocument::snapVertices(const FloatType snapTo) {
   const auto allSelectedBrushes = allSelectedBrushNodes();
   const bool applyAndSwapSuccess = applyAndSwap(
     *this, "Snap Brush Vertices", allSelectedBrushes,
-    findContainingLinkedGroupsToUpdate(*m_world, allSelectedBrushes),
+    findContainingLinkedGroups(*m_world, allSelectedBrushes),
     kdl::overload(
       [](Model::Layer&) {
         return true;
@@ -3184,13 +3177,13 @@ MapDocument::MoveVerticesResult MapDocument::moveVertices(
 
     const auto commandName =
       kdl::str_plural(vertexPositions.size(), "Move Brush Vertex", "Move Brush Vertices");
-    auto linkedGroupsToUpdate =
-      findContainingLinkedGroupsToUpdate(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
+    auto changedLinkedGroups =
+      findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
     const auto result = executeAndStore(std::make_unique<BrushVertexCommand>(
       commandName, std::move(*newNodes), std::move(vertexPositions), std::move(newVertexPositions),
-      std::move(linkedGroupsToUpdate)));
+      std::move(changedLinkedGroups)));
 
     const auto* moveVerticesResult = dynamic_cast<BrushVertexCommandResult*>(result.get());
     ensure(
@@ -3251,13 +3244,13 @@ bool MapDocument::moveEdges(std::vector<vm::segment3> edgePositions, const vm::v
 
     const auto commandName =
       kdl::str_plural(edgePositions.size(), "Move Brush Edge", "Move Brush Edges");
-    auto linkedGroupsToUpdate =
-      findContainingLinkedGroupsToUpdate(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
+    auto changedLinkedGroups =
+      findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
     return executeAndStore(std::make_unique<BrushEdgeCommand>(
                              commandName, std::move(*newNodes), std::move(edgePositions),
-                             std::move(newEdgePositions), std::move(linkedGroupsToUpdate)))
+                             std::move(newEdgePositions), std::move(changedLinkedGroups)))
       ->success();
   }
 
@@ -3312,13 +3305,13 @@ bool MapDocument::moveFaces(std::vector<vm::polygon3> facePositions, const vm::v
 
     const auto commandName =
       kdl::str_plural(facePositions.size(), "Move Brush Face", "Move Brush Faces");
-    auto linkedGroupsToUpdate =
-      findContainingLinkedGroupsToUpdate(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
+    auto changedLinkedGroups =
+      findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
     return executeAndStore(std::make_unique<BrushFaceCommand>(
                              commandName, std::move(*newNodes), std::move(facePositions),
-                             std::move(newFacePositions), std::move(linkedGroupsToUpdate)))
+                             std::move(newFacePositions), std::move(changedLinkedGroups)))
       ->success();
   }
 
@@ -3352,14 +3345,13 @@ bool MapDocument::addVertex(const vm::vec3& vertexPosition) {
                                }));
 
   if (newNodes) {
-    auto linkedGroupsToUpdate =
-      findContainingLinkedGroupsToUpdate(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
+    auto changedLinkedGroups =
+      findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
     return executeAndStore(std::make_unique<BrushVertexCommand>(
                              "Add Brush Vertex", std::move(*newNodes), std::vector<vm::vec3>{},
-                             std::vector<vm::vec3>{vertexPosition},
-                             std::move(linkedGroupsToUpdate)))
+                             std::vector<vm::vec3>{vertexPosition}, std::move(changedLinkedGroups)))
       ->success();
   }
 
@@ -3402,13 +3394,13 @@ bool MapDocument::removeVertices(
                                }));
 
   if (newNodes) {
-    auto linkedGroupsToUpdate =
-      findContainingLinkedGroupsToUpdate(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
+    auto changedLinkedGroups =
+      findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
     return executeAndStore(std::make_unique<BrushVertexCommand>(
                              commandName, std::move(*newNodes), std::move(vertexPositions),
-                             std::vector<vm::vec3>{}, std::move(linkedGroupsToUpdate)))
+                             std::vector<vm::vec3>{}, std::move(changedLinkedGroups)))
       ->success();
   }
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -513,8 +513,7 @@ public: // modifying objects, declared in MapFacade interface
   bool swapNodeContents(
     const std::string& commandName,
     std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
   bool swapNodeContents(
     const std::string& commandName,
     std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap);

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -619,9 +619,9 @@ private: // subclassing interface for command processing
   virtual void doCommitTransaction() = 0;
   virtual void doRollbackTransaction() = 0;
 
-  virtual std::unique_ptr<CommandResult> doExecute(std::unique_ptr<Command>&& command) = 0;
+  virtual std::unique_ptr<CommandResult> doExecute(std::unique_ptr<Command> command) = 0;
   virtual std::unique_ptr<CommandResult> doExecuteAndStore(
-    std::unique_ptr<UndoableCommand>&& command) = 0;
+    std::unique_ptr<UndoableCommand> command) = 0;
 
 public: // asset state management
   void commitPendingAssets();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -513,7 +513,7 @@ public: // modifying objects, declared in MapFacade interface
   bool swapNodeContents(
     const std::string& commandName,
     std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
   bool swapNodeContents(
     const std::string& commandName,
     std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap);

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -581,12 +581,12 @@ void MapDocumentCommandFacade::doRollbackTransaction() {
 }
 
 std::unique_ptr<CommandResult> MapDocumentCommandFacade::doExecute(
-  std::unique_ptr<Command>&& command) {
+  std::unique_ptr<Command> command) {
   return m_commandProcessor->execute(std::move(command));
 }
 
 std::unique_ptr<CommandResult> MapDocumentCommandFacade::doExecuteAndStore(
-  std::unique_ptr<UndoableCommand>&& command) {
+  std::unique_ptr<UndoableCommand> command) {
   return m_commandProcessor->executeAndStore(std::move(command));
 }
 } // namespace View

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -102,25 +102,6 @@ public:
   void performPushGroup(Model::GroupNode* group);
   void performPopGroup();
 
-public: // brush face attributes
-  void performMoveTextures(
-    const vm::vec3f& cameraUp, const vm::vec3f& cameraRight, const vm::vec2f& delta);
-  void performRotateTextures(float angle);
-  void performShearTextures(const vm::vec2f& factors);
-  void performCopyTexCoordSystemFromFace(
-    const Model::TexCoordSystemSnapshot& coordSystemSnapshot,
-    const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane,
-    const Model::WrapStyle wrapStyle);
-
-public: // entity definition file management
-  void performSetEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec);
-
-public: // texture collection management
-  void performSetTextureCollections(const std::vector<IO::Path>& paths);
-
-public: // mods management
-  void performSetMods(const std::vector<std::string>& mods);
-
 private:
   void doSetIssueHidden(Model::Issue* issue, bool hidden) override;
 
@@ -146,9 +127,9 @@ private: // implement MapDocument interface
   void doCommitTransaction() override;
   void doRollbackTransaction() override;
 
-  std::unique_ptr<CommandResult> doExecute(std::unique_ptr<Command>&& command) override;
+  std::unique_ptr<CommandResult> doExecute(std::unique_ptr<Command> command) override;
   std::unique_ptr<CommandResult> doExecuteAndStore(
-    std::unique_ptr<UndoableCommand>&& command) override;
+    std::unique_ptr<UndoableCommand> command) override;
 };
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -29,8 +29,7 @@ namespace View {
 std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
   return std::make_unique<ReparentNodesCommand>(
     std::move(nodesToAdd), std::move(nodesToRemove), std::move(linkedGroupsToUpdate));
 }
@@ -38,8 +37,7 @@ std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
 ReparentNodesCommand::ReparentNodesCommand(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : UndoableCommand("Reparent Objects", true)
   , m_nodesToAdd(std::move(nodesToAdd))
   , m_nodesToRemove(std::move(nodesToRemove))

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -29,19 +29,19 @@ namespace View {
 std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate) {
+  std::vector<const Model::GroupNode*> changedLinkedGroups) {
   return std::make_unique<ReparentNodesCommand>(
-    std::move(nodesToAdd), std::move(nodesToRemove), std::move(linkedGroupsToUpdate));
+    std::move(nodesToAdd), std::move(nodesToRemove), std::move(changedLinkedGroups));
 }
 
 ReparentNodesCommand::ReparentNodesCommand(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
   : UndoableCommand("Reparent Objects", true)
   , m_nodesToAdd(std::move(nodesToAdd))
   , m_nodesToRemove(std::move(nodesToRemove))
-  , m_updateLinkedGroupsHelper(std::move(linkedGroupsToUpdate)) {}
+  , m_updateLinkedGroupsHelper(std::move(changedLinkedGroups)) {}
 
 std::unique_ptr<CommandResult> ReparentNodesCommand::doPerformDo(
   MapDocumentCommandFacade* document) {

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -44,14 +44,12 @@ public:
   static std::unique_ptr<ReparentNodesCommand> reparent(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
   ReparentNodesCommand(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -44,12 +44,12 @@ public:
   static std::unique_ptr<ReparentNodesCommand> reparent(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
   ReparentNodesCommand(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/SwapNodeContentsCommand.cpp
+++ b/common/src/View/SwapNodeContentsCommand.cpp
@@ -32,10 +32,10 @@ namespace TrenchBroom {
 namespace View {
 SwapNodeContentsCommand::SwapNodeContentsCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> changedLinkedGroups)
   : UndoableCommand(name, true)
   , m_nodes(std::move(nodes))
-  , m_updateLinkedGroupsHelper(std::move(linkedGroupsToUpdate)) {}
+  , m_updateLinkedGroupsHelper(std::move(changedLinkedGroups)) {}
 
 SwapNodeContentsCommand::~SwapNodeContentsCommand() = default;
 

--- a/common/src/View/SwapNodeContentsCommand.cpp
+++ b/common/src/View/SwapNodeContentsCommand.cpp
@@ -32,8 +32,7 @@ namespace TrenchBroom {
 namespace View {
 SwapNodeContentsCommand::SwapNodeContentsCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-    linkedGroupsToUpdate)
+  std::vector<const Model::GroupNode*> linkedGroupsToUpdate)
   : UndoableCommand(name, true)
   , m_nodes(std::move(nodes))
   , m_updateLinkedGroupsHelper(std::move(linkedGroupsToUpdate)) {}

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -45,7 +45,7 @@ protected:
 public:
   SwapNodeContentsCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> changedLinkedGroups);
   ~SwapNodeContentsCommand();
 
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -26,7 +26,6 @@
 
 #include <memory>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace TrenchBroom {
@@ -46,8 +45,7 @@ protected:
 public:
   SwapNodeContentsCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>
-      linkedGroupsToUpdate);
+    std::vector<const Model::GroupNode*> linkedGroupsToUpdate);
   ~SwapNodeContentsCommand();
 
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/UpdateLinkedGroupsHelper.cpp
+++ b/common/src/View/UpdateLinkedGroupsHelper.cpp
@@ -31,6 +31,7 @@
 #include <kdl/result_for_each.h>
 #include <kdl/vector_utils.h>
 
+#include <algorithm>
 #include <cassert>
 #include <map>
 #include <unordered_set>
@@ -38,20 +39,13 @@
 namespace TrenchBroom {
 namespace View {
 bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& linkedGroupsToUpdate) {
-  if (linkedGroupsToUpdate.empty()) {
-    return true;
-  }
+  const auto linkedGroupIds =
+    kdl::vec_sort(kdl::vec_transform(linkedGroupsToUpdate, [](const auto* groupNode) {
+      return groupNode->group().linkedGroupId();
+    }));
 
-  for (auto it = std::begin(linkedGroupsToUpdate), last = std::prev(std::end(linkedGroupsToUpdate));
-       it != last; ++it) {
-    for (auto other = std::next(it); other != std::end(linkedGroupsToUpdate); ++other) {
-      if ((*it)->group().linkedGroupId() == (*other)->group().linkedGroupId()) {
-        return false;
-      }
-    }
-  }
-
-  return true;
+  return std::adjacent_find(std::begin(linkedGroupIds), std::end(linkedGroupIds)) ==
+         std::end(linkedGroupIds);
 }
 
 // Order groups so that descendants will be updated before their ancestors

--- a/common/src/View/UpdateLinkedGroupsHelper.cpp
+++ b/common/src/View/UpdateLinkedGroupsHelper.cpp
@@ -85,12 +85,10 @@ void UpdateLinkedGroupsHelper::collateWith(UpdateLinkedGroupsHelper& other) {
   auto& myLinkedGroupUpdates = std::get<LinkedGroupUpdates>(m_state);
   auto& theirLinkedGroupUpdates = std::get<LinkedGroupUpdates>(other.m_state);
 
-  for (auto& theirUpdate : theirLinkedGroupUpdates) {
-    Model::Node* theirGroupNodeToUpdate = theirUpdate.first;
-    std::vector<std::unique_ptr<Model::Node>>& theirOldChildren = theirUpdate.second;
-
-    auto myIt = std::find_if(
-      std::begin(myLinkedGroupUpdates), std::end(myLinkedGroupUpdates), [&](const auto& p) {
+  for (auto& [theirGroupNodeToUpdate, theirOldChildren] : theirLinkedGroupUpdates) {
+    const auto myIt = std::find_if(
+      std::begin(myLinkedGroupUpdates), std::end(myLinkedGroupUpdates),
+      [theirGroupNodeToUpdate = theirGroupNodeToUpdate](const auto& p) {
         return p.first == theirGroupNodeToUpdate;
       });
     if (myIt == std::end(myLinkedGroupUpdates)) {

--- a/common/src/View/UpdateLinkedGroupsHelper.h
+++ b/common/src/View/UpdateLinkedGroupsHelper.h
@@ -58,8 +58,7 @@ bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& linke
  */
 class UpdateLinkedGroupsHelper {
 private:
-  using LinkedGroupsToUpdate =
-    std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>;
+  using LinkedGroupsToUpdate = std::vector<const Model::GroupNode*>;
   using LinkedGroupUpdates =
     std::vector<std::pair<Model::Node*, std::vector<std::unique_ptr<Model::Node>>>>;
   std::variant<LinkedGroupsToUpdate, LinkedGroupUpdates> m_state;
@@ -77,7 +76,7 @@ private:
   kdl::result<void, Model::UpdateLinkedGroupsError> computeLinkedGroupUpdates(
     MapDocumentCommandFacade& document);
   static kdl::result<LinkedGroupUpdates, Model::UpdateLinkedGroupsError> computeLinkedGroupUpdates(
-    const LinkedGroupsToUpdate& linkedGroupsToUpdate, const vm::bbox3& worldBounds);
+    const LinkedGroupsToUpdate& linkedGroupsToUpdate, MapDocumentCommandFacade& document);
 
   void doApplyOrUndoLinkedGroupUpdates(MapDocumentCommandFacade& document);
 };

--- a/common/src/View/UpdateLinkedGroupsHelper.h
+++ b/common/src/View/UpdateLinkedGroupsHelper.h
@@ -44,7 +44,7 @@ class MapDocumentCommandFacade;
  * The given linked groups can be updated consistently if no two of them are in the same
  * linked set.
  */
-bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& linkedGroupsToUpdate);
+bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& changedLinkedGroups);
 
 /**
  * A helper class to add support for updating linked groups to commands.
@@ -58,13 +58,13 @@ bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& linke
  */
 class UpdateLinkedGroupsHelper {
 private:
-  using LinkedGroupsToUpdate = std::vector<const Model::GroupNode*>;
+  using ChangedLinkedGroups = std::vector<const Model::GroupNode*>;
   using LinkedGroupUpdates =
     std::vector<std::pair<Model::Node*, std::vector<std::unique_ptr<Model::Node>>>>;
-  std::variant<LinkedGroupsToUpdate, LinkedGroupUpdates> m_state;
+  std::variant<ChangedLinkedGroups, LinkedGroupUpdates> m_state;
 
 public:
-  explicit UpdateLinkedGroupsHelper(LinkedGroupsToUpdate linkedGroupsToUpdate);
+  explicit UpdateLinkedGroupsHelper(ChangedLinkedGroups changedLinkedGroups);
   ~UpdateLinkedGroupsHelper();
 
   kdl::result<void, Model::UpdateLinkedGroupsError> applyLinkedGroupUpdates(
@@ -76,7 +76,7 @@ private:
   kdl::result<void, Model::UpdateLinkedGroupsError> computeLinkedGroupUpdates(
     MapDocumentCommandFacade& document);
   static kdl::result<LinkedGroupUpdates, Model::UpdateLinkedGroupsError> computeLinkedGroupUpdates(
-    const LinkedGroupsToUpdate& linkedGroupsToUpdate, MapDocumentCommandFacade& document);
+    const ChangedLinkedGroups& changedLinkedGroups, MapDocumentCommandFacade& document);
 
   void doApplyOrUndoLinkedGroupUpdates(MapDocumentCommandFacade& document);
 };

--- a/common/test/src/View/UpdateLinkedGroupsHelperTest.cpp
+++ b/common/test/src/View/UpdateLinkedGroupsHelperTest.cpp
@@ -93,7 +93,7 @@ TEST_CASE_METHOD(UpdateLinkedGroupsHelperTest, "UpdateLinkedGroupsHelperTest.own
 
   SECTION("Helper takes ownership of replaced child nodes") {
     {
-      auto helper = UpdateLinkedGroupsHelper{{{linkedNode, {groupNode}}}};
+      auto helper = UpdateLinkedGroupsHelper{{linkedNode}};
       REQUIRE(
         helper.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
     }
@@ -102,7 +102,7 @@ TEST_CASE_METHOD(UpdateLinkedGroupsHelperTest, "UpdateLinkedGroupsHelperTest.own
 
   SECTION("Helper relinquishes ownership of replaced child nodes when undoing updates") {
     {
-      auto helper = UpdateLinkedGroupsHelper{{{linkedNode, {groupNode}}}};
+      auto helper = UpdateLinkedGroupsHelper{{linkedNode}};
       REQUIRE(
         helper.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
       helper.undoLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()));
@@ -163,7 +163,7 @@ TEST_CASE_METHOD(
   */
 
   // propagate changes
-  auto helper = UpdateLinkedGroupsHelper{{{groupNode, {linkedGroupNode}}}};
+  auto helper = UpdateLinkedGroupsHelper{{groupNode}};
   REQUIRE(helper.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
 
   /*
@@ -373,8 +373,7 @@ TEST_CASE_METHOD(
   */
 
   SECTION("First propagate changes to innerGroupNode, then outerGroupNode") {
-    auto helper1 = UpdateLinkedGroupsHelper{
-      {{innerGroupNode, {linkedInnerGroupNode, nestedLinkedInnerGroupNode}}}};
+    auto helper1 = UpdateLinkedGroupsHelper{{innerGroupNode}};
     CHECK(helper1.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
 
     /*
@@ -411,14 +410,14 @@ TEST_CASE_METHOD(
       newNestedLinkedBrushNode->physicalBounds() ==
       originalBrushBounds.translate(vm::vec3(32.0, 0.0, 8.0)));
 
-    auto helper2 = UpdateLinkedGroupsHelper{{{outerGroupNode, {linkedOuterGroupNode}}}};
+    auto helper2 = UpdateLinkedGroupsHelper{{outerGroupNode}};
     CHECK(helper2.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
 
     // see end of test for assertions of final state
   }
 
   SECTION("First propagate changes to outerGroupNode, then innerGroupNode") {
-    auto helper1 = UpdateLinkedGroupsHelper{{{outerGroupNode, {linkedOuterGroupNode}}}};
+    auto helper1 = UpdateLinkedGroupsHelper{{outerGroupNode}};
     REQUIRE(
       helper1.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
 
@@ -454,8 +453,7 @@ TEST_CASE_METHOD(
       newNestedLinkedBrushNode->physicalBounds() ==
       originalBrushBounds.translate(vm::vec3(32.0, 16.0, 8.0)));
 
-    auto helper2 = UpdateLinkedGroupsHelper{
-      {{innerGroupNode, {linkedInnerGroupNode, nestedLinkedInnerGroupNode}}}};
+    auto helper2 = UpdateLinkedGroupsHelper{{innerGroupNode}};
     REQUIRE(
       helper2.applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get())));
 
@@ -463,11 +461,7 @@ TEST_CASE_METHOD(
   }
 
   SECTION("Propagate both changes at once") {
-    auto groupNodes =
-      std::vector<std::pair<const Model::GroupNode*, std::vector<Model::GroupNode*>>>{
-        {outerGroupNode, {linkedOuterGroupNode}},
-        {innerGroupNode, {linkedInnerGroupNode, nestedLinkedInnerGroupNode}},
-      };
+    auto groupNodes = std::vector<const Model::GroupNode*>{outerGroupNode, innerGroupNode};
     std::sort(std::begin(groupNodes), std::end(groupNodes));
 
     // The following code generates both permutations of the group nodes


### PR DESCRIPTION
Instead of fully computing linked group updates immediately, we just collect the linked groups that have changes that need to be replicated to their link sets. This makes it a bit easier to implement later changes to this mechanism.