### PR TITLE
3887: Add a "Delete Files" task

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1530,6 +1530,12 @@ Copy Files
     Source 		The file(s) to copy. To specify more than one file, you can use wildcards (*,?) in the filename. Variables are allowed.
     Target  	The directory to copy the files to. The directory is recursively created if it does not exist. Existing files are overwritten without prompt. Variables are allowed.
 
+Delete Files
+:	Deletes one or more files.
+
+    Parameter 	Description
+    ---------   -----------
+    Target 		The file(s) to delete. To specify more than one file, you can use wildcards (*,?) in the filename. Variables are allowed.
 
 You can use [expressions](#expression_language) when specifying the working directory of a profile and also for the task parameters. The following table lists the available variables, their scopes, and their meaning. A scope of 'Tool' indicates that the variable is available when specifying tool parameters. A scope of 'Workdir' indicates that the variable is only available when specifying the working directory. Note that TrenchBroom helps you to enter variables by popping up an autocompletion list.
 

--- a/common/src/IO/CompilationConfigParser.cpp
+++ b/common/src/IO/CompilationConfigParser.cpp
@@ -107,6 +107,10 @@ std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseTask(
   {
     return parseCopyTask(value);
   }
+  else if (type == "delete")
+  {
+    return parseDeleteTask(value);
+  }
   else if (type == "tool")
   {
     return parseToolTask(value);
@@ -140,6 +144,18 @@ std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseCopyTask(
   const std::string target = value["target"].stringValue();
 
   return std::make_unique<Model::CompilationCopyFiles>(enabled, source, target);
+}
+
+std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseDeleteTask(
+  const EL::Value& value) const
+{
+  expectStructure(
+    value, "[ {'type': 'String', 'target': 'String'}, { 'enabled': 'Boolean' } ]");
+
+  const bool enabled = value.contains("enabled") ? value["enabled"].booleanValue() : true;
+  const std::string target = value["target"].stringValue();
+
+  return std::make_unique<Model::CompilationDeleteFiles>(enabled, target);
 }
 
 std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseToolTask(

--- a/common/src/IO/CompilationConfigParser.h
+++ b/common/src/IO/CompilationConfigParser.h
@@ -57,6 +57,7 @@ private:
   std::unique_ptr<Model::CompilationTask> parseTask(const EL::Value& value) const;
   std::unique_ptr<Model::CompilationTask> parseExportTask(const EL::Value& value) const;
   std::unique_ptr<Model::CompilationTask> parseCopyTask(const EL::Value& value) const;
+  std::unique_ptr<Model::CompilationTask> parseDeleteTask(const EL::Value& value) const;
   std::unique_ptr<Model::CompilationTask> parseToolTask(const EL::Value& value) const;
 
   deleteCopyAndMove(CompilationConfigParser);

--- a/common/src/IO/CompilationConfigWriter.cpp
+++ b/common/src/IO/CompilationConfigWriter.cpp
@@ -106,6 +106,18 @@ public:
     m_array.push_back(EL::Value(std::move(map)));
   }
 
+  void visit(const Model::CompilationDeleteFiles& task) override
+  {
+    EL::MapType map;
+    if (!task.enabled())
+    {
+      map["enabled"] = EL::Value(false);
+    }
+    map["type"] = EL::Value("delete");
+    map["target"] = EL::Value(task.targetSpec());
+    m_array.push_back(EL::Value(std::move(map)));
+  }
+
   void visit(const Model::CompilationRunTool& task) override
   {
     EL::MapType map;

--- a/common/src/Model/CompilationTask.cpp
+++ b/common/src/Model/CompilationTask.cpp
@@ -209,6 +209,74 @@ void CompilationCopyFiles::appendToStream(std::ostream& str) const
                           << "m_targetSpec" << m_targetSpec;
 }
 
+// CompilationDeleteFiles
+
+CompilationDeleteFiles::CompilationDeleteFiles(
+  const bool enabled, const std::string& targetSpec)
+  : CompilationTask(enabled)
+  , m_targetSpec(targetSpec)
+{
+}
+
+void CompilationDeleteFiles::accept(CompilationTaskVisitor& visitor)
+{
+  visitor.visit(*this);
+}
+
+void CompilationDeleteFiles::accept(ConstCompilationTaskVisitor& visitor) const
+{
+  visitor.visit(*this);
+}
+
+void CompilationDeleteFiles::accept(const CompilationTaskConstVisitor& visitor)
+{
+  visitor.visit(*this);
+}
+
+void CompilationDeleteFiles::accept(const ConstCompilationTaskConstVisitor& visitor) const
+{
+  visitor.visit(*this);
+}
+
+const std::string& CompilationDeleteFiles::targetSpec() const
+{
+  return m_targetSpec;
+}
+
+void CompilationDeleteFiles::setTargetSpec(const std::string& targetSpec)
+{
+  m_targetSpec = targetSpec;
+}
+
+CompilationDeleteFiles* CompilationDeleteFiles::clone() const
+{
+  return new CompilationDeleteFiles(enabled(), m_targetSpec);
+}
+
+bool CompilationDeleteFiles::operator==(const CompilationTask& other) const
+{
+  auto* otherCasted = dynamic_cast<const CompilationDeleteFiles*>(&other);
+  if (otherCasted == nullptr)
+  {
+    return false;
+  }
+  if (m_enabled != otherCasted->m_enabled)
+  {
+    return false;
+  }
+  if (m_targetSpec != otherCasted->m_targetSpec)
+  {
+    return false;
+  }
+  return true;
+}
+
+void CompilationDeleteFiles::appendToStream(std::ostream& str) const
+{
+  kdl::struct_stream{str} << "CompilationDeleteFiles"
+                          << "m_enabled" << m_enabled << "m_targetSpec" << m_targetSpec;
+}
+
 // CompilationRunTool
 
 CompilationRunTool::CompilationRunTool(

--- a/common/src/Model/CompilationTask.h
+++ b/common/src/Model/CompilationTask.h
@@ -114,6 +114,30 @@ public:
   deleteCopyAndMove(CompilationCopyFiles);
 };
 
+class CompilationDeleteFiles : public CompilationTask
+{
+private:
+  std::string m_targetSpec;
+
+public:
+  CompilationDeleteFiles(bool enabled, const std::string& targetSpec);
+
+  void accept(CompilationTaskVisitor& visitor) override;
+  void accept(ConstCompilationTaskVisitor& visitor) const override;
+  void accept(const CompilationTaskConstVisitor& visitor) override;
+  void accept(const ConstCompilationTaskConstVisitor& visitor) const override;
+
+  const std::string& targetSpec() const;
+
+  void setTargetSpec(const std::string& targetSpec);
+
+  CompilationDeleteFiles* clone() const override;
+  bool operator==(const CompilationTask& other) const override;
+  void appendToStream(std::ostream& str) const override;
+
+  deleteCopyAndMove(CompilationDeleteFiles);
+};
+
 class CompilationRunTool : public CompilationTask
 {
 private:
@@ -149,6 +173,7 @@ public:
 
   virtual void visit(CompilationExportMap& task) = 0;
   virtual void visit(CompilationCopyFiles& task) = 0;
+  virtual void visit(CompilationDeleteFiles& task) = 0;
   virtual void visit(CompilationRunTool& task) = 0;
 };
 
@@ -159,6 +184,7 @@ public:
 
   virtual void visit(const CompilationExportMap& task) = 0;
   virtual void visit(const CompilationCopyFiles& task) = 0;
+  virtual void visit(const CompilationDeleteFiles& task) = 0;
   virtual void visit(const CompilationRunTool& task) = 0;
 };
 
@@ -169,6 +195,7 @@ public:
 
   virtual void visit(CompilationExportMap& task) const = 0;
   virtual void visit(CompilationCopyFiles& task) const = 0;
+  virtual void visit(CompilationDeleteFiles& task) const = 0;
   virtual void visit(CompilationRunTool& task) const = 0;
 };
 
@@ -179,6 +206,7 @@ public:
 
   virtual void visit(const CompilationExportMap& task) const = 0;
   virtual void visit(const CompilationCopyFiles& task) const = 0;
+  virtual void visit(const CompilationDeleteFiles& task) const = 0;
   virtual void visit(const CompilationRunTool& task) const = 0;
 };
 } // namespace Model

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -202,6 +202,7 @@ void CompilationProfileEditor::addTask()
   QMenu menu;
   auto* exportMapAction = menu.addAction("Export Map");
   auto* copyFilesAction = menu.addAction("Copy Files");
