### PR TITLE
Use FBX axis transform if listed in Assimp metadata.

### DIFF
--- a/common/src/IO/AssimpParser.h
+++ b/common/src/IO/AssimpParser.h
@@ -80,6 +80,7 @@ private:
   void processMesh(
     const aiMesh& mesh, const aiMatrix4x4& transform, const aiMatrix4x4& axisTransform);
   void processMaterials(const aiScene& scene, Logger& logger);
+  static aiMatrix4x4 get_axis_transform(const aiScene& scene);
 };
 } // namespace IO
 } // namespace TrenchBroom


### PR DESCRIPTION
Fixes #4085

FBX files can have their own arbitrary axis transform. Assimp doesn't apply this transform automatically. It instead just stores it as metadata in the imported `aiScene`. Because of this, FBX files that don't already use the right coordinate system are oriented incorrectly in TB.

This PR reads the metadata, creates a new transformation matrix if there is metadata present that describes a different coordinate system, and applies it to our already-existing axis transform that converts the model from Assimp's coordinate system to ours.

See here the reproduction model from #4085 in this branch:
![image](https://user-images.githubusercontent.com/28099249/188131831-8dd5de37-00da-4954-a7eb-846526cf1520.png)

Here is a minimal game configuration containing models, entities and maps for testing.
Put the folder inside this zip in your TB games folder, and point the game directory in TB's settings to the `src` folder.
[tbtest.zip](https://github.com/TrenchBroom/TrenchBroom/files/9846924/tbtest.zip)

Two relevant sources for this issue are:
* This page in the Assimp docs about the orientation that models _should_ be imported in:
   https://assimp-docs.readthedocs.io/en/v5.1.0/usage/use_the_lib.html#data-structures
* A GH issue about this specific problem:
   https://github.com/assimp/assimp/issues/849