### PR TITLE
Collate transactions

### DIFF
--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -29,7 +29,7 @@ namespace View {
 BrushVertexCommandBase::BrushVertexCommandBase(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<const Model::GroupNode*> changedLinkedGroups)
-  : SwapNodeContentsCommand(name, std::move(nodes), std::move(changedLinkedGroups)) {}
+  : SwapNodeContentsCommand{name, std::move(nodes), std::move(changedLinkedGroups)} {}
 
 std::unique_ptr<CommandResult> BrushVertexCommandBase::doPerformDo(
   MapDocumentCommandFacade* document) {
@@ -75,8 +75,8 @@ void BrushVertexCommandBase::selectOldHandlePositions(
 
 BrushVertexCommandResult::BrushVertexCommandResult(
   const bool success, const bool hasRemainingVertices)
-  : CommandResult(success)
-  , m_hasRemainingVertices(hasRemainingVertices) {}
+  : CommandResult{success}
+  , m_hasRemainingVertices{hasRemainingVertices} {}
 
 bool BrushVertexCommandResult::hasRemainingVertices() const {
   return m_hasRemainingVertices;
@@ -86,9 +86,9 @@ BrushVertexCommand::BrushVertexCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
   std::vector<const Model::GroupNode*> changedLinkedGroups)
-  : BrushVertexCommandBase(name, std::move(nodes), std::move(changedLinkedGroups))
-  , m_oldVertexPositions(std::move(oldVertexPositions))
-  , m_newVertexPositions(std::move(newVertexPositions)) {}
+  : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
+  , m_oldVertexPositions{std::move(oldVertexPositions)}
+  , m_newVertexPositions{std::move(newVertexPositions)} {}
 
 std::unique_ptr<CommandResult> BrushVertexCommand::createCommandResult(
   std::unique_ptr<CommandResult> swapResult) {
@@ -129,9 +129,9 @@ BrushEdgeCommand::BrushEdgeCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
   std::vector<const Model::GroupNode*> changedLinkedGroups)
-  : BrushVertexCommandBase(name, std::move(nodes), std::move(changedLinkedGroups))
-  , m_oldEdgePositions(std::move(oldEdgePositions))
-  , m_newEdgePositions(std::move(newEdgePositions)) {}
+  : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
+  , m_oldEdgePositions{std::move(oldEdgePositions)}
+  , m_newEdgePositions{std::move(newEdgePositions)} {}
 
 bool BrushEdgeCommand::doCollateWith(UndoableCommand& command) {
   auto* other = dynamic_cast<BrushEdgeCommand*>(&command);
@@ -166,9 +166,9 @@ BrushFaceCommand::BrushFaceCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
   std::vector<const Model::GroupNode*> changedLinkedGroups)
-  : BrushVertexCommandBase(name, std::move(nodes), std::move(changedLinkedGroups))
-  , m_oldFacePositions(std::move(oldFacePositions))
-  , m_newFacePositions(std::move(newFacePositions)) {}
+  : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
+  , m_oldFacePositions{std::move(oldFacePositions)}
+  , m_newFacePositions{std::move(newFacePositions)} {}
 
 bool BrushFaceCommand::doCollateWith(UndoableCommand& command) {
   auto* other = dynamic_cast<BrushFaceCommand*>(&command);

--- a/common/src/View/Command.cpp
+++ b/common/src/View/Command.cpp
@@ -24,7 +24,7 @@
 namespace TrenchBroom {
 namespace View {
 CommandResult::CommandResult(const bool success)
-  : m_success(success) {}
+  : m_success{success} {}
 
 CommandResult::~CommandResult() = default;
 
@@ -32,11 +32,11 @@ bool CommandResult::success() const {
   return m_success;
 }
 
-Command::Command(const std::string& name)
-  : m_state(CommandState::Default)
-  , m_name(name) {}
+Command::Command(std::string name)
+  : m_state{CommandState::Default}
+  , m_name{std::move(name)} {}
 
-Command::~Command() {}
+Command::~Command() = default;
 
 Command::CommandState Command::state() const {
   return m_state;

--- a/common/src/View/Command.h
+++ b/common/src/View/Command.h
@@ -53,7 +53,7 @@ protected:
   std::string m_name;
 
 public:
-  Command(const std::string& name);
+  Command(std::string name);
   virtual ~Command();
 
 public:

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -26,9 +26,9 @@
 
 namespace TrenchBroom {
 namespace View {
-UndoableCommand::UndoableCommand(const std::string& name, const bool updateModificationCount)
-  : Command(name)
-  , m_modificationCount(updateModificationCount ? 1u : 0u) {}
+UndoableCommand::UndoableCommand(std::string name, const bool updateModificationCount)
+  : Command{std::move(name)}
+  , m_modificationCount{updateModificationCount ? 1u : 0u} {}
 
 UndoableCommand::~UndoableCommand() {}
 

--- a/common/src/View/UndoableCommand.h
+++ b/common/src/View/UndoableCommand.h
@@ -34,7 +34,7 @@ private:
   size_t m_modificationCount;
 
 protected:
-  UndoableCommand(const std::string& name, bool updateModificationCount);
+  UndoableCommand(std::string name, bool updateModificationCount);
 
 public:
   virtual ~UndoableCommand();

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -79,7 +79,7 @@ public:
    * since the last call to popNotifications().
    */
   std::vector<NotificationTuple> popNotifications() {
-    std::vector<NotificationTuple> result;
+    auto result = std::vector<NotificationTuple>{};
 
     using std::swap;
     swap(m_notifications, result);
@@ -90,28 +90,28 @@ public:
 private:
   // these would be tidier as lambdas in the TestObserver() constructor
   void commandDo(Command& command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDo, command.name()));
+    m_notifications.emplace_back(CommandNotif::CommandDo, command.name());
   }
   void commandDone(Command& command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDone, command.name()));
+    m_notifications.emplace_back(CommandNotif::CommandDone, command.name());
   }
   void commandDoFailed(Command& command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandDoFailed, command.name()));
+    m_notifications.emplace_back(CommandNotif::CommandDoFailed, command.name());
   }
   void commandUndo(UndoableCommand& command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndo, command.name()));
+    m_notifications.emplace_back(CommandNotif::CommandUndo, command.name());
   }
   void commandUndone(UndoableCommand& command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndone, command.name()));
+    m_notifications.emplace_back(CommandNotif::CommandUndone, command.name());
   }
   void commandUndoFailed(UndoableCommand& command) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::CommandUndoFailed, command.name()));
