### PR TITLE
Use macos-11 image for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
       # Don't cancel the macOS build if the Linux build fails, etc.
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, windows-2019]
         tb-build-type: [release]
         tb-arch: [default-arch]
         exclude:
           - os: windows-2019
             tb-arch: default-arch
         include:
-          - os: macos-10.15
+          - os: macos-11
             tb-build-type: asan
           - os: windows-2019
             tb-arch: x64
@@ -91,7 +91,7 @@ jobs:
           arch: 'win32_msvc2019'
 
       - name: Install macOS dependencies
-        if: ${{ matrix.os == 'macos-10.15' }}
+        if: ${{ matrix.os == 'macos-11' }}
         run: |
           brew install cmake p7zip pandoc qt5 ninja autoconf automake
 
@@ -129,7 +129,7 @@ jobs:
         run: ./CI-linux.sh
 
       - name: macOS build
-        if: ${{ matrix.os == 'macos-10.15' }}
+        if: ${{ matrix.os == 'macos-11' }}
         run: |
           if [ '${{ matrix.tb-build-type }}' = 'asan' ]; then
             export TB_DEBUG_BUILD=true
@@ -186,7 +186,7 @@ jobs:
       # macOS
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.os == 'macos-10.15' && matrix.tb-build-type != 'asan' }}
+        if: ${{ matrix.os == 'macos-11' && matrix.tb-build-type != 'asan' }}
         with:
           name: macos
           path: |
@@ -199,7 +199,7 @@ jobs:
       # based on a glob, so use https://github.com/softprops/action-gh-release
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: ${{ startsWith(github.ref, 'refs/tags/') && (matrix.os == 'windows-2019' || matrix.os == 'ubuntu-18.04' || matrix.os == 'macos-10.15') && matrix.tb-build-type != 'asan' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && (matrix.os == 'windows-2019' || matrix.os == 'ubuntu-18.04' || matrix.os == 'macos-11') && matrix.tb-build-type != 'asan' }}
         with:
           draft: true
           files: |

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -107,7 +107,12 @@ macro(set_compiler_config TARGET)
 
         # Disable a warning in clang when using PCH:
         target_compile_options(${TARGET} PRIVATE -Wno-pragma-system-header-outside-header)
-    elseif(COMPILER_IS_GNU)
+
+        if(${CMAKE_VERSION} VERSION_EQUAL "3.24.1") 
+            # Disable missing prototype for automoc files, see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7558
+            set_source_files_properties("${TARGET}_autogen/mocs_compilation.cpp" PROPERTIES COMPILE_FLAGS "-Wno-missing-prototypes")
+        endif()
+  elseif(COMPILER_IS_GNU)
         target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wconversion -Wshadow=local -Wnon-virtual-dtor -Wmissing-declarations -pedantic)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
 
@@ -118,7 +123,12 @@ macro(set_compiler_config TARGET)
         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
             target_compile_options(${TARGET} PRIVATE -Wno-unused-variable)
         endif()
-    elseif(COMPILER_IS_MSVC)
+
+        if(${CMAKE_VERSION} VERSION_EQUAL "3.24.1") 
+            # Disable missing prototype for automoc files, see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7558
+            set_source_files_properties("${TARGET}_autogen/mocs_compilation.cpp" PROPERTIES COMPILE_FLAGS "-Wno-missing-declarations")
+        endif()
+  elseif(COMPILER_IS_MSVC)
         target_compile_definitions(${TARGET} PRIVATE _CRT_SECURE_NO_DEPRECATE _CRT_NONSTDC_NO_DEPRECATE)
         target_compile_options(${TARGET} PRIVATE /W4 /EHsc /MP)
 


### PR DESCRIPTION
The macos-10.15 runner image is being removed, so we need to update to macos-11.