### PR TITLE
4047: new "single target" checkbox for the Copy Files task

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1525,10 +1525,11 @@ Run Tool
 Copy Files
 :	Copies one or more files.
 
-    Parameter 	Description
-    ---------   -----------
-    Source 		The file(s) to copy. To specify more than one file, you can use wildcards (*,?) in the filename. Variables are allowed.
-    Target  	The directory to copy the files to. The directory is recursively created if it does not exist. Existing files are overwritten without prompt. Variables are allowed.
+    Parameter 		Description
+    ---------   	-----------
+    Source 			The file(s) to copy. If "Target is File" (see below) is unchecked, this parameter can use wildcards (*,?) in the filename to specify more than one file to copy into the target directory. Variables are allowed.
+    Target  		This is the path for the file or directory (as indicated by "Target is File") to copy the source file(s) to. Any directories in this path are created if they do not exist. Existing files are overwritten without prompt. Variables are allowed.
+    Target is File 	Whether the Target path represents a file (rather than a directory).
 
 
 You can use [expressions](#expression_language) when specifying the working directory of a profile and also for the task parameters. The following table lists the available variables, their scopes, and their meaning. A scope of 'Tool' indicates that the variable is available when specifying tool parameters. A scope of 'Workdir' indicates that the variable is only available when specifying the working directory. Note that TrenchBroom helps you to enter variables by popping up an autocompletion list.
@@ -1553,7 +1554,7 @@ It is recommended to use the following general process for compiling maps and to
 1. Set the working directory to `${MAP_DIR_PATH}`.
 2. Add an *Export Map* task and set its target to `${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.map`.
 3. Add *Run Tool* tasks for the compilation tools that you wish to run. Use the expressions `${MAP_BASE_NAME}-compile.map` and `${MAP_BASE_NAME}.bsp` to specify the input and output files for the tools. Since you have set a working directory, you don't need to specify absolute paths here.
-4. Finally, add a *Copy Files* task and set its source to `${WORK_DIR_PATH}/${MAP_BASE_NAME}.bsp` and its target to `${GAME_DIR_PATH}/${MODS[-1]}/maps`. This copies the file to the maps directory within the last enabled mod.
+4. Finally, add a *Copy Files* task and set its source to `${WORK_DIR_PATH}/${MAP_BASE_NAME}.bsp` and its target to `${GAME_DIR_PATH}/${MODS[-1]}/maps`. Leave *Target is File* **un**checked, to indicate that the target path is a directory. This setup copies the file to the maps directory within the last enabled mod.
 
 The last step will copy the bsp file to the appropriate directory within the game path. You can add more *Copy Files* tasks if the compilation produces more than just a bsp file (e.g. lightmap files). Alternatively, you can use a wildcard expression such as `${WORK_DIR_PATH}/${MAP_BASE_NAME}.*` to copy related files.
 

--- a/common/src/IO/CompilationConfigParser.cpp
+++ b/common/src/IO/CompilationConfigParser.cpp
@@ -133,13 +133,16 @@ std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseCopyTask(
   expectStructure(
     value,
     "[ {'type': 'String', 'source': 'String', 'target': 'String'}, { 'enabled': "
-    "'Boolean' } ]");
+    "'Boolean', 'targetIsFile': 'Boolean' } ]");
 
   const bool enabled = value.contains("enabled") ? value["enabled"].booleanValue() : true;
+  const bool targetIsFile =
+    value.contains("targetIsFile") ? value["targetIsFile"].booleanValue() : false;
   const std::string source = value["source"].stringValue();
   const std::string target = value["target"].stringValue();
 
-  return std::make_unique<Model::CompilationCopyFiles>(enabled, source, target);
+  return std::make_unique<Model::CompilationCopyFiles>(
+    enabled, targetIsFile, source, target);
 }
 
 std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseToolTask(

--- a/common/src/IO/CompilationConfigWriter.cpp
+++ b/common/src/IO/CompilationConfigWriter.cpp
@@ -101,6 +101,7 @@ public:
       map["enabled"] = EL::Value(false);
     }
     map["type"] = EL::Value("copy");
+    map["targetIsFile"] = EL::Value(task.targetIsFileSpec());
     map["source"] = EL::Value(task.sourceSpec());
     map["target"] = EL::Value(task.targetSpec());
     m_array.push_back(EL::Value(std::move(map)));