+    m_notifications.emplace_back(CommandNotif::CommandUndoFailed, command.name());
   }
   void transactionDone(const std::string& transactionName) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::TransactionDone, transactionName));
+    m_notifications.emplace_back(CommandNotif::TransactionDone, transactionName);
   }
   void transactionUndone(const std::string& transactionName) {
-    m_notifications.push_back(std::make_tuple(CommandNotif::TransactionUndone, transactionName));
+    m_notifications.emplace_back(CommandNotif::TransactionUndone, transactionName);
   }
 };
 
@@ -133,10 +133,6 @@ private:
   mutable std::vector<TestCommandCall> m_expectedCalls;
 
 public:
-  static std::unique_ptr<TestCommand> create(const std::string& name) {
-    return std::make_unique<TestCommand>(name);
-  }
-
   explicit TestCommand(const std::string& name)
     : UndoableCommand(name, false) {}
 
@@ -145,8 +141,8 @@ public:
 private:
   template <class T> T popCall() const {
     CHECK_FALSE(m_expectedCalls.empty());
-    TestCommandCall variant = kdl::vec_pop_front(m_expectedCalls);
-    T call = std::get<T>(std::move(variant));
+    auto variant = kdl::vec_pop_front(m_expectedCalls);
+    auto call = std::get<T>(std::move(variant));
     return call;
   }
 
@@ -173,16 +169,14 @@ public:
    * Sets an expectation that doPerformDo() should be called.
    * When called, it will return the given `returnSuccess` value.
    */
