### PR TITLE
4166: Select brushes in entity if selecting the entity by line number

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1224,17 +1224,11 @@ void MapDocument::selectInverse()
 void MapDocument::selectNodesWithFilePosition(const std::vector<size_t>& positions)
 {
   const auto nodes = kdl::vec_filter(
-    Model::collectSelectableNodes(
-      std::vector<Model::Node*>{m_world.get()}, *m_editorContext),
+    Model::collectSelectableNodes({m_world.get()}, *m_editorContext),
     [&](const auto* node) {
-      for (const size_t position : positions)
-      {
-        if (node->containsLine(position))
-        {
-          return true;
-        }
-      }
-      return false;
+      return std::any_of(positions.begin(), positions.end(), [&](const auto position) {
+        return node->containsLine(position);
+      });
     });
 
   auto transaction = Transaction{*this, "Select by Line Number"};

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1223,17 +1223,70 @@ void MapDocument::selectInverse()
 
 void MapDocument::selectNodesWithFilePosition(const std::vector<size_t>& positions)
 {
-  const auto nodes = kdl::vec_filter(
-    Model::collectSelectableNodes({m_world.get()}, *m_editorContext),
-    [&](const auto* node) {
-      return std::any_of(positions.begin(), positions.end(), [&](const auto position) {
-        return node->containsLine(position);
-      });
+  auto nodesToSelect = std::vector<Model::Node*>{};
+  const auto hasFilePosition = [&](const auto* node) {
+    return std::any_of(positions.begin(), positions.end(), [&](const auto position) {
+      return node->containsLine(position);
     });
+  };
+
+  m_world->accept(kdl::overload(
+    [&](auto&& thisLambda, Model::WorldNode* worldNode) {
+      worldNode->visitChildren(thisLambda);
+    },
+    [&](auto&& thisLambda, Model::LayerNode* layerNode) {
+      layerNode->visitChildren(thisLambda);
+    },
+    [&](auto&& thisLambda, Model::GroupNode* groupNode) {
+      if (hasFilePosition(groupNode))
+      {
+        if (m_editorContext->selectable(groupNode))
+        {
+          nodesToSelect.push_back(groupNode);
+        }
+        else
+        {
+          groupNode->visitChildren(thisLambda);
+        }
+      }
+    },
+    [&](auto&& thisLambda, Model::EntityNode* entityNode) {
+      if (hasFilePosition(entityNode))
+      {
+        if (m_editorContext->selectable(entityNode))
+        {
+          nodesToSelect.push_back(entityNode);
+        }
+        else
+        {
+          const auto previousCount = nodesToSelect.size();
+          entityNode->visitChildren(thisLambda);
+          if (previousCount == nodesToSelect.size())
+          {
+            // no child was selected, select all children
+            nodesToSelect = kdl::vec_concat(
+              std::move(nodesToSelect),
+              Model::collectSelectableNodes(entityNode->children(), *m_editorContext));
+          }
+        }
+      }
+    },
+    [&](Model::BrushNode* brushNode) {
+      if (hasFilePosition(brushNode) && m_editorContext->selectable(brushNode))
+      {
+        nodesToSelect.push_back(brushNode);
+      }
+    },
+    [&](Model::PatchNode* patchNode) {
+      if (hasFilePosition(patchNode) && m_editorContext->selectable(patchNode))
+      {
+        nodesToSelect.push_back(patchNode);
+      }
+    }));
 
   auto transaction = Transaction{*this, "Select by Line Number"};
   deselectAll();
-  selectNodes(nodes);
+  selectNodes(nodesToSelect);
   transaction.commit();
 }
 

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -337,10 +337,7 @@ TEST_CASE_METHOD(MapDocumentTest, "selectByLineNumber")
       {{7}, {}},
       {{12}, {"pointEntity"}},
       {{16}, {"patch"}},
-      /* EXPECTED:
       {{20}, {"brushInEntity1", "brushInEntity2"}},
-      ACTUAL: */
-      {{20}, {}},
       {{24}, {"brushInEntity1"}},
       {{26}, {"brushInEntity2"}},
       {{31}, {"outerGroup"}},


### PR DESCRIPTION
Closes #4166.

This PR makes it so that selecting a brush entity by a line number in the entity itself (e.g. one of its properties) and not one of the contained brushes, then all brushes in the entity are selected. Previously, nothing would be selected because brush entities are not selectable.