### PR TITLE
4152: Cancel dragging when map view loses focus

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -915,6 +915,7 @@ void MapViewBase::focusInEvent(QFocusEvent* event)
 
 void MapViewBase::focusOutEvent(QFocusEvent* event)
 {
+  cancelMouseDrag();
   clearModifierKeys();
   update();
   RenderView::focusOutEvent(event);

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -367,7 +367,7 @@ private:
 
 private: // subclassing interface
   virtual vm::vec3 doGetMoveDirection(vm::direction direction) const = 0;
-  virtual size_t doGetFlipAxis(const vm::direction direction) const = 0;
+  virtual size_t doGetFlipAxis(vm::direction direction) const = 0;
   virtual vm::vec3 doComputePointEntityPosition(const vm::bbox3& bounds) const = 0;
 
   virtual ActionContext::Type doGetActionContext() const = 0;


### PR DESCRIPTION
Closes #4152.

The cause of the undo/redo menu items getting disabled is possibly that there is a transaction still running. Transactions get started for drags, and drags can end unexpectedly if the map view loses focus. We now explicitly cancel any drags when the map view loses focus to keep TB in a clean state.