-  void expectDo(const bool returnSuccess) {
-    m_expectedCalls.emplace_back(DoPerformDo{returnSuccess});
-  }
+  void expectDo(const bool returnSuccess) { m_expectedCalls.push_back(DoPerformDo{returnSuccess}); }
 
   /**
    * Sets an expectation that doPerformUndo() should be called.
    * When called, it will return the given `returnSuccess` value.
    */
   void expectUndo(const bool returnSuccess) {
-    m_expectedCalls.emplace_back(DoPerformUndo{returnSuccess});
+    m_expectedCalls.push_back(DoPerformUndo{returnSuccess});
   }
 
   /**
@@ -190,7 +184,7 @@ public:
    * When called, doCollateWith() will return `returnCanCollate`.
    */
   void expectCollate(UndoableCommand* expectedOtherCommand, const bool returnCanCollate) {
-    m_expectedCalls.emplace_back(DoCollateWith{returnCanCollate, expectedOtherCommand});
+    m_expectedCalls.push_back(DoCollateWith{returnCanCollate, expectedOtherCommand});
   }
 
   deleteCopyAndMove(TestCommand);
@@ -201,11 +195,11 @@ TEST_CASE("CommandProcessorTest.doAndUndoSuccessfulCommand", "[CommandProcessorT
    * Execute a successful command, then undo it successfully.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName = "test command";
-  auto command = TestCommand::create(commandName);
+  auto command = std::make_unique<TestCommand>(commandName);
 
   command->expectDo(true);
   command->expectUndo(true);
@@ -220,7 +214,8 @@ TEST_CASE("CommandProcessorTest.doAndUndoSuccessfulCommand", "[CommandProcessorT
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandDo, commandName},
                                    {CommandNotif::CommandDone, commandName},
-                                   {CommandNotif::TransactionDone, commandName}}));
+                                   {CommandNotif::TransactionDone, commandName},
+                                 }));
 
   const auto undoResult = commandProcessor.undo();
   CHECK(undoResult->success());
@@ -233,7 +228,8 @@ TEST_CASE("CommandProcessorTest.doAndUndoSuccessfulCommand", "[CommandProcessorT
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandUndo, commandName},
                                    {CommandNotif::CommandUndone, commandName},
-                                   {CommandNotif::TransactionUndone, commandName}}));
+                                   {CommandNotif::TransactionUndone, commandName},
+                                 }));
 }
 
 TEST_CASE("CommandProcessorTest.doSuccessfulCommandAndFailAtUndo", "[CommandProcessorTest]") {
@@ -241,11 +237,11 @@ TEST_CASE("CommandProcessorTest.doSuccessfulCommandAndFailAtUndo", "[CommandProc
    * Execute a successful command, then undo fails.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName = "test command";
-  auto command = TestCommand::create(commandName);
+  auto command = std::make_unique<TestCommand>(commandName);
   command->expectDo(true);
   command->expectUndo(false);
 
@@ -259,7 +255,8 @@ TEST_CASE("CommandProcessorTest.doSuccessfulCommandAndFailAtUndo", "[CommandProc
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandDo, commandName},
                                    {CommandNotif::CommandDone, commandName},
-                                   {CommandNotif::TransactionDone, commandName}}));
+                                   {CommandNotif::TransactionDone, commandName},
+                                 }));
 
   const auto undoResult = commandProcessor.undo();
   CHECK_FALSE(undoResult->success());
@@ -267,9 +264,10 @@ TEST_CASE("CommandProcessorTest.doSuccessfulCommandAndFailAtUndo", "[CommandProc
   CHECK_FALSE(commandProcessor.canRedo());
 
   CHECK_THAT(
-    observer.popNotifications(),
-    Catch::Equals(std::vector<NotificationTuple>{
-      {CommandNotif::CommandUndo, commandName}, {CommandNotif::CommandUndoFailed, commandName}}));
+    observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
+                                   {CommandNotif::CommandUndo, commandName},
+                                   {CommandNotif::CommandUndoFailed, commandName},
+                                 }));
 }
 
 TEST_CASE("CommandProcessorTest.doFailingCommand", "[CommandProcessorTest]") {
@@ -277,11 +275,11 @@ TEST_CASE("CommandProcessorTest.doFailingCommand", "[CommandProcessorTest]") {
    * Execute a failing command.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName = "test command";
-  auto command = TestCommand::create(commandName);
+  auto command = std::make_unique<TestCommand>(commandName);
   command->expectDo(false);
 
   const auto doResult = commandProcessor.executeAndStore(std::move(command));
@@ -291,9 +289,10 @@ TEST_CASE("CommandProcessorTest.doFailingCommand", "[CommandProcessorTest]") {
   CHECK_FALSE(commandProcessor.canRedo());
 
   CHECK_THAT(
-    observer.popNotifications(),
-    Catch::Equals(std::vector<NotificationTuple>{
-      {CommandNotif::CommandDo, commandName}, {CommandNotif::CommandDoFailed, commandName}}));
+    observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
+                                   {CommandNotif::CommandDo, commandName},
+                                   {CommandNotif::CommandDoFailed, commandName},
+                                 }));
 }
 
 TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTest]") {