+  auto* deleteFilesAction = menu.addAction("Delete Files");
   auto* runToolAction = menu.addAction("Run Tool");
 
   std::unique_ptr<Model::CompilationTask> task = nullptr;
@@ -214,6 +215,10 @@ void CompilationProfileEditor::addTask()
   else if (chosenAction == copyFilesAction)
   {
     task = std::make_unique<Model::CompilationCopyFiles>(true, "", "");
+  }
+  else if (chosenAction == deleteFilesAction)
+  {
+    task = std::make_unique<Model::CompilationDeleteFiles>(true, "");
   }
   else if (chosenAction == runToolAction)
   {

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -31,6 +31,9 @@
 #include "View/CompilationVariables.h"
 #include "View/MapDocument.h"
 
+#include <kdl/string_utils.h>
+#include <kdl/vector_utils.h>
+
 #include <string>
 
 #include <QDir>
@@ -143,17 +146,20 @@ void CompilationCopyFilesTaskRunner::doExecute()
     const auto targetPath = IO::Path{interpolate(m_task->targetSpec())};
 
     const auto sourceDirPath = sourcePath.deleteLastComponent();
-    const auto sourcePattern = sourcePath.lastComponent().asString();
+    const auto sourcePattern = IO::FileNameMatcher{sourcePath.lastComponent().asString()};
 
     try
     {
-      m_context << "#### Copying '" << IO::pathAsQString(sourcePath) << "' to '"
-                << IO::pathAsQString(targetPath) << "'\n";
+      const auto sourcePaths = IO::Disk::findItems(sourceDirPath, sourcePattern);
+      const auto sourceStrs = kdl::vec_transform(
+        sourcePaths, [](const auto& path) { return "'" + path.asString() + "'"; });
+      const auto sourceListQStr = QString::fromStdString(kdl::str_join(sourceStrs, ", "));
+      m_context << "#### Copying to '" << IO::pathAsQString(targetPath)
+                << "/': " << sourceListQStr << "\n";
       if (!m_context.test())
       {
         IO::Disk::ensureDirectoryExists(targetPath);
-        IO::Disk::copyFiles(
-          sourceDirPath, IO::FileNameMatcher{sourcePattern}, targetPath, true);
+        IO::Disk::copyFiles(sourceDirPath, sourcePattern, targetPath, true);
       }
       emit end();
     }
@@ -190,14 +196,18 @@ void CompilationDeleteFilesTaskRunner::doExecute()
     const auto targetPath = IO::Path{interpolate(m_task->targetSpec())};
 
     const auto targetDirPath = targetPath.deleteLastComponent();
-    const auto targetPattern = targetPath.lastComponent().asString();
+    const auto targetPattern = IO::FileNameMatcher{targetPath.lastComponent().asString()};
 
     try
     {
-      m_context << "#### Deleting '" << IO::pathAsQString(targetPath) << "'\n";
+      const auto targetPaths = IO::Disk::findItems(targetDirPath, targetPattern);
+      const auto targetStrs = kdl::vec_transform(
+        targetPaths, [](const auto& path) { return "'" + path.asString() + "'"; });
+      const auto targetListQStr = QString::fromStdString(kdl::str_join(targetStrs, ", "));
+      m_context << "#### Deleting: " << targetListQStr << "\n";
       if (!m_context.test())
       {
-        IO::Disk::deleteFiles(targetDirPath, IO::FileNameMatcher{targetPattern});
+        IO::Disk::deleteFiles(targetDirPath, targetPattern);
       }
       emit end();
     }

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -172,6 +172,50 @@ void CompilationCopyFilesTaskRunner::doExecute()
 
 void CompilationCopyFilesTaskRunner::doTerminate() {}
 
+CompilationDeleteFilesTaskRunner::CompilationDeleteFilesTaskRunner(
+  CompilationContext& context, const Model::CompilationDeleteFiles& task)
+  : CompilationTaskRunner{context}
+  , m_task{task.clone()}
+{
+}
+
+CompilationDeleteFilesTaskRunner::~CompilationDeleteFilesTaskRunner() = default;
+
+void CompilationDeleteFilesTaskRunner::doExecute()
+{
+  emit start();
+
+  try
+  {
+    const auto targetPath = IO::Path{interpolate(m_task->targetSpec())};
+
+    const auto targetDirPath = targetPath.deleteLastComponent();
+    const auto targetPattern = targetPath.lastComponent().asString();
+
+    try
+    {
+      m_context << "#### Deleting '" << IO::pathAsQString(targetPath) << "'\n";
+      if (!m_context.test())
+      {
+        IO::Disk::deleteFiles(targetDirPath, IO::FileNameMatcher{targetPattern});
+      }
+      emit end();
+    }
+    catch (const Exception& e)
+    {
+      m_context << "#### Could not delete '" << IO::pathAsQString(targetPath)
+                << "': " << e.what() << "\n";
+      throw;
+    }
+  }
+  catch (const Exception&)
+  {
+    emit error();
+  }
+}
+
+void CompilationDeleteFilesTaskRunner::doTerminate() {}
+
 CompilationRunToolTaskRunner::CompilationRunToolTaskRunner(
   CompilationContext& context, const Model::CompilationRunTool& task)
   : CompilationTaskRunner{context}
@@ -354,6 +398,14 @@ public:
     if (task.enabled())
     {
       appendRunner(std::make_unique<CompilationCopyFilesTaskRunner>(m_context, task));
+    }
+  }
+
+  void visit(const Model::CompilationDeleteFiles& task) override
+  {
+    if (task.enabled())
+    {
+      appendRunner(std::make_unique<CompilationDeleteFilesTaskRunner>(m_context, task));
     }
   }
 

