### PR TITLE
4171: Avoid simultaneous access to preferences file

### DIFF
--- a/common/src/Preference.cpp
+++ b/common/src/Preference.cpp
@@ -21,9 +21,26 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 namespace TrenchBroom
 {
-PrefSerializer::~PrefSerializer() {}
+PrefSerializer::~PrefSerializer() = default;
 
-PreferenceBase::~PreferenceBase() {}
+PreferenceBase::PreferenceBase() = default;
 
-DynamicPreferencePatternBase::~DynamicPreferencePatternBase() {}
+PreferenceBase::PreferenceBase(const PreferenceBase& other) = default;
+PreferenceBase::PreferenceBase(PreferenceBase&& other) noexcept = default;
+PreferenceBase& PreferenceBase::operator=(const PreferenceBase& other) = default;
+PreferenceBase& PreferenceBase::operator=(PreferenceBase&& other) = default;
+
+bool operator==(const PreferenceBase& lhs, const PreferenceBase& rhs)
+{
+  return &lhs == &rhs;
+}
+
+bool operator!=(const PreferenceBase& lhs, const PreferenceBase& rhs)
+{
+  return !(lhs == rhs);
+}
+
+PreferenceBase::~PreferenceBase() = default;
+
+DynamicPreferencePatternBase::~DynamicPreferencePatternBase() = default;
 } // namespace TrenchBroom

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -476,7 +476,7 @@ void AppPreferenceManager::loadCacheFromDisk()
   readV2SettingsFromPath(m_preferencesFilePath)
     .and_then([&](std::map<IO::Path, QJsonValue>&& prefs) { m_cache = std::move(prefs); })
     .handle_errors(kdl::overload(
-      [&](const PreferenceErrors::FileReadError&) {
+      [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath
         showErrorAndDisableFileReadWrite(
@@ -840,7 +840,7 @@ PreferencesResult readV2SettingsFromPath(const QString& path)
   }
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
   {
-    return PreferenceErrors::FileReadError{};
+    return PreferenceErrors::FileAccessError{};
   }
 
   return parseV2SettingsFromJSON(file.readAll());

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -831,7 +831,7 @@ QString v2SettingsPath()
     IO::SystemPaths::userDataDirectory() + IO::Path{"Preferences.json"});
 }
 
-PreferencesResult readV2SettingsFromPath(const QString& path)
+ReadPreferencesResult readV2SettingsFromPath(const QString& path)
 {
   auto file = QFile{path};
   if (!file.exists())
@@ -872,12 +872,12 @@ bool writeV2SettingsToPath(
   return saveFile.commit();
 }
 
-PreferencesResult readV2Settings()
+ReadPreferencesResult readV2Settings()
 {
   return readV2SettingsFromPath(v2SettingsPath());
 }
 
-PreferencesResult parseV2SettingsFromJSON(const QByteArray& jsonData)
+ReadPreferencesResult parseV2SettingsFromJSON(const QByteArray& jsonData)
 {
   auto error = QJsonParseError();
   const auto document = QJsonDocument::fromJson(jsonData, &error);

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -31,11 +31,11 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QMessageBox>
 #include <QSaveFile>
 #if defined(Q_OS_WIN)
 #include <QSettings>
 #endif
-#include <QMessageBox>
 #include <QStandardPaths>
 #include <QStringBuilder>
 

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -50,13 +50,13 @@ class Color;
 class PreferenceSerializerV1 : public PrefSerializer
 {
 public:
-  bool readFromJSON(const QJsonValue& in, bool* out) const override;
-  bool readFromJSON(const QJsonValue& in, Color* out) const override;
-  bool readFromJSON(const QJsonValue& in, float* out) const override;
-  bool readFromJSON(const QJsonValue& in, int* out) const override;
-  bool readFromJSON(const QJsonValue& in, IO::Path* out) const override;
-  bool readFromJSON(const QJsonValue& in, QKeySequence* out) const override;
-  bool readFromJSON(const QJsonValue& in, QString* out) const override;
+  bool readFromJSON(const QJsonValue& in, bool& out) const override;
+  bool readFromJSON(const QJsonValue& in, Color& out) const override;
+  bool readFromJSON(const QJsonValue& in, float& out) const override;
+  bool readFromJSON(const QJsonValue& in, int& out) const override;
+  bool readFromJSON(const QJsonValue& in, IO::Path& out) const override;
+  bool readFromJSON(const QJsonValue& in, QKeySequence& out) const override;
+  bool readFromJSON(const QJsonValue& in, QString& out) const override;
 
   QJsonValue writeToJSON(bool in) const override;
   QJsonValue writeToJSON(const Color& in) const override;
@@ -79,10 +79,10 @@ public:
 class PreferenceSerializerV2 : public PreferenceSerializerV1
 {
 public:
-  bool readFromJSON(const QJsonValue& in, bool* out) const override;
-  bool readFromJSON(const QJsonValue& in, float* out) const override;
-  bool readFromJSON(const QJsonValue& in, int* out) const override;
-  bool readFromJSON(const QJsonValue& in, QKeySequence* out) const override;
+  bool readFromJSON(const QJsonValue& in, bool& out) const override;
+  bool readFromJSON(const QJsonValue& in, float& out) const override;
+  bool readFromJSON(const QJsonValue& in, int& out) const override;
+  bool readFromJSON(const QJsonValue& in, QKeySequence& out) const override;
 
   QJsonValue writeToJSON(bool in) const override;
   QJsonValue writeToJSON(float in) const override;
@@ -317,7 +317,7 @@ using PreferencesResult = kdl::result<
   PreferenceErrors::FileReadError>;
 
 // V1 settings
-std::map<IO::Path, QJsonValue> parseINI(QTextStream* iniStream);
+std::map<IO::Path, QJsonValue> parseINI(QTextStream& iniStream);
 std::map<IO::Path, QJsonValue> getINISettingsV1(const QString& path);
 std::map<IO::Path, QJsonValue> readV1Settings();
 std::map<IO::Path, QJsonValue> migrateV1ToV2(

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -36,6 +36,7 @@
 #include <QJsonParseError>
 #include <QString>
 #include <QThread>
+#include <QTimer>
 
 class QTextStream;
 class QFileSystemWatcher;
@@ -196,6 +197,8 @@ private:
   QString m_preferencesFilePath;
   bool m_saveInstantly;
   UnsavedPreferences m_unsavedPreferences;
+  QTimer m_saveTimer;
+
   /**
    * This should always be in sync with what is on disk.
    * Preference objects may have different values if there are unsaved changes.
@@ -213,6 +216,8 @@ private:
 
 public:
   AppPreferenceManager();
+  ~AppPreferenceManager() override;
+
   void initialize() override;
 
   bool saveInstantly() const override;
@@ -220,6 +225,8 @@ public:
   void discardChanges() override;
 
 private:
+  void saveChangesImmediately();
+
   void markAsUnsaved(PreferenceBase& preference);
   void showErrorAndDisableFileReadWrite(const QString& reason, const QString& suggestion);
   void loadCacheFromDisk();

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -315,15 +315,20 @@ struct JsonParseError
 struct FileAccessError
 {
 };
+struct LockFileError
+{
+};
 } // namespace PreferenceErrors
 
 using ReadPreferencesResult = kdl::result<
   std::map<IO::Path, QJsonValue>, // Success case
   PreferenceErrors::NoFilePresent,
   PreferenceErrors::JsonParseError,
-  PreferenceErrors::FileAccessError>;
+  PreferenceErrors::FileAccessError,
+  PreferenceErrors::LockFileError>;
 
-using WritePreferencesResult = kdl::result<void, PreferenceErrors::FileAccessError>;
+using WritePreferencesResult =
+  kdl::result<void, PreferenceErrors::FileAccessError, PreferenceErrors::LockFileError>;
 
 // V1 settings
 std::map<IO::Path, QJsonValue> parseINI(QTextStream& iniStream);

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -323,6 +323,8 @@ using ReadPreferencesResult = kdl::result<
   PreferenceErrors::JsonParseError,
   PreferenceErrors::FileAccessError>;
 
+using WritePreferencesResult = kdl::result<void, PreferenceErrors::FileAccessError>;
+
 // V1 settings
 std::map<IO::Path, QJsonValue> parseINI(QTextStream& iniStream);
 std::map<IO::Path, QJsonValue> getINISettingsV1(const QString& path);
@@ -335,11 +337,12 @@ QString v2SettingsPath();
 ReadPreferencesResult readV2SettingsFromPath(const QString& path);
 ReadPreferencesResult readV2Settings();
 
-bool writeV2SettingsToPath(
+WritePreferencesResult writeV2SettingsToPath(
   const QString& path, const std::map<IO::Path, QJsonValue>& v2Prefs);
 ReadPreferencesResult parseV2SettingsFromJSON(const QByteArray& jsonData);
 QByteArray writeV2SettingsToJSON(const std::map<IO::Path, QJsonValue>& v2Prefs);
 
 // Migration
-bool migrateSettingsFromV1IfPathDoesNotExist(const QString& destinationPath);
+WritePreferencesResult migrateSettingsFromV1IfPathDoesNotExist(
+  const QString& destinationPath);
 } // namespace TrenchBroom

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -317,7 +317,7 @@ struct FileAccessError
 };
 } // namespace PreferenceErrors
 
-using PreferencesResult = kdl::result<
+using ReadPreferencesResult = kdl::result<
   std::map<IO::Path, QJsonValue>, // Success case
   PreferenceErrors::NoFilePresent,
   PreferenceErrors::JsonParseError,
@@ -332,12 +332,12 @@ std::map<IO::Path, QJsonValue> migrateV1ToV2(
 
 // V2 settings
 QString v2SettingsPath();
-PreferencesResult readV2SettingsFromPath(const QString& path);
-PreferencesResult readV2Settings();
+ReadPreferencesResult readV2SettingsFromPath(const QString& path);
+ReadPreferencesResult readV2Settings();
 
 bool writeV2SettingsToPath(
   const QString& path, const std::map<IO::Path, QJsonValue>& v2Prefs);
-PreferencesResult parseV2SettingsFromJSON(const QByteArray& jsonData);
+ReadPreferencesResult parseV2SettingsFromJSON(const QByteArray& jsonData);
 QByteArray writeV2SettingsToJSON(const std::map<IO::Path, QJsonValue>& v2Prefs);
 
 // Migration

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -312,7 +312,7 @@ struct JsonParseError
 {
   QJsonParseError jsonError;
 };
-struct FileReadError
+struct FileAccessError
 {
 };
 } // namespace PreferenceErrors
@@ -321,7 +321,7 @@ using PreferencesResult = kdl::result<
   std::map<IO::Path, QJsonValue>, // Success case
   PreferenceErrors::NoFilePresent,
   PreferenceErrors::JsonParseError,
-  PreferenceErrors::FileReadError>;
+  PreferenceErrors::FileAccessError>;
 
 // V1 settings
 std::map<IO::Path, QJsonValue> parseINI(QTextStream& iniStream);

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -400,7 +400,8 @@ TEST_CASE("PreferencesTest.readV2", "[PreferencesTest]")
   CHECK(parseV2SettingsFromJSON(QByteArray(R"({"foo": "bar"})")).is_success());
   CHECK(parseV2SettingsFromJSON(QByteArray("{}")).is_success());
 
-  const PreferencesResult v2 = readV2SettingsFromPath("fixture/test/preferences-v2.json");
+  const ReadPreferencesResult v2 =
+    readV2SettingsFromPath("fixture/test/preferences-v2.json");
   CHECK(v2.is_success());
   v2.visit(kdl::overload(
     [](const std::map<IO::Path, QJsonValue>& prefs) { testV2Prefs(prefs); },

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -434,7 +434,7 @@ static std::optional<PrimitiveType> maybeDeserialize(const QJsonValue& string)
 {
   const Serializer s;
   PrimitiveType result;
-  if (s.readFromJSON(string, &result))
+  if (s.readFromJSON(string, result))
   {
     return {result};
   }

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -407,7 +407,8 @@ TEST_CASE("PreferencesTest.readV2", "[PreferencesTest]")
     [](const std::map<IO::Path, QJsonValue>& prefs) { testV2Prefs(prefs); },
     [](const PreferenceErrors::NoFilePresent&) { FAIL_CHECK(); },
     [](const PreferenceErrors::JsonParseError&) { FAIL_CHECK(); },
-    [](const PreferenceErrors::FileAccessError&) { FAIL_CHECK(); }));
+    [](const PreferenceErrors::FileAccessError&) { FAIL_CHECK(); },
+    [](const PreferenceErrors::LockFileError&) { FAIL_CHECK(); }));
 }
 
 TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]")
@@ -424,7 +425,8 @@ TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]")
     [&](const std::map<IO::Path, QJsonValue>& prefs) { CHECK(v2 == prefs); },
     [](const PreferenceErrors::NoFilePresent&) { FAIL_CHECK(); },
     [](const PreferenceErrors::JsonParseError&) { FAIL_CHECK(); },
-    [](const PreferenceErrors::FileAccessError&) { FAIL_CHECK(); }));
+    [](const PreferenceErrors::FileAccessError&) { FAIL_CHECK(); },
+    [](const PreferenceErrors::LockFileError&) { FAIL_CHECK(); }));
 }
 
 /**

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -406,7 +406,7 @@ TEST_CASE("PreferencesTest.readV2", "[PreferencesTest]")
     [](const std::map<IO::Path, QJsonValue>& prefs) { testV2Prefs(prefs); },
     [](const PreferenceErrors::NoFilePresent&) { FAIL_CHECK(); },
     [](const PreferenceErrors::JsonParseError&) { FAIL_CHECK(); },
-    [](const PreferenceErrors::FileReadError&) { FAIL_CHECK(); }));
+    [](const PreferenceErrors::FileAccessError&) { FAIL_CHECK(); }));
 }
 
 TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]")
@@ -423,7 +423,7 @@ TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]")
     [&](const std::map<IO::Path, QJsonValue>& prefs) { CHECK(v2 == prefs); },
     [](const PreferenceErrors::NoFilePresent&) { FAIL_CHECK(); },
     [](const PreferenceErrors::JsonParseError&) { FAIL_CHECK(); },
-    [](const PreferenceErrors::FileReadError&) { FAIL_CHECK(); }));
+    [](const PreferenceErrors::FileAccessError&) { FAIL_CHECK(); }));
 }
 
 /**


### PR DESCRIPTION
Closes #4171.

This PR makes two changes: First, we delay writing the preferences after a change for 500ms to avoid writing the preferences file multiple times in a short time. Second, we use a lock file to synchronize access to the preferences file so that multiple instances of TB can write and read the preferences without interfering with each other.