### PR TITLE
Add missing null check

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1294,7 +1294,7 @@ Model::Node* MapViewBase::findNewGroupForObjects(const std::vector<Model::Node*>
   const auto hits = pickResult().all(type(Model::nodeHitType()));
   if (!hits.empty()) {
     auto* newGroup = Model::findOutermostClosedGroup(Model::hitToNode(hits.front()));
-    if (canReparentNodes(nodes, newGroup)) {
+    if (newGroup && canReparentNodes(nodes, newGroup)) {
       return newGroup;
     }
   }


### PR DESCRIPTION
The missing null check would lead to a crash. It was unintentionally removed in bebcf735af4286beb12f4f0bc02087dbc725991a.