--- a/common/src/View/CompilationRunner.h
+++ b/common/src/View/CompilationRunner.h
@@ -33,6 +33,7 @@ namespace TrenchBroom
 namespace Model
 {
 class CompilationCopyFiles;
+class CompilationDeleteFiles;
 class CompilationExportMap;
 class CompilationProfile;
 class CompilationRunTool;
@@ -105,6 +106,24 @@ private:
   void doTerminate() override;
 
   deleteCopyAndMove(CompilationCopyFilesTaskRunner);
+};
+
+class CompilationDeleteFilesTaskRunner : public CompilationTaskRunner
+{
+  Q_OBJECT
+private:
+  std::unique_ptr<const Model::CompilationDeleteFiles> m_task;
+
+public:
+  CompilationDeleteFilesTaskRunner(
+    CompilationContext& context, const Model::CompilationDeleteFiles& task);
+  ~CompilationDeleteFilesTaskRunner() override;
+
+private:
+  void doExecute() override;
+  void doTerminate() override;
+
+  deleteCopyAndMove(CompilationDeleteFilesTaskRunner);
 };
 
 class CompilationRunToolTaskRunner : public CompilationTaskRunner

--- a/common/src/View/CompilationTaskListBox.h
+++ b/common/src/View/CompilationTaskListBox.h
@@ -36,6 +36,7 @@ namespace TrenchBroom
 namespace Model
 {
 class CompilationCopyFiles;
+class CompilationDeleteFiles;
 class CompilationExportMap;
 class CompilationProfile;
 class CompilationRunTool;
@@ -120,6 +121,26 @@ private:
   Model::CompilationCopyFiles& task();
 private slots:
   void sourceSpecChanged(const QString& text);
+  void targetSpecChanged(const QString& text);
+};
+
+class CompilationDeleteFilesTaskEditor : public CompilationTaskEditorBase
+{
+  Q_OBJECT
+private:
+  MultiCompletionLineEdit* m_targetEditor;
+
+public:
+  CompilationDeleteFilesTaskEditor(
+    std::weak_ptr<MapDocument> document,
+    Model::CompilationProfile& profile,
+    Model::CompilationDeleteFiles& task,
+    QWidget* parent = nullptr);
+
+private:
+  void updateItem() override;
+  Model::CompilationDeleteFiles& task();
+private slots:
   void targetSpecChanged(const QString& text);
 };
 

