### PR TITLE
4152: Cancel dragging when UV view loses focus

### DIFF
--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -78,6 +78,12 @@ void UVView::setSubDivisions(const vm::vec2i& subDivisions)
   update();
 }
 
+void UVView::focusOutEvent(QFocusEvent* event)
+{
+  ToolBoxConnector::cancelDrag();
+  RenderView::focusOutEvent(event);
+}
+
 void UVView::createTools()
 {
   addTool(std::make_unique<UVRotateTool>(m_document, m_helper));

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -91,6 +91,9 @@ public:
 
   void setSubDivisions(const vm::vec2i& subDivisions);
 
+protected:
+  void focusOutEvent(QFocusEvent* event) override;
+
 private:
   void createTools();
 


### PR DESCRIPTION
This is a follow up to https://github.com/TrenchBroom/TrenchBroom/pull/4169 so that the UV view will also cancel mouse drags when it loses focus.