@@ -302,14 +301,14 @@ TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTe
    * Finally, redo it, also with success.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName1 = "test command 1";
-  auto command1 = TestCommand::create(commandName1);
+  auto command1 = std::make_unique<TestCommand>(commandName1);
 
   const auto commandName2 = "test command 2";
-  auto command2 = TestCommand::create(commandName2);
+  auto command2 = std::make_unique<TestCommand>(commandName2);
 
   command1->expectDo(true);
   command2->expectDo(true);
@@ -336,7 +335,8 @@ TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTe
                                    {CommandNotif::CommandDone, commandName1},
                                    {CommandNotif::CommandDo, commandName2},
                                    {CommandNotif::CommandDone, commandName2},
-                                   {CommandNotif::TransactionDone, transactionName}}));
+                                   {CommandNotif::TransactionDone, transactionName},
+                                 }));
 
   CHECK(commandProcessor.canUndo());
   CHECK_FALSE(commandProcessor.canRedo());
@@ -354,7 +354,8 @@ TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTe
                                    {CommandNotif::CommandUndone, commandName2},
                                    {CommandNotif::CommandUndo, commandName1},
                                    {CommandNotif::CommandUndone, commandName1},
-                                   {CommandNotif::TransactionUndone, transactionName}}));
+                                   {CommandNotif::TransactionUndone, transactionName},
+                                 }));
 
   CHECK(commandProcessor.redo()->success());
 
@@ -368,7 +369,8 @@ TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTe
                                    {CommandNotif::CommandDone, commandName1},
                                    {CommandNotif::CommandDo, commandName2},
                                    {CommandNotif::CommandDone, commandName2},
-                                   {CommandNotif::TransactionDone, transactionName}}));
+                                   {CommandNotif::TransactionDone, transactionName},
+                                 }));
 }
 
 TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]") {
@@ -376,14 +378,14 @@ TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]") 
    * Execute two successful commands in a transaction, then rollback the transaction and commit it.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName1 = "test command 1";
-  auto command1 = TestCommand::create(commandName1);
+  auto command1 = std::make_unique<TestCommand>(commandName1);
 
   const auto commandName2 = "test command 2";
-  auto command2 = TestCommand::create(commandName2);
+  auto command2 = std::make_unique<TestCommand>(commandName2);
 
   command1->expectDo(true);
   command2->expectDo(true);
@@ -397,15 +399,17 @@ TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]") 
   commandProcessor.startTransaction(transactionName);
   CHECK(commandProcessor.executeAndStore(std::move(command1))->success());
   CHECK_THAT(
-    observer.popNotifications(),
-    Catch::Equals(std::vector<NotificationTuple>{
-      {CommandNotif::CommandDo, commandName1}, {CommandNotif::CommandDone, commandName1}}));
+    observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
+                                   {CommandNotif::CommandDo, commandName1},
+                                   {CommandNotif::CommandDone, commandName1},
+                                 }));
 
   CHECK(commandProcessor.executeAndStore(std::move(command2))->success());
   CHECK_THAT(
-    observer.popNotifications(),
-    Catch::Equals(std::vector<NotificationTuple>{
-      {CommandNotif::CommandDo, commandName2}, {CommandNotif::CommandDone, commandName2}}));
+    observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
+                                   {CommandNotif::CommandDo, commandName2},
+                                   {CommandNotif::CommandDone, commandName2},
+                                 }));
 
   commandProcessor.rollbackTransaction();
   CHECK_THAT(
@@ -413,7 +417,8 @@ TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]") 
                                    {CommandNotif::CommandUndo, commandName2},
                                    {CommandNotif::CommandUndone, commandName2},
                                    {CommandNotif::CommandUndo, commandName1},
