### PR TITLE
4059: Dont propagate intermediate states to linked groups

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -965,6 +965,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/ToolBoxConnector.h
         ${COMMON_SOURCE_DIR}/View/ToolChain.h
         ${COMMON_SOURCE_DIR}/View/ToolController.h
+        ${COMMON_SOURCE_DIR}/View/TransactionScope.h
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.h
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.h
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsHelper.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -445,6 +445,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/ToolController.cpp
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.cpp
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.cpp
+        ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsCommandBase.cpp
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsHelper.cpp
         ${COMMON_SOURCE_DIR}/View/UVCameraTool.cpp
         ${COMMON_SOURCE_DIR}/View/UVEditor.cpp
@@ -968,6 +969,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/TransactionScope.h
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.h
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.h
+        ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsCommandBase.h
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsHelper.h
         ${COMMON_SOURCE_DIR}/View/UVCameraTool.h
         ${COMMON_SOURCE_DIR}/View/UVEditor.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -445,6 +445,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/ToolController.cpp
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.cpp
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.cpp
+        ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsCommand.cpp
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsCommandBase.cpp
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsHelper.cpp
         ${COMMON_SOURCE_DIR}/View/UVCameraTool.cpp
@@ -969,6 +970,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/TransactionScope.h
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.h
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.h
+        ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsCommand.h
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsCommandBase.h
         ${COMMON_SOURCE_DIR}/View/UpdateLinkedGroupsHelper.h
         ${COMMON_SOURCE_DIR}/View/UVCameraTool.h

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -309,7 +309,8 @@ kdl::result<UpdateLinkedGroupsResult, UpdateLinkedGroupsError> updateLinkedGroup
 GroupNode::GroupNode(Group group)
   : m_group{std::move(group)}
   , m_editState{EditState::Closed}
