### PR TITLE
Draft: create AppImage build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo apt update
-          sudo apt install qtbase5-dev libqt5svg5-dev
+          sudo apt install qtbase5-dev libqt5svg5-dev libfuse2
 
       - name: Install Qt5 on Ubuntu 20.04
         if: ${{ matrix.os == 'ubuntu-20.04' }}
@@ -96,6 +96,13 @@ jobs:
         run: |
           brew install cmake p7zip pandoc qt5 ninja autoconf automake
 
+      # taken from here https://github.com/marketplace/actions/install-linuxdeploy
+      - name: Install LinuxDeploy
+        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        uses: miurahr/install-linuxdeploy-action@v1
+        with:
+          plugins: qt appimage
+
       # Restore from cache the previously built ports. If a "cache miss" occurs,
       # then vcpkg is bootstrapped. Since a the vcpkg.json is being used later on
       # to install the packages when `run-cmake` runs, no packages are installed at
@@ -127,7 +134,7 @@ jobs:
 
       - name: Linux build
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
-        run: ./CI-linux.sh
+        run: ./CI-linux.sh && ./CI-linux-AppImage.sh
 
       - name: macOS build
         if: ${{ matrix.os == 'macos-11' }}
@@ -183,6 +190,7 @@ jobs:
             build/*.deb
             build/*.rpm
             build/*.md5
+            buildAppImage/*.AppImage
 
       # macOS
       - name: Upload macOS artifact
@@ -210,6 +218,7 @@ jobs:
             build/*.md5
             cmakebuild/*.7z
             cmakebuild/*.7z.md5
+            buildAppImage/*.AppImage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ Thumbs.db
 /coverity
 
 app/resources/documentation/help/index.html
-
+CMakeLists.txt.user

--- a/Build.md
+++ b/Build.md
@@ -100,7 +100,7 @@ sudo apt-get install g++ qt5-default libqt5svg5-dev libxi-dev libgl1-mesa-dev li
 Or, on Fedora:
 
 ```bash
-sudo dnf install g++ cmake qt5-qtbase-devel qt5-qtsvg-devel ninja-build pandoc mesa-libGLU-devel
+sudo dnf install g++ cmake qt5-qtbase-devel qt5-qtsvg-devel ninja-build pandoc mesa-libGLU-devel freeimage-devel tinyxml2-devel freetype-devel fmt-devel miniz-devel catch-devel glew-devel
 ```
 
 ### Build TrenchBroom

--- a/CI-linux-AppImage.sh
+++ b/CI-linux-AppImage.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o verbose
+
+# Check versions
+qmake -v
+cmake --version
+pandoc --version
+
+# Build TB
+
+mkdir buildAppImage
+cd buildAppImage
+cmake .. -DCMAKE_PREFIX_PATH="cmake/packages" -DAPPIMAGE_BUILD=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_EXE_LINKER_FLAGS="-Wl,--fatal-warnings" -DTB_SUPPRESS_PCH=1 || exit 1
+make
+make install DESTDIR=AppDir
+
+# TODO: need to be resolved VERSION=??
+linuxdeploy-x86_64.AppImage --appdir AppDir -e "AppDir/usr/bin/trenchbroom" \
+                                            -d "AppDir/usr/share/applications/trenchbroom.desktop" \
+                                            --plugin qt --output appimage

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateManual.cmake)
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    option(APPIMAGE_BUILD "Prepare AppImage build" OFF)
+endif()
+
 set(APP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(APP_RESOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/resources")
 
@@ -99,7 +103,7 @@ if(WIN32)
     endif()
 endif()
 
-# Set CPACK_PACKAGE_VERSION which is used by CPack.
+# Set CPACK_PACKAGE_ which is used by CPack.
 # Strip the "v" prefix off GIT_DESCRIBE (e.g. "v2020.1-RC1") to produce a CPACK_PACKAGE_VERSION of "2020.1-RC1"
 # Debian wants the first character to be a number
 string(REGEX REPLACE "^v(.*)" "\\1" CPACK_PACKAGE_VERSION "${GIT_DESCRIBE}")
@@ -335,67 +339,86 @@ elseif(APPLE)
     set(CPACK_PACKAGE_FILE_EXT "dmg")
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateChecksum.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/generate_checksum.sh" @ONLY)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    # add architecture to filename
-    set(APP_PACKAGE_FILE_NAME "${APP_PACKAGE_FILE_NAME}.${CMAKE_SYSTEM_PROCESSOR}")
-    set(CPACK_PACKAGE_FILE_NAME ${APP_PACKAGE_FILE_NAME})
 
-    # generate deb and rpm packages
-    set(CPACK_GENERATOR "DEB;RPM")
-    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+    # either build AppImage or generate deb and rpm packages
+    if(APPIMAGE_BUILD)
+        install(TARGETS TrenchBroom RUNTIME DESTINATION bin COMPONENT TrenchBroom)
+        install(FILES "${APP_DIR}/resources/linux/trenchbroom.desktop" DESTINATION "share/applications" COMPONENT TrenchBroom)
 
-    set(LINUX_RESOURCE_LOCATION "share/TrenchBroom")
-    set(LINUX_TARGET_RESOURCE_DIRECTORY ${CPACK_PACKAGING_INSTALL_PREFIX}/${LINUX_RESOURCE_LOCATION})
+        # filter and install all icons
+        file(GLOB ICON_FILES "${APP_DIR}/resources/linux/icons/*.png")
+        list(FILTER ICON_FILES EXCLUDE REGEX ".*tb_icon_orig\\.png$")
+        foreach(icon ${ICON_FILES})
+            if (${icon} MATCHES "_([0-9]+)\\.png$")
+                set(IR ${CMAKE_MATCH_1})
+                install(FILES "${APP_DIR}/resources/linux/icons/icon_${IR}.png" DESTINATION "share/icons/hicolor/${IR}x${IR}/apps/" COMPONENT TrenchBroom RENAME "trenchbroom.png")
+            endif()
+        endforeach()
+    else()
+        # add architecture to filename
+        set(APP_PACKAGE_FILE_NAME "${APP_PACKAGE_FILE_NAME}.${CMAKE_SYSTEM_PROCESSOR}")
+        set(CPACK_PACKAGE_FILE_NAME ${APP_PACKAGE_FILE_NAME})
 
-    # add mime type definitions
-    install(FILES "${APP_DIR}/resources/linux/trenchbroom.xml" DESTINATION "${CPACK_PACKAGING_INSTALL_PREFIX}/share/mime/packages/" COMPONENT TrenchBroom)
+        # generate deb and rpm packages
+        set(CPACK_GENERATOR "DEB;RPM")
+        set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 
-    # configure install scripts
-    configure_file(${APP_DIR}/resources/linux/postinst ${CMAKE_CURRENT_BINARY_DIR}/linux/postinst @ONLY)
-    configure_file(${APP_DIR}/resources/linux/prerm ${CMAKE_CURRENT_BINARY_DIR}/linux/prerm @ONLY)
-    configure_file(${APP_DIR}/resources/linux/postrm ${CMAKE_CURRENT_BINARY_DIR}/linux/postrm @ONLY)
+        set(LINUX_RESOURCE_LOCATION "share/TrenchBroom")
+        set(LINUX_TARGET_RESOURCE_DIRECTORY ${CPACK_PACKAGING_INSTALL_PREFIX}/${LINUX_RESOURCE_LOCATION})
 
-    # add files
-    install(TARGETS TrenchBroom RUNTIME DESTINATION bin COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fonts"           DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/defaults"        DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/games"           DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/manual"          DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/images"          DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/shader"          DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/stylesheets"     DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(DIRECTORY "${APP_DIR}/resources/linux/icons"            DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom FILES_MATCHING PATTERN "*.png")
-    install(FILES "${CMAKE_SOURCE_DIR}/LICENSE.txt"                 DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(FILES "${APP_DIR}/resources/linux/copyright"            DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
-    install(FILES "${APP_DIR}/resources/linux/trenchbroom.desktop"  DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        # add mime type definitions
+        install(FILES "${APP_DIR}/resources/linux/trenchbroom.xml" DESTINATION "${CPACK_PACKAGING_INSTALL_PREFIX}/share/mime/packages/" COMPONENT TrenchBroom)
 
-    # deb package specifics
-    set(CPACK_DEBIAN_PACKAGE_MAINTAINER ${CPACK_PACKAGE_VENDOR})
-    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-    # The following dependencies were generated by running with CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON and dumping the list of dependencies with dpkg-deb --info <debfile>,
-    # and making the following modification(s)
-    # - remove libgcc-s1 (>= 3.0)
-    # set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.27), libgl1, libqt5core5a (>= 5.9.0~beta), libqt5gui5 (>= 5.6.0~beta), libqt5svg5 (>= 5.6.0~beta), libqt5widgets5 (>= 5.7.0), libstdc++6 (>= 7)")
-    set(CPACK_DEBIAN_PACKAGE_SECTION "games")
-    set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://kristianduske.com/trenchbroom/")
-    set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/linux/postinst;${CMAKE_CURRENT_BINARY_DIR}/linux/prerm;${CMAKE_CURRENT_BINARY_DIR}/linux/postrm")
+        # configure install scripts
+        configure_file(${APP_DIR}/resources/linux/postinst ${CMAKE_CURRENT_BINARY_DIR}/linux/postinst @ONLY)
+        configure_file(${APP_DIR}/resources/linux/prerm ${CMAKE_CURRENT_BINARY_DIR}/linux/prerm @ONLY)
+        configure_file(${APP_DIR}/resources/linux/postrm ${CMAKE_CURRENT_BINARY_DIR}/linux/postrm @ONLY)
 
-    # rpm package specifics
-    set(CPACK_RPM_PACKAGE_LICENSE "GPLv3")
-    set(CPACK_RPM_PACKAGE_GROUP "Applications/Editors")
-    set(CPACK_RPM_PACKAGE_DESCRIPTION ${CPACK_PACKAGE_DESCRIPTION_SUMMARY})
-    set(CPACK_RPM_PACKAGE_SUMMARY ${CPACK_PACKAGE_DESCRIPTION_SUMMARY})
-    set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/linux/postinst")
-    set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/linux/prerm")
-    set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/linux/postrm")
-    set(CPACK_RPM_SPEC_INSTALL_POST "/bin/true") # prevents stripping of debug symbols during rpmbuild
+        # add files
+        install(TARGETS TrenchBroom RUNTIME DESTINATION bin COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fonts"           DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/defaults"        DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/games"           DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/manual"          DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/images"          DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/shader"          DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/stylesheets"     DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(DIRECTORY "${APP_DIR}/resources/linux/icons"            DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom FILES_MATCHING PATTERN "*.png")
+        install(FILES "${CMAKE_SOURCE_DIR}/LICENSE.txt"                 DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(FILES "${APP_DIR}/resources/linux/copyright"            DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
+        install(FILES "${APP_DIR}/resources/linux/trenchbroom.desktop"  DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
 
-    set(CPACK_PACKAGE_FILE_EXT "rpm")
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateChecksum.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/generate_checksum_rpm.sh" @ONLY)
+        # deb package specifics
+        set(CPACK_DEBIAN_PACKAGE_MAINTAINER ${CPACK_PACKAGE_VENDOR})
+        set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+        # The following dependencies were generated by running with CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON and dumping the list of dependencies with dpkg-deb --info <debfile>,
+        # and making the following modification(s)
+        # - remove libgcc-s1 (>= 3.0)
+        # set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.27), libgl1, libqt5core5a (>= 5.9.0~beta), libqt5gui5 (>= 5.6.0~beta), libqt5svg5 (>= 5.6.0~beta), libqt5widgets5 (>= 5.7.0), libstdc++6 (>= 7)")
+        set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+        set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "http://kristianduske.com/trenchbroom/")
+        set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/linux/postinst;${CMAKE_CURRENT_BINARY_DIR}/linux/prerm;${CMAKE_CURRENT_BINARY_DIR}/linux/postrm")
 
-    set(CPACK_PACKAGE_FILE_EXT "deb")
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateChecksum.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/generate_checksum_deb.sh" @ONLY)
+        # rpm package specifics
+        set(CPACK_RPM_PACKAGE_LICENSE "GPLv3")
+        set(CPACK_RPM_PACKAGE_GROUP "Applications/Editors")
+        set(CPACK_RPM_PACKAGE_DESCRIPTION ${CPACK_PACKAGE_DESCRIPTION_SUMMARY})
+        set(CPACK_RPM_PACKAGE_SUMMARY ${CPACK_PACKAGE_DESCRIPTION_SUMMARY})
+        set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/linux/postinst")
+        set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/linux/prerm")
+        set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/linux/postrm")
+        set(CPACK_RPM_SPEC_INSTALL_POST "/bin/true") # prevents stripping of debug symbols during rpmbuild
 
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/PrintLinuxPackageInfo.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/print_linux_package_info.sh" @ONLY)
+        set(CPACK_PACKAGE_FILE_EXT "rpm")
+        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateChecksum.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/generate_checksum_rpm.sh" @ONLY)
+
+        set(CPACK_PACKAGE_FILE_EXT "deb")
+        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateChecksum.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/generate_checksum_deb.sh" @ONLY)
+
+        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/PrintLinuxPackageInfo.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/print_linux_package_info.sh" @ONLY)
+    endif()
+
 endif()
+
 
 include(CPack)


### PR DESCRIPTION
TrenchBroom deserves its own AppImage as AppImage solves the majority of the headaches maintaining Linux packages bear (e.g.  current RPM package does not even install on the latest Fedora)
Still, a lot of problems need to be solved before being ready for release. 

Right now I turned on building this on both ubuntu, but **AppImage should be made on older stable systems** like Debian/AlmaLinux/RockyLinux e.t.c. the reason is because glibc and other system-dependent libraries are not shipped with the AppImage but are used from the host system. glibc is generally backward compatible, so this will produce an AppImage that can be used on most workstation distributions.

Also it is important to notice that everything is compressed into a single executable file. User by default does not have access to any attached files in the AppImage, which includes the manual e.t.c. Binary can still address these files by using relative path but most of the time I found that not working properly. I do suggest **moving all of the required TrenchBroom assets into Qt Resource** I'm also wondering and asking why Qt resource files are not used right now? They are generally more efficient, fast and handling in Qt is very easy as you would create your own file tree and just reference it like this `:/assets/icons/my_icon.png`, plus they are already loaded in memory so no real IO operation is needed.

Anyway, before I will start doing any of these things, I want to discuss the correct solution.

- [ ] Move the build to Debian or free RHEL variant with older glibc
- [ ] Move all assets to the resources
- [ ] Pass a correct version to AppImage
- [ ] Give AppImage a proper filename
- [ ] Consider skipping building tests while building AppImage