--- a/common/test/src/View/CompilationRunnerTest.cpp
+++ b/common/test/src/View/CompilationRunnerTest.cpp
@@ -143,10 +143,12 @@ TEST_CASE_METHOD(MapDocumentTest, "CompilationDeleteFilesTaskRunner.deleteTarget
   const auto file1 = IO::Path("file1.lit");
   const auto file2 = IO::Path("file2.lit");
   const auto file3 = IO::Path("file3.map");
+  const auto dir = IO::Path("somedir.lit");
 
   testEnvironment.createFile(file1, "");
   testEnvironment.createFile(file2, "");
   testEnvironment.createFile(file3, "");
+  testEnvironment.createDirectory(dir);
 
   auto task = Model::CompilationDeleteFiles{
     true, (testEnvironment.dir() + IO::Path("*.lit")).asString()};
@@ -157,6 +159,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CompilationDeleteFilesTaskRunner.deleteTarget
   CHECK(!testEnvironment.fileExists(file1));
   CHECK(!testEnvironment.fileExists(file2));
   CHECK(testEnvironment.fileExists(file3));
+  CHECK(testEnvironment.directoryExists(dir));
 }
 
 TEST_CASE("CompilationRunner.interpolateToolsVariables")

--- a/common/test/src/View/CompilationRunnerTest.cpp
+++ b/common/test/src/View/CompilationRunnerTest.cpp
@@ -130,6 +130,35 @@ TEST_CASE_METHOD(
   CHECK(testEnvironment.directoryExists(targetPath));
 }
 
