### PR TITLE
4010: make MAP_DIR_PATH interpolation available for tools

### DIFF
--- a/common/src/View/CompilationVariables.cpp
+++ b/common/src/View/CompilationVariables.cpp
@@ -70,20 +70,17 @@ CommonVariables::CommonVariables(std::shared_ptr<MapDocument> document) {
 CommonCompilationVariables::CommonCompilationVariables(std::shared_ptr<MapDocument> document)
   : CommonVariables(document) {
   const IO::Path filename = document->path().lastComponent();
+  const IO::Path filePath = document->path().deleteLastComponent();
   const IO::Path appPath = IO::SystemPaths::appDirectory();
 
   using namespace CompilationVariableNames;
   declare(MAP_FULL_NAME, EL::Value(filename.asString()));
+  declare(MAP_DIR_PATH, EL::Value(filePath.asString()));
   declare(APP_DIR_PATH, EL::Value(appPath.asString()));
 }
 
 CompilationWorkDirVariables::CompilationWorkDirVariables(std::shared_ptr<MapDocument> document)
-  : CommonCompilationVariables(document) {
-  const IO::Path filePath = document->path().deleteLastComponent();
-
-  using namespace CompilationVariableNames;
-  declare(MAP_DIR_PATH, EL::Value(filePath.asString()));
-}
+  : CommonCompilationVariables(document) {}
 
 CompilationVariables::CompilationVariables(
   std::shared_ptr<MapDocument> document, const std::string& workDir)


### PR DESCRIPTION
Closes #4010 .

This makes the code align with the documented behavior.

All this change does is bump MAP_DIR_PATH up in the "hierarchy" of variables, taking it out of CompilationWorkDirVariables and into its parent class CommonCompilationVariables which is used both for workdir and tool interpolations.

This does mean that CompilationWorkDirVariables now is functionally identical to CommonCompilationVariables, but it seems fine to leave them as two distinct classes to make it easy to handle any future changes where they diverge again.

The added test checks that MAP_DIR_PATH and WORK_DIR_PATH will be interpolated as expected in the context of compilation tools.