--- a/common/src/Model/CompilationTask.cpp
+++ b/common/src/Model/CompilationTask.cpp
@@ -128,8 +128,12 @@ void CompilationExportMap::appendToStream(std::ostream& str) const
 // CompilationCopyFiles
 
 CompilationCopyFiles::CompilationCopyFiles(
-  const bool enabled, const std::string& sourceSpec, const std::string& targetSpec)
+  const bool enabled,
+  const bool targetIsFileSpec,
+  const std::string& sourceSpec,
+  const std::string& targetSpec)
   : CompilationTask(enabled)
+  , m_targetIsFileSpec(targetIsFileSpec)
   , m_sourceSpec(sourceSpec)
   , m_targetSpec(targetSpec)
 {
@@ -155,6 +159,11 @@ void CompilationCopyFiles::accept(const ConstCompilationTaskConstVisitor& visito
   visitor.visit(*this);
 }
 
+bool CompilationCopyFiles::targetIsFileSpec() const
+{
+  return m_targetIsFileSpec;
+}
+
 const std::string& CompilationCopyFiles::sourceSpec() const
 {
   return m_sourceSpec;
@@ -163,6 +172,11 @@ const std::string& CompilationCopyFiles::sourceSpec() const
 const std::string& CompilationCopyFiles::targetSpec() const
 {
   return m_targetSpec;
+}
+
+void CompilationCopyFiles::setTargetIsFileSpec(const bool targetIsFileSpec)
+{
+  m_targetIsFileSpec = targetIsFileSpec;
 }
 
 void CompilationCopyFiles::setSourceSpec(const std::string& sourceSpec)
@@ -177,7 +191,8 @@ void CompilationCopyFiles::setTargetSpec(const std::string& targetSpec)
 
 CompilationCopyFiles* CompilationCopyFiles::clone() const
 {
-  return new CompilationCopyFiles(enabled(), m_sourceSpec, m_targetSpec);
+  return new CompilationCopyFiles(
+    enabled(), m_targetIsFileSpec, m_sourceSpec, m_targetSpec);
 }
 
 bool CompilationCopyFiles::operator==(const CompilationTask& other) const
@@ -188,6 +203,10 @@ bool CompilationCopyFiles::operator==(const CompilationTask& other) const
     return false;
   }
   if (m_enabled != otherCasted->m_enabled)
+  {
+    return false;
+  }
+  if (m_targetIsFileSpec != otherCasted->m_targetIsFileSpec)
   {
     return false;
   }
@@ -205,7 +224,8 @@ bool CompilationCopyFiles::operator==(const CompilationTask& other) const
 void CompilationCopyFiles::appendToStream(std::ostream& str) const
 {
   kdl::struct_stream{str} << "CompilationCopyFiles"
-                          << "m_enabled" << m_enabled << "m_sourceSpec" << m_sourceSpec
+                          << "m_enabled" << m_enabled << "m_targetIsFileSpec"
+                          << m_targetIsFileSpec << "m_sourceSpec" << m_sourceSpec
                           << "m_targetSpec" << m_targetSpec;
 }
 

--- a/common/src/Model/CompilationTask.h
+++ b/common/src/Model/CompilationTask.h
@@ -89,21 +89,27 @@ public:
 class CompilationCopyFiles : public CompilationTask
 {
 private:
+  bool m_targetIsFileSpec;
   std::string m_sourceSpec;
   std::string m_targetSpec;
 
 public:
   CompilationCopyFiles(
-    bool enabled, const std::string& sourceSpec, const std::string& targetSpec);
+    bool enabled,
+    bool targetIsFileSpec,
+    const std::string& sourceSpec,
+    const std::string& targetSpec);
 
   void accept(CompilationTaskVisitor& visitor) override;
   void accept(ConstCompilationTaskVisitor& visitor) const override;
   void accept(const CompilationTaskConstVisitor& visitor) override;
   void accept(const ConstCompilationTaskConstVisitor& visitor) const override;
 
+  bool targetIsFileSpec() const;
   const std::string& sourceSpec() const;
   const std::string& targetSpec() const;
 
+  void setTargetIsFileSpec(const bool targetIsFileSpec);
   void setSourceSpec(const std::string& sourceSpec);
   void setTargetSpec(const std::string& targetSpec);
 

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -213,7 +213,7 @@ void CompilationProfileEditor::addTask()
   }
   else if (chosenAction == copyFilesAction)
   {
-    task = std::make_unique<Model::CompilationCopyFiles>(true, "", "");
+    task = std::make_unique<Model::CompilationCopyFiles>(true, false, "", "");
   }
   else if (chosenAction == runToolAction)
   {

--- a/common/src/View/CompilationTaskListBox.cpp
+++ b/common/src/View/CompilationTaskListBox.cpp
@@ -195,6 +195,7 @@ CompilationCopyFilesTaskEditor::CompilationCopyFilesTaskEditor(
   Model::CompilationCopyFiles& task,
   QWidget* parent)
   : CompilationTaskEditorBase("Copy Files", std::move(document), profile, task, parent)
+  , m_targetIsFileCheckbox(nullptr)
   , m_sourceEditor(nullptr)
   , m_targetEditor(nullptr)
 {
@@ -218,6 +219,16 @@ CompilationCopyFilesTaskEditor::CompilationCopyFilesTaskEditor(
   setupCompleter(m_targetEditor);
   formLayout->addRow("Target", m_targetEditor);
 
+  m_targetIsFileCheckbox = new QCheckBox();
+  m_targetIsFileCheckbox->setToolTip(
+    tr("Whether the Target path represents a file (rather than a directory)"));
+  formLayout->addRow("Target is File", m_targetIsFileCheckbox);
+
+  connect(
+    m_targetIsFileCheckbox,
+    &QCheckBox::clicked,
+    this,
+    &CompilationCopyFilesTaskEditor::targetIsFileSpecChanged);
   connect(
     m_sourceEditor,
     &QLineEdit::textChanged,
@@ -233,6 +244,9 @@ CompilationCopyFilesTaskEditor::CompilationCopyFilesTaskEditor(
 void CompilationCopyFilesTaskEditor::updateItem()
 {
   CompilationTaskEditorBase::updateItem();
+
+  const auto targetIsFileSpec = task().targetIsFileSpec();
+  m_targetIsFileCheckbox->setChecked(targetIsFileSpec);
 
   const auto sourceSpec = QString::fromStdString(task().sourceSpec());
   if (m_sourceEditor->text() != sourceSpec)
@@ -252,6 +266,11 @@ Model::CompilationCopyFiles& CompilationCopyFilesTaskEditor::task()
   // This is safe because we know what type of task the editor was initialized with.
   // We have to do this to avoid using a template as the base class.
   return static_cast<Model::CompilationCopyFiles&>(*m_task);
+}
+
+void CompilationCopyFilesTaskEditor::targetIsFileSpecChanged(const bool checked)
+{
+  task().setTargetIsFileSpec(checked);
 }
 
 void CompilationCopyFilesTaskEditor::sourceSpecChanged(const QString& text)

--- a/common/src/View/CompilationTaskListBox.h
+++ b/common/src/View/CompilationTaskListBox.h
@@ -105,6 +105,7 @@ class CompilationCopyFilesTaskEditor : public CompilationTaskEditorBase
 {
   Q_OBJECT
 private:
+  QCheckBox* m_targetIsFileCheckbox;
   MultiCompletionLineEdit* m_sourceEditor;
   MultiCompletionLineEdit* m_targetEditor;
 
@@ -119,6 +120,7 @@ private:
   void updateItem() override;
   Model::CompilationCopyFiles& task();
 private slots:
+  void targetIsFileSpecChanged(const bool checked);
   void sourceSpecChanged(const QString& text);
   void targetSpecChanged(const QString& text);
 };

--- a/common/test/src/View/CompilationRunnerTest.cpp
+++ b/common/test/src/View/CompilationRunnerTest.cpp
@@ -121,6 +121,7 @@ TEST_CASE_METHOD(
 
   auto task = Model::CompilationCopyFiles{
     true,
+    false,
     (testEnvironment.dir() + sourcePath).asString(),
     (testEnvironment.dir() + targetPath).asString()};
   auto runner = CompilationCopyFilesTaskRunner{context, task};


### PR DESCRIPTION
![formtest](https://user-images.githubusercontent.com/2068148/206267078-99dc8300-a429-447e-a7e5-3ce0927f77e1.png)

As discussed in issue #4047, having this option would address the limitations of the current "copy to directory" behavior in a way that tackles a couple of the affected usecases.

This would also address the documentation part of issue #4019 (or at least make it moot). As a way to provide a platform-independent tool for this task it is also work toward issue #1924 and issue #2033.

Note that this does NOT address config file versioning in any way (cf. the comments for issue #3887). If a config that includes a copy-files task with this option is somehow used with an older version of TB, parsing that config will fail with an "Unknown compilation task type" exception. However, existing config files that include a "Copy Files" task will still work with this code, since this new flag is optional (defaults to false).