### PR TITLE
4115: Transform grouped brush entities if all children are transformed

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -538,7 +538,7 @@ static CreateNodeResult createNodeFromEntityInfo(
 {
   const auto& classname = findEntityPropertyOrDefault(
     entityInfo.properties, Model::EntityPropertyKeys::Classname);
-  if (isWorldspawn(classname, entityInfo.properties))
+  if (Model::isWorldspawn(classname))
   {
     return createWorldNode(std::move(entityInfo), entityPropertyConfig, mapFormat);
   }

--- a/common/src/Model/EntityProperties.cpp
+++ b/common/src/Model/EntityProperties.cpp
@@ -186,8 +186,7 @@ bool isGroup(const std::string& classname, const std::vector<EntityProperty>& pr
   }
 }
 
-bool isWorldspawn(
-  const std::string& classname, const std::vector<EntityProperty>& /* properties */)
+bool isWorldspawn(const std::string& classname)
 {
   return classname == EntityPropertyValues::WorldspawnClassname;
 }

--- a/common/src/Model/EntityProperties.h
+++ b/common/src/Model/EntityProperties.h
@@ -121,8 +121,7 @@ public:
 
 bool isLayer(const std::string& classname, const std::vector<EntityProperty>& properties);
 bool isGroup(const std::string& classname, const std::vector<EntityProperty>& properties);
-bool isWorldspawn(
-  const std::string& classname, const std::vector<EntityProperty>& properties);
+bool isWorldspawn(const std::string& classname);
 
 std::vector<EntityProperty>::const_iterator findEntityProperty(
   const std::vector<EntityProperty>& properties, const std::string& key);

--- a/common/src/View/EntityPropertyModel.cpp
+++ b/common/src/View/EntityPropertyModel.cpp
@@ -70,7 +70,7 @@ static bool isPropertyKeyMutable(const Model::Entity& entity, const std::string&
   assert(!Model::isGroup(entity.classname(), entity.properties()));
   assert(!Model::isLayer(entity.classname(), entity.properties()));
 
-  if (Model::isWorldspawn(entity.classname(), entity.properties()))
+  if (Model::isWorldspawn(entity.classname()))
   {
     return !(
       key == Model::EntityPropertyKeys::Classname
@@ -93,7 +93,7 @@ static bool isPropertyValueMutable(const Model::Entity& entity, const std::strin
   assert(!Model::isGroup(entity.classname(), entity.properties()));
   assert(!Model::isLayer(entity.classname(), entity.properties()));
 
-  if (Model::isWorldspawn(entity.classname(), entity.properties()))
+  if (Model::isWorldspawn(entity.classname()))
   {
     return !(
       key == Model::EntityPropertyKeys::Classname

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2805,11 +2805,11 @@ bool MapDocument::transformObjects(
   auto nodesToTransform = std::vector<Model::Node*>{};
 
   const auto addEntity = [&](auto* node) {
-    if (auto* entity = node->entity())
+    if (auto* entityNode = node->entity())
     {
-      if (entity->childSelectionCount() == entity->childCount())
+      if (entityNode->childSelectionCount() == entityNode->childCount())
       {
-        nodesToTransform.push_back(entity);
+        nodesToTransform.push_back(entityNode);
       }
     }
   };
@@ -2817,31 +2817,33 @@ bool MapDocument::transformObjects(
   for (auto* node : m_selectedNodes)
   {
     node->accept(kdl::overload(
-      [&](
-        auto&& thisLambda, Model::WorldNode* world) { world->visitChildren(thisLambda); },
-      [&](
-        auto&& thisLambda, Model::LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, Model::GroupNode* group) {
-        nodesToTransform.push_back(group);
-        group->visitChildren(thisLambda);
+      [&](auto&& thisLambda, Model::WorldNode* worldNode) {
+        worldNode->visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, Model::EntityNode* entity) {
-        if (!entity->hasChildren())
+      [&](auto&& thisLambda, Model::LayerNode* layerNode) {
+        layerNode->visitChildren(thisLambda);
+      },
+      [&](auto&& thisLambda, Model::GroupNode* groupNode) {
+        nodesToTransform.push_back(groupNode);
+        groupNode->visitChildren(thisLambda);
+      },
+      [&](auto&& thisLambda, Model::EntityNode* entityNode) {
+        if (!entityNode->hasChildren())
         {
-          nodesToTransform.push_back(entity);
+          nodesToTransform.push_back(entityNode);
         }
         else
         {
-          entity->visitChildren(thisLambda);
+          entityNode->visitChildren(thisLambda);
         }
       },
-      [&](Model::BrushNode* brush) {
-        nodesToTransform.push_back(brush);
-        addEntity(brush);
+      [&](Model::BrushNode* brushNode) {
+        nodesToTransform.push_back(brushNode);
+        addEntity(brushNode);
       },
-      [&](Model::PatchNode* patch) {
-        nodesToTransform.push_back(patch);
-        addEntity(patch);
+      [&](Model::PatchNode* patchNode) {
+        nodesToTransform.push_back(patchNode);
+        addEntity(patchNode);
       }));
   }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -751,8 +751,7 @@ bool MapDocument::pasteNodes(const std::vector<Model::Node*>& nodes)
         nodesToAdd[parent].push_back(group);
       },
       [&](auto&& thisLambda, Model::EntityNode* entityNode) {
-        if (Model::isWorldspawn(
-              entityNode->entity().classname(), entityNode->entity().properties()))
+        if (Model::isWorldspawn(entityNode->entity().classname()))
         {
           entityNode->visitChildren(thisLambda);
           nodesToDetach.push_back(entityNode);

--- a/common/test/src/View/TransformNodesTest.cpp
+++ b/common/test/src/View/TransformNodesTest.cpp
@@ -279,6 +279,22 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.rotateBrushEntity")
 
     CHECK(*entityNode->entity().property("angle") == "135");
   }
+
+  SECTION("Rotating grouped brush entity")
+  {
+    document->selectNodes({entityNode});
+    auto* groupNode = document->groupSelection("some_name");
+
+    document->deselectAll();
+    document->selectNodes({groupNode});
+    document->rotateObjects(
+      document->selectionBounds().center(), vm::vec3::pos_z(), vm::to_radians(90.0));
+
+    /* EXPECTED:
+    CHECK(*entityNode->entity().property("angle") == "135");
+    ACTUAL: */
+    CHECK(*entityNode->entity().property("angle") == "45");
+  }
 }
 
 TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.shearCube")

--- a/common/test/src/View/TransformNodesTest.cpp
+++ b/common/test/src/View/TransformNodesTest.cpp
@@ -290,10 +290,7 @@ TEST_CASE_METHOD(MapDocumentTest, "TransformNodesTest.rotateBrushEntity")
     document->rotateObjects(
       document->selectionBounds().center(), vm::vec3::pos_z(), vm::to_radians(90.0));
 
-    /* EXPECTED:
     CHECK(*entityNode->entity().property("angle") == "135");
-    ACTUAL: */
-    CHECK(*entityNode->entity().property("angle") == "45");
   }
 }
 


### PR DESCRIPTION
Closes #4115.

The current logic for transforming a brush entity if all children are transformed relies on the selection status of the children. When rotating a group, the rotated brushes in the group are not selected, so the check would fail, and any brush entity in the group would not be transformed even though all of its children were. This PR addresses this flaw by explicitly examining the objects being transformed and not just the objects that are selected.