-                                   {CommandNotif::CommandUndone, commandName1}}));
+                                   {CommandNotif::CommandUndone, commandName1},
+                                 }));
 
   CHECK_FALSE(commandProcessor.canUndo());
   CHECK_FALSE(commandProcessor.canRedo());
@@ -424,7 +429,7 @@ TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]") 
   CHECK_FALSE(commandProcessor.canUndo());
   CHECK_FALSE(commandProcessor.canRedo());
 
-  REQUIRE(observer.popNotifications() == (std::vector<NotificationTuple>{}));
+  REQUIRE(observer.popNotifications().empty());
 }
 
 TEST_CASE("CommandProcessorTest.nestedTransactions", "[CommandProcessorTest]") {
@@ -433,14 +438,14 @@ TEST_CASE("CommandProcessorTest.nestedTransactions", "[CommandProcessorTest]") {
    * commit both transactions. Then undo the outer transaction.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto outerCommandName = "outer command";
-  auto outerCommand = TestCommand::create(outerCommandName);
+  auto outerCommand = std::make_unique<TestCommand>(outerCommandName);
 
   const auto innerCommandName = "inner command";
-  auto innerCommand = TestCommand::create(innerCommandName);
+  auto innerCommand = std::make_unique<TestCommand>(innerCommandName);
 
   outerCommand->expectDo(true);
   innerCommand->expectDo(true);
@@ -455,26 +460,30 @@ TEST_CASE("CommandProcessorTest.nestedTransactions", "[CommandProcessorTest]") {
   commandProcessor.startTransaction(outerTransactionName);
   CHECK(commandProcessor.executeAndStore(std::move(outerCommand))->success());
   CHECK_THAT(
-    observer.popNotifications(),
-    Catch::Equals(std::vector<NotificationTuple>{
-      {CommandNotif::CommandDo, outerCommandName}, {CommandNotif::CommandDone, outerCommandName}}));
+    observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
+                                   {CommandNotif::CommandDo, outerCommandName},
+                                   {CommandNotif::CommandDone, outerCommandName},
+                                 }));
 
   commandProcessor.startTransaction(innerTransactionName);
   CHECK(commandProcessor.executeAndStore(std::move(innerCommand))->success());
   CHECK_THAT(
-    observer.popNotifications(),
-    Catch::Equals(std::vector<NotificationTuple>{
-      {CommandNotif::CommandDo, innerCommandName}, {CommandNotif::CommandDone, innerCommandName}}));
+    observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
+                                   {CommandNotif::CommandDo, innerCommandName},
+                                   {CommandNotif::CommandDone, innerCommandName},
+                                 }));
 
   commandProcessor.commitTransaction();
   CHECK_THAT(
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
-                                   {CommandNotif::TransactionDone, innerTransactionName}}));
+                                   {CommandNotif::TransactionDone, innerTransactionName},
+                                 }));
 
   commandProcessor.commitTransaction();
   CHECK_THAT(
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
-                                   {CommandNotif::TransactionDone, outerTransactionName}}));
+                                   {CommandNotif::TransactionDone, outerTransactionName},
+                                 }));
 
   CHECK(commandProcessor.canUndo());
   CHECK_FALSE(commandProcessor.canRedo());
