### PR TITLE
Half-Life: render NULL and ORIGIN textures transparent

### DIFF
--- a/app/resources/games/Halflife/GameConfig.cfg
+++ b/app/resources/games/Halflife/GameConfig.cfg
@@ -47,6 +47,18 @@
                 "pattern": "hint*"
             },
             {
+                "name": "Origin",
+                "attribs": [ "transparent" ],
+                "match": "texture",
+                "pattern": "origin"
+            },
+            {
+                "name": "Null",
+                "attribs": [ "transparent" ],
+                "match": "texture",
+                "pattern": "null"
+            },
+            {
                 "name": "Liquid",
                 "match": "texture",
                 "pattern": "\**"


### PR DESCRIPTION
These two textures are missing from the list of textures that only serve a functional purpose and are commonly transparent. NULL is especially important as these faces are skipped entirely during compiling. Making them transparent would seriously improve visibility in maps with complex geometry.