+TEST_CASE_METHOD(MapDocumentTest, "CompilationDeleteFilesTaskRunner.deleteTargetPattern")
+{
+  auto variables = EL::NullVariableStore{};
+  auto output = QTextEdit{};
+  auto outputAdapter = TextOutputAdapter{&output};
+
+  auto context = CompilationContext{document, variables, outputAdapter, false};
+
+  auto testEnvironment = IO::TestEnvironment{};
+
+  const auto file1 = IO::Path("file1.lit");
+  const auto file2 = IO::Path("file2.lit");
+  const auto file3 = IO::Path("file3.map");
+
+  testEnvironment.createFile(file1, "");
+  testEnvironment.createFile(file2, "");
+  testEnvironment.createFile(file3, "");
+
+  auto task = Model::CompilationDeleteFiles{
+    true, (testEnvironment.dir() + IO::Path("*.lit")).asString()};
+  auto runner = CompilationDeleteFilesTaskRunner{context, task};
+
+  REQUIRE_NOTHROW(runner.execute());
+
+  CHECK(!testEnvironment.fileExists(file1));
+  CHECK(!testEnvironment.fileExists(file2));
+  CHECK(testEnvironment.fileExists(file3));
+}
+
 TEST_CASE("CompilationRunner.interpolateToolsVariables")
 {
   auto [document, game, gameConfig] = View::loadMapDocument(


### PR DESCRIPTION
Closes #3887.

This adds a "Delete Files" task to implement a platform-independent representation of rm/del/whatever. It accepts wildcards in the final path component.

The change is pretty mechanical; it's just kind of following CopyFiles around the codebase.

Note that this does NOT address config file versioning in any way (cf. the issue comments). If a config that includes a delete task is somehow used with an older version of TB, parsing that config will fail with an "Unknown compilation task type" exception.