@@ -492,7 +501,8 @@ TEST_CASE("CommandProcessorTest.nestedTransactions", "[CommandProcessorTest]") {
                                    {CommandNotif::CommandUndone, innerCommandName},
                                    {CommandNotif::CommandUndo, outerCommandName},
                                    {CommandNotif::CommandUndone, outerCommandName},
-                                   {CommandNotif::TransactionUndone, outerTransactionName}}));
+                                   {CommandNotif::TransactionUndone, outerTransactionName},
+                                 }));
 }
 
 TEST_CASE("CommandProcessorTest.collateCommands", "[CommandProcessorTest]") {
@@ -500,14 +510,14 @@ TEST_CASE("CommandProcessorTest.collateCommands", "[CommandProcessorTest]") {
    * Execute a command and collate the next command, then undo.
    */
 
-  CommandProcessor commandProcessor(nullptr);
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName1 = "test command 1";
-  auto command1 = TestCommand::create(commandName1);
+  auto command1 = std::make_unique<TestCommand>(commandName1);
 
   const auto commandName2 = "test command 2";
-  auto command2 = TestCommand::create(commandName2);
+  auto command2 = std::make_unique<TestCommand>(commandName2);
 
   command1->expectDo(true);
   command2->expectDo(true);
@@ -519,14 +529,16 @@ TEST_CASE("CommandProcessorTest.collateCommands", "[CommandProcessorTest]") {
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandDo, commandName1},
                                    {CommandNotif::CommandDone, commandName1},
-                                   {CommandNotif::TransactionDone, commandName1}}));
+                                   {CommandNotif::TransactionDone, commandName1},
+                                 }));
 
   commandProcessor.executeAndStore(std::move(command2));
   CHECK_THAT(
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandDo, commandName2},
                                    {CommandNotif::CommandDone, commandName2},
-                                   {CommandNotif::TransactionDone, commandName2}}));
+                                   {CommandNotif::TransactionDone, commandName2},
+                                 }));
 
   CHECK(commandProcessor.canUndo());
   CHECK_FALSE(commandProcessor.canRedo());
@@ -543,7 +555,8 @@ TEST_CASE("CommandProcessorTest.collateCommands", "[CommandProcessorTest]") {
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandUndo, commandName1},
                                    {CommandNotif::CommandUndone, commandName1},
-                                   {CommandNotif::TransactionUndone, commandName1}}));
+                                   {CommandNotif::TransactionUndone, commandName1},
+                                 }));
 }
 
 TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]") {
@@ -552,14 +565,14 @@ TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]") {
    * interval. Then, undo the second command.
    */
 
-  CommandProcessor commandProcessor(nullptr, std::chrono::milliseconds(100));
-  TestObserver observer(commandProcessor);
+  auto commandProcessor = CommandProcessor{nullptr, std::chrono::milliseconds(100)};
+  auto observer = TestObserver{commandProcessor};
 
   const auto commandName1 = "test command 1";
-  auto command1 = TestCommand::create(commandName1);
+  auto command1 = std::make_unique<TestCommand>(commandName1);
 
   const auto commandName2 = "test command 2";
-  auto command2 = TestCommand::create(commandName2);
+  auto command2 = std::make_unique<TestCommand>(commandName2);
 
   command1->expectDo(true);
   command2->expectDo(true);
@@ -571,7 +584,8 @@ TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]") {
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandDo, commandName1},
                                    {CommandNotif::CommandDone, commandName1},
-                                   {CommandNotif::TransactionDone, commandName1}}));
+                                   {CommandNotif::TransactionDone, commandName1},
+                                 }));
 
   using namespace std::chrono_literals;
   std::this_thread::sleep_for(100ms);
@@ -582,7 +596,8 @@ TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]") {
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandDo, commandName2},
                                    {CommandNotif::CommandDone, commandName2},
-                                   {CommandNotif::TransactionDone, commandName2}}));
+                                   {CommandNotif::TransactionDone, commandName2},
+                                 }));
 
   CHECK(commandProcessor.canUndo());
   CHECK_FALSE(commandProcessor.canRedo());
@@ -594,7 +609,8 @@ TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]") {
     observer.popNotifications(), Catch::Equals(std::vector<NotificationTuple>{
                                    {CommandNotif::CommandUndo, commandName2},
                                    {CommandNotif::CommandUndone, commandName2},
-                                   {CommandNotif::TransactionUndone, commandName2}}));
+                                   {CommandNotif::TransactionUndone, commandName2},
+                                 }));
 
   CHECK(commandProcessor.canUndo());
   CHECK(commandProcessor.canRedo());


### PR DESCRIPTION
This change allows transactions to be collated if the last command of the preceeding transaction and the first command of the succeeding transaction can be collated.