### PR TITLE
4094: Fix short circuit evaluation for logical and case operators

### DIFF
--- a/common/src/EL/Expressions.cpp
+++ b/common/src/EL/Expressions.cpp
@@ -408,9 +408,13 @@ Expression BinaryExpression::createAutoRangeWithLeftOperand(
 
 static Value evaluateAddition(const Value& lhs, const Value& rhs) {
   switch (lhs.type()) {
+    case ValueType::Undefined:
+      return Value::Undefined;
     case ValueType::Boolean:
     case ValueType::Number:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Boolean:
         case ValueType::Number:
           return Value{
@@ -421,12 +425,13 @@ static Value evaluateAddition(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
     case ValueType::String:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::String:
           return Value{
             lhs.convertTo(ValueType::String).stringValue() +
@@ -437,12 +442,13 @@ static Value evaluateAddition(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
     case ValueType::Array:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Array:
           return Value{kdl::vec_concat(lhs.arrayValue(), rhs.arrayValue())};
         case ValueType::Boolean:
@@ -451,12 +457,13 @@ static Value evaluateAddition(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
     case ValueType::Map:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Map:
           return Value{kdl::map_union(lhs.mapValue(), rhs.mapValue())};
         case ValueType::Boolean:
@@ -465,13 +472,11 @@ static Value evaluateAddition(const Value& lhs, const Value& rhs) {
         case ValueType::Array:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
     case ValueType::Range:
     case ValueType::Null:
-    case ValueType::Undefined:
       break;
   }
 
@@ -482,9 +487,13 @@ static Value evaluateAddition(const Value& lhs, const Value& rhs) {
 
 static Value evaluateSubtraction(const Value& lhs, const Value& rhs) {
   switch (lhs.type()) {
+    case ValueType::Undefined:
+      return Value::Undefined;
     case ValueType::Boolean:
     case ValueType::Number:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Boolean:
         case ValueType::Number:
           return Value{
@@ -495,7 +504,6 @@ static Value evaluateSubtraction(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
@@ -504,7 +512,6 @@ static Value evaluateSubtraction(const Value& lhs, const Value& rhs) {
     case ValueType::Map:
     case ValueType::Range:
     case ValueType::Null:
-    case ValueType::Undefined:
       break;
   }
 
@@ -515,9 +522,13 @@ static Value evaluateSubtraction(const Value& lhs, const Value& rhs) {
 
 static Value evaluateMultiplication(const Value& lhs, const Value& rhs) {
   switch (lhs.type()) {
+    case ValueType::Undefined:
+      return Value::Undefined;
     case ValueType::Boolean:
     case ValueType::Number:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Boolean:
         case ValueType::Number:
           return Value{
@@ -528,7 +539,6 @@ static Value evaluateMultiplication(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
@@ -537,7 +547,6 @@ static Value evaluateMultiplication(const Value& lhs, const Value& rhs) {
     case ValueType::Map:
     case ValueType::Range:
     case ValueType::Null:
-    case ValueType::Undefined:
       break;
   }
 
@@ -548,9 +557,13 @@ static Value evaluateMultiplication(const Value& lhs, const Value& rhs) {
 
 static Value evaluateDivision(const Value& lhs, const Value& rhs) {
   switch (lhs.type()) {
+    case ValueType::Undefined:
+      return Value::Undefined;
     case ValueType::Boolean:
     case ValueType::Number:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Boolean:
         case ValueType::Number:
           return Value{
@@ -561,7 +574,6 @@ static Value evaluateDivision(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
@@ -570,7 +582,6 @@ static Value evaluateDivision(const Value& lhs, const Value& rhs) {
     case ValueType::Map:
     case ValueType::Range:
     case ValueType::Null:
-    case ValueType::Undefined:
       break;
   }
 
@@ -581,9 +592,13 @@ static Value evaluateDivision(const Value& lhs, const Value& rhs) {
 
 static Value evaluateModulus(const Value& lhs, const Value& rhs) {
   switch (lhs.type()) {
+    case ValueType::Undefined:
+      return Value::Undefined;
     case ValueType::Boolean:
     case ValueType::Number:
       switch (rhs.type()) {
+        case ValueType::Undefined:
+          return Value::Undefined;
         case ValueType::Boolean:
         case ValueType::Number:
           return Value{std::fmod(
@@ -594,7 +609,6 @@ static Value evaluateModulus(const Value& lhs, const Value& rhs) {
         case ValueType::Map:
         case ValueType::Range:
         case ValueType::Null:
-        case ValueType::Undefined:
           break;
       }
       break;
@@ -603,7 +617,6 @@ static Value evaluateModulus(const Value& lhs, const Value& rhs) {
     case ValueType::Map:
     case ValueType::Range:
     case ValueType::Null:
-    case ValueType::Undefined:
       break;
   }
 
@@ -679,6 +692,10 @@ static Value evaluateLogicalOr(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateBitwiseAnd(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   if (lhs.convertibleTo(ValueType::Number) && rhs.convertibleTo(ValueType::Number)) {
     const IntegerType lhsInt = lhs.convertTo(ValueType::Number).integerValue();
     const IntegerType rhsInt = rhs.convertTo(ValueType::Number).integerValue();
@@ -690,6 +707,10 @@ static Value evaluateBitwiseAnd(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateBitwiseXOr(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   if (lhs.convertibleTo(ValueType::Number) && rhs.convertibleTo(ValueType::Number)) {
     const IntegerType lhsInt = lhs.convertTo(ValueType::Number).integerValue();
     const IntegerType rhsInt = rhs.convertTo(ValueType::Number).integerValue();
@@ -701,6 +722,10 @@ static Value evaluateBitwiseXOr(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateBitwiseOr(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   if (lhs.convertibleTo(ValueType::Number) && rhs.convertibleTo(ValueType::Number)) {
     const IntegerType lhsInt = lhs.convertTo(ValueType::Number).integerValue();
     const IntegerType rhsInt = rhs.convertTo(ValueType::Number).integerValue();
@@ -712,6 +737,10 @@ static Value evaluateBitwiseOr(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateBitwiseShiftLeft(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   if (lhs.convertibleTo(ValueType::Number) && rhs.convertibleTo(ValueType::Number)) {
     const IntegerType lhsInt = lhs.convertTo(ValueType::Number).integerValue();
     const IntegerType rhsInt = rhs.convertTo(ValueType::Number).integerValue();
@@ -723,6 +752,10 @@ static Value evaluateBitwiseShiftLeft(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateBitwiseShiftRight(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   if (lhs.convertibleTo(ValueType::Number) && rhs.convertibleTo(ValueType::Number)) {
     const IntegerType lhsInt = lhs.convertTo(ValueType::Number).integerValue();
     const IntegerType rhsInt = rhs.convertTo(ValueType::Number).integerValue();
@@ -883,6 +916,10 @@ static int evaluateCompare(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateRange(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   const auto from = static_cast<long>(lhs.convertTo(ValueType::Number).numberValue());
   const auto to = static_cast<long>(rhs.convertTo(ValueType::Number).numberValue());
 
@@ -906,6 +943,10 @@ static Value evaluateRange(const Value& lhs, const Value& rhs) {
 }
 
 static Value evaluateCase(const Value& lhs, const Value& rhs) {
+  if (lhs.type() == ValueType::Undefined || rhs.type() == ValueType::Undefined) {
+    return Value::Undefined;
+  }
+
   if (lhs.convertTo(ValueType::Boolean).booleanValue()) {
     return rhs;
   }
@@ -915,10 +956,6 @@ static Value evaluateCase(const Value& lhs, const Value& rhs) {
 
 static Value evaluateBinaryExpression(
   const BinaryOperator operator_, const Value& leftOperand, const Value& rightOperand) {
-  if (leftOperand == Value::Undefined || rightOperand == Value::Undefined) {
-    return Value::Undefined;
-  }
-
   switch (operator_) {
     case BinaryOperator::Addition:
       return evaluateAddition(leftOperand, rightOperand);

--- a/common/src/IO/DefParser.cpp
+++ b/common/src/IO/DefParser.cpp
@@ -21,6 +21,7 @@
 
 #include "Assets/ModelDefinition.h"
 #include "Assets/PropertyDefinition.h"
+#include "EL/ELExceptions.h"
 #include "Exceptions.h"
 #include "IO/ELParser.h"
 #include "IO/EntityDefinitionClassInfo.h"
@@ -365,6 +366,8 @@ Assets::ModelDefinition DefParser::parseModelDefinition(ParserStatus& status) {
       m_tokenizer.restore(snapshot);
       throw e;
     }
+  } catch (const EL::EvaluationError& evaluationError) {
+    throw ParserException{m_tokenizer.line(), m_tokenizer.column(), evaluationError.what()};
   }
 }
 

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -21,6 +21,7 @@
 
 #include "Assets/EntityDefinition.h"
 #include "Assets/PropertyDefinition.h"
+#include "EL/ELExceptions.h"
 #include "EL/Expressions.h"
 #include "EL/Types.h"
 #include "EL/Value.h"
@@ -159,6 +160,9 @@ Assets::ModelDefinition EntParser::parseModel(
         EL::Value(EL::MapType({{Assets::ModelSpecificationKeys::Path, EL::Value{model}}}))),
       lineNum, 0);
     return Assets::ModelDefinition(expression);
+  } catch (const EL::EvaluationError& evaluationError) {
+    const auto line = static_cast<size_t>(element.GetLineNum());
+    throw ParserException{line, evaluationError.what()};
   }
 }
 

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -20,6 +20,7 @@
 #include "FgdParser.h"
 
 #include "Assets/PropertyDefinition.h"
+#include "EL/ELExceptions.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/ELParser.h"
 #include "IO/EntityDefinitionClassInfo.h"
@@ -392,6 +393,8 @@ Assets::ModelDefinition FgdParser::parseModel(ParserStatus& status) {
       m_tokenizer.restore(snapshot);
       throw e;
     }
+  } catch (const EL::EvaluationError& evaluationError) {
+    throw ParserException{m_tokenizer.line(), m_tokenizer.column(), evaluationError.what()};
   }
 }
 

--- a/common/test/src/EL/ExpressionTest.cpp
+++ b/common/test/src/EL/ExpressionTest.cpp
@@ -386,6 +386,10 @@ TEST_CASE("ExpressionTest.testOperators", "[ExpressionTest]") {
   {"true || false",   Value{true}},
   {"true || true",    Value{true}},
 
+  // Logical short circuit evaluation 
+  {"false && x[-1]",  Value{false}},
+  {"true || x[-1]",   Value{true}},
+
   // Bitwise negation
   {"~23423",          Value{~23423}},
   {"~23423.1",        Value{~23423}},
@@ -617,6 +621,10 @@ TEST_CASE("ExpressionTest.testOperators", "[ExpressionTest]") {
   {"{k1:1} == {k1:2}",       Value{false}},
   {"{k1:1} == {k1:1, k2:2}", Value{false}},
   {"{k1:1} == {k1:2, k2:2}", Value{false}},
+
+  {"true -> 'asdf'",  Value{"asdf"}},
+  {"false -> 'asdf'", Value::Undefined},
+  {"false -> x[-1]",  Value::Undefined},
   }));
   // clang-format on
 


### PR DESCRIPTION
Closes #4094.

The operators `&&`, `||`, `->` should only evaluate the right hand side if that is necessary to evaluate the entire operator. If the left hand side already determined the outcome, then the right hand side should not be evaluated. This makes it possible to guard expressions from left to right, e.g. `model != null && model[0]` should only evaluate the right hand side if the `model` variable is not null.