### PR TITLE
If loading fails due to an unexpected error, let the crash handler deal with it

### DIFF
--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -342,9 +342,7 @@ bool TrenchBroomApp::openDocument(const IO::Path& path) {
     if (frame != nullptr) {
       frame->close();
     }
-    QMessageBox::critical(
-      nullptr, "TrenchBroom", IO::pathAsQString(path) + " could not be opened.", QMessageBox::Ok);
-    return false;
+    throw;
   }
 }
 


### PR DESCRIPTION
Closes #3572.

This change doesn't fix the issues underlying the reports mentioned in #3572, but if it happens again, we will get more info.