-  , m_boundsValid{false} {}
+  , m_boundsValid{false}
+  , m_hasPendingChanges{false} {}
 
 const Group& GroupNode::group() const {
   return m_group;
@@ -355,6 +356,14 @@ void GroupNode::setPersistentId(const IdType persistentId) {
 
 void GroupNode::resetPersistentId() {
   m_persistentId = std::nullopt;
+}
+
+bool GroupNode::hasPendingChanges() const {
+  return m_hasPendingChanges;
+}
+
+void GroupNode::setHasPendingChanges(const bool hasPendingChanges) {
+  m_hasPendingChanges = hasPendingChanges;
 }
 
 void GroupNode::setEditState(const EditState editState) {

--- a/common/src/Model/GroupNode.h
+++ b/common/src/Model/GroupNode.h
@@ -97,6 +97,8 @@ private:
    */
   std::optional<IdType> m_persistentId;
 
+  bool m_hasPendingChanges;
+
 public:
   explicit GroupNode(Group group);
 
@@ -112,6 +114,9 @@ public:
   const std::optional<IdType>& persistentId() const;
   void setPersistentId(IdType persistentId);
   void resetPersistentId();
+
+  bool hasPendingChanges() const;
+  void setHasPendingChanges(bool hasPendingChanges);
 
 private:
   void setEditState(EditState editState);

--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -108,7 +108,7 @@ public: // adding, removing, reparenting, and duplicating nodes
   virtual void removeNodes(const std::vector<Node*>& nodes) = 0;
 
   virtual bool reparentNodes(const std::map<Node*, std::vector<Node*>>& nodes) = 0;
-  virtual bool deleteObjects() = 0;
+  virtual void deleteObjects() = 0;
   virtual void duplicateObjects() = 0;
 
 public: // entity management

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -33,27 +33,22 @@
 namespace TrenchBroom {
 namespace View {
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
-  Model::Node* parent, const std::vector<Model::Node*>& children,
-  std::vector<Model::GroupNode*> changedLinkedGroups) {
+  Model::Node* parent, const std::vector<Model::Node*>& children) {
   ensure(parent != nullptr, "parent is null");
   auto nodes = std::map<Model::Node*, std::vector<Model::Node*>>{};
   nodes[parent] = children;
 
-  return add(nodes, std::move(changedLinkedGroups));
+  return add(nodes);
 }
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
-  const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<Model::GroupNode*> changedLinkedGroups) {
-  return std::make_unique<AddRemoveNodesCommand>(
-    Action::Add, nodes, std::move(changedLinkedGroups));
+  const std::map<Model::Node*, std::vector<Model::Node*>>& nodes) {
+  return std::make_unique<AddRemoveNodesCommand>(Action::Add, nodes);
 }
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::remove(
-  const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<Model::GroupNode*> changedLinkedGroups) {
-  return std::make_unique<AddRemoveNodesCommand>(
-    Action::Remove, nodes, std::move(changedLinkedGroups));
+  const std::map<Model::Node*, std::vector<Model::Node*>>& nodes) {
+  return std::make_unique<AddRemoveNodesCommand>(Action::Remove, nodes);
 }
 
 AddRemoveNodesCommand::~AddRemoveNodesCommand() {
@@ -61,9 +56,8 @@ AddRemoveNodesCommand::~AddRemoveNodesCommand() {
 }
 
 AddRemoveNodesCommand::AddRemoveNodesCommand(
-  const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : UpdateLinkedGroupsCommandBase{makeName(action), true, std::move(changedLinkedGroups)}
+  const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes)
+  : UpdateLinkedGroupsCommandBase{makeName(action), true}
   , m_action{action} {
   switch (m_action) {
     case Action::Add:

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
 namespace View {
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   Model::Node* parent, const std::vector<Model::Node*>& children,
-  std::vector<const Model::GroupNode*> changedLinkedGroups) {
+  std::vector<Model::GroupNode*> changedLinkedGroups) {
   ensure(parent != nullptr, "parent is null");
   auto nodes = std::map<Model::Node*, std::vector<Model::Node*>>{};
   nodes[parent] = children;
@@ -45,14 +45,14 @@ std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::add(
   const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<const Model::GroupNode*> changedLinkedGroups) {
+  std::vector<Model::GroupNode*> changedLinkedGroups) {
   return std::make_unique<AddRemoveNodesCommand>(
     Action::Add, nodes, std::move(changedLinkedGroups));
 }
 
 std::unique_ptr<AddRemoveNodesCommand> AddRemoveNodesCommand::remove(
   const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<const Model::GroupNode*> changedLinkedGroups) {
+  std::vector<Model::GroupNode*> changedLinkedGroups) {
   return std::make_unique<AddRemoveNodesCommand>(
     Action::Remove, nodes, std::move(changedLinkedGroups));
 }
@@ -63,7 +63,7 @@ AddRemoveNodesCommand::~AddRemoveNodesCommand() {
 
 AddRemoveNodesCommand::AddRemoveNodesCommand(
   const Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : UndoableCommand{makeName(action), true}
   , m_action{action}
   , m_updateLinkedGroupsHelper{std::move(changedLinkedGroups)} {

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -49,17 +49,17 @@ private:
 public:
   static std::unique_ptr<AddRemoveNodesCommand> add(
     Model::Node* parent, const std::vector<Model::Node*>& children,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> edLinkedGroups);
   static std::unique_ptr<AddRemoveNodesCommand> add(
     const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
   static std::unique_ptr<AddRemoveNodesCommand> remove(
     const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
   AddRemoveNodesCommand(
     Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
   ~AddRemoveNodesCommand() override;
 
 private:

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -20,8 +20,7 @@
 #pragma once
 
 #include "Macros.h"
-#include "View/UndoableCommand.h"
-#include "View/UpdateLinkedGroupsHelper.h"
+#include "View/UpdateLinkedGroupsCommandBase.h"
 
 #include <map>
 #include <memory>
@@ -34,7 +33,7 @@ class Node;
 } // namespace Model
 
 namespace View {
-class AddRemoveNodesCommand : public UndoableCommand {
+class AddRemoveNodesCommand : public UpdateLinkedGroupsCommandBase {
 private:
   enum class Action {
     Add,
@@ -44,7 +43,6 @@ private:
   Action m_action;
   std::map<Model::Node*, std::vector<Model::Node*>> m_nodesToAdd;
   std::map<Model::Node*, std::vector<Model::Node*>> m_nodesToRemove;
-  UpdateLinkedGroupsHelper m_updateLinkedGroupsHelper;
 
 public:
   static std::unique_ptr<AddRemoveNodesCommand> add(

--- a/common/src/View/AddRemoveNodesCommand.h
+++ b/common/src/View/AddRemoveNodesCommand.h
@@ -28,7 +28,6 @@
 
 namespace TrenchBroom {
 namespace Model {
-class GroupNode;
 class Node;
 } // namespace Model
 
@@ -46,18 +45,14 @@ private:
 
 public:
   static std::unique_ptr<AddRemoveNodesCommand> add(
-    Model::Node* parent, const std::vector<Model::Node*>& children,
-    std::vector<Model::GroupNode*> edLinkedGroups);
+    Model::Node* parent, const std::vector<Model::Node*>& children);
   static std::unique_ptr<AddRemoveNodesCommand> add(
-    const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    const std::map<Model::Node*, std::vector<Model::Node*>>& nodes);
   static std::unique_ptr<AddRemoveNodesCommand> remove(
-    const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    const std::map<Model::Node*, std::vector<Model::Node*>>& nodes);
 
   AddRemoveNodesCommand(
-    Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    Action action, const std::map<Model::Node*, std::vector<Model::Node*>>& nodes);
   ~AddRemoveNodesCommand() override;
 
 private:

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -28,7 +28,7 @@ namespace TrenchBroom {
 namespace View {
 BrushVertexCommandBase::BrushVertexCommandBase(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : SwapNodeContentsCommand{name, std::move(nodes), std::move(changedLinkedGroups)} {}
 
 std::unique_ptr<CommandResult> BrushVertexCommandBase::doPerformDo(
@@ -85,7 +85,7 @@ bool BrushVertexCommandResult::hasRemainingVertices() const {
 BrushVertexCommand::BrushVertexCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
   , m_oldVertexPositions{std::move(oldVertexPositions)}
   , m_newVertexPositions{std::move(newVertexPositions)} {}
@@ -128,7 +128,7 @@ void BrushVertexCommand::selectOldHandlePositions(
 BrushEdgeCommand::BrushEdgeCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
   , m_oldEdgePositions{std::move(oldEdgePositions)}
   , m_newEdgePositions{std::move(newEdgePositions)} {}
@@ -165,7 +165,7 @@ void BrushEdgeCommand::selectOldHandlePositions(
 BrushFaceCommand::BrushFaceCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
   , m_oldFacePositions{std::move(oldFacePositions)}
   , m_newFacePositions{std::move(newFacePositions)} {}

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -27,9 +27,8 @@
 namespace TrenchBroom {
 namespace View {
 BrushVertexCommandBase::BrushVertexCommandBase(
-  const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : SwapNodeContentsCommand{name, std::move(nodes), std::move(changedLinkedGroups)} {}
+  const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes)
+  : SwapNodeContentsCommand{name, std::move(nodes)} {}
 
 std::unique_ptr<CommandResult> BrushVertexCommandBase::doPerformDo(
   MapDocumentCommandFacade* document) {
@@ -84,9 +83,8 @@ bool BrushVertexCommandResult::hasRemainingVertices() const {
 
 BrushVertexCommand::BrushVertexCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
+  std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions)
+  : BrushVertexCommandBase{name, std::move(nodes)}
   , m_oldVertexPositions{std::move(oldVertexPositions)}
   , m_newVertexPositions{std::move(newVertexPositions)} {}
 
@@ -127,9 +125,8 @@ void BrushVertexCommand::selectOldHandlePositions(
 
 BrushEdgeCommand::BrushEdgeCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
+  std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions)
+  : BrushVertexCommandBase{name, std::move(nodes)}
   , m_oldEdgePositions{std::move(oldEdgePositions)}
   , m_newEdgePositions{std::move(newEdgePositions)} {}
 
@@ -164,9 +161,8 @@ void BrushEdgeCommand::selectOldHandlePositions(
 
 BrushFaceCommand::BrushFaceCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : BrushVertexCommandBase{name, std::move(nodes), std::move(changedLinkedGroups)}
+  std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions)
+  : BrushVertexCommandBase{name, std::move(nodes)}
   , m_oldFacePositions{std::move(oldFacePositions)}
   , m_newFacePositions{std::move(newFacePositions)} {}
 

--- a/common/src/View/BrushVertexCommands.h
+++ b/common/src/View/BrushVertexCommands.h
@@ -39,8 +39,7 @@ template <typename H> class VertexHandleManagerBaseT;
 class BrushVertexCommandBase : public SwapNodeContentsCommand {
 protected:
   BrushVertexCommandBase(
-    const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
@@ -80,8 +79,7 @@ private:
 public:
   BrushVertexCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions);
 
 private:
   std::unique_ptr<CommandResult> createCommandResult(
@@ -103,8 +101,7 @@ private:
 public:
   BrushEdgeCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;
@@ -123,8 +120,7 @@ private:
 public:
   BrushFaceCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;

--- a/common/src/View/BrushVertexCommands.h
+++ b/common/src/View/BrushVertexCommands.h
@@ -40,7 +40,7 @@ class BrushVertexCommandBase : public SwapNodeContentsCommand {
 protected:
   BrushVertexCommandBase(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
@@ -81,7 +81,7 @@ public:
   BrushVertexCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::vec3> oldVertexPositions, std::vector<vm::vec3> newVertexPositions,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
 private:
   std::unique_ptr<CommandResult> createCommandResult(
@@ -104,7 +104,7 @@ public:
   BrushEdgeCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::segment3> oldEdgePositions, std::vector<vm::segment3> newEdgePositions,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;
@@ -124,7 +124,7 @@ public:
   BrushFaceCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
     std::vector<vm::polygon3> oldFacePositions, std::vector<vm::polygon3> newFacePositions,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
 private:
   bool doCollateWith(UndoableCommand& command) override;

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -624,7 +624,7 @@ void ClipTool::performClip() {
     const kdl::set_temp ignoreNotifications(m_ignoreNotifications);
 
     auto document = kdl::mem_lock(m_document);
-    const Transaction transaction(document, "Clip Brushes");
+    const auto transaction = Transaction{document, "Clip Brushes"};
 
     // need to make a copies here so that we are not affected by the deselection
     const auto toAdd = clipBrushes();

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -624,7 +624,7 @@ void ClipTool::performClip() {
     const kdl::set_temp ignoreNotifications(m_ignoreNotifications);
 
     auto document = kdl::mem_lock(m_document);
-    const auto transaction = Transaction{document, "Clip Brushes"};
+    auto transaction = Transaction{document, "Clip Brushes"};
 
     // need to make a copies here so that we are not affected by the deselection
     const auto toAdd = clipBrushes();
@@ -634,6 +634,7 @@ void ClipTool::performClip() {
     document->deselectAll();
     document->removeNodes(toRemove);
     document->selectNodes(addedNodes);
+    transaction.commit();
 
     update();
   }

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -186,6 +186,11 @@ void CommandProcessor::rollbackTransaction() {
   transaction.commands.clear();
 }
 
+bool CommandProcessor::isCurrentDocumentStateObservable() const {
+  return m_transactionStack.size() < 2 ||
+         m_transactionStack[m_transactionStack.size() - 2].scope == TransactionScope::LongRunning;
+}
+
 std::unique_ptr<CommandResult> CommandProcessor::execute(std::unique_ptr<Command> command) {
   auto result = executeCommand(*command);
   if (result->success()) {

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -22,6 +22,7 @@
 #include "Exceptions.h"
 #include "Notifier.h"
 #include "View/Command.h"
+#include "View/TransactionScope.h"
 #include "View/UndoableCommand.h"
 
 #include <kdl/set_temp.h>
@@ -43,10 +44,12 @@ void notifyCommandIfNotType(T& notifier, C& command) {
 
 struct CommandProcessor::TransactionState {
   std::string name;
+  TransactionScope scope;
   std::vector<std::unique_ptr<UndoableCommand>> commands;
 
-  explicit TransactionState(std::string i_name)
-    : name{std::move(i_name)} {}
+  TransactionState(std::string i_name, const TransactionScope i_scope)
+    : name{std::move(i_name)}
+    , scope{i_scope} {}
 };
 
 struct CommandProcessor::SubmitAndStoreResult {
@@ -158,8 +161,8 @@ const std::string& CommandProcessor::redoCommandName() const {
   }
 }
 
-void CommandProcessor::startTransaction(std::string name) {
-  m_transactionStack.emplace_back(std::move(name));
+void CommandProcessor::startTransaction(std::string name, const TransactionScope scope) {
+  m_transactionStack.emplace_back(std::move(name), scope);
 }
 
 void CommandProcessor::commitTransaction() {

--- a/common/src/View/CommandProcessor.h
+++ b/common/src/View/CommandProcessor.h
@@ -32,6 +32,7 @@ class Command;
 class CommandResult;
 class MapDocumentCommandFacade;
 class UndoableCommand;
+enum class TransactionScope;
 
 /**
  * The command processor is responsible for executing and undoing commands and for maintining the
@@ -167,8 +168,9 @@ public:
    * transaction upon commit.
    *
    * @param name the name of the transaction to start
+   * @param scope the scope of the transaction to start
    */
-  void startTransaction(std::string name);
+  void startTransaction(std::string name, TransactionScope scope);
 
   /**
    * Commits the currently executing transaction. If it is a nested transaction, then its commands

--- a/common/src/View/CommandProcessor.h
+++ b/common/src/View/CommandProcessor.h
@@ -194,6 +194,15 @@ public:
   void rollbackTransaction();
 
   /**
+   * Indicates whether the current document state is observable.
+   *
+   * If no transaction is active, the state is observable.
+   * If a transaction is active, the state is observable unless the transaction is nested inside a
+   * one shot transaction.
+   */
+  bool isCurrentDocumentStateObservable() const;
+
+  /**
    * Executes the given command by calling its `performDo` method without storing it for later undo.
    * If the command is executed successfully, both the undo and the redo stacks are cleared since
    * the application's state is likely to have become inconsistent with the state expected by the

--- a/common/src/View/CreateBrushToolBase.cpp
+++ b/common/src/View/CreateBrushToolBase.cpp
@@ -49,10 +49,13 @@ const Grid& CreateBrushToolBase::grid() const {
 void CreateBrushToolBase::createBrush() {
   if (m_brush != nullptr) {
     auto document = kdl::mem_lock(m_document);
-    const auto transaction = Transaction{document, "Create Brush"};
+
+    auto transaction = Transaction{document, "Create Brush"};
     document->deselectAll();
     document->addNodes({{document->parentForNodes(), {m_brush}}});
     document->selectNodes({m_brush});
+    transaction.commit();
+
     m_brush = nullptr;
     doBrushWasCreated();
   }

--- a/common/src/View/CreateBrushToolBase.cpp
+++ b/common/src/View/CreateBrushToolBase.cpp
@@ -49,7 +49,7 @@ const Grid& CreateBrushToolBase::grid() const {
 void CreateBrushToolBase::createBrush() {
   if (m_brush != nullptr) {
     auto document = kdl::mem_lock(m_document);
-    const Transaction transaction(document, "Create Brush");
+    const auto transaction = Transaction{document, "Create Brush"};
     document->deselectAll();
     document->addNodes({{document->parentForNodes(), {m_brush}}});
     document->selectNodes({m_brush});

--- a/common/src/View/CreateEntityTool.cpp
+++ b/common/src/View/CreateEntityTool.cpp
@@ -35,6 +35,7 @@
 #include "Renderer/Camera.h"
 #include "View/Grid.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 #include <vecmath/bbox.h>
@@ -64,7 +65,7 @@ bool CreateEntityTool::createEntity(const std::string& classname) {
 
   m_referenceBounds = document->referenceBounds();
 
-  document->startTransaction("Create '" + definition->name() + "'");
+  document->startTransaction("Create '" + definition->name() + "'", TransactionScope::LongRunning);
   document->deselectAll();
   document->addNodes({{document->parentForNodes(), {m_entity}}});
   document->selectNodes({m_entity});

--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -132,20 +132,20 @@ void EntityPropertyGrid::removeSelectedProperties() {
 
   const auto selectedRows = selectedRowsAndCursorRow();
 
-  std::vector<std::string> propertyKeys;
-  for (const int row : selectedRows) {
+  auto propertyKeys = std::vector<std::string>{};
+  for (const auto row : selectedRows) {
     propertyKeys.push_back(m_model->propertyKey(row));
   }
 
-  const size_t numRows = propertyKeys.size();
+  const auto numRows = propertyKeys.size();
   auto document = kdl::mem_lock(m_document);
 
   {
-    Transaction transaction(
-      document, kdl::str_plural(numRows, "Remove Property", "Remove Properties"));
+    auto transaction =
+      Transaction{document, kdl::str_plural(numRows, "Remove Property", "Remove Properties")};
 
-    bool success = true;
-    for (const std::string& propertyKey : propertyKeys) {
+    auto success = true;
+    for (const auto& propertyKey : propertyKeys) {
       success = success && document->removeProperty(propertyKey);
     }
 

--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -140,18 +140,18 @@ void EntityPropertyGrid::removeSelectedProperties() {
   const auto numRows = propertyKeys.size();
   auto document = kdl::mem_lock(m_document);
 
-  {
-    auto transaction =
-      Transaction{document, kdl::str_plural(numRows, "Remove Property", "Remove Properties")};
+  auto transaction =
+    Transaction{document, kdl::str_plural(numRows, "Remove Property", "Remove Properties")};
 
-    auto success = true;
-    for (const auto& propertyKey : propertyKeys) {
-      success = success && document->removeProperty(propertyKey);
-    }
+  auto success = true;
+  for (const auto& propertyKey : propertyKeys) {
+    success = success && document->removeProperty(propertyKey);
+  }
 
-    if (!success) {
-      transaction.rollback();
-    }
+  if (success) {
+    transaction.commit();
+  } else {
+    transaction.cancel();
   }
 }
 

--- a/common/src/View/ExtrudeTool.cpp
+++ b/common/src/View/ExtrudeTool.cpp
@@ -33,6 +33,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/map_utils.h>
 #include <kdl/memory_utils.h>
@@ -311,7 +312,7 @@ std::vector<Model::BrushFaceHandle> ExtrudeTool::getDragFaces(
 void ExtrudeTool::beginExtrude() {
   ensure(!m_dragging, "may not be called during a drag");
   m_dragging = true;
-  kdl::mem_lock(m_document)->startTransaction("Resize Brushes");
+  kdl::mem_lock(m_document)->startTransaction("Resize Brushes", TransactionScope::LongRunning);
 }
 
 namespace {
@@ -515,7 +516,7 @@ bool ExtrudeTool::extrude(const vm::vec3& handleDelta, ExtrudeDragState& dragSta
 void ExtrudeTool::beginMove() {
   ensure(!m_dragging, "may not be called during a drag");
   m_dragging = true;
-  kdl::mem_lock(m_document)->startTransaction("Move Faces");
+  kdl::mem_lock(m_document)->startTransaction("Move Faces", TransactionScope::LongRunning);
 }
 
 bool ExtrudeTool::move(const vm::vec3& delta, ExtrudeDragState& dragState) {

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -163,9 +163,10 @@ void IssueBrowserView::applyQuickFix(const Model::IssueQuickFix* quickFix) {
   ensure(quickFix != nullptr, "quickFix is null");
 
   auto document = kdl::mem_lock(m_document);
-  const std::vector<Model::Issue*> issues = collectIssues(getSelection());
+  const auto issues = collectIssues(getSelection());
 
-  const Transaction transaction(document, "Apply Quick Fix (" + quickFix->description() + ")");
+  const auto transaction =
+    Transaction{document, "Apply Quick Fix (" + quickFix->description() + ")"};
   updateSelection();
   quickFix->apply(document.get(), issues);
 }

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -165,10 +165,10 @@ void IssueBrowserView::applyQuickFix(const Model::IssueQuickFix* quickFix) {
   auto document = kdl::mem_lock(m_document);
   const auto issues = collectIssues(getSelection());
 
-  const auto transaction =
-    Transaction{document, "Apply Quick Fix (" + quickFix->description() + ")"};
+  auto transaction = Transaction{document, "Apply Quick Fix (" + quickFix->description() + ")"};
   updateSelection();
   quickFix->apply(document.get(), issues);
+  transaction.commit();
 }
 
 std::vector<Model::Issue*> IssueBrowserView::collectIssues(

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -222,16 +222,16 @@ void LayerEditor::onAddLayer() {
     auto layer = Model::Layer(name);
 
     // Sort it at the bottom of the list
-    const std::vector<Model::LayerNode*> customLayers = world->customLayersUserSorted();
+    const auto customLayers = world->customLayersUserSorted();
     if (customLayers.empty()) {
       layer.setSortIndex(0);
     } else {
       layer.setSortIndex(customLayers.back()->layer().sortIndex() + 1);
     }
 
-    auto* layerNode = new Model::LayerNode(std::move(layer));
+    auto* layerNode = new Model::LayerNode{std::move(layer)};
 
-    Transaction transaction(document, "Create Layer " + layerNode->name());
+    const auto transaction = Transaction{document, "Create Layer " + layerNode->name()};
     document->addNodes({{world, {layerNode}}});
     document->setCurrentLayer(layerNode);
     m_layerList->setSelectedLayer(layerNode);
@@ -245,7 +245,7 @@ void LayerEditor::onRemoveLayer() {
   auto document = kdl::mem_lock(m_document);
   auto* defaultLayer = document->world()->defaultLayer();
 
-  Transaction transaction(document, "Remove Layer " + layer->name());
+  const auto transaction = Transaction{document, "Remove Layer " + layer->name()};
   document->deselectAll();
   if (layer->hasChildren()) {
     document->reparentNodes({{defaultLayer, layer->children()}});

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -135,9 +135,9 @@ namespace View {
 template <typename T>
 static auto findLinkedGroupsRecursively(
   Model::WorldNode& worldNode, const std::vector<T*>& nodes, const bool includeGivenNodes) {
-  auto result = std::vector<const Model::GroupNode*>{};
+  auto result = std::vector<Model::GroupNode*>{};
 
-  const auto addGroupNode = [&](const Model::GroupNode* groupNode) {
+  const auto addGroupNode = [&](Model::GroupNode* groupNode) {
     while (groupNode) {
       if (const auto linkedGroupId = groupNode->group().linkedGroupId()) {
         if (Model::findLinkedGroups(worldNode, *linkedGroupId).size() > 1u) {
@@ -257,7 +257,7 @@ static std::optional<std::vector<std::pair<Model::Node*, Model::NodeContents>>> 
 template <typename N, typename L>
 static bool applyAndSwap(
   MapDocument& document, const std::string& commandName, const std::vector<N*>& nodes,
-  std::vector<const Model::GroupNode*> changedLinkedGroups, L lambda) {
+  std::vector<Model::GroupNode*> changedLinkedGroups, L lambda) {
   if (nodes.empty()) {
     return true;
   }
@@ -2321,7 +2321,7 @@ void MapDocument::downgradeUnlockedToInherit(const std::vector<Model::Node*>& no
 bool MapDocument::swapNodeContents(
   const std::string& commandName,
   std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap,
-  std::vector<const Model::GroupNode*> changedLinkedGroups) {
+  std::vector<Model::GroupNode*> changedLinkedGroups) {
   return executeAndStore(std::make_unique<SwapNodeContentsCommand>(
                            commandName, std::move(nodesToSwap), std::move(changedLinkedGroups)))
     ->success();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3251,13 +3251,17 @@ MapDocument::MoveVerticesResult MapDocument::moveVertices(
 
     const auto commandName =
       kdl::str_plural(vertexPositions.size(), "Move Brush Vertex", "Move Brush Vertices");
+    auto transaction = Transaction{*this, commandName};
+
     auto changedLinkedGroups =
       findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
+
     const auto result = executeAndStore(std::make_unique<BrushVertexCommand>(
       commandName, std::move(*newNodes), std::move(vertexPositions), std::move(newVertexPositions),
       std::move(changedLinkedGroups)));
+    transaction.commit();
 
     const auto* moveVerticesResult = dynamic_cast<BrushVertexCommandResult*>(result.get());
     ensure(
@@ -3318,14 +3322,19 @@ bool MapDocument::moveEdges(std::vector<vm::segment3> edgePositions, const vm::v
 
     const auto commandName =
       kdl::str_plural(edgePositions.size(), "Move Brush Edge", "Move Brush Edges");
+    auto transaction = Transaction{*this, commandName};
+
     auto changedLinkedGroups =
       findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
-    return executeAndStore(std::make_unique<BrushEdgeCommand>(
-                             commandName, std::move(*newNodes), std::move(edgePositions),
-                             std::move(newEdgePositions), std::move(changedLinkedGroups)))
-      ->success();
+
+    const auto result = executeAndStore(std::make_unique<BrushEdgeCommand>(
+      commandName, std::move(*newNodes), std::move(edgePositions), std::move(newEdgePositions),
+      std::move(changedLinkedGroups)));
+
+    transaction.commit();
+    return result->success();
   }
 
   return false;
@@ -3379,14 +3388,19 @@ bool MapDocument::moveFaces(std::vector<vm::polygon3> facePositions, const vm::v
 
     const auto commandName =
       kdl::str_plural(facePositions.size(), "Move Brush Face", "Move Brush Faces");
+    auto transaction = Transaction{*this, commandName};
+
     auto changedLinkedGroups =
       findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
-    return executeAndStore(std::make_unique<BrushFaceCommand>(
-                             commandName, std::move(*newNodes), std::move(facePositions),
-                             std::move(newFacePositions), std::move(changedLinkedGroups)))
-      ->success();
+
+    const auto result = executeAndStore(std::make_unique<BrushFaceCommand>(
+      commandName, std::move(*newNodes), std::move(facePositions), std::move(newFacePositions),
+      std::move(changedLinkedGroups)));
+
+    transaction.commit();
+    return result->success();
   }
 
   return false;
@@ -3419,14 +3433,20 @@ bool MapDocument::addVertex(const vm::vec3& vertexPosition) {
                                }));
 
   if (newNodes) {
+    const auto commandName = "Add Brush Vertex";
+    auto transaction = Transaction{*this, commandName};
+
     auto changedLinkedGroups =
       findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
-    return executeAndStore(std::make_unique<BrushVertexCommand>(
-                             "Add Brush Vertex", std::move(*newNodes), std::vector<vm::vec3>{},
-                             std::vector<vm::vec3>{vertexPosition}, std::move(changedLinkedGroups)))
-      ->success();
+
+    const auto result = executeAndStore(std::make_unique<BrushVertexCommand>(
+      commandName, std::move(*newNodes), std::vector<vm::vec3>{},
+      std::vector<vm::vec3>{vertexPosition}, std::move(changedLinkedGroups)));
+
+    transaction.commit();
+    return result->success();
   }
 
   return false;
@@ -3468,14 +3488,19 @@ bool MapDocument::removeVertices(
                                }));
 
   if (newNodes) {
+    auto transaction = Transaction{*this, commandName};
+
     auto changedLinkedGroups =
       findContainingLinkedGroups(*m_world, kdl::vec_transform(*newNodes, [](const auto& p) {
         return p.first;
       }));
-    return executeAndStore(std::make_unique<BrushVertexCommand>(
-                             commandName, std::move(*newNodes), std::move(vertexPositions),
-                             std::vector<vm::vec3>{}, std::move(changedLinkedGroups)))
-      ->success();
+
+    const auto result = executeAndStore(std::make_unique<BrushVertexCommand>(
+      commandName, std::move(*newNodes), std::move(vertexPositions), std::vector<vm::vec3>{},
+      std::move(changedLinkedGroups)));
+
+    transaction.commit();
+    return result->success();
   }
 
   return false;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -99,6 +99,7 @@
 #include "View/SetLockStateCommand.h"
 #include "View/SetVisibilityCommand.h"
 #include "View/SwapNodeContentsCommand.h"
+#include "View/TransactionScope.h"
 #include "View/UpdateLinkedGroupsHelper.h"
 #include "View/ViewEffectsService.h"
 
@@ -3493,9 +3494,9 @@ void MapDocument::clearRepeatableCommands() {
   m_repeatStack->clear();
 }
 
-void MapDocument::startTransaction(std::string name) {
+void MapDocument::startTransaction(std::string name, const TransactionScope scope) {
   debug("Starting transaction '" + name + "'");
-  doStartTransaction(std::move(name));
+  doStartTransaction(std::move(name), scope);
   m_repeatStack->startTransaction();
 }
 
@@ -4323,7 +4324,7 @@ void Transaction::cancel() {
 }
 
 void Transaction::begin(std::string name) {
-  m_document->startTransaction(std::move(name));
+  m_document->startTransaction(std::move(name), TransactionScope::Oneshot);
 }
 
 void Transaction::commit() {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -409,7 +409,7 @@ void MapDocument::setCurrentLayer(Model::LayerNode* currentLayer) {
   ensure(m_currentLayer != nullptr, "old currentLayer is null");
   ensure(currentLayer != nullptr, "new currentLayer is null");
 
-  const auto transaction = Transaction{this, "Set Current Layer"};
+  const auto transaction = Transaction{*this, "Set Current Layer"};
 
   while (currentGroup() != nullptr) {
     closeGroup();
@@ -1009,7 +1009,7 @@ void MapDocument::selectSiblings() {
     }
   }
 
-  const auto transaction = Transaction{this, "Select Siblings"};
+  const auto transaction = Transaction{*this, "Select Siblings"};
   deselectAll();
   selectNodes(nodesToSelect);
 }
@@ -1022,7 +1022,7 @@ void MapDocument::selectTouching(const bool del) {
       return m_editorContext->selectable(node);
     });
 
-  const auto transaction = Transaction{this, "Select Touching"};
+  const auto transaction = Transaction{*this, "Select Touching"};
   if (del) {
     deleteObjects();
   } else {
@@ -1039,7 +1039,7 @@ void MapDocument::selectInside(const bool del) {
       return m_editorContext->selectable(node);
     });
 
-  const auto transaction = Transaction{this, "Select Inside"};
+  const auto transaction = Transaction{*this, "Select Inside"};
   if (del) {
     deleteObjects();
   } else {
@@ -1085,7 +1085,7 @@ void MapDocument::selectInverse() {
       collectNode(patch);
     }));
 
-  const auto transaction = Transaction{this, "Select Inverse"};
+  const auto transaction = Transaction{*this, "Select Inverse"};
   deselectAll();
   selectNodes(nodesToSelect);
 }
@@ -1102,7 +1102,7 @@ void MapDocument::selectNodesWithFilePosition(const std::vector<size_t>& positio
       return false;
     });
 
-  const auto transaction = Transaction{this, "Select by Line Number"};
+  const auto transaction = Transaction{*this, "Select by Line Number"};
   deselectAll();
   selectNodes(nodes);
 }
@@ -1132,7 +1132,7 @@ void MapDocument::selectFacesWithTexture(const Assets::Texture* texture) {
       return faceHandle.face().texture() == texture;
     });
 
-  const auto transaction = Transaction{this, "Select Faces with Texture"};
+  const auto transaction = Transaction{*this, "Select Faces with Texture"};
   deselectAll();
   selectBrushFaces(faces);
 }
@@ -1173,7 +1173,7 @@ void MapDocument::selectTall(const vm::axis::type cameraAxis) {
     })
     .and_then([&](const std::vector<std::unique_ptr<Model::BrushNode>>& tallBrushes) {
       // delete the original selection brushes before searching for the objects to select
-      const auto transaction = Transaction{this, "Select Tall"};
+      const auto transaction = Transaction{*this, "Select Tall"};
       deleteObjects();
 
       const auto nodesToSelect = kdl::vec_filter(
@@ -1245,7 +1245,7 @@ std::vector<Model::Node*> MapDocument::addNodes(
     unused(parent);
   }
 
-  const auto transaction = Transaction{this, "Add Objects"};
+  const auto transaction = Transaction{*this, "Add Objects"};
   const auto result = executeAndStore(
     AddRemoveNodesCommand::add(nodes, findAllLinkedGroups(*m_world, kdl::map_keys(nodes))));
   if (!result->success()) {
@@ -1293,7 +1293,7 @@ void MapDocument::removeNodes(const std::vector<Model::Node*>& nodes) {
   auto removableNodes = parentChildrenMap(removeImplicitelyRemovedNodes(nodes));
   auto linkedGroupIdsOfRemovedGroups = std::vector<std::string>{};
 
-  auto transaction = Transaction{this};
+  auto transaction = Transaction{*this};
   while (!removableNodes.empty()) {
     linkedGroupIdsOfRemovedGroups = kdl::vec_concat(
       std::move(linkedGroupIdsOfRemovedGroups), getLinkedGroupIdsRecursively(removableNodes));
@@ -1398,7 +1398,7 @@ bool MapDocument::reparentNodes(
     nodesToRemove = kdl::map_merge(nodesToRemove, Model::parentChildrenMap(children));
   }
 
-  auto transaction = Transaction{this, "Reparent Objects"};
+  auto transaction = Transaction{*this, "Reparent Objects"};
 
   // This handles two main cases:
   // - creating brushes in a hidden layer, and then grouping / ungrouping them keeps them visible
@@ -1447,7 +1447,7 @@ bool MapDocument::checkReparenting(
 }
 
 bool MapDocument::deleteObjects() {
-  const auto transaction = Transaction{this, "Delete Objects"};
+  const auto transaction = Transaction{*this, "Delete Objects"};
   const auto nodes = m_selectedNodes.nodes();
   deselectAll();
   removeNodes(nodes);
@@ -1517,7 +1517,7 @@ void MapDocument::duplicateObjects() {
   }
 
   {
-    const auto transaction = Transaction{this, "Duplicate Objects"};
+    const auto transaction = Transaction{*this, "Duplicate Objects"};
     deselectAll();
     addNodes(nodesToAdd);
     selectNodes(nodesToSelect);
@@ -1541,7 +1541,7 @@ Model::EntityNode* MapDocument::createPointEntity(
   auto name = std::stringstream{};
   name << "Create " << definition->name();
 
-  const auto transaction = Transaction{this, name.str()};
+  const auto transaction = Transaction{*this, name.str()};
   if (addNodes({{parentForNodes(), {entityNode}}}).empty()) {
     return nullptr;
   }
@@ -1586,7 +1586,7 @@ Model::EntityNode* MapDocument::createBrushEntity(const Assets::BrushEntityDefin
 
   const auto nodes = kdl::vec_element_cast<Model::Node*>(brushes);
 
-  const auto transaction = Transaction{this, name.str()};
+  const auto transaction = Transaction{*this, name.str()};
   deselectAll();
   if (addNodes({{parentForNodes(), {entityNode}}}).empty()) {
     return nullptr;
@@ -1640,7 +1640,7 @@ Model::GroupNode* MapDocument::groupSelection(const std::string& name) {
 
   auto* group = new Model::GroupNode{Model::Group{name}};
 
-  const auto transaction = Transaction{this, "Group Selected Objects"};
+  const auto transaction = Transaction{*this, "Group Selected Objects"};
   deselectAll();
   addNodes({{parentForNodes(nodes), {group}}});
   reparentNodes({{group, nodes}});
@@ -1654,7 +1654,7 @@ void MapDocument::mergeSelectedGroupsWithGroup(Model::GroupNode* group) {
     return;
   }
 
-  const auto transaction = Transaction{this, "Merge Groups"};
+  const auto transaction = Transaction{*this, "Merge Groups"};
   const auto groupsToMerge = m_selectedNodes.groups();
 
   deselectAll();
@@ -1672,7 +1672,7 @@ void MapDocument::ungroupSelection() {
     return;
   }
 
-  const auto transaction = Transaction{this, "Ungroup"};
+  const auto transaction = Transaction{*this, "Ungroup"};
   separateSelectedLinkedGroups(false);
 
   const auto selectedNodes = m_selectedNodes.nodes();
@@ -1730,7 +1730,7 @@ void MapDocument::renameGroups(const std::string& name) {
 }
 
 void MapDocument::openGroup(Model::GroupNode* group) {
-  const auto transaction = Transaction{this, "Open Group"};
+  const auto transaction = Transaction{*this, "Open Group"};
 
   deselectAll();
   auto* previousGroup = m_editorContext->currentGroup();
@@ -1744,7 +1744,7 @@ void MapDocument::openGroup(Model::GroupNode* group) {
 }
 
 void MapDocument::closeGroup() {
-  const auto transaction = Transaction{this, "Open Group"};
+  const auto transaction = Transaction{*this, "Open Group"};
 
   deselectAll();
   auto* previousGroup = m_editorContext->currentGroup();
@@ -1764,7 +1764,7 @@ Model::GroupNode* MapDocument::createLinkedDuplicate() {
     return nullptr;
   }
 
-  const auto transaction = Transaction{this, "Create Linked Duplicate"};
+  const auto transaction = Transaction{*this, "Create Linked Duplicate"};
 
   auto* groupNode = m_selectedNodes.groups().front();
   if (!groupNode->group().linkedGroupId()) {
@@ -1824,7 +1824,7 @@ void MapDocument::selectLinkedGroups() {
 
   groupNodesToSelect = kdl::vec_sort_and_remove_duplicates(std::move(groupNodesToSelect));
 
-  auto transaction = Transaction{this, "Select Linked Groups"};
+  auto transaction = Transaction{*this, "Select Linked Groups"};
   deselectAll();
   selectNodes(groupNodesToSelect);
 }
@@ -1889,7 +1889,7 @@ void MapDocument::unlinkGroups(const std::vector<Model::GroupNode*>& groupNodes)
 }
 
 void MapDocument::separateLinkedGroups() {
-  const auto transaction = Transaction{this, "Separate Linked Groups"};
+  const auto transaction = Transaction{*this, "Separate Linked Groups"};
   separateSelectedLinkedGroups(true);
 }
 
@@ -2031,7 +2031,7 @@ bool MapDocument::moveLayerByOne(Model::LayerNode* layerNode, MoveDirection dire
 void MapDocument::moveLayer(Model::LayerNode* layer, const int offset) {
   ensure(layer != m_world->defaultLayer(), "attempted to move default layer");
 
-  const auto transaction = Transaction{this, "Move Layer"};
+  const auto transaction = Transaction{*this, "Move Layer"};
 
   const auto direction = (offset > 0) ? MoveDirection::Down : MoveDirection::Up;
   for (int i = 0; i < std::abs(offset); ++i) {
@@ -2060,7 +2060,7 @@ bool MapDocument::canMoveLayer(Model::LayerNode* layer, const int offset) const 
 }
 
 void MapDocument::moveSelectionToLayer(Model::LayerNode* layer) {
-  const auto transaction = Transaction{this, "Move Nodes to " + layer->name()};
+  const auto transaction = Transaction{*this, "Move Nodes to " + layer->name()};
 
   const auto& selectedNodes = this->selectedNodes().nodes();
 
@@ -2136,7 +2136,7 @@ bool MapDocument::canMoveSelectionToLayer(Model::LayerNode* layer) const {
 }
 
 void MapDocument::hideLayers(const std::vector<Model::LayerNode*>& layers) {
-  const auto transaction = Transaction{this, "Hide Layers"};
+  const auto transaction = Transaction{*this, "Hide Layers"};
   hide(std::vector<Model::Node*>{std::begin(layers), std::end(layers)});
 }
 
@@ -2149,7 +2149,7 @@ bool MapDocument::canHideLayers(const std::vector<Model::LayerNode*>& layers) co
 void MapDocument::isolateLayers(const std::vector<Model::LayerNode*>& layers) {
   const auto allLayers = world()->allLayers();
 
-  const auto transaction = Transaction{this, "Isolate Layers"};
+  const auto transaction = Transaction{*this, "Isolate Layers"};
   hide(std::vector<Model::Node*>{std::begin(allLayers), std::end(allLayers)});
   show(std::vector<Model::Node*>{std::begin(layers), std::end(layers)});
 }
@@ -2195,7 +2195,7 @@ void MapDocument::isolate() {
       collectNode(patch);
     }));
 
-  const auto transaction = Transaction{this, "Isolate Objects"};
+  const auto transaction = Transaction{*this, "Isolate Objects"};
   executeAndStore(SetVisibilityCommand::hide(unselectedNodes));
   executeAndStore(SetVisibilityCommand::show(selectedNodes));
 }
@@ -2221,7 +2221,7 @@ bool MapDocument::canSelectAllInLayers(const std::vector<Model::LayerNode*>& /* 
 }
 
 void MapDocument::hide(const std::vector<Model::Node*> nodes) {
-  const auto transaction = Transaction{this, "Hide Objects"};
+  const auto transaction = Transaction{*this, "Hide Objects"};
 
   // Deselect any selected nodes inside `nodes`
   deselectNodes(Model::collectSelectedNodes(nodes));
@@ -2254,7 +2254,7 @@ void MapDocument::resetVisibility(const std::vector<Model::Node*>& nodes) {
 }
 
 void MapDocument::lock(const std::vector<Model::Node*>& nodes) {
-  const auto transaction = Transaction{this, "Lock Objects"};
+  const auto transaction = Transaction{*this, "Lock Objects"};
 
   // Deselect any selected nodes or faces inside `nodes`
   deselectNodes(Model::collectSelectedNodes(nodes));
@@ -2478,7 +2478,7 @@ bool MapDocument::createBrush(const std::vector<vm::vec3>& points) {
     .and_then([&](Model::Brush&& b) {
       auto* brushNode = new Model::BrushNode{std::move(b)};
 
-      const auto transaction = Transaction{this, "Create Brush"};
+      const auto transaction = Transaction{*this, "Create Brush"};
       deselectAll();
       addNodes({{parentForNodes(), {brushNode}}});
       selectNodes({brushNode});
@@ -2538,7 +2538,7 @@ bool MapDocument::csgConvexMerge() {
 
       auto* brushNode = new Model::BrushNode{std::move(b)};
 
-      const auto transaction = Transaction{this, "CSG Convex Merge"};
+      const auto transaction = Transaction{*this, "CSG Convex Merge"};
       deselectAll();
       addNodes({{parentNode, {brushNode}}});
       removeNodes(toRemove);
@@ -2555,7 +2555,7 @@ bool MapDocument::csgSubtract() {
     return false;
   }
 
-  const auto transaction = Transaction{this, "CSG Subtract"};
+  const auto transaction = Transaction{*this, "CSG Subtract"};
   // Select touching, but don't delete the subtrahends yet
   selectTouching(false);
 
@@ -2615,7 +2615,7 @@ bool MapDocument::csgIntersect() {
 
   const auto toRemove = std::vector<Model::Node*>{std::begin(brushes), std::end(brushes)};
 
-  const auto transaction = Transaction{this, "CSG Intersect"};
+  const auto transaction = Transaction{*this, "CSG Intersect"};
   deselectNodes(toRemove);
 
   if (valid) {
@@ -2678,7 +2678,7 @@ bool MapDocument::csgHollow() {
     toRemove.push_back(sourceNode);
   }
 
-  const auto transaction = Transaction{this, "CSG Hollow"};
+  const auto transaction = Transaction{*this, "CSG Hollow"};
   deselectAll();
   const auto added = addNodes(toAdd);
   removeNodes(toRemove);
@@ -2710,7 +2710,7 @@ bool MapDocument::clipBrushes(const vm::vec3& p1, const vm::vec3& p2, const vm::
         toAdd[parentNode].push_back(new Model::BrushNode{std::move(clippedBrush)});
       }
 
-      const auto transaction = Transaction{this, "Clip Brushes"};
+      const auto transaction = Transaction{*this, "Clip Brushes"};
       deselectAll();
       removeNodes(toRemove);
 
@@ -4282,18 +4282,12 @@ void MapDocument::transactionUndone(const std::string& name) {
 }
 
 Transaction::Transaction(std::weak_ptr<MapDocument> document, std::string name)
-  : m_document{kdl::mem_lock(document).get()}
-  , m_cancelled{false} {
-  begin(std::move(name));
-}
+  : Transaction{kdl::mem_lock(document), std::move(name)} {}
 
 Transaction::Transaction(std::shared_ptr<MapDocument> document, std::string name)
-  : m_document{document.get()}
-  , m_cancelled{false} {
-  begin(std::move(name));
-}
+  : Transaction{*document, std::move(name)} {}
 
-Transaction::Transaction(MapDocument* document, std::string name)
+Transaction::Transaction(MapDocument& document, std::string name)
   : m_document{document}
   , m_cancelled{false} {
   begin(std::move(name));
@@ -4306,20 +4300,20 @@ Transaction::~Transaction() {
 }
 
 void Transaction::rollback() {
-  m_document->rollbackTransaction();
+  m_document.rollbackTransaction();
 }
 
 void Transaction::cancel() {
-  m_document->cancelTransaction();
+  m_document.cancelTransaction();
   m_cancelled = true;
 }
 
 void Transaction::begin(std::string name) {
-  m_document->startTransaction(std::move(name), TransactionScope::Oneshot);
+  m_document.startTransaction(std::move(name), TransactionScope::Oneshot);
 }
 
 void Transaction::commit() {
-  m_document->commitTransaction();
+  m_document.commitTransaction();
 }
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1562,10 +1562,7 @@ Model::EntityNode* MapDocument::createPointEntity(
   auto* entityNode = new Model::EntityNode{Model::Entity{
     m_world->entityPropertyConfig(), {{Model::EntityPropertyKeys::Classname, definition->name()}}}};
 
-  auto name = std::stringstream{};
-  name << "Create " << definition->name();
-
-  auto transaction = Transaction{*this, name.str()};
+  auto transaction = Transaction{*this, "Create " + definition->name()};
   if (addNodes({{parentForNodes(), {entityNode}}}).empty()) {
     transaction.cancel();
     return nullptr;
@@ -1608,12 +1605,9 @@ Model::EntityNode* MapDocument::createBrushEntity(const Assets::BrushEntityDefin
     m_world->entityPropertyConfig(), Model::EntityPropertyKeys::Classname, definition->name());
   auto* entityNode = new Model::EntityNode{std::move(entity)};
 
-  auto name = std::stringstream{};
-  name << "Create " << definition->name();
-
   const auto nodes = kdl::vec_element_cast<Model::Node*>(brushes);
 
-  auto transaction = Transaction{*this, name.str()};
+  auto transaction = Transaction{*this, "Create " + definition->name()};
   deselectAll();
   if (addNodes({{parentForNodes(), {entityNode}}}).empty()) {
     transaction.cancel();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -604,7 +604,7 @@ public: // command processing
 public: // transactions
   void startTransaction(std::string name, TransactionScope scope);
   void rollbackTransaction();
-  void commitTransaction();
+  bool commitTransaction();
   void cancelTransaction();
 
   virtual bool isCurrentDocumentStateObservable() const = 0;
@@ -781,7 +781,7 @@ public:
   explicit Transaction(MapDocument& document, std::string name = "");
   ~Transaction();
 
-  void commit();
+  bool commit();
   void rollback();
   void cancel();
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -602,6 +602,8 @@ public: // transactions
   void commitTransaction();
   void cancelTransaction();
 
+  virtual bool isCurrentDocumentStateObservable() const = 0;
+
 private:
   std::unique_ptr<CommandResult> execute(std::unique_ptr<Command>&& command);
   std::unique_ptr<CommandResult> executeAndStore(std::unique_ptr<UndoableCommand>&& command);

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -761,13 +761,13 @@ private: // observers
 
 class Transaction {
 private:
-  MapDocument* m_document;
+  MapDocument& m_document;
   bool m_cancelled;
 
 public:
   explicit Transaction(std::weak_ptr<MapDocument> document, std::string name = "");
   explicit Transaction(std::shared_ptr<MapDocument> document, std::string name = "");
-  explicit Transaction(MapDocument* document, std::string name = "");
+  explicit Transaction(MapDocument& document, std::string name = "");
   ~Transaction();
 
   void rollback();

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -514,7 +514,7 @@ public: // modifying objects, declared in MapFacade interface
   bool swapNodeContents(
     const std::string& commandName,
     std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
   bool swapNodeContents(
     const std::string& commandName,
     std::vector<std::pair<Model::Node*, Model::NodeContents>> nodesToSwap);

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -414,7 +414,7 @@ private:
   bool checkReparenting(const std::map<Model::Node*, std::vector<Model::Node*>>& nodesToAdd) const;
 
 public:
-  bool deleteObjects() override;
+  void deleteObjects() override;
   void duplicateObjects() override;
 
 public: // entity management
@@ -761,8 +761,14 @@ private: // observers
 
 class Transaction {
 private:
+  enum class TransactionState {
+    Running,
+    Committed,
+    Cancelled,
+  };
+
   MapDocument& m_document;
-  bool m_cancelled;
+  TransactionState m_state;
 
 public:
   explicit Transaction(std::weak_ptr<MapDocument> document, std::string name = "");
@@ -770,12 +776,12 @@ public:
   explicit Transaction(MapDocument& document, std::string name = "");
   ~Transaction();
 
+  void commit();
   void rollback();
   void cancel();
 
 private:
   void begin(std::string name);
-  void commit();
 };
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -84,6 +84,7 @@ class Selection;
 class UndoableCommand;
 class ViewEffectsService;
 enum class MapTextEncoding;
+enum class TransactionScope;
 
 struct PointFile {
   Model::PointTrace trace;
@@ -596,7 +597,7 @@ public: // command processing
   void clearRepeatableCommands();
 
 public: // transactions
-  void startTransaction(std::string name);
+  void startTransaction(std::string name, TransactionScope scope);
   void rollbackTransaction();
   void commitTransaction();
   void cancelTransaction();
@@ -614,7 +615,7 @@ private: // subclassing interface for command processing
   virtual void doRedoCommand() = 0;
 
   virtual void doClearCommandProcessor() = 0;
-  virtual void doStartTransaction(std::string name) = 0;
+  virtual void doStartTransaction(std::string name, TransactionScope scope) = 0;
   virtual void doCommitTransaction() = 0;
   virtual void doRollbackTransaction() = 0;
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -466,6 +466,11 @@ public:
 
   bool canUpdateLinkedGroups(const std::vector<Model::Node*>& nodes) const;
 
+protected:
+  void setHasPendingChanges(
+    const std::vector<Model::GroupNode*>& groupNodes, bool hasPendingChanges);
+  bool updateLinkedGroups();
+
 private:
   void separateSelectedLinkedGroups(bool relinkGroups);
 

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -540,6 +540,10 @@ void MapDocumentCommandFacade::connectObservers() {
     m_commandProcessor->transactionUndoneNotifier.connect(transactionUndoneNotifier);
 }
 
+bool MapDocumentCommandFacade::isCurrentDocumentStateObservable() const {
+  return m_commandProcessor->isCurrentDocumentStateObservable();
+}
+
 bool MapDocumentCommandFacade::doCanUndoCommand() const {
   return m_commandProcessor->canUndo();
 }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -568,8 +568,8 @@ void MapDocumentCommandFacade::doClearCommandProcessor() {
   m_commandProcessor->clear();
 }
 
-void MapDocumentCommandFacade::doStartTransaction(std::string name) {
-  m_commandProcessor->startTransaction(std::move(name));
+void MapDocumentCommandFacade::doStartTransaction(std::string name, const TransactionScope scope) {
+  m_commandProcessor->startTransaction(std::move(name), scope);
 }
 
 void MapDocumentCommandFacade::doCommitTransaction() {

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -123,7 +123,7 @@ private: // implement MapDocument interface
   void doRedoCommand() override;
 
   void doClearCommandProcessor() override;
-  void doStartTransaction(std::string name) override;
+  void doStartTransaction(std::string name, TransactionScope scope) override;
   void doCommitTransaction() override;
   void doRollbackTransaction() override;
 

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -115,6 +115,8 @@ private: // notification
   void documentWasLoaded(MapDocument* document);
 
 private: // implement MapDocument interface
+  bool isCurrentDocumentStateObservable() const override;
+
   bool doCanUndoCommand() const override;
   bool doCanRedoCommand() const override;
   const std::string& doGetUndoCommandName() const override;

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1158,7 +1158,7 @@ bool MapFrame::hasRepeatableCommands() const {
 void MapFrame::cutSelection() {
   if (canCutSelection()) {
     copyToClipboard();
-    Transaction transaction(m_document, "Cut");
+    const auto transaction = Transaction{m_document, "Cut"};
     m_document->deleteObjects();
   }
 }
@@ -1194,16 +1194,16 @@ bool MapFrame::canCopySelection() const {
 
 void MapFrame::pasteAtCursorPosition() {
   if (canPaste()) {
-    const vm::bbox3 referenceBounds = m_document->referenceBounds();
-    Transaction transaction(m_document);
+    const auto referenceBounds = m_document->referenceBounds();
+    const auto transaction = Transaction{m_document};
     if (paste() == PasteType::Node && m_document->hasSelectedNodes()) {
-      const vm::bbox3 bounds = m_document->selectionBounds();
+      const auto bounds = m_document->selectionBounds();
 
       // The pasted objects must be hidden to prevent the picking done in pasteObjectsDelta
       // from hitting them (https://github.com/TrenchBroom/TrenchBroom/issues/2755)
-      const std::vector<Model::Node*> nodes = m_document->selectedNodes().nodes();
+      const auto nodes = m_document->selectedNodes().nodes();
       m_document->hide(nodes);
-      const vm::vec3 delta = m_mapView->pasteObjectsDelta(bounds, referenceBounds);
+      const auto delta = m_mapView->pasteObjectsDelta(bounds, referenceBounds);
       m_document->show(nodes);
       m_document->selectNodes(nodes); // Hiding deselected the nodes, so reselect them
       m_document->translateObjects(delta);

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1158,8 +1158,9 @@ bool MapFrame::hasRepeatableCommands() const {
 void MapFrame::cutSelection() {
   if (canCutSelection()) {
     copyToClipboard();
-    const auto transaction = Transaction{m_document, "Cut"};
+    auto transaction = Transaction{m_document, "Cut"};
     m_document->deleteObjects();
+    transaction.commit();
   }
 }
 
@@ -1195,18 +1196,23 @@ bool MapFrame::canCopySelection() const {
 void MapFrame::pasteAtCursorPosition() {
   if (canPaste()) {
     const auto referenceBounds = m_document->referenceBounds();
-    const auto transaction = Transaction{m_document};
     if (paste() == PasteType::Node && m_document->hasSelectedNodes()) {
       const auto bounds = m_document->selectionBounds();
 
       // The pasted objects must be hidden to prevent the picking done in pasteObjectsDelta
       // from hitting them (https://github.com/TrenchBroom/TrenchBroom/issues/2755)
       const auto nodes = m_document->selectedNodes().nodes();
+
+      auto transaction = Transaction{m_document};
       m_document->hide(nodes);
       const auto delta = m_mapView->pasteObjectsDelta(bounds, referenceBounds);
       m_document->show(nodes);
       m_document->selectNodes(nodes); // Hiding deselected the nodes, so reselect them
-      m_document->translateObjects(delta);
+      if (!m_document->translateObjects(delta)) {
+        transaction.cancel();
+        return;
+      }
+      transaction.commit();
     }
   }
 }

--- a/common/src/View/MoveObjectsTool.cpp
+++ b/common/src/View/MoveObjectsTool.cpp
@@ -25,6 +25,7 @@
 #include "View/InputState.h"
 #include "View/MapDocument.h"
 #include "View/MoveObjectsToolPage.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 
@@ -50,7 +51,9 @@ bool MoveObjectsTool::startMove(const InputState& inputState) {
     return false;
   }
 
-  document->startTransaction(duplicateObjects(inputState) ? "Duplicate Objects" : "Move Objects");
+  document->startTransaction(
+    duplicateObjects(inputState) ? "Duplicate Objects" : "Move Objects",
+    TransactionScope::LongRunning);
   m_duplicateObjects = duplicateObjects(inputState);
   return true;
 }

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -22,8 +22,6 @@
 #include "Model/UpdateLinkedGroupsError.h"
 #include "View/MapDocumentCommandFacade.h"
 
-#include <kdl/result.h>
-
 namespace TrenchBroom {
 namespace View {
 std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
@@ -38,39 +36,22 @@ ReparentNodesCommand::ReparentNodesCommand(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
   std::vector<Model::GroupNode*> changedLinkedGroups)
-  : UndoableCommand("Reparent Objects", true)
+  : UpdateLinkedGroupsCommandBase("Reparent Objects", true, std::move(changedLinkedGroups))
   , m_nodesToAdd(std::move(nodesToAdd))
-  , m_nodesToRemove(std::move(nodesToRemove))
-  , m_updateLinkedGroupsHelper(std::move(changedLinkedGroups)) {}
+  , m_nodesToRemove(std::move(nodesToRemove)) {}
 
 std::unique_ptr<CommandResult> ReparentNodesCommand::doPerformDo(
   MapDocumentCommandFacade* document) {
-  doAction(document);
-
-  const auto success = m_updateLinkedGroupsHelper.applyLinkedGroupUpdates(*document).handle_errors(
-    [&](const Model::UpdateLinkedGroupsError& e) {
-      document->error() << e;
-      undoAction(document);
-    });
-
-  return std::make_unique<CommandResult>(success);
+  document->performRemoveNodes(m_nodesToRemove);
+  document->performAddNodes(m_nodesToAdd);
+  return std::make_unique<CommandResult>(true);
 }
 
 std::unique_ptr<CommandResult> ReparentNodesCommand::doPerformUndo(
   MapDocumentCommandFacade* document) {
-  undoAction(document);
-  m_updateLinkedGroupsHelper.undoLinkedGroupUpdates(*document);
-  return std::make_unique<CommandResult>(true);
-}
-
-void ReparentNodesCommand::doAction(MapDocumentCommandFacade* document) {
-  document->performRemoveNodes(m_nodesToRemove);
-  document->performAddNodes(m_nodesToAdd);
-}
-
-void ReparentNodesCommand::undoAction(MapDocumentCommandFacade* document) {
   document->performRemoveNodes(m_nodesToAdd);
   document->performAddNodes(m_nodesToRemove);
+  return std::make_unique<CommandResult>(true);
 }
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -29,7 +29,7 @@ namespace View {
 std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<const Model::GroupNode*> changedLinkedGroups) {
+  std::vector<Model::GroupNode*> changedLinkedGroups) {
   return std::make_unique<ReparentNodesCommand>(
     std::move(nodesToAdd), std::move(nodesToRemove), std::move(changedLinkedGroups));
 }
@@ -37,7 +37,7 @@ std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
 ReparentNodesCommand::ReparentNodesCommand(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : UndoableCommand("Reparent Objects", true)
   , m_nodesToAdd(std::move(nodesToAdd))
   , m_nodesToRemove(std::move(nodesToRemove))

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -26,17 +26,14 @@ namespace TrenchBroom {
 namespace View {
 std::unique_ptr<ReparentNodesCommand> ReparentNodesCommand::reparent(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
-  std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<Model::GroupNode*> changedLinkedGroups) {
-  return std::make_unique<ReparentNodesCommand>(
-    std::move(nodesToAdd), std::move(nodesToRemove), std::move(changedLinkedGroups));
+  std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove) {
+  return std::make_unique<ReparentNodesCommand>(std::move(nodesToAdd), std::move(nodesToRemove));
 }
 
 ReparentNodesCommand::ReparentNodesCommand(
   std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
-  std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : UpdateLinkedGroupsCommandBase("Reparent Objects", true, std::move(changedLinkedGroups))
+  std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove)
+  : UpdateLinkedGroupsCommandBase("Reparent Objects", true)
   , m_nodesToAdd(std::move(nodesToAdd))
   , m_nodesToRemove(std::move(nodesToRemove)) {}
 

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -20,8 +20,7 @@
 #pragma once
 
 #include "Macros.h"
-#include "View/UndoableCommand.h"
-#include "View/UpdateLinkedGroupsHelper.h"
+#include "View/UpdateLinkedGroupsCommandBase.h"
 
 #include <map>
 #include <memory>
@@ -34,11 +33,10 @@ class Node;
 } // namespace Model
 
 namespace View {
-class ReparentNodesCommand : public UndoableCommand {
+class ReparentNodesCommand : public UpdateLinkedGroupsCommandBase {
 private:
   std::map<Model::Node*, std::vector<Model::Node*>> m_nodesToAdd;
   std::map<Model::Node*, std::vector<Model::Node*>> m_nodesToRemove;
-  UpdateLinkedGroupsHelper m_updateLinkedGroupsHelper;
 
 public:
   static std::unique_ptr<ReparentNodesCommand> reparent(
@@ -54,9 +52,6 @@ public:
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
-
-  void doAction(MapDocumentCommandFacade* document);
-  void undoAction(MapDocumentCommandFacade* document);
 
   deleteCopyAndMove(ReparentNodesCommand);
 };

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -41,13 +41,11 @@ private:
 public:
   static std::unique_ptr<ReparentNodesCommand> reparent(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
-    std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove);
 
   ReparentNodesCommand(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
-    std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/ReparentNodesCommand.h
+++ b/common/src/View/ReparentNodesCommand.h
@@ -44,12 +44,12 @@ public:
   static std::unique_ptr<ReparentNodesCommand> reparent(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
   ReparentNodesCommand(
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToAdd,
     std::map<Model::Node*, std::vector<Model::Node*>> nodesToRemove,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
 private:
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -54,10 +54,10 @@ ReplaceTextureDialog::ReplaceTextureDialog(
 }
 
 void ReplaceTextureDialog::accept() {
-  const Assets::Texture* subject = m_subjectBrowser->selectedTexture();
+  const auto* subject = m_subjectBrowser->selectedTexture();
   ensure(subject != nullptr, "subject is null");
 
-  const Assets::Texture* replacement = m_replacementBrowser->selectedTexture();
+  const auto* replacement = m_replacementBrowser->selectedTexture();
   ensure(replacement != nullptr, "replacement is null");
 
   auto document = kdl::mem_lock(m_document);
@@ -69,14 +69,14 @@ void ReplaceTextureDialog::accept() {
     return;
   }
 
-  Model::ChangeBrushFaceAttributesRequest request;
+  auto request = Model::ChangeBrushFaceAttributesRequest{};
   request.setTextureName(replacement->name());
 
-  Transaction transaction(document, "Replace Textures");
+  const auto transaction = Transaction{document, "Replace Textures"};
   document->selectBrushFaces(faces);
   document->setFaceAttributes(request);
 
-  std::stringstream msg;
+  auto msg = std::stringstream{};
   msg << "Replaced texture '" << subject->name() << "' with '" << replacement->name() << "' on "
       << faces.size() << " faces.";
 

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -72,9 +72,10 @@ void ReplaceTextureDialog::accept() {
   auto request = Model::ChangeBrushFaceAttributesRequest{};
   request.setTextureName(replacement->name());
 
-  const auto transaction = Transaction{document, "Replace Textures"};
+  auto transaction = Transaction{document, "Replace Textures"};
   document->selectBrushFaces(faces);
   document->setFaceAttributes(request);
+  transaction.commit();
 
   auto msg = std::stringstream{};
   msg << "Replaced texture '" << subject->name() << "' with '" << replacement->name() << "' on "

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -74,7 +74,10 @@ void ReplaceTextureDialog::accept() {
 
   auto transaction = Transaction{document, "Replace Textures"};
   document->selectBrushFaces(faces);
-  document->setFaceAttributes(request);
+  if (!document->setFaceAttributes(request)) {
+    transaction.cancel();
+    return;
+  }
   transaction.commit();
 
   auto msg = std::stringstream{};

--- a/common/src/View/RotateObjectsTool.cpp
+++ b/common/src/View/RotateObjectsTool.cpp
@@ -24,6 +24,7 @@
 #include "View/MapDocument.h"
 #include "View/RotateObjectsHandle.h"
 #include "View/RotateObjectsToolPage.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 #include <kdl/vector_utils.h>
@@ -93,7 +94,7 @@ FloatType RotateObjectsTool::minorHandleRadius(const Renderer::Camera& camera) c
 
 void RotateObjectsTool::beginRotation() {
   auto document = kdl::mem_lock(m_document);
-  document->startTransaction("Rotate Objects");
+  document->startTransaction("Rotate Objects", TransactionScope::LongRunning);
 }
 
 void RotateObjectsTool::commitRotation() {

--- a/common/src/View/ScaleObjectsTool.cpp
+++ b/common/src/View/ScaleObjectsTool.cpp
@@ -30,6 +30,7 @@
 #include "View/Grid.h"
 #include "View/MapDocument.h"
 #include "View/ScaleObjectsToolPage.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 #include <kdl/string_utils.h>
@@ -904,7 +905,7 @@ void ScaleObjectsTool::startScaleWithHit(const Model::Hit& hit) {
   m_dragCumulativeDelta = vm::vec3::zero();
 
   auto document = kdl::mem_lock(m_document);
-  document->startTransaction("Scale Objects");
+  document->startTransaction("Scale Objects", TransactionScope::LongRunning);
   m_resizing = true;
 }
 

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -35,6 +35,7 @@
 #include "View/Grid.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 
@@ -410,7 +411,7 @@ std::unique_ptr<DragTracker> SelectionTool::acceptMouseDrag(const InputState& in
       const auto* brush = faceHandle->node();
       const auto& face = faceHandle->face();
       if (editorContext.selectable(brush, face)) {
-        document->startTransaction("Drag Select Brush Faces");
+        document->startTransaction("Drag Select Brush Faces", TransactionScope::LongRunning);
         if (document->hasSelection() && !document->hasSelectedBrushFaces()) {
           document->deselectAll();
         }
@@ -430,7 +431,7 @@ std::unique_ptr<DragTracker> SelectionTool::acceptMouseDrag(const InputState& in
 
     auto* node = findOutermostClosedGroupOrNode(Model::hitToNode(hit));
     if (editorContext.selectable(node)) {
-      document->startTransaction("Drag Select Objects");
+      document->startTransaction("Drag Select Objects", TransactionScope::LongRunning);
       if (document->hasSelection() && !document->hasSelectedNodes()) {
         document->deselectAll();
       }

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -169,6 +169,7 @@ bool SelectionTool::mouseClick(const InputState& inputState) {
               auto transaction = Transaction{document, "Select Brush Face"};
               document->convertToFaceSelection();
               document->selectBrushFaces({*faceHandle});
+              transaction.commit();
             }
           } else {
             if (face.selected()) {
@@ -181,6 +182,7 @@ bool SelectionTool::mouseClick(const InputState& inputState) {
           auto transaction = Transaction{document, "Select Brush Face"};
           document->deselectAll();
           document->selectBrushFaces({*faceHandle});
+          transaction.commit();
         }
       }
     } else {
@@ -201,11 +203,13 @@ bool SelectionTool::mouseClick(const InputState& inputState) {
               document->deselectAll();
             }
             document->selectNodes({node});
+            transaction.commit();
           }
         } else {
           auto transaction = Transaction{document, "Select Object"};
           document->deselectAll();
           document->selectNodes({node});
+          transaction.commit();
         }
       }
     } else {
@@ -241,6 +245,7 @@ bool SelectionTool::mouseDoubleClick(const InputState& inputState) {
           auto transaction = Transaction{document, "Select Brush Faces"};
           document->deselectAll();
           document->selectBrushFaces(Model::toHandles(brush));
+          transaction.commit();
         }
       }
     }
@@ -272,6 +277,7 @@ bool SelectionTool::mouseDoubleClick(const InputState& inputState) {
               auto transaction = Transaction{document, "Select Brushes"};
               document->deselectAll();
               document->selectNodes(siblings);
+              transaction.commit();
             }
           }
         }
@@ -340,6 +346,7 @@ static void drillSelection(const InputState& inputState, MapDocument& document) 
     auto transaction = Transaction{document, "Drill Selection"};
     document.deselectNodes({selectedNode});
     document.selectNodes({nextNode});
+    transaction.commit();
   }
 }
 

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -337,7 +337,7 @@ static void drillSelection(const InputState& inputState, MapDocument& document) 
   auto* nextNode = nodePair.second;
 
   if (nextNode != nullptr) {
-    auto transaction = Transaction{&document, "Drill Selection"};
+    auto transaction = Transaction{document, "Drill Selection"};
     document.deselectNodes({selectedNode});
     document.selectNodes({nextNode});
   }

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -124,7 +124,7 @@ static void transferFaceAttributes(
                        ? Model::WrapStyle::Rotation
                        : Model::WrapStyle::Projection;
 
-  const auto transaction = Transaction{document, TransferFaceAttributesTransactionName};
+  auto transaction = Transaction{document, TransferFaceAttributesTransactionName};
   document.deselectAll();
   document.selectBrushFaces(targetFaceHandles);
 
@@ -143,6 +143,7 @@ static void transferFaceAttributes(
 
   document.deselectAll();
   document.selectBrushFaces({faceToSelectAfter});
+  transaction.commit();
 }
 
 namespace {

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -120,16 +120,16 @@ static void transferFaceAttributes(
   const Model::BrushFaceHandle& sourceFaceHandle,
   const std::vector<Model::BrushFaceHandle>& targetFaceHandles,
   const Model::BrushFaceHandle& faceToSelectAfter) {
-  const Model::WrapStyle style = copyTextureAttribsRotationModifiersDown(inputState)
-                                   ? Model::WrapStyle::Rotation
-                                   : Model::WrapStyle::Projection;
+  const auto style = copyTextureAttribsRotationModifiersDown(inputState)
+                       ? Model::WrapStyle::Rotation
+                       : Model::WrapStyle::Projection;
 
-  const Transaction transaction(&document, TransferFaceAttributesTransactionName);
+  const auto transaction = Transaction{&document, TransferFaceAttributesTransactionName};
   document.deselectAll();
   document.selectBrushFaces(targetFaceHandles);
 
   if (copyTextureOnlyModifiersDown(inputState)) {
-    Model::ChangeBrushFaceAttributesRequest request;
+    auto request = Model::ChangeBrushFaceAttributesRequest{};
     request.setTextureName(sourceFaceHandle.face().attributes().textureName());
     document.setFaceAttributes(request);
   } else {

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -31,6 +31,7 @@
 #include "View/DragTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 
@@ -210,7 +211,7 @@ std::unique_ptr<DragTracker> SetBrushFaceAttributesTool::acceptMouseDrag(
     return nullptr;
   }
 
-  document->startTransaction("Drag Apply Face Attributes");
+  document->startTransaction("Drag Apply Face Attributes", TransactionScope::LongRunning);
 
   return std::make_unique<SetBrushFaceAttributesDragTracker>(
     *kdl::mem_lock(m_document), selectedFaces.front());

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -124,7 +124,7 @@ static void transferFaceAttributes(
                        ? Model::WrapStyle::Rotation
                        : Model::WrapStyle::Projection;
 
-  const auto transaction = Transaction{&document, TransferFaceAttributesTransactionName};
+  const auto transaction = Transaction{document, TransferFaceAttributesTransactionName};
   document.deselectAll();
   document.selectBrushFaces(targetFaceHandles);
 

--- a/common/src/View/ShearObjectsTool.cpp
+++ b/common/src/View/ShearObjectsTool.cpp
@@ -33,6 +33,7 @@
 #include "View/Grid.h"
 #include "View/MapDocument.h"
 #include "View/ScaleObjectsTool.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
 
@@ -173,7 +174,7 @@ void ShearObjectsTool::startShearWithHit(const Model::Hit& hit) {
   m_dragCumulativeDelta = vm::vec3::zero();
 
   auto document = kdl::mem_lock(m_document);
-  document->startTransaction("Shear Objects");
+  document->startTransaction("Shear Objects", TransactionScope::LongRunning);
   m_resizing = true;
 }
 

--- a/common/src/View/SwapNodeContentsCommand.cpp
+++ b/common/src/View/SwapNodeContentsCommand.cpp
@@ -30,9 +30,8 @@
 namespace TrenchBroom {
 namespace View {
 SwapNodeContentsCommand::SwapNodeContentsCommand(
-  const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<Model::GroupNode*> changedLinkedGroups)
-  : UpdateLinkedGroupsCommandBase(name, true, std::move(changedLinkedGroups))
+  const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes)
+  : UpdateLinkedGroupsCommandBase(name, true)
   , m_nodes(std::move(nodes)) {}
 
 SwapNodeContentsCommand::~SwapNodeContentsCommand() = default;

--- a/common/src/View/SwapNodeContentsCommand.cpp
+++ b/common/src/View/SwapNodeContentsCommand.cpp
@@ -22,7 +22,6 @@
 #include "Model/Brush.h"
 #include "Model/Entity.h"
 #include "Model/Node.h"
-#include "Model/UpdateLinkedGroupsError.h"
 #include "View/MapDocumentCommandFacade.h"
 
 #include <kdl/result.h>
@@ -33,29 +32,20 @@ namespace View {
 SwapNodeContentsCommand::SwapNodeContentsCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
   std::vector<Model::GroupNode*> changedLinkedGroups)
-  : UndoableCommand(name, true)
-  , m_nodes(std::move(nodes))
-  , m_updateLinkedGroupsHelper(std::move(changedLinkedGroups)) {}
+  : UpdateLinkedGroupsCommandBase(name, true, std::move(changedLinkedGroups))
+  , m_nodes(std::move(nodes)) {}
 
 SwapNodeContentsCommand::~SwapNodeContentsCommand() = default;
 
 std::unique_ptr<CommandResult> SwapNodeContentsCommand::doPerformDo(
   MapDocumentCommandFacade* document) {
   document->performSwapNodeContents(m_nodes);
-
-  const auto success = m_updateLinkedGroupsHelper.applyLinkedGroupUpdates(*document).handle_errors(
-    [&](const Model::UpdateLinkedGroupsError& e) {
-      document->error() << e;
-      document->performSwapNodeContents(m_nodes);
-    });
-
-  return std::make_unique<CommandResult>(success);
+  return std::make_unique<CommandResult>(true);
 }
 
 std::unique_ptr<CommandResult> SwapNodeContentsCommand::doPerformUndo(
   MapDocumentCommandFacade* document) {
   document->performSwapNodeContents(m_nodes);
-  m_updateLinkedGroupsHelper.undoLinkedGroupUpdates(*document);
   return std::make_unique<CommandResult>(true);
 }
 
@@ -71,10 +61,7 @@ bool SwapNodeContentsCommand::doCollateWith(UndoableCommand& command) {
     kdl::vec_sort(myNodes);
     kdl::vec_sort(theirNodes);
 
-    if (myNodes == theirNodes) {
-      m_updateLinkedGroupsHelper.collateWith(other->m_updateLinkedGroupsHelper);
-      return true;
-    }
+    return myNodes == theirNodes;
   }
 
   return false;

--- a/common/src/View/SwapNodeContentsCommand.cpp
+++ b/common/src/View/SwapNodeContentsCommand.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
 namespace View {
 SwapNodeContentsCommand::SwapNodeContentsCommand(
   const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-  std::vector<const Model::GroupNode*> changedLinkedGroups)
+  std::vector<Model::GroupNode*> changedLinkedGroups)
   : UndoableCommand(name, true)
   , m_nodes(std::move(nodes))
   , m_updateLinkedGroupsHelper(std::move(changedLinkedGroups)) {}

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -21,8 +21,7 @@
 
 #include "Macros.h"
 #include "Model/NodeContents.h"
-#include "View/UndoableCommand.h"
-#include "View/UpdateLinkedGroupsHelper.h"
+#include "View/UpdateLinkedGroupsCommandBase.h"
 
 #include <memory>
 #include <string>
@@ -37,10 +36,9 @@ class Node;
 } // namespace Model
 
 namespace View {
-class SwapNodeContentsCommand : public UndoableCommand {
+class SwapNodeContentsCommand : public UpdateLinkedGroupsCommandBase {
 protected:
   std::vector<std::pair<Model::Node*, Model::NodeContents>> m_nodes;
-  UpdateLinkedGroupsHelper m_updateLinkedGroupsHelper;
 
 public:
   SwapNodeContentsCommand(

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -45,7 +45,7 @@ protected:
 public:
   SwapNodeContentsCommand(
     const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<const Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups);
   ~SwapNodeContentsCommand();
 
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/SwapNodeContentsCommand.h
+++ b/common/src/View/SwapNodeContentsCommand.h
@@ -42,8 +42,7 @@ protected:
 
 public:
   SwapNodeContentsCommand(
-    const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    const std::string& name, std::vector<std::pair<Model::Node*, Model::NodeContents>> nodes);
   ~SwapNodeContentsCommand();
 
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/TransactionScope.h
+++ b/common/src/View/TransactionScope.h
@@ -1,0 +1,33 @@
+/*
+ Copyright (C) 2022 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace TrenchBroom {
+namespace View {
+
+enum class TransactionScope {
+  /** A user my only observe the initial and final state of the transaction. */
+  Oneshot,
+  /** A user may observe intermediate states of the transaction. */
+  LongRunning,
+};
+
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -27,6 +27,7 @@
 #include "View/DragTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 #include "View/UVView.h"
 
 #include <kdl/memory_utils.h>
@@ -97,7 +98,7 @@ public:
     : m_document{document}
     , m_helper{helper}
     , m_lastPoint{computeHitPoint(m_helper, inputState.pickRay())} {
-    m_document.startTransaction("Move Texture");
+    m_document.startTransaction("Move Texture", TransactionScope::LongRunning);
   }
 
   bool drag(const InputState& inputState) {

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -40,6 +40,7 @@
 #include "View/DragTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 #include "View/UVViewHelper.h"
 
 #include <kdl/memory_utils.h>
@@ -219,7 +220,7 @@ public:
     : m_document{document}
     , m_helper{helper}
     , m_initialAngle{initialAngle} {
-    document.startTransaction("Rotate Texture");
+    document.startTransaction("Rotate Texture", TransactionScope::LongRunning);
   }
 
   bool drag(const InputState& inputState) override {

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -35,6 +35,7 @@
 #include "View/DragTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 #include "View/UVOriginTool.h"
 #include "View/UVViewHelper.h"
 
@@ -186,7 +187,7 @@ public:
     , m_handle{handle}
     , m_selector{selector}
     , m_lastHitPoint{initialHitPoint} {
-    document.startTransaction("Scale Texture");
+    document.startTransaction("Scale Texture", TransactionScope::LongRunning);
   }
 
   bool drag(const InputState& inputState) override {

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -27,6 +27,7 @@
 #include "View/DragTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
+#include "View/TransactionScope.h"
 #include "View/UVViewHelper.h"
 
 #include <kdl/memory_utils.h>
@@ -94,7 +95,7 @@ public:
     , m_yAxis{yAxis}
     , m_initialHit{initialHit}
     , m_lastHit{initialHit} {
-    m_document.startTransaction("Shear Texture");
+    m_document.startTransaction("Shear Texture", TransactionScope::LongRunning);
   }
 
   bool drag(const InputState& inputState) override {

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -34,10 +34,8 @@ UndoableCommand::~UndoableCommand() {}
 
 std::unique_ptr<CommandResult> UndoableCommand::performDo(MapDocumentCommandFacade* document) {
   auto result = Command::performDo(document);
-  if (result->success() && m_modificationCount) {
-    if (document) {
-      document->incModificationCount(m_modificationCount);
-    }
+  if (result->success()) {
+    setModificationCount(document);
   }
   return result;
 }
@@ -46,9 +44,7 @@ std::unique_ptr<CommandResult> UndoableCommand::performUndo(MapDocumentCommandFa
   m_state = CommandState::Undoing;
   auto result = doPerformUndo(document);
   if (result->success()) {
-    if (document) {
-      document->decModificationCount(m_modificationCount);
-    }
+    resetModificationCount(document);
     m_state = CommandState::Default;
   } else {
     m_state = CommandState::Done;
@@ -68,5 +64,18 @@ bool UndoableCommand::collateWith(UndoableCommand& command) {
 bool UndoableCommand::doCollateWith(UndoableCommand&) {
   return false;
 }
+
+void UndoableCommand::setModificationCount(MapDocumentCommandFacade* document) {
+  if (document && m_modificationCount) {
+    document->incModificationCount(m_modificationCount);
+  }
+}
+
+void UndoableCommand::resetModificationCount(MapDocumentCommandFacade* document) {
+  if (document) {
+    document->decModificationCount(m_modificationCount);
+  }
+}
+
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/UpdateLinkedGroupsCommand.cpp
+++ b/common/src/View/UpdateLinkedGroupsCommand.cpp
@@ -1,0 +1,40 @@
+/*
+ Copyright (C) 2022 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "UpdateLinkedGroupsCommand.h"
+
+#include "View/MapDocumentCommandFacade.h"
+
+namespace TrenchBroom {
+namespace View {
+UpdateLinkedGroupsCommand::UpdateLinkedGroupsCommand(
+  std::vector<Model::GroupNode*> changedLinkedGroups)
+  : UpdateLinkedGroupsCommandBase{"Update Linked Groups", true, std::move(changedLinkedGroups)} {}
+
+UpdateLinkedGroupsCommand::~UpdateLinkedGroupsCommand() = default;
+
+std::unique_ptr<CommandResult> UpdateLinkedGroupsCommand::doPerformDo(MapDocumentCommandFacade*) {
+  return std::make_unique<CommandResult>(true);
+}
+
+std::unique_ptr<CommandResult> UpdateLinkedGroupsCommand::doPerformUndo(MapDocumentCommandFacade*) {
+  return std::make_unique<CommandResult>(true);
+}
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/UpdateLinkedGroupsCommand.h
+++ b/common/src/View/UpdateLinkedGroupsCommand.h
@@ -1,0 +1,47 @@
+/*
+ Copyright (C) 2022 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Macros.h"
+#include "Model/NodeContents.h"
+#include "View/UpdateLinkedGroupsCommandBase.h"
+
+#include <string>
+#include <vector>
+
+namespace TrenchBroom {
+namespace Model {
+class GroupNode;
+class Node;
+} // namespace Model
+
+namespace View {
+class UpdateLinkedGroupsCommand : public UpdateLinkedGroupsCommandBase {
+public:
+  UpdateLinkedGroupsCommand(std::vector<Model::GroupNode*> changedLinkedGroups);
+  ~UpdateLinkedGroupsCommand();
+
+  std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
+  std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
+
+  deleteCopyAndMove(UpdateLinkedGroupsCommand);
+};
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/UpdateLinkedGroupsCommandBase.cpp
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.cpp
@@ -1,0 +1,92 @@
+/*
+ Copyright (C) 2022 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "UpdateLinkedGroupsCommandBase.h"
+
+#include "Exceptions.h"
+#include "Model/UpdateLinkedGroupsError.h"
+#include "View/MapDocumentCommandFacade.h"
+
+#include <kdl/result.h>
+
+#include <string>
+
+namespace TrenchBroom {
+namespace View {
+UpdateLinkedGroupsCommandBase::UpdateLinkedGroupsCommandBase(
+  std::string name, const bool updateModificationCount,
+  std::vector<Model::GroupNode*> changedLinkedGroups)
+  : UndoableCommand{std::move(name), updateModificationCount}
+  , m_updateLinkedGroupsHelper{std::move(changedLinkedGroups)} {}
+
+UpdateLinkedGroupsCommandBase::~UpdateLinkedGroupsCommandBase() {}
+
+std::unique_ptr<CommandResult> UpdateLinkedGroupsCommandBase::performDo(
+  MapDocumentCommandFacade* document) {
+  // reimplemented from UndoableCommand::performDo
+  auto commandResult = Command::performDo(document);
+  if (!commandResult->success()) {
+    return commandResult;
+  }
+
+  const auto linkedGroupUpdateResult =
+    m_updateLinkedGroupsHelper.applyLinkedGroupUpdates(*document).handle_errors(
+      [&](const Model::UpdateLinkedGroupsError& e) {
+        doPerformUndo(document);
+        if (document) {
+          document->error() << e;
+        }
+      });
+
+  if (!linkedGroupUpdateResult) {
+    return std::make_unique<CommandResult>(false);
+  }
+
+  setModificationCount(document);
+
+  return commandResult;
+}
+
+std::unique_ptr<CommandResult> UpdateLinkedGroupsCommandBase::performUndo(
+  MapDocumentCommandFacade* document) {
+  auto commandResult = UndoableCommand::performUndo(document);
+  if (commandResult->success()) {
+    m_updateLinkedGroupsHelper.undoLinkedGroupUpdates(*document);
+  }
+  return commandResult;
+}
+
+bool UpdateLinkedGroupsCommandBase::collateWith(UndoableCommand& command) {
+  assert(&command != this);
+
+  if (UndoableCommand::collateWith(command)) {
+    if (
+      auto* updateLinkedGroupsCommandBase =
+        dynamic_cast<UpdateLinkedGroupsCommandBase*>(&command)) {
+      m_updateLinkedGroupsHelper.collateWith(
+        updateLinkedGroupsCommandBase->m_updateLinkedGroupsHelper);
+    }
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/UpdateLinkedGroupsCommandBase.cpp
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.cpp
@@ -22,6 +22,7 @@
 #include "Exceptions.h"
 #include "Model/UpdateLinkedGroupsError.h"
 #include "View/MapDocumentCommandFacade.h"
+#include "View/UpdateLinkedGroupsCommand.h"
 
 #include <kdl/result.h>
 
@@ -74,6 +75,11 @@ std::unique_ptr<CommandResult> UpdateLinkedGroupsCommandBase::performUndo(
 
 bool UpdateLinkedGroupsCommandBase::collateWith(UndoableCommand& command) {
   assert(&command != this);
+
+  if (auto* updateLinkedGroupsCommand = dynamic_cast<UpdateLinkedGroupsCommand*>(&command)) {
+    m_updateLinkedGroupsHelper.collateWith(updateLinkedGroupsCommand->m_updateLinkedGroupsHelper);
+    return true;
+  }
 
   if (UndoableCommand::collateWith(command)) {
     if (

--- a/common/src/View/UpdateLinkedGroupsCommandBase.h
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.h
@@ -37,7 +37,7 @@ private:
 protected:
   UpdateLinkedGroupsCommandBase(
     std::string name, bool updateModificationCount,
-    std::vector<Model::GroupNode*> changedLinkedGroups);
+    std::vector<Model::GroupNode*> changedLinkedGroups = {});
 
 public:
   virtual ~UpdateLinkedGroupsCommandBase();

--- a/common/src/View/UpdateLinkedGroupsCommandBase.h
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.h
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2010-2017 Kristian Duske
+ Copyright (C) 2022 Kristian Duske
 
  This file is part of TrenchBroom.
 
@@ -20,7 +20,8 @@
 #pragma once
 
 #include "Macros.h"
-#include "View/Command.h"
+#include "View/UndoableCommand.h"
+#include "View/UpdateLinkedGroupsHelper.h"
 
 #include <memory>
 #include <string>
@@ -29,30 +30,25 @@ namespace TrenchBroom {
 namespace View {
 class MapDocumentCommandFacade;
 
-class UndoableCommand : public Command {
+class UpdateLinkedGroupsCommandBase : public UndoableCommand {
 private:
-  size_t m_modificationCount;
+  UpdateLinkedGroupsHelper m_updateLinkedGroupsHelper;
 
 protected:
-  UndoableCommand(std::string name, bool updateModificationCount);
+  UpdateLinkedGroupsCommandBase(
+    std::string name, bool updateModificationCount,
+    std::vector<Model::GroupNode*> changedLinkedGroups);
 
 public:
-  virtual ~UndoableCommand();
+  virtual ~UpdateLinkedGroupsCommandBase();
 
   std::unique_ptr<CommandResult> performDo(MapDocumentCommandFacade* document) override;
-  virtual std::unique_ptr<CommandResult> performUndo(MapDocumentCommandFacade* document);
+  std::unique_ptr<CommandResult> performUndo(MapDocumentCommandFacade* document) override;
 
-  virtual bool collateWith(UndoableCommand& command);
+  bool collateWith(UndoableCommand& command) override;
 
-protected:
-  virtual std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) = 0;
-
-  virtual bool doCollateWith(UndoableCommand& command);
-
-  void setModificationCount(MapDocumentCommandFacade* document);
-  void resetModificationCount(MapDocumentCommandFacade* document);
-
-  deleteCopyAndMove(UndoableCommand);
+private:
+  deleteCopyAndMove(UpdateLinkedGroupsCommandBase);
 };
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/UpdateLinkedGroupsHelper.cpp
+++ b/common/src/View/UpdateLinkedGroupsHelper.cpp
@@ -38,7 +38,7 @@
 
 namespace TrenchBroom {
 namespace View {
-bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& changedLinkedGroups) {
+bool checkLinkedGroupsToUpdate(const std::vector<Model::GroupNode*>& changedLinkedGroups) {
   const auto linkedGroupIds =
     kdl::vec_sort(kdl::vec_transform(changedLinkedGroups, [](const auto* groupNode) {
       return groupNode->group().linkedGroupId();

--- a/common/src/View/UpdateLinkedGroupsHelper.h
+++ b/common/src/View/UpdateLinkedGroupsHelper.h
@@ -44,7 +44,7 @@ class MapDocumentCommandFacade;
  * The given linked groups can be updated consistently if no two of them are in the same
  * linked set.
  */
-bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& changedLinkedGroups);
+bool checkLinkedGroupsToUpdate(const std::vector<Model::GroupNode*>& changedLinkedGroups);
 
 /**
  * A helper class to add support for updating linked groups to commands.
@@ -58,7 +58,7 @@ bool checkLinkedGroupsToUpdate(const std::vector<const Model::GroupNode*>& chang
  */
 class UpdateLinkedGroupsHelper {
 private:
-  using ChangedLinkedGroups = std::vector<const Model::GroupNode*>;
+  using ChangedLinkedGroups = std::vector<Model::GroupNode*>;
   using LinkedGroupUpdates =
     std::vector<std::pair<Model::Node*, std::vector<std::unique_ptr<Model::Node>>>>;
   std::variant<ChangedLinkedGroups, LinkedGroupUpdates> m_state;

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -39,6 +39,7 @@
 #include "View/MapDocument.h"
 #include "View/Selection.h"
 #include "View/Tool.h"
+#include "View/TransactionScope.h"
 #include "View/VertexHandleManager.h"
 
 #include <kdl/memory_utils.h>
@@ -243,7 +244,7 @@ public: // performing moves
     refreshViews();
 
     auto document = kdl::mem_lock(m_document);
-    document->startTransaction(actionName());
+    document->startTransaction(actionName(), TransactionScope::LongRunning);
 
     m_dragHandlePosition = getHandlePosition(hits.front());
     m_dragging = true;

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -277,11 +277,11 @@ public: // csg convex merge
   bool canDoCsgConvexMerge() { return handleManager().selectedHandleCount() > 1; }
 
   void csgConvexMerge() {
-    std::vector<vm::vec3> vertices;
+    auto vertices = std::vector<vm::vec3>{};
     const auto handles = handleManager().selectedHandles();
     H::get_vertices(std::begin(handles), std::end(handles), std::back_inserter(vertices));
 
-    const Model::Polyhedron3 polyhedron(vertices);
+    const auto polyhedron = Model::Polyhedron3{vertices};
     if (!polyhedron.polyhedron() || !polyhedron.closed()) {
       return;
     }
@@ -289,18 +289,18 @@ public: // csg convex merge
     auto document = kdl::mem_lock(m_document);
     auto game = document->game();
 
-    const Model::BrushBuilder builder(
-      document->world()->mapFormat(), document->worldBounds(), game->defaultFaceAttribs());
+    const auto builder = Model::BrushBuilder{
+      document->world()->mapFormat(), document->worldBounds(), game->defaultFaceAttribs()};
     builder.createBrush(polyhedron, document->currentTextureName())
       .and_then([&](Model::Brush&& b) {
-        for (const Model::BrushNode* selectedBrushNode : document->selectedNodes().brushes()) {
+        for (const auto* selectedBrushNode : document->selectedNodes().brushes()) {
           b.cloneFaceAttributesFrom(selectedBrushNode->brush());
         }
 
-        Model::Node* newParent = document->parentForNodes(document->selectedNodes().nodes());
-        const Transaction transaction(document, "CSG Convex Merge");
+        auto* newParent = document->parentForNodes(document->selectedNodes().nodes());
+        const auto transaction = Transaction{document, "CSG Convex Merge"};
         deselectAll();
-        document->addNodes({{newParent, {new Model::BrushNode(std::move(b))}}});
+        document->addNodes({{newParent, {new Model::BrushNode{std::move(b)}}}});
       })
       .handle_errors([&](const Model::BrushError e) {
         document->error() << "Could not create brush: " << e;
@@ -317,9 +317,9 @@ public: // csg convex merge
 
 public:
   void moveSelection(const vm::vec3& delta) {
-    const kdl::inc_temp ignoreChangeNotifications(m_ignoreChangeNotifications);
+    const auto ignoreChangeNotifications = kdl::inc_temp{m_ignoreChangeNotifications};
 
-    Transaction transaction(m_document, actionName());
+    const auto transaction = Transaction{m_document, actionName()};
     move(delta);
   }
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -125,6 +125,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/TextOutputAdapterTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/TransformNodesTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/UndoTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/UpdateLinkedGroupsCommandTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/UpdateLinkedGroupsHelperTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/AABBTreeStressTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/AABBTreeTest.cpp"

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -299,18 +299,6 @@ void setLinkedGroupId(GroupNode& groupNode, std::string linkedGroupId) {
 } // namespace Model
 
 namespace View {
-void addNode(MapDocument& document, Model::Node* parent, Model::Node* node) {
-  document.addNodes({{parent, {node}}});
-}
-
-void removeNode(MapDocument& document, Model::Node* node) {
-  document.removeNodes({node});
-}
-
-bool reparentNodes(MapDocument& document, Model::Node* newParent, std::vector<Model::Node*> nodes) {
-  return document.reparentNodes({{newParent, std::move(nodes)}});
-}
-
 DocumentGameConfig loadMapDocument(
   const IO::Path& mapPath, const std::string& gameName, const Model::MapFormat mapFormat) {
   auto [document, game, gameConfig] = newMapDocument(gameName, mapFormat);

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -111,10 +111,6 @@ void setLinkedGroupId(GroupNode& groupNode, std::string linkedGroupId);
 namespace View {
 class MapDocument;
 
-void addNode(MapDocument& document, Model::Node* parent, Model::Node* node);
-void removeNode(MapDocument& document, Model::Node* node);
-bool reparentNodes(MapDocument& document, Model::Node* newParent, std::vector<Model::Node*> nodes);
-
 struct DocumentGameConfig {
   std::shared_ptr<MapDocument> document;
   std::shared_ptr<Model::Game> game;

--- a/common/test/src/View/AutosaverTest.cpp
+++ b/common/test/src/View/AutosaverTest.cpp
@@ -58,7 +58,7 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverNoSaveUntilSaveInter
   Autosaver autosaver(document, 10s);
 
   // modify the map
-  addNode(*document, document->currentLayer(), createBrushNode("some_texture"));
+  document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
   autosaver.triggerAutosave(logger);
 
@@ -94,7 +94,7 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAfterSaveInterv
   Autosaver autosaver(document, 100ms);
 
   // modify the map
-  addNode(*document, document->currentLayer(), createBrushNode("some_texture"));
+  document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
   // Wait for 2 seconds.
   using namespace std::chrono_literals;
@@ -118,7 +118,7 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAgainAfterSaveI
   Autosaver autosaver(document, 100ms);
 
   // modify the map
-  addNode(*document, document->currentLayer(), createBrushNode("some_texture"));
+  document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
   // Wait for 2 seconds.
   using namespace std::chrono_literals;
@@ -137,7 +137,7 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAgainAfterSaveI
   CHECK_FALSE(env.fileExists(IO::Path("autosave/test.2.map")));
 
   // modify the map
-  addNode(*document, document->currentLayer(), createBrushNode("some_texture"));
+  document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
   autosaver.triggerAutosave(logger);
   CHECK(env.fileExists(IO::Path("autosave/test.2.map")));
@@ -161,7 +161,7 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesWhenCrashFilesP
   Autosaver autosaver(document, 0s);
 
   // modify the map
-  addNode(*document, document->currentLayer(), createBrushNode("some_texture"));
+  document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
   autosaver.triggerAutosave(logger);
 

--- a/common/test/src/View/ChangeBrushFaceAttributesTest.cpp
+++ b/common/test/src/View/ChangeBrushFaceAttributesTest.cpp
@@ -38,16 +38,16 @@ namespace TrenchBroom {
 namespace View {
 TEST_CASE_METHOD(
   ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.resetAttributesOfValve220Face") {
-  Model::BrushNode* brushNode = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode);
+  auto* brushNode = createBrushNode();
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const size_t faceIndex = 0u;
-  const vm::vec3 initialX = brushNode->brush().face(faceIndex).textureXAxis();
-  const vm::vec3 initialY = brushNode->brush().face(faceIndex).textureYAxis();
+  const auto initialX = brushNode->brush().face(faceIndex).textureXAxis();
+  const auto initialY = brushNode->brush().face(faceIndex).textureYAxis();
 
   document->selectBrushFaces({{brushNode, faceIndex}});
 
-  Model::ChangeBrushFaceAttributesRequest rotate;
+  auto rotate = Model::ChangeBrushFaceAttributesRequest{};
   rotate.addRotation(2.0);
   for (size_t i = 0; i < 5; ++i) {
     document->setFaceAttributes(rotate);
@@ -55,12 +55,12 @@ TEST_CASE_METHOD(
 
   CHECK(brushNode->brush().face(faceIndex).attributes().rotation() == 10.0f);
 
-  Model::BrushFaceAttributes defaultFaceAttrs(Model::BrushFaceAttributes::NoTextureName);
+  auto defaultFaceAttrs = Model::BrushFaceAttributes{Model::BrushFaceAttributes::NoTextureName};
   defaultFaceAttrs.setXScale(0.5f);
   defaultFaceAttrs.setYScale(2.0f);
   game->setDefaultFaceAttributes(defaultFaceAttrs);
 
-  Model::ChangeBrushFaceAttributesRequest reset;
+  auto reset = Model::ChangeBrushFaceAttributesRequest{};
   reset.resetAll(defaultFaceAttrs);
 
   document->setFaceAttributes(reset);
@@ -76,45 +76,43 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.undoRedo") {
-  Model::BrushNode* brushNode = createBrushNode("original");
-  addNode(*document, document->parentForNodes(), brushNode);
+  auto* brushNode = createBrushNode("original");
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
-  const auto requireTexture = [&](const std::string& textureName) {
-    for (const auto& face : brushNode->brush().faces()) {
-      REQUIRE(face.attributes().textureName() == textureName);
-    }
-  };
-
-  const auto checkTexture = [&](const std::string& textureName) {
-    for (const auto& face : brushNode->brush().faces()) {
-      CHECK(face.attributes().textureName() == textureName);
-    }
-  };
-
-  requireTexture("original");
+  for (const auto& face : brushNode->brush().faces()) {
+    REQUIRE(face.attributes().textureName() == "original");
+  }
 
   document->selectNodes({brushNode});
 
-  Model::ChangeBrushFaceAttributesRequest setTexture1;
+  auto setTexture1 = Model::ChangeBrushFaceAttributesRequest{};
   setTexture1.setTextureName("texture1");
   document->setFaceAttributes(setTexture1);
-  requireTexture("texture1");
+  for (const auto& face : brushNode->brush().faces()) {
+    REQUIRE(face.attributes().textureName() == "texture1");
+  }
 
-  Model::ChangeBrushFaceAttributesRequest setTexture2;
+  auto setTexture2 = Model::ChangeBrushFaceAttributesRequest{};
   setTexture2.setTextureName("texture2");
   document->setFaceAttributes(setTexture2);
-  requireTexture("texture2");
+  for (const auto& face : brushNode->brush().faces()) {
+    REQUIRE(face.attributes().textureName() == "texture2");
+  }
 
   document->undoCommand();
-  checkTexture("original");
+  for (const auto& face : brushNode->brush().faces()) {
+    CHECK(face.attributes().textureName() == "original");
+  }
 
   document->redoCommand();
-  checkTexture("texture2");
+  for (const auto& face : brushNode->brush().faces()) {
+    CHECK(face.attributes().textureName() == "texture2");
+  }
 }
 
 TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
-  Model::BrushNode* brushNode = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode);
+  auto* brushNode = createBrushNode();
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const size_t firstFaceIndex = 0u;
   const size_t secondFaceIndex = 1u;
@@ -122,7 +120,8 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
 
   document->deselectAll();
   document->selectBrushFaces({{brushNode, firstFaceIndex}});
-  Model::ChangeBrushFaceAttributesRequest setFirstFace;
+
+  auto setFirstFace = Model::ChangeBrushFaceAttributesRequest{};
   setFirstFace.setTextureName("first");
   setFirstFace.setXOffset(32.0f);
   setFirstFace.setYOffset(64.0f);
@@ -132,8 +131,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
   setFirstFace.replaceSurfaceFlags(63u);
   setFirstFace.replaceContentFlags(12u);
   setFirstFace.setSurfaceValue(3.14f);
-  const Color firstColor(1.0f, 1.0f, 1.0f, 1.0f);
-  setFirstFace.setColor(firstColor);
+  setFirstFace.setColor(Color{1.0f, 1.0f, 1.0f, 1.0f});
   document->setFaceAttributes(setFirstFace);
 
   {
@@ -147,12 +145,13 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
     CHECK(firstAttrs.surfaceFlags() == 63u);
     CHECK(firstAttrs.surfaceContents() == 12u);
     CHECK(firstAttrs.surfaceValue() == 3.14f);
-    CHECK(firstAttrs.color() == firstColor);
+    CHECK(firstAttrs.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
   }
 
   document->deselectAll();
   document->selectBrushFaces({{brushNode, secondFaceIndex}});
-  Model::ChangeBrushFaceAttributesRequest setSecondFace;
+
+  auto setSecondFace = Model::ChangeBrushFaceAttributesRequest{};
   setSecondFace.setTextureName("second");
   setSecondFace.setXOffset(16.0f);
   setSecondFace.setYOffset(48.0f);
@@ -162,8 +161,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
   setSecondFace.replaceSurfaceFlags(18u);
   setSecondFace.replaceContentFlags(2048u);
   setSecondFace.setSurfaceValue(1.0f);
-  const Color secondColor(0.5f, 0.5f, 0.5f, 0.5f);
-  setSecondFace.setColor(secondColor);
+  setSecondFace.setColor(Color{0.5f, 0.5f, 0.5f, 0.5f});
   document->setFaceAttributes(setSecondFace);
 
   {
@@ -177,35 +175,33 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
     CHECK(secondAttrs.surfaceFlags() == 18u);
     CHECK(secondAttrs.surfaceContents() == 2048u);
     CHECK(secondAttrs.surfaceValue() == 1.0f);
-    CHECK(secondAttrs.color() == secondColor);
+    CHECK(secondAttrs.color() == Color{0.5f, 0.5f, 0.5f, 0.5f});
   }
 
   document->deselectAll();
   document->selectBrushFaces({{brushNode, thirdFaceIndex}});
-  Model::ChangeBrushFaceAttributesRequest copySecondToThirdFace;
+
+  auto copySecondToThirdFace = Model::ChangeBrushFaceAttributesRequest{};
   copySecondToThirdFace.setAll(brushNode->brush().face(secondFaceIndex));
   document->setFaceAttributes(copySecondToThirdFace);
 
-  {
-    const auto& secondAttrs = brushNode->brush().face(secondFaceIndex).attributes();
-    const auto& thirdAttrs = brushNode->brush().face(thirdFaceIndex).attributes();
-    CHECK(thirdAttrs == secondAttrs);
-  }
+  CHECK(
+    brushNode->brush().face(thirdFaceIndex).attributes() ==
+    brushNode->brush().face(secondFaceIndex).attributes());
 
   auto thirdFaceContentsFlags =
     brushNode->brush().face(thirdFaceIndex).attributes().surfaceContents();
 
   document->deselectAll();
   document->selectBrushFaces({{brushNode, secondFaceIndex}});
-  Model::ChangeBrushFaceAttributesRequest copyFirstToSecondFace;
+
+  auto copyFirstToSecondFace = Model::ChangeBrushFaceAttributesRequest{};
   copyFirstToSecondFace.setAll(brushNode->brush().face(firstFaceIndex));
   document->setFaceAttributes(copyFirstToSecondFace);
 
-  {
-    const auto& firstAttrs = brushNode->brush().face(firstFaceIndex).attributes();
-    const auto& newSecondAttrs = brushNode->brush().face(secondFaceIndex).attributes();
-    CHECK(newSecondAttrs == firstAttrs);
-  }
+  CHECK(
+    brushNode->brush().face(secondFaceIndex).attributes() ==
+    brushNode->brush().face(firstFaceIndex).attributes());
 
   document->deselectAll();
   document->selectBrushFaces({{brushNode, thirdFaceIndex}});
@@ -231,13 +227,13 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setAll") {
 
 TEST_CASE_METHOD(
   ValveMapDocumentTest, "ChangeBrushFaceAttributesTest.setTextureKeepsSurfaceFlagsUnset") {
-  Model::BrushNode* brushNode = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode);
+  auto* brushNode = createBrushNode();
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   document->selectNodes({brushNode});
   CHECK(!brushNode->brush().face(0).attributes().hasSurfaceAttributes());
 
-  Model::ChangeBrushFaceAttributesRequest request;
+  auto request = Model::ChangeBrushFaceAttributesRequest{};
   request.setTextureName("something_else");
   document->setFaceAttributes(request);
 
@@ -284,7 +280,7 @@ TEST_CASE("ChangeBrushFaceAttributesTest.Quake2IntegrationTest") {
   SECTION("setting a content flag when the existing one is inherited keeps the existing one") {
     document->selectNodes({lavabrush});
 
-    Model::ChangeBrushFaceAttributesRequest request;
+    auto request = Model::ChangeBrushFaceAttributesRequest{};
     request.setContentFlags(WaterFlag);
     CHECK(document->setFaceAttributes(request));
 

--- a/common/test/src/View/CopyPasteTest.cpp
+++ b/common/test/src/View/CopyPasteTest.cpp
@@ -233,7 +233,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteAndTranslateGroup") {
   const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
   auto* brushNode1 = new Model::BrushNode(builder.createCuboid(box, "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   const auto groupName = std::string("testGroup");
@@ -261,7 +261,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteInGroup", "[CopyPasteTest]
                          "}");
 
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush);
+  document->addNodes({{document->parentForNodes(), {brush}}});
   document->selectNodes({brush});
 
   Model::GroupNode* group = document->groupSelection("test");

--- a/common/test/src/View/CsgTest.cpp
+++ b/common/test/src/View/CsgTest.cpp
@@ -39,14 +39,14 @@ TEST_CASE_METHOD(MapDocumentTest, "CsgTest.csgConvexMergeBrushes") {
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   auto* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   auto* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture").value());
   auto* brushNode2 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, entity, brushNode1);
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{entity, {brushNode1}}});
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
   CHECK(entity->children().size() == 1u);
 
   document->selectNodes({brushNode1, brushNode2});
@@ -61,14 +61,14 @@ TEST_CASE_METHOD(MapDocumentTest, "CsgTest.csgConvexMergeFaces") {
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   auto* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   auto* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture").value());
   auto* brushNode2 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, entity, brushNode1);
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{entity, {brushNode1}}});
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
   CHECK(entity->children().size() == 1u);
 
   const auto faceIndex = 0u;
@@ -101,7 +101,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ValveMapDocumentTest.csgConvexMergeTextu
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   Model::ParallelTexCoordSystem texAlignment(vm::vec3(1, 0, 0), vm::vec3(0, 1, 0));
   auto texAlignmentSnapshot = texAlignment.takeSnapshot();
@@ -119,8 +119,8 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ValveMapDocumentTest.csgConvexMergeTextu
   Model::BrushNode* brushNode1 = new Model::BrushNode(std::move(brush1));
   Model::BrushNode* brushNode2 = new Model::BrushNode(std::move(brush2));
 
-  addNode(*document, entity, brushNode1);
-  addNode(*document, entity, brushNode2);
+  document->addNodes({{entity, {brushNode1}}});
+  document->addNodes({{entity, {brushNode2}}});
   CHECK(entity->children().size() == 2u);
 
   document->selectNodes({brushNode1, brushNode2});
@@ -139,7 +139,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ValveMapDocumentTest.csgSubtractTexturin
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   Model::ParallelTexCoordSystem texAlignment(vm::vec3(1, 0, 0), vm::vec3(0, 1, 0));
   auto texAlignmentSnapshot = texAlignment.takeSnapshot();
@@ -154,8 +154,8 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ValveMapDocumentTest.csgSubtractTexturin
   Model::BrushNode* brushNode1 = new Model::BrushNode(std::move(brush1));
   Model::BrushNode* brushNode2 = new Model::BrushNode(std::move(brush2));
 
-  addNode(*document, entity, brushNode1);
-  addNode(*document, entity, brushNode2);
+  document->addNodes({{entity, {brushNode1}}});
+  document->addNodes({{entity, {brushNode2}}});
   CHECK(entity->children().size() == 2u);
 
   // we want to compute brush1 - brush2
@@ -179,7 +179,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CsgTest.csgSubtractMultipleBrushes") {
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   auto* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   Model::BrushNode* minuend = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
@@ -216,11 +216,11 @@ TEST_CASE_METHOD(MapDocumentTest, "CsgTest.csgSubtractAndUndoRestoresSelection")
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   auto* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   Model::BrushNode* subtrahend1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, entity, subtrahend1);
+  document->addNodes({{entity, {subtrahend1}}});
 
   document->selectNodes({subtrahend1});
   CHECK(document->csgSubtract());

--- a/common/test/src/View/ExtrudeToolTest.cpp
+++ b/common/test/src/View/ExtrudeToolTest.cpp
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ExtrudeToolTest.pick2D") {
   auto builder = Model::BrushBuilder{document->world()->mapFormat(), document->worldBounds()};
   auto* brushNode1 = new Model::BrushNode{builder.createCuboid(brushBounds, "texture").value()};
 
-  addNode(*document, document->currentLayer(), brushNode1);
+  document->addNodes({{document->currentLayer(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   SECTION("Pick ray hits brush directly") {
@@ -123,7 +123,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "ExtrudeToolTest.pick3D") {
   auto builder = Model::BrushBuilder{document->world()->mapFormat(), document->worldBounds()};
   auto* brushNode1 = new Model::BrushNode{builder.createCuboid(brushBounds, "texture").value()};
 
-  addNode(*document, document->currentLayer(), brushNode1);
+  document->addNodes({{document->currentLayer(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   SECTION("Pick ray hits brush directly") {

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -61,7 +61,7 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.createGroupWithOneNode", "[Gro
     }});
 
   auto* node = createNode(*this);
-  addNode(*document, document->parentForNodes(), node);
+  document->addNodes({{document->parentForNodes(), {node}}});
   document->selectNodes({node});
 
   Model::GroupNode* group = document->groupSelection("test");
@@ -80,14 +80,14 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.createGroupWithOneNode", "[Gro
 TEST_CASE_METHOD(
   MapDocumentTest, "GroupNodesTest.createGroupWithPartialBrushEntity", "[GroupNodesTest]") {
   Model::BrushNode* child1 = createBrushNode();
-  addNode(*document, document->parentForNodes(), child1);
+  document->addNodes({{document->parentForNodes(), {child1}}});
 
   Model::PatchNode* child2 = createPatchNode();
-  addNode(*document, document->parentForNodes(), child2);
+  document->addNodes({{document->parentForNodes(), {child2}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
-  reparentNodes(*document, entity, {child1, child2});
+  document->addNodes({{document->parentForNodes(), {entity}}});
+  document->reparentNodes({{entity, {child1, child2}}});
 
   document->selectNodes({child1});
 
@@ -112,14 +112,14 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
   MapDocumentTest, "GroupNodesTest.createGroupWithFullBrushEntity", "[GroupNodesTest]") {
   Model::BrushNode* child1 = createBrushNode();
-  addNode(*document, document->parentForNodes(), child1);
+  document->addNodes({{document->parentForNodes(), {child1}}});
 
   Model::PatchNode* child2 = createPatchNode();
-  addNode(*document, document->parentForNodes(), child2);
+  document->addNodes({{document->parentForNodes(), {child2}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
-  reparentNodes(*document, entity, {child1, child2});
+  document->addNodes({{document->parentForNodes(), {entity}}});
+  document->reparentNodes({{entity, {child1, child2}}});
 
   document->selectNodes({child1, child2});
 
@@ -157,11 +157,11 @@ TEST_CASE_METHOD(
   // Test for issue #1715
 
   Model::BrushNode* brush1 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush1);
+  document->addNodes({{document->parentForNodes(), {brush1}}});
 
   Model::EntityNode* entityNode = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entityNode);
-  reparentNodes(*document, entityNode, {brush1});
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
+  document->reparentNodes({{entityNode, {brush1}}});
 
   document->selectNodes({brush1});
 
@@ -182,11 +182,11 @@ TEST_CASE_METHOD(
   // Test for issue #1754
 
   Model::BrushNode* brush1 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush1);
+  document->addNodes({{document->parentForNodes(), {brush1}}});
 
   Model::EntityNode* entityNode = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entityNode);
-  reparentNodes(*document, entityNode, {brush1});
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
+  document->reparentNodes({{entityNode, {brush1}}});
 
   document->selectNodes({brush1});
 
@@ -204,7 +204,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.renameGroup", "[GroupNodesTest]") {
   Model::BrushNode* brush1 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush1);
+  document->addNodes({{document->parentForNodes(), {brush1}}});
   document->selectNodes({brush1});
 
   Model::GroupNode* group = document->groupSelection("test");
@@ -221,7 +221,7 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.renameGroup", "[GroupNodesTest
 
 TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.duplicateNodeInGroup", "[GroupNodesTest]") {
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush);
+  document->addNodes({{document->parentForNodes(), {brush}}});
   document->selectNodes({brush});
 
   Model::GroupNode* group = document->groupSelection("test");
@@ -243,15 +243,15 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupInnerGroup") {
   Model::EntityNode* innerEnt1 = new Model::EntityNode{Model::Entity{}};
   Model::EntityNode* innerEnt2 = new Model::EntityNode{Model::Entity{}};
 
-  addNode(*document, document->parentForNodes(), innerEnt1);
-  addNode(*document, document->parentForNodes(), innerEnt2);
+  document->addNodes({{document->parentForNodes(), {innerEnt1}}});
+  document->addNodes({{document->parentForNodes(), {innerEnt2}}});
   document->selectNodes({innerEnt1, innerEnt2});
 
   Model::GroupNode* inner = document->groupSelection("Inner");
 
   document->deselectAll();
-  addNode(*document, document->parentForNodes(), outerEnt1);
-  addNode(*document, document->parentForNodes(), outerEnt2);
+  document->addNodes({{document->parentForNodes(), {outerEnt1}}});
+  document->addNodes({{document->parentForNodes(), {outerEnt2}}});
   document->selectNodes({inner, outerEnt1, outerEnt2});
 
   Model::GroupNode* outer = document->groupSelection("Outer");
@@ -293,7 +293,7 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupInnerGroup") {
 TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLeavesPointEntitySelected") {
   Model::EntityNode* ent1 = new Model::EntityNode{Model::Entity{}};
 
-  addNode(*document, document->parentForNodes(), ent1);
+  document->addNodes({{document->parentForNodes(), {ent1}}});
   document->selectNodes({ent1});
 
   Model::GroupNode* group = document->groupSelection("Group");
@@ -307,11 +307,11 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLeavesBrushEntitySelect
   const Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
 
   Model::EntityNode* ent1 = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), ent1);
+  document->addNodes({{document->parentForNodes(), {ent1}}});
 
   Model::BrushNode* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, ent1, brushNode1);
+  document->addNodes({{ent1, {brushNode1}}});
   document->selectNodes({ent1});
   CHECK_THAT(
     document->selectedNodes().nodes(), Catch::Equals(std::vector<Model::Node*>{brushNode1}));
@@ -338,8 +338,8 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupGroupAndPointEntity") {
   auto* ent1 = new Model::EntityNode{Model::Entity{}};
   auto* ent2 = new Model::EntityNode{Model::Entity{}};
 
-  addNode(*document, document->parentForNodes(), ent1);
-  addNode(*document, document->parentForNodes(), ent2);
+  document->addNodes({{document->parentForNodes(), {ent1}}});
+  document->addNodes({{document->parentForNodes(), {ent2}}});
   document->selectNodes({ent1});
 
   auto* group = document->groupSelection("Group");
@@ -359,13 +359,13 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.mergeGroups") {
   document->deleteObjects();
 
   Model::EntityNode* ent1 = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), ent1);
+  document->addNodes({{document->parentForNodes(), {ent1}}});
   document->deselectAll();
   document->selectNodes({ent1});
   Model::GroupNode* group1 = document->groupSelection("group1");
 
   Model::EntityNode* ent2 = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), ent2);
+  document->addNodes({{document->parentForNodes(), {ent2}}});
   document->deselectAll();
   document->selectNodes({ent2});
   Model::GroupNode* group2 = document->groupSelection("group2");
@@ -627,7 +627,7 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups", "[GroupNodes
 
 TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.newWithGroupOpen") {
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
   document->selectNodes({entity});
   Model::GroupNode* group = document->groupSelection("my group");
   document->openGroup(group);

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -770,7 +770,7 @@ TEST_CASE_METHOD(
     // create a new point entity below the origin -- this entity is temporarily created at the
     // origin and then moved to its eventual position, but the entity at the origin is propagated
     // into the linked group, where it ends up out of  world bounds
-    CHECK(document->createPointEntity(m_pointEntityDef, {0, 0, -32}) == nullptr);
+    CHECK(document->createPointEntity(m_pointEntityDef, {0, 0, -32}) != nullptr);
   }
 
   SECTION("create brush entity") {
@@ -785,7 +785,7 @@ TEST_CASE_METHOD(
 
     // create a brush entity - a temporarily empty entity will be created at the origin and
     // propagated into the linked group, where it ends up out of world bounds and thus failing
-    CHECK(document->createBrushEntity(m_brushEntityDef) == nullptr);
+    CHECK(document->createBrushEntity(m_brushEntityDef) != nullptr);
   }
 }
 } // namespace View

--- a/common/test/src/View/LayerNodesTest.cpp
+++ b/common/test/src/View/LayerNodesTest.cpp
@@ -55,7 +55,7 @@ TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.renameLayer", "[LayerNodesTest]
   document->deleteObjects();
 
   Model::LayerNode* layerNode = new Model::LayerNode(Model::Layer("test1"));
-  addNode(*document, document->world(), layerNode);
+  document->addNodes({{document->world(), {layerNode}}});
   CHECK(layerNode->name() == "test1");
 
   document->renameLayer(layerNode, "test2");
@@ -73,8 +73,8 @@ TEST_CASE_METHOD(
 
   Model::LayerNode* layerNode1 = new Model::LayerNode(Model::Layer("test1"));
   Model::LayerNode* layerNode2 = new Model::LayerNode(Model::Layer("test2"));
-  addNode(*document, document->world(), layerNode1);
-  addNode(*document, document->world(), layerNode2);
+  document->addNodes({{document->world(), {layerNode1}}});
+  document->addNodes({{document->world(), {layerNode2}}});
 
   document->setCurrentLayer(layerNode1);
   Model::EntityNode* entity = document->createPointEntity(m_pointEntityDef, vm::vec3::zero());
@@ -99,8 +99,8 @@ TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.newGroupGoesIntoSourceLayer", "
 
   Model::LayerNode* layerNode1 = new Model::LayerNode(Model::Layer("test1"));
   Model::LayerNode* layerNode2 = new Model::LayerNode(Model::Layer("test2"));
-  addNode(*document, document->world(), layerNode1);
-  addNode(*document, document->world(), layerNode2);
+  document->addNodes({{document->world(), {layerNode1}}});
+  document->addNodes({{document->world(), {layerNode2}}});
 
   document->setCurrentLayer(layerNode1);
   Model::EntityNode* entity = document->createPointEntity(m_pointEntityDef, vm::vec3::zero());
@@ -126,8 +126,8 @@ TEST_CASE_METHOD(
 
   Model::LayerNode* layerNode1 = new Model::LayerNode(Model::Layer("test1"));
   Model::LayerNode* layerNode2 = new Model::LayerNode(Model::Layer("test2"));
-  addNode(*document, document->world(), layerNode1);
-  addNode(*document, document->world(), layerNode2);
+  document->addNodes({{document->world(), {layerNode1}}});
+  document->addNodes({{document->world(), {layerNode2}}});
 
   document->setCurrentLayer(layerNode1);
 
@@ -195,7 +195,7 @@ TEST_CASE_METHOD(
   document->deleteObjects();
 
   Model::LayerNode* layerNode1 = new Model::LayerNode(Model::Layer("test1"));
-  addNode(*document, document->world(), layerNode1);
+  document->addNodes({{document->world(), {layerNode1}}});
 
   document->setCurrentLayer(layerNode1);
   document->hideLayers({layerNode1});
@@ -203,7 +203,7 @@ TEST_CASE_METHOD(
   // Create entity1 and brush1 in the hidden layer1
   Model::EntityNode* entity1 = document->createPointEntity(m_pointEntityDef, vm::vec3::zero());
   Model::BrushNode* brush1 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush1);
+  document->addNodes({{document->parentForNodes(), {brush1}}});
 
   CHECK(entity1->parent() == layerNode1);
   CHECK(brush1->parent() == layerNode1);
@@ -241,8 +241,8 @@ TEST_CASE_METHOD(
 
   auto* layerNode1 = new Model::LayerNode(Model::Layer("test1"));
   auto* layerNode2 = new Model::LayerNode(Model::Layer("test2"));
-  addNode(*document, document->world(), layerNode1);
-  addNode(*document, document->world(), layerNode2);
+  document->addNodes({{document->world(), {layerNode1}}});
+  document->addNodes({{document->world(), {layerNode2}}});
 
   document->setCurrentLayer(layerNode1);
 
@@ -317,9 +317,9 @@ TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.moveLayer", "[LayerNodesTest]")
   setLayerSortIndex(*layerNode1, 1);
   setLayerSortIndex(*layerNode2, 2);
 
-  addNode(*document, document->world(), layerNode0);
-  addNode(*document, document->world(), layerNode1);
-  addNode(*document, document->world(), layerNode2);
+  document->addNodes({{document->world(), {layerNode0}}});
+  document->addNodes({{document->world(), {layerNode1}}});
+  document->addNodes({{document->world(), {layerNode2}}});
 
   SECTION("check canMoveLayer") {
     // defaultLayer() can never be moved
@@ -365,7 +365,7 @@ TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.moveSelectionToLayer", "[LayerN
   document->deleteObjects();
 
   auto* customLayer = new Model::LayerNode(Model::Layer("layer"));
-  addNode(*document, document->world(), customLayer);
+  document->addNodes({{document->world(), {customLayer}}});
 
   auto* defaultLayer = document->world()->defaultLayer();
 
@@ -483,8 +483,8 @@ TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.setCurrentLayerCollation", "[La
   auto* defaultLayerNode = document->world()->defaultLayer();
   auto* layerNode1 = new Model::LayerNode(Model::Layer("test1"));
   auto* layerNode2 = new Model::LayerNode(Model::Layer("test2"));
-  addNode(*document, document->world(), layerNode1);
-  addNode(*document, document->world(), layerNode2);
+  document->addNodes({{document->world(), {layerNode1}}});
+  document->addNodes({{document->world(), {layerNode2}}});
   CHECK(document->currentLayer() == defaultLayerNode);
 
   document->setCurrentLayer(layerNode1);

--- a/common/test/src/View/PickingTest.cpp
+++ b/common/test/src/View/PickingTest.cpp
@@ -54,7 +54,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickSingleBrush") {
 
   auto* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   Model::PickResult pickResult;
   document->pick(vm::ray3(vm::vec3(-32, 0, 0), vm::vec3::pos_x()), pickResult);
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickSingleEntity") {
   document->deleteObjects();
 
   Model::EntityNode* ent1 = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), ent1);
+  document->addNodes({{document->parentForNodes(), {ent1}}});
 
   const auto origin = ent1->entity().origin();
   const auto bounds = ent1->logicalBounds();
@@ -111,7 +111,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickSimpleGroup") {
 
   auto* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   auto* brushNode2 = new Model::BrushNode(
     builder
@@ -119,7 +119,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickSimpleGroup") {
         vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)),
         "texture")
       .value());
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   document->selectAllNodes();
   auto* group = document->groupSelection("test");
@@ -185,7 +185,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickNestedGroup") {
 
   auto* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   auto* brushNode2 = new Model::BrushNode(
     builder
@@ -193,7 +193,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickNestedGroup") {
         vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)),
         "texture")
       .value());
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   document->selectAllNodes();
   auto* innerGroup = document->groupSelection("inner");
@@ -205,7 +205,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickNestedGroup") {
         vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 256)),
         "texture")
       .value());
-  addNode(*document, document->parentForNodes(), brushNode3);
+  document->addNodes({{document->parentForNodes(), {brushNode3}}});
 
   document->selectAllNodes();
   auto* outerGroup = document->groupSelection("outer");
@@ -348,7 +348,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickBrushEntity") {
 
   auto* brushNode1 = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   auto* brushNode2 = new Model::BrushNode(
     builder
@@ -356,7 +356,7 @@ TEST_CASE_METHOD(MapDocumentTest, "PickingTest.pickBrushEntity") {
         vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)),
         "texture")
       .value());
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   document->selectAllNodes();
 

--- a/common/test/src/View/RemoveNodesTest.cpp
+++ b/common/test/src/View/RemoveNodesTest.cpp
@@ -73,9 +73,9 @@ TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeNodes") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeLayer") {
   Model::LayerNode* layer = new Model::LayerNode(Model::Layer("Layer 1"));
-  addNode(*document, document->world(), layer);
+  document->addNodes({{document->world(), {layer}}});
 
-  removeNode(*document, layer);
+  document->removeNodes({layer});
   CHECK(layer->parent() == nullptr);
 
   document->undoCommand();
@@ -84,15 +84,15 @@ TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeLayer") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeEmptyBrushEntity") {
   Model::LayerNode* layer = new Model::LayerNode(Model::Layer("Layer 1"));
-  addNode(*document, document->world(), layer);
+  document->addNodes({{document->world(), {layer}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, layer, entity);
+  document->addNodes({{layer, {entity}}});
 
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, entity, brush);
+  document->addNodes({{entity, {brush}}});
 
-  removeNode(*document, brush);
+  document->removeNodes({brush});
   CHECK(brush->parent() == nullptr);
   CHECK(entity->parent() == nullptr);
 
@@ -103,14 +103,14 @@ TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeEmptyBrushEntity") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeEmptyGroup") {
   Model::GroupNode* group = new Model::GroupNode(Model::Group("group"));
-  addNode(*document, document->parentForNodes(), group);
+  document->addNodes({{document->parentForNodes(), {group}}});
 
   document->openGroup(group);
 
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush);
+  document->addNodes({{document->parentForNodes(), {brush}}});
 
-  removeNode(*document, brush);
+  document->removeNodes({brush});
   CHECK(document->currentGroup() == nullptr);
   CHECK(brush->parent() == nullptr);
   CHECK(group->parent() == nullptr);
@@ -123,19 +123,19 @@ TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.removeEmptyGroup") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RemoveNodesTest.recursivelyRemoveEmptyGroups") {
   Model::GroupNode* outer = new Model::GroupNode(Model::Group("outer"));
-  addNode(*document, document->parentForNodes(), outer);
+  document->addNodes({{document->parentForNodes(), {outer}}});
 
   document->openGroup(outer);
 
   Model::GroupNode* inner = new Model::GroupNode(Model::Group("inner"));
-  addNode(*document, document->parentForNodes(), inner);
+  document->addNodes({{document->parentForNodes(), {inner}}});
 
   document->openGroup(inner);
 
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, document->parentForNodes(), brush);
+  document->addNodes({{document->parentForNodes(), {brush}}});
 
-  removeNode(*document, brush);
+  document->removeNodes({brush});
   CHECK(document->currentGroup() == nullptr);
   CHECK(brush->parent() == nullptr);
   CHECK(inner->parent() == nullptr);

--- a/common/test/src/View/ReparentNodesTest.cpp
+++ b/common/test/src/View/ReparentNodesTest.cpp
@@ -33,26 +33,26 @@ namespace TrenchBroom {
 namespace View {
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.reparentLayerToLayer") {
   Model::LayerNode* layer1 = new Model::LayerNode(Model::Layer("Layer 1"));
-  addNode(*document, document->world(), layer1);
+  document->addNodes({{document->world(), {layer1}}});
 
   Model::LayerNode* layer2 = new Model::LayerNode(Model::Layer("Layer 2"));
-  addNode(*document, document->world(), layer2);
+  document->addNodes({{document->world(), {layer2}}});
 
-  CHECK_FALSE(reparentNodes(*document, layer2, {layer1}));
+  CHECK_FALSE(document->reparentNodes({{layer2, {layer1}}}));
 }
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.reparentBetweenLayers") {
   Model::LayerNode* oldParent = new Model::LayerNode(Model::Layer("Layer 1"));
-  addNode(*document, document->world(), oldParent);
+  document->addNodes({{document->world(), {oldParent}}});
 
   Model::LayerNode* newParent = new Model::LayerNode(Model::Layer("Layer 2"));
-  addNode(*document, document->world(), newParent);
+  document->addNodes({{document->world(), {newParent}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, oldParent, entity);
+  document->addNodes({{oldParent, {entity}}});
 
   assert(entity->parent() == oldParent);
-  CHECK(reparentNodes(*document, newParent, {entity}));
+  CHECK(document->reparentNodes({{newParent, {entity}}}));
   CHECK(entity->parent() == newParent);
 
   document->undoCommand();
@@ -61,29 +61,29 @@ TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.reparentBetweenLayers") {
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.reparentGroupToItself") {
   Model::GroupNode* group = new Model::GroupNode(Model::Group("Group"));
-  addNode(*document, document->parentForNodes(), group);
+  document->addNodes({{document->parentForNodes(), {group}}});
 
-  CHECK_FALSE(reparentNodes(*document, group, {group}));
+  CHECK_FALSE(document->reparentNodes({{group, {group}}}));
 }
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.reparentGroupToChild") {
   Model::GroupNode* outer = new Model::GroupNode(Model::Group("Outer"));
-  addNode(*document, document->parentForNodes(), outer);
+  document->addNodes({{document->parentForNodes(), {outer}}});
 
   Model::GroupNode* inner = new Model::GroupNode(Model::Group("Inner"));
-  addNode(*document, outer, inner);
+  document->addNodes({{outer, {inner}}});
 
-  CHECK_FALSE(reparentNodes(*document, inner, {outer}));
+  CHECK_FALSE(document->reparentNodes({{inner, {outer}}}));
 }
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.removeEmptyGroup") {
   Model::GroupNode* group = new Model::GroupNode(Model::Group("Group"));
-  addNode(*document, document->parentForNodes(), group);
+  document->addNodes({{document->parentForNodes(), {group}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, group, entity);
+  document->addNodes({{group, {entity}}});
 
-  CHECK(reparentNodes(*document, document->parentForNodes(), {entity}));
+  CHECK(document->reparentNodes({{document->parentForNodes(), {entity}}}));
   CHECK(entity->parent() == document->parentForNodes());
   CHECK(group->parent() == nullptr);
 
@@ -94,15 +94,15 @@ TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.removeEmptyGroup") {
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.recursivelyRemoveEmptyGroups") {
   Model::GroupNode* outer = new Model::GroupNode(Model::Group("Outer"));
-  addNode(*document, document->parentForNodes(), outer);
+  document->addNodes({{document->parentForNodes(), {outer}}});
 
   Model::GroupNode* inner = new Model::GroupNode(Model::Group("Inner"));
-  addNode(*document, outer, inner);
+  document->addNodes({{outer, {inner}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, inner, entity);
+  document->addNodes({{inner, {entity}}});
 
-  CHECK(reparentNodes(*document, document->parentForNodes(), {entity}));
+  CHECK(document->reparentNodes({{document->parentForNodes(), {entity}}}));
   CHECK(entity->parent() == document->parentForNodes());
   CHECK(inner->parent() == nullptr);
   CHECK(outer->parent() == nullptr);
@@ -115,12 +115,12 @@ TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.recursivelyRemoveEmptyGroup
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.removeEmptyEntity") {
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entity);
+  document->addNodes({{document->parentForNodes(), {entity}}});
 
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, entity, brush);
+  document->addNodes({{entity, {brush}}});
 
-  CHECK(reparentNodes(*document, document->parentForNodes(), {brush}));
+  CHECK(document->reparentNodes({{document->parentForNodes(), {brush}}}));
   CHECK(brush->parent() == document->parentForNodes());
   CHECK(entity->parent() == nullptr);
 
@@ -131,15 +131,15 @@ TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.removeEmptyEntity") {
 
 TEST_CASE_METHOD(MapDocumentTest, "ReparentNodesTest.removeEmptyGroupAndEntity") {
   Model::GroupNode* group = new Model::GroupNode(Model::Group("Group"));
-  addNode(*document, document->parentForNodes(), group);
+  document->addNodes({{document->parentForNodes(), {group}}});
 
   Model::EntityNode* entity = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, group, entity);
+  document->addNodes({{group, {entity}}});
 
   Model::BrushNode* brush = createBrushNode();
-  addNode(*document, entity, brush);
+  document->addNodes({{entity, {brush}}});
 
-  CHECK(reparentNodes(*document, document->parentForNodes(), {brush}));
+  CHECK(document->reparentNodes({{document->parentForNodes(), {brush}}}));
   CHECK(brush->parent() == document->parentForNodes());
   CHECK(group->parent() == nullptr);
   CHECK(entity->parent() == nullptr);

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -44,7 +44,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.canRepeat") {
   CHECK_FALSE(document->canRepeatCommands());
 
   auto* entityNode = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
   CHECK_FALSE(document->canRepeatCommands());
 
   document->selectNodes({entityNode});
@@ -59,7 +59,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.canRepeat") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTranslate") {
   auto* entityNode = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
   document->selectNodes({entityNode});
 
   REQUIRE_FALSE(document->canRepeatCommands());
@@ -77,7 +77,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatRotate") {
 
   auto* entityNode = new Model::EntityNode(std::move(entity));
 
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
   document->selectNodes({entityNode});
 
   REQUIRE_FALSE(document->canRepeatCommands());
@@ -96,7 +96,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatRotate") {
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatScaleWithBBox") {
   auto* brushNode1 = createBrushNode();
 
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   REQUIRE_FALSE(document->canRepeatCommands());
@@ -106,7 +106,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatScaleWithBBox") {
   CHECK(document->canRepeatCommands());
 
   auto* brushNode2 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
   document->selectNodes({brushNode2});
 
   document->repeatCommands();
@@ -116,7 +116,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatScaleWithBBox") {
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatScaleWithFactors") {
   auto* brushNode1 = createBrushNode();
 
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   REQUIRE_FALSE(document->canRepeatCommands());
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatScaleWithFactors"
   CHECK(document->canRepeatCommands());
 
   auto* brushNode2 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
   document->deselectAll();
   document->selectNodes({brushNode2});
 
@@ -136,7 +136,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.shearObjects") {
   auto* brushNode1 = createBrushNode();
   const auto originalBounds = brushNode1->logicalBounds();
 
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   REQUIRE_FALSE(document->canRepeatCommands());
@@ -145,7 +145,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.shearObjects") {
   CHECK(document->canRepeatCommands());
 
   auto* brushNode2 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
   document->deselectAll();
   document->selectNodes({brushNode2});
 
@@ -157,7 +157,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.flipObjects") {
   auto* brushNode1 = createBrushNode();
   const auto originalBounds = brushNode1->logicalBounds();
 
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   REQUIRE_FALSE(document->canRepeatCommands());
@@ -166,7 +166,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.flipObjects") {
   CHECK(document->canRepeatCommands());
 
   auto* brushNode2 = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
   document->deselectAll();
   document->selectNodes({brushNode2});
 
@@ -176,10 +176,10 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.flipObjects") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.selectionClears") {
   auto* entityNode1 = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entityNode1);
+  document->addNodes({{document->parentForNodes(), {entityNode1}}});
 
   auto* entityNode2 = new Model::EntityNode{Model::Entity{}};
-  addNode(*document, document->parentForNodes(), entityNode2);
+  document->addNodes({{document->parentForNodes(), {entityNode2}}});
 
   document->selectNodes({entityNode1});
 
@@ -212,7 +212,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.selectionClears") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTransaction") {
   auto* entityNode1 = new Model::EntityNode({});
-  addNode(*document, document->parentForNodes(), entityNode1);
+  document->addNodes({{document->parentForNodes(), {entityNode1}}});
 
   document->selectNodes({entityNode1});
   CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
@@ -229,7 +229,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTransaction") {
   // now repeat the transaction on a second entity
 
   auto* entityNode2 = new Model::EntityNode({});
-  addNode(*document, document->parentForNodes(), entityNode2);
+  document->addNodes({{document->parentForNodes(), {entityNode2}}});
 
   document->deselectAll();
   document->selectNodes({entityNode2});
@@ -249,7 +249,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTransaction") {
 
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatDuplicateAndTranslate") {
   auto* entityNode1 = new Model::EntityNode({});
-  addNode(*document, document->parentForNodes(), entityNode1);
+  document->addNodes({{document->parentForNodes(), {entityNode1}}});
 
   document->selectNodes({entityNode1});
   CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatDuplicateAndTrans
 
 TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatUndo") {
   auto* entityNode1 = new Model::EntityNode({});
-  addNode(*document, document->parentForNodes(), entityNode1);
+  document->addNodes({{document->parentForNodes(), {entityNode1}}});
 
   document->selectNodes({entityNode1});
   CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));

--- a/common/test/src/View/RepeatableActionsTest.cpp
+++ b/common/test/src/View/RepeatableActionsTest.cpp
@@ -22,6 +22,7 @@
 #include "View/Command.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
+#include "View/TransactionScope.h"
 
 #include <kdl/result.h>
 
@@ -217,7 +218,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatTransaction") {
   document->selectNodes({entityNode1});
   CHECK(entityNode1->entity().origin() == vm::vec3(0, 0, 0));
 
-  document->startTransaction("");
+  document->startTransaction("", TransactionScope::Oneshot);
   document->translateObjects(vm::vec3(0, 0, 10));
   document->rollbackTransaction();
   document->translateObjects(vm::vec3(10, 0, 0));
@@ -257,7 +258,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatDuplicateAndTrans
   SECTION("transaction containing a rollback") {
     document->duplicateObjects();
 
-    document->startTransaction("");
+    document->startTransaction("", TransactionScope::Oneshot);
     document->translateObjects(vm::vec3(0, 0, 10));
     document->rollbackTransaction();
     document->translateObjects(vm::vec3(10, 0, 0));
@@ -270,7 +271,7 @@ TEST_CASE_METHOD(MapDocumentTest, "RepeatableActionsTest.repeatDuplicateAndTrans
     document->translateObjects(vm::vec3(5, 0, 0));
   }
   SECTION("duplicate inside transaction, then standalone movements") {
-    document->startTransaction("");
+    document->startTransaction("", TransactionScope::Oneshot);
     document->duplicateObjects();
     document->translateObjects(vm::vec3(2, 0, 0));
     document->translateObjects(vm::vec3(2, 0, 0));

--- a/common/test/src/View/SelectionTest.cpp
+++ b/common/test/src/View/SelectionTest.cpp
@@ -198,9 +198,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectTouching") {
   transformNode(
     *brushNode3, vm::translation_matrix(vm::vec3{100.0, 0.0, 0.0}), document->worldBounds());
 
-  addNode(*document, document->parentForNodes(), brushNode1);
-  addNode(*document, document->parentForNodes(), brushNode2);
-  addNode(*document, document->parentForNodes(), brushNode3);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
+  document->addNodes({{document->parentForNodes(), {brushNode3}}});
 
   REQUIRE(brushNode1->intersects(brushNode2));
   REQUIRE(brushNode2->intersects(brushNode1));
@@ -227,11 +227,11 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectTouching_2476") {
   const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
   auto* brushNode1 = new Model::BrushNode(builder.createCuboid(box, "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   auto* brushNode2 =
     new Model::BrushNode(builder.createCuboid(box.translate(vm::vec3(1, 1, 1)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   document->selectAllNodes();
 
@@ -260,23 +260,23 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectTouchingWithGroup") {
   assert(document->selectedNodes().nodeCount() == 0);
 
   Model::LayerNode* layer = new Model::LayerNode(Model::Layer("Layer 1"));
-  addNode(*document, document->world(), layer);
+  document->addNodes({{document->world(), {layer}}});
 
   Model::GroupNode* group = new Model::GroupNode(Model::Group("Unnamed"));
-  addNode(*document, layer, group);
+  document->addNodes({{layer, {group}}});
 
   Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
   const vm::bbox3 brushBounds(vm::vec3(-32.0, -32.0, -32.0), vm::vec3(+32.0, +32.0, +32.0));
 
   Model::BrushNode* brush =
     new Model::BrushNode(builder.createCuboid(brushBounds, "texture").value());
-  addNode(*document, group, brush);
+  document->addNodes({{group, {brush}}});
 
   const vm::bbox3 selectionBounds(vm::vec3(-16.0, -16.0, -48.0), vm::vec3(+16.0, +16.0, +48.0));
 
   Model::BrushNode* selectionBrush =
     new Model::BrushNode(builder.createCuboid(selectionBounds, "texture").value());
-  addNode(*document, layer, selectionBrush);
+  document->addNodes({{layer, {selectionBrush}}});
 
   document->selectNodes({selectionBrush});
   document->selectTouching(true);
@@ -290,23 +290,23 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectInsideWithGroup") {
   assert(document->selectedNodes().nodeCount() == 0);
 
   Model::LayerNode* layer = new Model::LayerNode(Model::Layer("Layer 1"));
-  addNode(*document, document->world(), layer);
+  document->addNodes({{document->world(), {layer}}});
 
   Model::GroupNode* group = new Model::GroupNode(Model::Group("Unnamed"));
-  addNode(*document, layer, group);
+  document->addNodes({{layer, {group}}});
 
   Model::BrushBuilder builder(document->world()->mapFormat(), document->worldBounds());
   const vm::bbox3 brushBounds(vm::vec3(-32.0, -32.0, -32.0), vm::vec3(+32.0, +32.0, +32.0));
 
   Model::BrushNode* brush =
     new Model::BrushNode(builder.createCuboid(brushBounds, "texture").value());
-  addNode(*document, group, brush);
+  document->addNodes({{group, {brush}}});
 
   const vm::bbox3 selectionBounds(vm::vec3(-48.0, -48.0, -48.0), vm::vec3(+48.0, +48.0, +48.0));
 
   Model::BrushNode* selectionBrush =
     new Model::BrushNode(builder.createCuboid(selectionBounds, "texture").value());
-  addNode(*document, layer, selectionBrush);
+  document->addNodes({{layer, {selectionBrush}}});
 
   document->selectNodes({selectionBrush});
   document->selectInside(true);
@@ -327,9 +327,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectTall") {
   transformNode(
     *brushNode3, vm::translation_matrix(vm::vec3{100.0, 0.0, 0.0}), document->worldBounds());
 
-  addNode(*document, document->parentForNodes(), brushNode1);
-  addNode(*document, document->parentForNodes(), brushNode2);
-  addNode(*document, document->parentForNodes(), brushNode3);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
+  document->addNodes({{document->parentForNodes(), {brushNode3}}});
 
   REQUIRE(!brushNode1->intersects(brushNode2));
   REQUIRE(!brushNode1->intersects(brushNode3));
@@ -361,18 +361,18 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectInverse") {
   const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
   auto* brushNode1 = new Model::BrushNode(builder.createCuboid(box, "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   auto* brushNode2 =
     new Model::BrushNode(builder.createCuboid(box.translate(vm::vec3(1, 1, 1)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   auto* brushNode3 =
     new Model::BrushNode(builder.createCuboid(box.translate(vm::vec3(2, 2, 2)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode3);
+  document->addNodes({{document->parentForNodes(), {brushNode3}}});
 
   auto* patchNode = createPatchNode();
-  addNode(*document, document->parentForNodes(), patchNode);
+  document->addNodes({{document->parentForNodes(), {patchNode}}});
 
   document->selectNodes({brushNode1, brushNode2});
   Model::EntityNode* brushEnt = document->createBrushEntity(m_brushEntityDef);
@@ -416,10 +416,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectTouchingInsideNestedGroup
   auto* outerGroup = new Model::GroupNode{Model::Group{"outerGroup"}};
   auto* innerGroup = new Model::GroupNode{Model::Group{"innerGroup"}};
 
-  addNode(*document, document->parentForNodes(), outerGroup);
-  addNode(*document, outerGroup, innerGroup);
-  addNode(*document, innerGroup, brushNode1);
-  addNode(*document, innerGroup, brushNode2);
+  document->addNodes({{document->parentForNodes(), {outerGroup}}});
+  document->addNodes({{outerGroup, {innerGroup}}});
+  document->addNodes({{innerGroup, {brushNode1}}});
+  document->addNodes({{innerGroup, {brushNode2}}});
 
   // worldspawn {
   //   outerGroup {
@@ -446,18 +446,18 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectSiblings") {
   const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
   auto* brushNode1 = new Model::BrushNode(builder.createCuboid(box, "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
 
   auto* brushNode2 =
     new Model::BrushNode(builder.createCuboid(box.translate(vm::vec3(1, 1, 1)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   auto* brushNode3 =
     new Model::BrushNode(builder.createCuboid(box.translate(vm::vec3(2, 2, 2)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode3);
+  document->addNodes({{document->parentForNodes(), {brushNode3}}});
 
   auto* patchNode = createPatchNode();
-  addNode(*document, document->parentForNodes(), patchNode);
+  document->addNodes({{document->parentForNodes(), {patchNode}}});
 
   document->selectNodes({brushNode1, brushNode2});
   document->createBrushEntity(m_brushEntityDef);
@@ -507,7 +507,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.selectSiblings") {
 
 TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.updateLastSelectionBounds") {
   auto* entityNode = new Model::EntityNode({}, {{"classname", "point_entity"}});
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
   REQUIRE(!entityNode->logicalBounds().is_empty());
 
   document->selectAllNodes();
@@ -520,7 +520,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionTest.updateLastSelectionBounds") {
   CHECK(document->lastSelectionBounds() == bounds);
 
   auto* brushNode = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   document->selectNodes({brushNode});
   CHECK(document->lastSelectionBounds() == bounds);
@@ -535,7 +535,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionCommandTest.faceSelectionUndoAfterTr
   Model::BrushNode* brushNode = createBrushNode();
   CHECK(brushNode->logicalBounds().center() == vm::vec3::zero());
 
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const auto topFaceIndex = brushNode->brush().findFace(vm::vec3::pos_z());
   REQUIRE(topFaceIndex);

--- a/common/test/src/View/SetEntityPropertiesTest.cpp
+++ b/common/test/src/View/SetEntityPropertiesTest.cpp
@@ -68,7 +68,8 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "SetEntityPropertiesTest.changeClassname"
   CHECK(document->selectionBounds().size() == Model::EntityNode::DefaultBounds.size());
 
   {
-    Transaction transaction(document); // we only want to undo the following changes later
+    const auto transaction =
+      Transaction{document}; // we only want to undo the following changes later
     document->setProperty("temp", "large_entity");
     document->renameProperty("temp", "classname");
     CHECK(entityNode->entity().definition() == largeEntityDef);

--- a/common/test/src/View/SetEntityPropertiesTest.cpp
+++ b/common/test/src/View/SetEntityPropertiesTest.cpp
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "SetEntityPropertiesTest.changeClassname"
 
   Model::EntityNode* entityNode = new Model::EntityNode({}, {{"classname", "large_entity"}});
 
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
   REQUIRE(entityNode->entity().definition() == largeEntityDef);
 
   document->deselectAll();
@@ -375,7 +375,7 @@ TEST_CASE_METHOD(MapDocumentTest, "EntityNodesTest.updateSpawnflagOnBrushEntity"
 
   auto* brushNode = new Model::BrushNode(
     builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   document->selectAllNodes();
 

--- a/common/test/src/View/SetEntityPropertiesTest.cpp
+++ b/common/test/src/View/SetEntityPropertiesTest.cpp
@@ -68,10 +68,11 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "SetEntityPropertiesTest.changeClassname"
   CHECK(document->selectionBounds().size() == Model::EntityNode::DefaultBounds.size());
 
   {
-    const auto transaction =
-      Transaction{document}; // we only want to undo the following changes later
+    auto transaction = Transaction{document}; // we only want to undo the following changes later
     document->setProperty("temp", "large_entity");
     document->renameProperty("temp", "classname");
+    transaction.commit();
+
     CHECK(entityNode->entity().definition() == largeEntityDef);
     CHECK(document->selectionBounds().size() == largeEntityDef->bounds().size());
   }

--- a/common/test/src/View/SwapNodeContentsTest.cpp
+++ b/common/test/src/View/SwapNodeContentsTest.cpp
@@ -56,7 +56,7 @@ namespace TrenchBroom {
 namespace View {
 TEST_CASE_METHOD(MapDocumentTest, "SwapNodeContentsTest.swapBrushes") {
   auto* brushNode = createBrushNode();
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const auto originalBrush = brushNode->brush();
   auto modifiedBrush = originalBrush;
@@ -76,7 +76,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SwapNodeContentsTest.swapBrushes") {
 
 TEST_CASE_METHOD(MapDocumentTest, "SwapNodeContentsTest.swapPatches") {
   auto* patchNode = createPatchNode();
-  addNode(*document, document->parentForNodes(), patchNode);
+  document->addNodes({{document->parentForNodes(), {patchNode}}});
 
   const auto originalPatch = patchNode->patch();
   auto modifiedPatch = originalPatch;
@@ -100,7 +100,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SwapNodeContentsTest.textureUsageCount") {
   REQUIRE(texture != nullptr);
 
   auto* brushNode = createBrushNode(TextureName);
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const auto& originalBrush = brushNode->brush();
   auto modifiedBrush = originalBrush;
@@ -125,7 +125,7 @@ TEST_CASE_METHOD(MapDocumentTest, "SwapNodeContentsTest.entityDefinitionUsageCou
 
   auto* entityNode = new Model::EntityNode{{}, {{Model::EntityPropertyKeys::Classname, Classname}}};
 
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
 
   const auto& originalEntity = entityNode->entity();
   auto modifiedEntity = originalEntity;

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -178,7 +178,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchTextureNameTag") {
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.enableTextureNameTag") {
   auto* nonMatchingBrushNode = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), nonMatchingBrushNode);
+  document->addNodes({{document->parentForNodes(), {nonMatchingBrushNode}}});
 
   const auto& tag = document->smartTag("texture");
   CHECK(tag.canEnable());
@@ -233,7 +233,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchSurfaceParmTag") {
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.enableSurfaceParmTag") {
   auto* nonMatchingBrushNode = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), nonMatchingBrushNode);
+  document->addNodes({{document->parentForNodes(), {nonMatchingBrushNode}}});
 
   const auto& tag = document->smartTag("surfaceparm_single");
   CHECK(tag.canEnable());
@@ -282,7 +282,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchContentFlagsTag") {
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.enableContentFlagsTag") {
   auto* nonMatchingBrushNode = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), nonMatchingBrushNode);
+  document->addNodes({{document->parentForNodes(), {nonMatchingBrushNode}}});
 
   const auto& tag = document->smartTag("contentflags");
   CHECK(tag.canEnable());
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.disableContentFlagsTag") 
     }
   });
 
-  addNode(*document, document->parentForNodes(), matchingBrushNode);
+  document->addNodes({{document->parentForNodes(), {matchingBrushNode}}});
 
   const auto& tag = document->smartTag("contentflags");
   CHECK(tag.canDisable());
@@ -351,7 +351,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchSurfaceFlagsTag") {
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.enableSurfaceFlagsTag") {
   auto* nonMatchingBrushNode = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), nonMatchingBrushNode);
+  document->addNodes({{document->parentForNodes(), {nonMatchingBrushNode}}});
 
   const auto& tag = document->smartTag("surfaceflags");
   CHECK(tag.canEnable());
@@ -376,7 +376,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.disableSurfaceFlagsTag") 
     }
   });
 
-  addNode(*document, document->parentForNodes(), matchingBrushNode);
+  document->addNodes({{document->parentForNodes(), {matchingBrushNode}}});
 
   const auto& tag = document->smartTag("surfaceflags");
   CHECK(tag.canDisable());
@@ -411,7 +411,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchEntityClassnameTag")
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.enableEntityClassnameTag") {
   auto* brushNode = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const auto& tag = document->smartTag("entity");
   CHECK_FALSE(tag.matches(*brushNode));
@@ -431,8 +431,8 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.enableEntityClassnameTagR
   auto* oldEntity =
     new Model::EntityNode{{}, {{"classname", "something"}, {"some_attr", "some_value"}}};
 
-  addNode(*document, document->parentForNodes(), oldEntity);
-  addNode(*document, oldEntity, brushNode);
+  document->addNodes({{document->parentForNodes(), {oldEntity}}});
+  document->addNodes({{oldEntity, {brushNode}}});
 
   const auto& tag = document->smartTag("entity");
   document->selectNodes({brushNode});
@@ -454,8 +454,8 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.disableEntityClassnameTag
 
   auto* oldEntity = new Model::EntityNode{{}, {{"classname", "brush_entity"}}};
 
-  addNode(*document, document->parentForNodes(), oldEntity);
-  addNode(*document, oldEntity, brushNode);
+  document->addNodes({{document->parentForNodes(), {oldEntity}}});
+  document->addNodes({{oldEntity, {brushNode}}});
 
   const auto& tag = document->smartTag("entity");
   CHECK(tag.matches(*brushNode));
@@ -471,10 +471,10 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.disableEntityClassnameTag
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagInitializeBrushTags") {
   auto* entityNode = new Model::EntityNode{{}, {{"classname", "brush_entity"}}};
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
 
   auto* brush = createBrushNode("some_texture");
-  addNode(*document, entityNode, brush);
+  document->addNodes({{entityNode, {brush}}});
 
   const auto& tag = document->smartTag("entity");
   CHECK(brush->hasTag(tag));
@@ -482,12 +482,12 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagInitializeBrushTags") 
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagRemoveBrushTags") {
   auto* entityNode = new Model::EntityNode{{}, {{"classname", "brush_entity"}}};
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
 
   auto* brush = createBrushNode("some_texture");
-  addNode(*document, entityNode, brush);
+  document->addNodes({{entityNode, {brush}}});
 
-  removeNode(*document, brush);
+  document->removeNodes({brush});
 
   const auto& tag = document->smartTag("entity");
   CHECK_FALSE(brush->hasTag(tag));
@@ -495,41 +495,41 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagRemoveBrushTags") {
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagUpdateBrushTags") {
   auto* brushNode = createBrushNode("some_texture");
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   auto* entityNode = new Model::EntityNode{{}, {{"classname", "brush_entity"}}};
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
 
   const auto& tag = document->smartTag("entity");
   CHECK_FALSE(brushNode->hasTag(tag));
 
-  reparentNodes(*document, entityNode, {brushNode});
+  document->reparentNodes({{entityNode, {brushNode}}});
   CHECK(brushNode->hasTag(tag));
 }
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagUpdateBrushTagsAfterReparenting") {
   auto* lightEntityNode = new Model::EntityNode{{}, {{"classname", "brush_entity"}}};
-  addNode(*document, document->parentForNodes(), lightEntityNode);
+  document->addNodes({{document->parentForNodes(), {lightEntityNode}}});
 
   auto* otherEntityNode = new Model::EntityNode{{}, {{"classname", "other"}}};
-  addNode(*document, document->parentForNodes(), otherEntityNode);
+  document->addNodes({{document->parentForNodes(), {otherEntityNode}}});
 
   auto* brushNode = createBrushNode("some_texture");
-  addNode(*document, otherEntityNode, brushNode);
+  document->addNodes({{otherEntityNode, {brushNode}}});
 
   const auto& tag = document->smartTag("entity");
   CHECK_FALSE(brushNode->hasTag(tag));
 
-  reparentNodes(*document, lightEntityNode, {brushNode});
+  document->reparentNodes({{lightEntityNode, {brushNode}}});
   CHECK(brushNode->hasTag(tag));
 }
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagUpdateBrushTagsAfterChangingClassname") {
   auto* lightEntityNode = new Model::EntityNode{{}, {{"classname", "asdf"}}};
-  addNode(*document, document->parentForNodes(), lightEntityNode);
+  document->addNodes({{document->parentForNodes(), {lightEntityNode}}});
 
   auto* brushNode = createBrushNode("some_texture");
-  addNode(*document, lightEntityNode, brushNode);
+  document->addNodes({{lightEntityNode, {brushNode}}});
 
   const auto& tag = document->smartTag("entity");
   CHECK_FALSE(brushNode->hasTag(tag));
@@ -544,7 +544,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagUpdateBrushTagsAfterCh
 TEST_CASE_METHOD(
   TagManagementTest, "TagManagementTest.tagInitializeBrushFaceTags", "[TagManagementTest]") {
   auto* brushNodeWithTags = createBrushNode("some_texture");
-  addNode(*document, document->parentForNodes(), brushNodeWithTags);
+  document->addNodes({{document->parentForNodes(), {brushNodeWithTags}}});
   document->selectNodes({brushNodeWithTags});
 
   SECTION("No modification to brush") {}
@@ -560,7 +560,7 @@ TEST_CASE_METHOD(
   }
 
   auto* brushNodeWithoutTags = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), brushNodeWithoutTags);
+  document->addNodes({{document->parentForNodes(), {brushNodeWithoutTags}}});
 
   for (const auto& face : brushNodeWithoutTags->brush().faces()) {
     CHECK(!face.hasTag(tag));
@@ -569,8 +569,8 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagRemoveBrushFaceTags") {
   auto* brushNodeWithTags = createBrushNode("some_texture");
-  addNode(*document, document->parentForNodes(), brushNodeWithTags);
-  removeNode(*document, brushNodeWithTags);
+  document->addNodes({{document->parentForNodes(), {brushNodeWithTags}}});
+  document->removeNodes({brushNodeWithTags});
 
   const auto& tag = document->smartTag("texture");
   for (const auto& face : brushNodeWithTags->brush().faces()) {
@@ -580,7 +580,7 @@ TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagRemoveBrushFaceTags") 
 
 TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagUpdateBrushFaceTags") {
   auto* brushNode = createBrushNode("asdf");
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const auto& tag = document->smartTag("contentflags");
 

--- a/common/test/src/View/TransformNodesTest.cpp
+++ b/common/test/src/View/TransformNodesTest.cpp
@@ -101,8 +101,8 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.flip") {
   checkBrushIntegral(brushNode1);
   checkBrushIntegral(brushNode2);
 
-  addNode(*document, document->parentForNodes(), brushNode1);
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   std::vector<Model::Node*> brushes;
   brushes.push_back(brushNode1);
@@ -192,8 +192,8 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.rotate") {
   checkBrushIntegral(brushNode1);
   checkBrushIntegral(brushNode2);
 
-  addNode(*document, document->parentForNodes(), brushNode1);
-  addNode(*document, document->parentForNodes(), brushNode2);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
+  document->addNodes({{document->parentForNodes(), {brushNode2}}});
 
   std::vector<Model::Node*> brushes;
   brushes.push_back(brushNode1);
@@ -256,7 +256,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.shearCube") {
   Model::BrushNode* brushNode =
     new Model::BrushNode(builder.createCuboid(initialBBox, "texture").value());
 
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
   document->selectNodes({std::vector<Model::Node*>{brushNode}});
 
   CHECK_THAT(
@@ -298,7 +298,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.shearPillar") {
   Model::BrushNode* brushNode =
     new Model::BrushNode(builder.createCuboid(initialBBox, "texture").value());
 
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
   document->selectNodes({std::vector<Model::Node*>{brushNode}});
 
   CHECK_THAT(
@@ -343,7 +343,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.scaleObjects") {
     new Model::BrushNode(builder.createCuboid(initialBBox, "texture").value());
   const Model::Brush& brush = brushNode->brush();
 
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
   document->selectNodes({std::vector<Model::Node*>{brushNode}});
 
   CHECK(brushNode->logicalBounds().size() == vm::vec3(200, 200, 200));
@@ -374,7 +374,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.scaleObjectsInGroup") {
   Model::BrushNode* brushNode =
     new Model::BrushNode(builder.createCuboid(initialBBox, "texture").value());
 
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
   document->selectNodes({std::vector<Model::Node*>{brushNode}});
   [[maybe_unused]] Model::GroupNode* group = document->groupSelection("my group");
 
@@ -394,7 +394,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.scaleObjectsWithCenter") {
   Model::BrushNode* brushNode =
     new Model::BrushNode(builder.createCuboid(initialBBox, "texture").value());
 
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
   document->selectNodes({std::vector<Model::Node*>{brushNode}});
 
   const vm::vec3 boundsCenter = initialBBox.center();
@@ -412,7 +412,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.translateLinkedGroup") {
   const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
   auto* brushNode1 = new Model::BrushNode(builder.createCuboid(box, "texture").value());
-  addNode(*document, document->parentForNodes(), brushNode1);
+  document->addNodes({{document->parentForNodes(), {brushNode1}}});
   document->selectNodes({brushNode1});
 
   auto* group = document->groupSelection("testGroup");

--- a/common/test/src/View/UndoTest.cpp
+++ b/common/test/src/View/UndoTest.cpp
@@ -44,7 +44,7 @@ TEST_CASE_METHOD(MapDocumentTest, "UndoTest.setTexturesAfterRestore", "[UndoTest
     std::vector<IO::Path>{IO::Path("fixture/test/IO/Wad/cr8_czg.wad")});
 
   Model::BrushNode* brushNode = createBrushNode("coffin1");
-  addNode(*document, document->parentForNodes(), brushNode);
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
 
   const Assets::Texture* texture = document->textureManager().texture("coffin1");
   CHECK(texture != nullptr);
@@ -99,7 +99,7 @@ TEST_CASE_METHOD(MapDocumentTest, "UndoTest.setTexturesAfterRestore", "[UndoTest
 TEST_CASE_METHOD(MapDocumentTest, "UndoTest.undoRotation", "[UndoTest]") {
   auto* entityNode = new Model::EntityNode{{}, {{Model::EntityPropertyKeys::Classname, "test"}}};
 
-  addNode(*document, document->parentForNodes(), entityNode);
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
   CHECK(!entityNode->entity().hasProperty("angle"));
 
   document->selectNodes({entityNode});

--- a/common/test/src/View/UpdateLinkedGroupsCommandTest.cpp
+++ b/common/test/src/View/UpdateLinkedGroupsCommandTest.cpp
@@ -1,0 +1,76 @@
+/*
+ Copyright (C) 2022 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "View/UpdateLinkedGroupsCommand.h"
+
+#include "Model/BrushNode.h"
+#include "Model/Group.h"
+#include "Model/GroupNode.h"
+#include "View/CurrentGroupCommand.h"
+#include "View/MapDocument.h"
+#include "View/MapDocumentCommandFacade.h"
+#include "View/MapDocumentTest.h"
+
+#include "TestUtils.h"
+
+#include "Catch2.h"
+
+namespace TrenchBroom {
+namespace View {
+
+TEST_CASE_METHOD(MapDocumentTest, "UpdateLinkedGroupsCommandTest.collateWith") {
+  const auto createLinkedGroup = [&]() {
+    auto* brushNode = createBrushNode();
+    document->addNodes({{document->parentForNodes(), {brushNode}}});
+    document->selectNodes({brushNode});
+
+    auto* groupNode = document->groupSelection("group");
+    document->selectNodes({groupNode});
+
+    auto* linkedGroupNode = document->createLinkedDuplicate();
+    document->deselectAll();
+
+    return std::make_tuple(groupNode, linkedGroupNode);
+  };
+
+  auto [groupNode1, linkedGroupNode1] = createLinkedGroup();
+  auto [groupNode2, linkedGroupNode2] = createLinkedGroup();
+
+  SECTION("Collate two UpdateLinkedGroupCommand instances") {
+    auto firstCommand = UpdateLinkedGroupsCommand{{groupNode1}};
+    auto secondCommand = UpdateLinkedGroupsCommand{{groupNode1, groupNode2}};
+
+    firstCommand.performDo(static_cast<MapDocumentCommandFacade*>(document.get()));
+    secondCommand.performDo(static_cast<MapDocumentCommandFacade*>(document.get()));
+
+    CHECK(firstCommand.collateWith(secondCommand));
+  }
+
+  SECTION("Collate UpdateLinkedGroupCommand with another command") {
+    auto firstCommand = UpdateLinkedGroupsCommand{{groupNode1}};
+    auto secondCommand = CurrentGroupCommand{groupNode2};
+
+    firstCommand.performDo(static_cast<MapDocumentCommandFacade*>(document.get()));
+    secondCommand.performDo(static_cast<MapDocumentCommandFacade*>(document.get()));
+
+    CHECK_FALSE(firstCommand.collateWith(secondCommand));
+  }
+}
+} // namespace View
+} // namespace TrenchBroom

--- a/common/test/src/View/UpdateLinkedGroupsHelperTest.cpp
+++ b/common/test/src/View/UpdateLinkedGroupsHelperTest.cpp
@@ -461,7 +461,7 @@ TEST_CASE_METHOD(
   }
 
   SECTION("Propagate both changes at once") {
-    auto groupNodes = std::vector<const Model::GroupNode*>{outerGroupNode, innerGroupNode};
+    auto groupNodes = std::vector<Model::GroupNode*>{outerGroupNode, innerGroupNode};
     std::sort(std::begin(groupNodes), std::end(groupNodes));
 
     // The following code generates both permutations of the group nodes


### PR DESCRIPTION
Closes #4059

This PR changes how linked group updates are propagated. Before this PR, any change to a linked group is propagated to its link set immediately. This PR changes this so that these updates are only propagated if the change is observable by the user. This way, invalid intermediate states are not propagated and we avoid errors related to such states.