### PR TITLE
4177: Disallow creating and loading recursive linked groups

### DIFF
--- a/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
+++ b/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
@@ -92,7 +92,7 @@ makeBrushes()
   return {result, textures};
 }
 
-TEST_CASE("BrushRendererBenchmark.benchBrushRenderer", "[BrushRendererBenchmark]")
+TEST_CASE("BrushRendererBenchmark.benchBrushRenderer")
 {
   auto brushesTextures = makeBrushes();
   std::vector<Model::BrushNode*> brushes = brushesTextures.first;

--- a/common/src/IO/BrushFaceReader.cpp
+++ b/common/src/IO/BrushFaceReader.cpp
@@ -35,7 +35,7 @@ namespace IO
 {
 BrushFaceReader::BrushFaceReader(
   const std::string& str, const Model::MapFormat sourceAndTargetMapFormat)
-  : MapReader(str, sourceAndTargetMapFormat, sourceAndTargetMapFormat, {})
+  : MapReader(str, sourceAndTargetMapFormat, sourceAndTargetMapFormat, {}, {})
 {
 }
 

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -849,8 +849,8 @@ static NodeToParentMap buildNodeToParentMap(
  * group. If such a node belongs to a custom layer or a group, the ID of the containing
  * layer or group is stored in the entity properties of the entity info from which the
  * node was created. Since the entity properties of these nodes are discarded when the
- * node is created, we record this information in a separate map before creating we create
- * nodes. We later use it to find the parent layer or group of a group or entity node.
+ * node is created, we record this information in a separate map before creating nodes. We
+ * later use it to find the parent layer or group of a group or entity node.
  *
  * Nodes for which the parent node is not known (e.g. when parsing only brushes) are added
  * to a default parent, which is returned from the `onWorldNode` callback.

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -736,19 +736,6 @@ static void logValidationIssues(
 }
 
 /**
- * Validates the given node infos.
- *
- * - Removes layer and group nodes with duplicate IDs.
- * - Logs issues that occured during node creation.
- */
-static void validateNodes(
-  std::vector<std::optional<NodeInfo>>& nodeInfos, ParserStatus& status)
-{
-  validateDuplicateLayersAndGroups(nodeInfos, status);
-  logValidationIssues(nodeInfos, status);
-}
-
-/**
  * Builds a map of nodes to their intended parents using the parent info stored in each
  * node info object (this either refers to a parent node by index or a parent layer or
  * group by ID).
@@ -898,7 +885,8 @@ void MapReader::createNodes(ParserStatus& status)
     }
   }
 
-  validateNodes(nodeInfos, status);
+  validateDuplicateLayersAndGroups(nodeInfos, status);
+  logValidationIssues(nodeInfos, status);
 
   // build a map that maps nodes to their intended parents
   // if a node is not in this map, we will pass defaultParent to the callbacks for the

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -698,6 +698,14 @@ static void validateDuplicateLayersAndGroups(
   }
 }
 
+static void unlinkGroup(Model::GroupNode& groupNode)
+{
+  auto newGroup = groupNode.group();
+  newGroup.resetLinkedGroupId();
+  newGroup.setTransformation(vm::mat4x4::identity());
+  groupNode.setGroup(std::move(newGroup));
+}
+
 static void validateOrphanedLinkedGroups(
   std::vector<std::optional<NodeInfo>>& nodeInfos, ParserStatus& status)
 {
@@ -737,11 +745,7 @@ static void validateOrphanedLinkedGroups(
                 groupNode->lineNumber(),
                 kdl::str_to_string(
                   "Unlinking orphaned linked group with ID '", *linkedGroupId, "'"));
-
-              auto newGroup = groupNode->group();
-              newGroup.resetLinkedGroupId();
-              newGroup.setTransformation(vm::mat4x4::identity());
-              groupNode->setGroup(std::move(newGroup));
+              unlinkGroup(*groupNode);
             }
           }
         },

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -106,6 +106,7 @@ public: // only public so that helper methods can see these declarations
 
 private:
   Model::EntityPropertyConfig m_entityPropertyConfig;
+  std::vector<std::string> m_linkedGroupsToKeep;
   vm::bbox3 m_worldBounds;
 
 private: // data populated in response to MapParser callbacks
@@ -121,12 +122,15 @@ protected:
    * @param sourceMapFormat the expected format of the given string
    * @param targetMapFormat the format to convert the created objects to
    * @param entityPropertyConfig the entity property config to use
+   * @param linkedGroupsToKeep the IDs of linked groups which should not be unlinked even
+   * if orphaned
    */
   MapReader(
     std::string_view str,
     Model::MapFormat sourceMapFormat,
     Model::MapFormat targetMapFormat,
-    Model::EntityPropertyConfig entityPropertyConfig);
+    Model::EntityPropertyConfig entityPropertyConfig,
+    std::vector<std::string> linkedGroupsToKeep);
 
   /**
    * Attempts to parse as one or more entities.

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -126,7 +126,7 @@ protected:
     std::string_view str,
     Model::MapFormat sourceMapFormat,
     Model::MapFormat targetMapFormat,
-    const Model::EntityPropertyConfig& entityPropertyConfig);
+    Model::EntityPropertyConfig entityPropertyConfig);
 
   /**
    * Attempts to parse as one or more entities.

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -42,7 +42,7 @@ NodeReader::NodeReader(
   const Model::MapFormat sourceMapFormat,
   const Model::MapFormat targetMapFormat,
   const Model::EntityPropertyConfig& entityPropertyConfig)
-  : MapReader(str, sourceMapFormat, targetMapFormat, entityPropertyConfig)
+  : MapReader{str, sourceMapFormat, targetMapFormat, entityPropertyConfig}
 {
 }
 
@@ -91,7 +91,7 @@ std::vector<Model::Node*> NodeReader::readAsFormat(
   ParserStatus& status)
 {
   {
-    NodeReader reader(str, sourceMapFormat, targetMapFormat, entityPropertyConfig);
+    auto reader = NodeReader{str, sourceMapFormat, targetMapFormat, entityPropertyConfig};
     try
     {
       reader.readEntities(worldBounds, status);
@@ -109,7 +109,7 @@ std::vector<Model::Node*> NodeReader::readAsFormat(
   }
 
   {
-    NodeReader reader(str, sourceMapFormat, targetMapFormat, entityPropertyConfig);
+    auto reader = NodeReader{str, sourceMapFormat, targetMapFormat, entityPropertyConfig};
     try
     {
       reader.readBrushes(worldBounds, status);

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -41,8 +41,14 @@ NodeReader::NodeReader(
   std::string_view str,
   const Model::MapFormat sourceMapFormat,
   const Model::MapFormat targetMapFormat,
-  const Model::EntityPropertyConfig& entityPropertyConfig)
-  : MapReader{str, sourceMapFormat, targetMapFormat, entityPropertyConfig}
+  const Model::EntityPropertyConfig& entityPropertyConfig,
+  std::vector<std::string> linkedGroupsToKeep)
+  : MapReader{
+    str,
+    sourceMapFormat,
+    targetMapFormat,
+    entityPropertyConfig,
+    std::move(linkedGroupsToKeep)}
 {
 }
 
@@ -51,6 +57,7 @@ std::vector<Model::Node*> NodeReader::read(
   const Model::MapFormat preferredMapFormat,
   const vm::bbox3& worldBounds,
   const Model::EntityPropertyConfig& entityPropertyConfig,
+  const std::vector<std::string>& linkedGroupsToKeep,
   ParserStatus& status)
 {
   // Try preferred format first
@@ -62,6 +69,7 @@ std::vector<Model::Node*> NodeReader::read(
           str,
           worldBounds,
           entityPropertyConfig,
+          linkedGroupsToKeep,
           status);
         !result.empty())
     {
@@ -88,10 +96,12 @@ std::vector<Model::Node*> NodeReader::readAsFormat(
   const std::string& str,
   const vm::bbox3& worldBounds,
   const Model::EntityPropertyConfig& entityPropertyConfig,
+  const std::vector<std::string>& linkedGroupsToKeep,
   ParserStatus& status)
 {
   {
-    auto reader = NodeReader{str, sourceMapFormat, targetMapFormat, entityPropertyConfig};
+    auto reader = NodeReader{
+      str, sourceMapFormat, targetMapFormat, entityPropertyConfig, linkedGroupsToKeep};
     try
     {
       reader.readEntities(worldBounds, status);
@@ -109,7 +119,8 @@ std::vector<Model::Node*> NodeReader::readAsFormat(
   }
 
   {
-    auto reader = NodeReader{str, sourceMapFormat, targetMapFormat, entityPropertyConfig};
+    auto reader = NodeReader{
+      str, sourceMapFormat, targetMapFormat, entityPropertyConfig, linkedGroupsToKeep};
     try
     {
       reader.readBrushes(worldBounds, status);

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -53,13 +53,15 @@ public:
     std::string_view str,
     Model::MapFormat sourceMapFormat,
     Model::MapFormat targetMapFormat,
-    const Model::EntityPropertyConfig& entityPropertyConfig);
+    const Model::EntityPropertyConfig& entityPropertyConfig,
+    std::vector<std::string> linkedGroupsToKeep);
 
   static std::vector<Model::Node*> read(
     const std::string& str,
     Model::MapFormat preferredMapFormat,
     const vm::bbox3& worldBounds,
     const Model::EntityPropertyConfig& entityPropertyConfig,
+    const std::vector<std::string>& linkedGroupsToKeep,
     ParserStatus& status);
 
 private:
@@ -69,6 +71,7 @@ private:
     const std::string& str,
     const vm::bbox3& worldBounds,
     const Model::EntityPropertyConfig& entityPropertyConfig,
+    const std::vector<std::string>& linkedGroupsToKeep,
     ParserStatus& status);
 
 private: // implement MapReader interface

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -72,7 +72,8 @@ WorldReader::WorldReader(
     std::move(str),
     sourceAndTargetMapFormat,
     sourceAndTargetMapFormat,
-    entityPropertyConfig)
+    entityPropertyConfig,
+    {})
   , m_world(std::make_unique<Model::WorldNode>(
       entityPropertyConfig, Model::Entity{}, sourceAndTargetMapFormat))
 {

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -54,10 +54,8 @@ static std::string formatParserExceptions(
   return result.str();
 }
 
-WorldReaderException::WorldReaderException()
-  : Exception()
-{
-}
+WorldReaderException::WorldReaderException() = default;
+
 WorldReaderException::WorldReaderException(
   const std::vector<std::tuple<Model::MapFormat, std::string>>& parserExceptions)
   : Exception{formatParserExceptions(parserExceptions)}

--- a/common/src/IO/WorldReader.h
+++ b/common/src/IO/WorldReader.h
@@ -43,7 +43,7 @@ class WorldReaderException : public Exception
 {
 public:
   WorldReaderException();
-  WorldReaderException(
+  explicit WorldReaderException(
     const std::vector<std::tuple<Model::MapFormat, std::string>>& parserExceptions);
 };
 

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -119,9 +119,10 @@ std::vector<Node*> Game::parseNodes(
   const std::string& str,
   const MapFormat mapFormat,
   const vm::bbox3& worldBounds,
+  const std::vector<std::string>& linkedGroupsToKeep,
   Logger& logger) const
 {
-  return doParseNodes(str, mapFormat, worldBounds, logger);
+  return doParseNodes(str, mapFormat, worldBounds, linkedGroupsToKeep, logger);
 }
 
 std::vector<BrushFace> Game::parseBrushFaces(

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -123,6 +123,7 @@ public: // parsing and serializing objects
     const std::string& str,
     MapFormat mapFormat,
     const vm::bbox3& worldBounds,
+    const std::vector<std::string>& linkedGroupsToKeep,
     Logger& logger) const;
   std::vector<BrushFace> parseBrushFaces(
     const std::string& str,
@@ -202,6 +203,7 @@ private: // subclassing interface
     const std::string& str,
     MapFormat mapFormat,
     const vm::bbox3& worldBounds,
+    const std::vector<std::string>& linkedGroupsToKeep,
     Logger& logger) const = 0;
   virtual std::vector<BrushFace> doParseBrushFaces(
     const std::string& str,

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -296,11 +296,17 @@ std::vector<Node*> GameImpl::doParseNodes(
   const std::string& str,
   const MapFormat mapFormat,
   const vm::bbox3& worldBounds,
+  const std::vector<std::string>& linkedGroupsToKeep,
   Logger& logger) const
 {
   auto parserStatus = IO::SimpleParserStatus{logger};
   return IO::NodeReader::read(
-    str, mapFormat, worldBounds, entityPropertyConfig(), parserStatus);
+    str,
+    mapFormat,
+    worldBounds,
+    entityPropertyConfig(),
+    linkedGroupsToKeep,
+    parserStatus);
 }
 
 std::vector<BrushFace> GameImpl::doParseBrushFaces(

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -89,6 +89,7 @@ private:
     const std::string& str,
     MapFormat mapFormat,
     const vm::bbox3& worldBounds,
+    const std::vector<std::string>& linkedGroupsToKeep,
     Logger& logger) const override;
   std::vector<BrushFace> doParseBrushFaces(
     const std::string& str,

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -485,12 +485,58 @@ Node* GroupNode::doClone(const vm::bbox3& /* worldBounds */) const
   return groupNode.release();
 }
 
+/** Check whether the given parent node or any of its ancestors and the given group node
+ *  or any of its descendants have the same linked group id.
+ */
+static bool checkRecursiveLinkedGroups(
+  const Node& parentNode, const GroupNode& groupNodeToAdd)
+{
+  const auto ancestorLinkedGroupIds = [&]() {
+    auto result = std::vector<std::string>{};
+    const auto* node = &parentNode;
+    while (node)
+    {
+      const auto* groupNode = dynamic_cast<const Model::GroupNode*>(node);
+      const auto linkedGroupId =
+        groupNode ? groupNode->group().linkedGroupId() : std::nullopt;
+      if (linkedGroupId)
+      {
+        result.push_back(*linkedGroupId);
+      }
+      node = node->parent();
+    }
+    return kdl::vec_sort_and_remove_duplicates(std::move(result));
+  }();
+
+  const auto linkedGroupIdsToAdd = [&]() {
+    auto result = std::vector<std::string>{};
+    groupNodeToAdd.accept(kdl::overload(
+      [](const WorldNode*) {},
+      [](const LayerNode*) {},
+      [&](auto&& thisLambda, const GroupNode* groupNode) {
+        if (const auto linkedGroupId = groupNode->group().linkedGroupId())
+        {
+          result.push_back(*linkedGroupId);
+        }
+        Node::visitAll(groupNode->children(), thisLambda);
+      },
+      [](const EntityNode*) {},
+      [](const BrushNode*) {},
+      [](const PatchNode*) {}));
+    return kdl::vec_sort_and_remove_duplicates(std::move(result));
+  }();
+
+  return kdl::set_has_shared_element(ancestorLinkedGroupIds, linkedGroupIdsToAdd);
+}
+
 bool GroupNode::doCanAddChild(const Node* child) const
 {
   return child->accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return false; },
-    [](const GroupNode*) { return true; },
+    [&](const GroupNode* groupNode) {
+      return !checkRecursiveLinkedGroups(*this, *groupNode);
+    },
     [](const EntityNode*) { return true; },
     [](const BrushNode*) { return true; },
     [](const PatchNode*) { return true; }));

--- a/common/src/Model/ModelUtils.cpp
+++ b/common/src/Model/ModelUtils.cpp
@@ -201,6 +201,24 @@ std::vector<Model::GroupNode*> findAllLinkedGroups(Model::WorldNode& worldNode)
   return result;
 }
 
+std::vector<std::string> collectParentLinkedGroupIds(const Model::Node& parentNode)
+{
+  auto result = std::vector<std::string>{};
+  const auto* currentNode = &parentNode;
+  while (currentNode)
+  {
+    if (const auto* currentGroupNode = dynamic_cast<const Model::GroupNode*>(currentNode))
+    {
+      if (const auto& linkedGroupId = currentGroupNode->group().linkedGroupId())
+      {
+        result.push_back(*linkedGroupId);
+      }
+    }
+    currentNode = currentNode->parent();
+  }
+  return result;
+}
+
 static void collectWithParents(Node* node, std::vector<Node*>& result)
 {
   if (node != nullptr)

--- a/common/src/Model/ModelUtils.h
+++ b/common/src/Model/ModelUtils.h
@@ -62,6 +62,11 @@ std::vector<Model::GroupNode*> findLinkedGroups(
   Model::WorldNode& worldNode, const std::string& linkedGroupId);
 std::vector<Model::GroupNode*> findAllLinkedGroups(Model::WorldNode& worldNode);
 
+/**
+ * Collect the linked group IDs of the given node and all of its ancestors.
+ */
+std::vector<std::string> collectParentLinkedGroupIds(const Model::Node& parent);
+
 std::vector<Node*> collectParents(const std::vector<Node*>& nodes);
 std::vector<Node*> collectParents(const std::map<Node*, std::vector<Node*>>& nodes);
 std::vector<Node*> collectParents(

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -706,9 +706,11 @@ static auto getLinkedGroupIdsRecursively(const std::vector<Model::Node*>& nodes)
 
 PasteType MapDocument::paste(const std::string& str)
 {
+  const auto linkedGroupIds = getLinkedGroupIdsRecursively({m_world.get()});
+
   // Try parsing as entities, then as brushes, in all compatible formats
-  const std::vector<Model::Node*> nodes =
-    m_game->parseNodes(str, m_world->mapFormat(), m_worldBounds, logger());
+  const std::vector<Model::Node*> nodes = m_game->parseNodes(
+    str, m_world->mapFormat(), m_worldBounds, linkedGroupIds, logger());
   if (!nodes.empty())
   {
     if (pasteNodes(nodes))

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -771,7 +771,6 @@ void MapViewBase::makeStructural()
   {
     reparentNodes(toReparent, document->parentForNodes(toReparent), false);
   }
-
   bool anyTagDisabled = false;
   auto callback = EnableDisableTagCallback{};
   for (auto* brush : document->selectedNodes().brushes())
@@ -1219,7 +1218,7 @@ void MapViewBase::showPopupMenuLater()
     menu.addAction(tr("Rename Groups"), mapFrame, &MapFrame::renameSelectedGroups);
   renameAction->setEnabled(mapFrame->canRenameSelectedGroups());
 
-  if (newGroup && newGroup != currentGroup)
+  if (newGroup && canReparentNodes(nodes, newGroup))
   {
     menu.addAction(
       tr("Add Objects to Group %1").arg(QString::fromStdString(newGroup->name())),
@@ -1560,8 +1559,7 @@ Model::GroupNode* MapViewBase::findGroupToMergeGroupsInto(
 bool MapViewBase::canReparentNode(
   const Model::Node* node, const Model::Node* newParent) const
 {
-  return newParent != node && newParent != node->parent()
-         && !newParent->isDescendantOf(node);
+  return newParent != node && newParent != node->parent() && newParent->canAddChild(node);
 }
 
 void MapViewBase::moveSelectedBrushesToEntity()

--- a/common/test/src/Assets/AssetUtilsTest.cpp
+++ b/common/test/src/Assets/AssetUtilsTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom
 {
 namespace Assets
 {
-TEST_CASE("AssetUtilsTest.safeGetModelSpecification", "[AssetUtilsTest]")
+TEST_CASE("AssetUtilsTest.safeGetModelSpecification")
 {
   TestLogger logger;
 

--- a/common/test/src/EL/ELTest.cpp
+++ b/common/test/src/EL/ELTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom
 {
 namespace EL
 {
-TEST_CASE("ELTest.constructValues", "[ELTest]")
+TEST_CASE("ELTest.constructValues")
 {
   CHECK(Value(true).type() == ValueType::Boolean);
   CHECK(Value(false).type() == ValueType::Boolean);
@@ -42,7 +42,7 @@ TEST_CASE("ELTest.constructValues", "[ELTest]")
   CHECK(Value().type() == ValueType::Null);
 }
 
-TEST_CASE("ELTest.typeConversions", "[ELTest]")
+TEST_CASE("ELTest.typeConversions")
 {
   CHECK(Value(true).convertTo(ValueType::Boolean) == Value(true));
   CHECK(Value(false).convertTo(ValueType::Boolean) == Value(false));
@@ -127,12 +127,12 @@ TEST_CASE("ELTest.typeConversions", "[ELTest]")
   CHECK(Value::Undefined.convertTo(ValueType::Undefined) == Value::Undefined);
 }
 
-TEST_CASE("ELTest.serializeValues", "[ELTest]")
+TEST_CASE("ELTest.serializeValues")
 {
   CHECK(Value(16.0).asString() == std::string("16"));
 }
 
-TEST_CASE("ELTest.subscriptOperator", "[ELTest]")
+TEST_CASE("ELTest.subscriptOperator")
 {
   CHECK_THROWS_AS(Value(true)[Value(0)], EvaluationError);
   CHECK_THROWS_AS(Value(1.0)[Value(0)], EvaluationError);

--- a/common/test/src/EL/ExpressionTest.cpp
+++ b/common/test/src/EL/ExpressionTest.cpp
@@ -48,7 +48,7 @@ static Value evaluate(const std::string& expression, const MapType& variables = 
   return IO::ELParser::parseStrict(expression).evaluate(context);
 }
 
-TEST_CASE("ExpressionTest.testValueLiterals", "[ExpressionTest]")
+TEST_CASE("ExpressionTest.testValueLiterals")
 {
   using T = std::tuple<std::string, Value>;
 
@@ -70,7 +70,7 @@ TEST_CASE("ExpressionTest.testValueLiterals", "[ExpressionTest]")
   CHECK(evaluate(expression) == expectedValue);
 }
 
-TEST_CASE("ExpressionTest.testVariableExpression", "[ExpressionTest]")
+TEST_CASE("ExpressionTest.testVariableExpression")
 {
   using T = std::tuple<std::string, MapType, Value>;
 
@@ -89,7 +89,7 @@ TEST_CASE("ExpressionTest.testVariableExpression", "[ExpressionTest]")
   CHECK(evaluate(expression, variables) == expectedValue);
 }
 
-TEST_CASE("ExpressionTest.testArrayExpression", "[ExpressionTest]")
+TEST_CASE("ExpressionTest.testArrayExpression")
 {
   using T = std::tuple<std::string, MapType, ArrayType>;
 
@@ -107,7 +107,7 @@ TEST_CASE("ExpressionTest.testArrayExpression", "[ExpressionTest]")
   CHECK(evaluate(expression, variables) == Value{expectedValue});
 }
 
-TEST_CASE("ExpressionTest.testMapExpression", "[ExpressionTest]")
+TEST_CASE("ExpressionTest.testMapExpression")
 {
   using T = std::tuple<std::string, MapType, MapType>;
 
@@ -126,7 +126,7 @@ TEST_CASE("ExpressionTest.testMapExpression", "[ExpressionTest]")
   CHECK(evaluate(expression, variables) == Value{expectedValue});
 }
 
-TEST_CASE("ExpressionTest.testOperators", "[ExpressionTest]")
+TEST_CASE("ExpressionTest.testOperators")
 {
   using T = std::tuple<std::string, std::variant<Value, EvaluationError>>;
 
@@ -684,7 +684,7 @@ TEST_CASE("ExpressionTest.testOperators", "[ExpressionTest]")
   }
 }
 
-TEST_CASE("ExpressionTest.testOperatorPrecedence", "[ExpressionTest]")
+TEST_CASE("ExpressionTest.testOperatorPrecedence")
 {
   using T = std::tuple<std::string, Value>;
 

--- a/common/test/src/EL/InterpolatorTest.cpp
+++ b/common/test/src/EL/InterpolatorTest.cpp
@@ -37,13 +37,13 @@ static void interpolateAndCheck(
   CHECK(Interpolator(expression).interpolate(context) == expected);
 }
 
-TEST_CASE("ELInterpolatorTest.interpolateEmptyString", "[ELInterpolatorTest]")
+TEST_CASE("ELInterpolatorTest.interpolateEmptyString")
 {
   interpolateAndCheck("", "");
   interpolateAndCheck("   ", "   ");
 }
 
-TEST_CASE("ELInterpolatorTest.interpolateStringWithoutExpression", "[ELInterpolatorTest]")
+TEST_CASE("ELInterpolatorTest.interpolateStringWithoutExpression")
 {
   interpolateAndCheck(" asdfasdf  sdf ", " asdfasdf  sdf ");
 }
@@ -66,7 +66,7 @@ TEST_CASE(
     " asdfasdf nested ${TEST} expression  sdf ");
 }
 
-TEST_CASE("ELInterpolatorTest.interpolateStringWithVariable", "[ELInterpolatorTest]")
+TEST_CASE("ELInterpolatorTest.interpolateStringWithVariable")
 {
   EvaluationContext context;
   context.declareVariable("TEST", Value("interesting"));

--- a/common/test/src/EnsureTest.cpp
+++ b/common/test/src/EnsureTest.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom
 {
 namespace Ensure
 {
-TEST_CASE("EnsureTest.successfulEnsure", "[EnsureTest]")
+TEST_CASE("EnsureTest.successfulEnsure")
 {
   CHECK_NOTHROW([]() { ensure(true, "this shouldn't fail"); }());
 }
@@ -37,7 +37,7 @@ TEST_CASE("EnsureTest.successfulEnsure", "[EnsureTest]")
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #endif
 
-TEST_CASE("EnsureTest.failingEnsure", "[EnsureTest]")
+TEST_CASE("EnsureTest.failingEnsure")
 {
   // FIXME: not with catch2
   // ASSERT_DEATH(ensure(false, "this should fail"), "");

--- a/common/test/src/IO/AseParserRegressionTest.cpp
+++ b/common/test/src/IO/AseParserRegressionTest.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("AseParserTest.parseFailure_2657", "[AseParserTest]")
+TEST_CASE("AseParserTest.parseFailure_2657")
 {
   NullLogger logger;
 
@@ -62,7 +62,7 @@ TEST_CASE("AseParserTest.parseFailure_2657", "[AseParserTest]")
   CHECK(model->frame(0)->loaded());
 }
 
-TEST_CASE("AseParserTest.parseFailure_2679", "[AseParserTest]")
+TEST_CASE("AseParserTest.parseFailure_2679")
 {
   NullLogger logger;
 
@@ -90,7 +90,7 @@ TEST_CASE("AseParserTest.parseFailure_2679", "[AseParserTest]")
   CHECK(model->frame(0)->loaded());
 }
 
-TEST_CASE("AseParserTest.parseFailure_2898_vertex_index", "[AseParserTest]")
+TEST_CASE("AseParserTest.parseFailure_2898_vertex_index")
 {
   NullLogger logger;
 
@@ -118,7 +118,7 @@ TEST_CASE("AseParserTest.parseFailure_2898_vertex_index", "[AseParserTest]")
   CHECK(model->frame(0)->loaded());
 }
 
-TEST_CASE("AseParserTest.parseFailure_2898_no_uv", "[AseParserTest]")
+TEST_CASE("AseParserTest.parseFailure_2898_no_uv")
 {
   NullLogger logger;
 

--- a/common/test/src/IO/AseParserTest.cpp
+++ b/common/test/src/IO/AseParserTest.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("AseParserTest.loadWithoutException", "[AseParserTest]")
+TEST_CASE("AseParserTest.loadWithoutException")
 {
   NullLogger logger;
 
@@ -62,7 +62,7 @@ TEST_CASE("AseParserTest.loadWithoutException", "[AseParserTest]")
   CHECK(model->frame(0)->loaded());
 }
 
-TEST_CASE("AseParserTest.fallbackToMaterialName", "[AseParserTest]")
+TEST_CASE("AseParserTest.fallbackToMaterialName")
 {
   NullLogger logger;
 
@@ -94,7 +94,7 @@ TEST_CASE("AseParserTest.fallbackToMaterialName", "[AseParserTest]")
   CHECK(model->surface(0).skin(0)->name() == "textures/bigtile");
 }
 
-TEST_CASE("AseParserTest.loadDefaultMaterial", "[AseParserTest]")
+TEST_CASE("AseParserTest.loadDefaultMaterial")
 {
   NullLogger logger;
 

--- a/common/test/src/IO/CompilationConfigParserTest.cpp
+++ b/common/test/src/IO/CompilationConfigParserTest.cpp
@@ -31,14 +31,14 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("CompilationConfigParserTest.parseBlankConfig", "[CompilationConfigParserTest]")
+TEST_CASE("CompilationConfigParserTest.parseBlankConfig")
 {
   const std::string config("   ");
   CompilationConfigParser parser(config);
   CHECK_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("CompilationConfigParserTest.parseEmptyConfig", "[CompilationConfigParserTest]")
+TEST_CASE("CompilationConfigParserTest.parseEmptyConfig")
 {
   const std::string config("  {  } ");
   CompilationConfigParser parser(config);

--- a/common/test/src/IO/DefParserTest.cpp
+++ b/common/test/src/IO/DefParserTest.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("DefParserTest.parseIncludedDefFiles", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseIncludedDefFiles")
 {
   const Path basePath = Disk::getCurrentWorkingDir() + Path("fixture/games/");
   const std::vector<Path> cfgFiles =
@@ -75,7 +75,7 @@ TEST_CASE("DefParserTest.parseIncludedDefFiles", "[DefParserTest]")
   }
 }
 
-TEST_CASE("DefParserTest.parseExtraDefFiles", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseExtraDefFiles")
 {
   const Path basePath = Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Def");
   const std::vector<Path> cfgFiles =
@@ -97,7 +97,7 @@ TEST_CASE("DefParserTest.parseExtraDefFiles", "[DefParserTest]")
   }
 }
 
-TEST_CASE("DefParserTest.parseEmptyFile", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseEmptyFile")
 {
   const std::string file = "";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -109,7 +109,7 @@ TEST_CASE("DefParserTest.parseEmptyFile", "[DefParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("DefParserTest.parseWhitespaceFile", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseWhitespaceFile")
 {
   const std::string file = "     \n  \t \n  ";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -121,7 +121,7 @@ TEST_CASE("DefParserTest.parseWhitespaceFile", "[DefParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("DefParserTest.parseCommentsFile", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseCommentsFile")
 {
   const std::string file = "// asdfasdfasdf\n//kj3k4jkdjfkjdf\n";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -133,7 +133,7 @@ TEST_CASE("DefParserTest.parseCommentsFile", "[DefParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("DefParserTest.parseSolidClass", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseSolidClass")
 {
   const std::string file =
     "/*QUAKED worldspawn (0.0 0.0 0.0) ?\n"
@@ -175,7 +175,7 @@ TEST_CASE("DefParserTest.parseSolidClass", "[DefParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("DefParserTest.parsePointClass", "[DefParserTest]")
+TEST_CASE("DefParserTest.parsePointClass")
 {
   const std::string file =
     "/*QUAKED monster_zombie (1.0 0.0 0.0) (-16 -16 -24) (16 16 32) Crucified ambush\n"
@@ -226,7 +226,7 @@ TEST_CASE("DefParserTest.parsePointClass", "[DefParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("DefParserTest.parseSpawnflagWithSkip", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseSpawnflagWithSkip")
 {
   const std::string file =
     "/*QUAKED item_health (.3 .3 1) (-16 -16 -16) (16 16 16) - SUSPENDED SPIN - RESPAWN\n"
@@ -333,7 +333,7 @@ TEST_CASE(
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("DefParserTest.parsePointClassWithBaseClasses", "[DefParserTest]")
+TEST_CASE("DefParserTest.parsePointClassWithBaseClasses")
 {
   const std::string file =
     "/*QUAKED _light_style\n"
@@ -409,7 +409,7 @@ static const std::string DefModelDefinitionTemplate =
 
 using Assets::assertModelDefinition;
 
-TEST_CASE("DefParserTest.parseLegacyStaticModelDefinition", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseLegacyStaticModelDefinition")
 {
   static const std::string ModelDefinition =
     "\":maps/b_shell0.bsp\", \":maps/b_shell1.bsp\" spawnflags = 1";
@@ -425,7 +425,7 @@ TEST_CASE("DefParserTest.parseLegacyStaticModelDefinition", "[DefParserTest]")
     "{ 'spawnflags': 1 }");
 }
 
-TEST_CASE("DefParserTest.parseLegacyDynamicModelDefinition", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseLegacyDynamicModelDefinition")
 {
   static const std::string ModelDefinition =
     "pathKey = \"model\" skinKey = \"skin\" frameKey = \"frame\"";
@@ -442,7 +442,7 @@ TEST_CASE("DefParserTest.parseLegacyDynamicModelDefinition", "[DefParserTest]")
     "{ 'model': 'maps/b_shell1.bsp', 'skin': 1, 'frame': 2 }");
 }
 
-TEST_CASE("DefParserTest.parseELModelDefinition", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseELModelDefinition")
 {
   static const std::string ModelDefinition =
     "{{ spawnflags == 1 -> 'maps/b_shell1.bsp', 'maps/b_shell0.bsp' }}";
@@ -453,7 +453,7 @@ TEST_CASE("DefParserTest.parseELModelDefinition", "[DefParserTest]")
     DefModelDefinitionTemplate);
 }
 
-TEST_CASE("DefParserTest.parseInvalidBounds", "[DefParserTest]")
+TEST_CASE("DefParserTest.parseInvalidBounds")
 {
   const std::string file =
     "/*QUAKED light (0.0 1.0 0.0) (8 -8 -8) (-8 8 8) START_OFF\n"

--- a/common/test/src/IO/DiskFileSystemTest.cpp
+++ b/common/test/src/IO/DiskFileSystemTest.cpp
@@ -61,7 +61,7 @@ static TestEnvironment makeTestEnvironment()
     }};
 }
 
-TEST_CASE("FileSystemTest.makeAbsolute", "[FileSystemTest]")
+TEST_CASE("FileSystemTest.makeAbsolute")
 {
   const auto env = makeTestEnvironment();
 
@@ -78,7 +78,7 @@ TEST_CASE("FileSystemTest.makeAbsolute", "[FileSystemTest]")
   CHECK(absPathNotExisting == env.dir() + Path("dir1/asdf.map"));
 }
 
-TEST_CASE("DiskTest.fixPath", "[DiskTest]")
+TEST_CASE("DiskTest.fixPath")
 {
   const auto env = makeTestEnvironment();
 
@@ -106,7 +106,7 @@ TEST_CASE("DiskTest.fixPath", "[DiskTest]")
     Disk::fixPath(env.dir() + Path("anotHERDIR/./SUBdirTEST/../SubdirTesT/TesT2.MAP")))));
 }
 
-TEST_CASE("DiskTest.directoryExists", "[DiskTest]")
+TEST_CASE("DiskTest.directoryExists")
 {
   const auto env = makeTestEnvironment();
 
@@ -128,7 +128,7 @@ TEST_CASE("DiskTest.directoryExists", "[DiskTest]")
     env.dir() + Path("anotherDir/asdf"))); // asdf directory doesn't exist
 }
 
-TEST_CASE("DiskTest.fileExists", "[DiskTest]")
+TEST_CASE("DiskTest.fileExists")
 {
   const auto env = makeTestEnvironment();
 
@@ -138,7 +138,7 @@ TEST_CASE("DiskTest.fileExists", "[DiskTest]")
   CHECK(Disk::fileExists(env.dir() + Path("anotherDir/subDirTest/test2.map")));
 }
 
-TEST_CASE("DiskTest.getDirectoryContents", "[DiskTest]")
+TEST_CASE("DiskTest.getDirectoryContents")
 {
   const auto env = makeTestEnvironment();
 
@@ -157,7 +157,7 @@ TEST_CASE("DiskTest.getDirectoryContents", "[DiskTest]")
     }));
 }
 
-TEST_CASE("DiskTest.openFile", "[DiskTest]")
+TEST_CASE("DiskTest.openFile")
 {
   const auto env = makeTestEnvironment();
 
@@ -171,7 +171,7 @@ TEST_CASE("DiskTest.openFile", "[DiskTest]")
   CHECK(Disk::openFile(env.dir() + Path("anotherDir/subDirTest/test2.map")) != nullptr);
 }
 
-TEST_CASE("DiskTest.resolvePath", "[DiskTest]")
+TEST_CASE("DiskTest.resolvePath")
 {
   const auto env = makeTestEnvironment();
 
@@ -196,7 +196,7 @@ TEST_CASE("DiskTest.resolvePath", "[DiskTest]")
   CHECK(Disk::resolvePath(rootPaths, paths[4]) == Path(""));
 }
 
-TEST_CASE("DiskFileSystemTest.createDiskFileSystem", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.createDiskFileSystem")
 {
   const auto env = makeTestEnvironment();
 
@@ -211,7 +211,7 @@ TEST_CASE("DiskFileSystemTest.createDiskFileSystem", "[DiskFileSystemTest]")
   CHECK(fs.makeAbsolute(Path("")) == fs.root());
 }
 
-TEST_CASE("DiskFileSystemTest.directoryExists", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.directoryExists")
 {
   const auto env = makeTestEnvironment();
   const DiskFileSystem fs(env.dir());
@@ -232,7 +232,7 @@ TEST_CASE("DiskFileSystemTest.directoryExists", "[DiskFileSystemTest]")
   CHECK_FALSE(fs.directoryExists(Path("fasdf")));
 }
 
-TEST_CASE("DiskFileSystemTest.fileExists", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.fileExists")
 {
   const auto env = makeTestEnvironment();
   const DiskFileSystem fs(env.dir());
@@ -254,7 +254,7 @@ TEST_CASE("DiskFileSystemTest.fileExists", "[DiskFileSystemTest]")
   CHECK_FALSE(fs.fileExists(Path("fdfdf.blah")));
 }
 
-TEST_CASE("DiskFileSystemTest.getDirectoryContents", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.getDirectoryContents")
 {
   const auto env = makeTestEnvironment();
   const DiskFileSystem fs(env.dir());
@@ -269,7 +269,7 @@ TEST_CASE("DiskFileSystemTest.getDirectoryContents", "[DiskFileSystemTest]")
     }));
 }
 
-TEST_CASE("DiskFileSystemTest.findItems", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.findItems")
 {
   const auto env = makeTestEnvironment();
   const DiskFileSystem fs(env.dir());
@@ -305,7 +305,7 @@ TEST_CASE("DiskFileSystemTest.findItems", "[DiskFileSystemTest]")
     }));
 }
 
-TEST_CASE("DiskFileSystemTest.findItemsRecursively", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.findItemsRecursively")
 {
   const auto env = makeTestEnvironment();
   const DiskFileSystem fs(env.dir());
@@ -349,7 +349,7 @@ TEST_CASE("DiskFileSystemTest.findItemsRecursively", "[DiskFileSystemTest]")
 
 // getDirectoryContents gets tested thoroughly by the tests for the find* methods
 
-TEST_CASE("DiskFileSystemTest.openFile", "[DiskFileSystemTest]")
+TEST_CASE("DiskFileSystemTest.openFile")
 {
   const auto env = makeTestEnvironment();
   const DiskFileSystem fs(env.dir());
@@ -392,7 +392,7 @@ TEST_CASE(
   CHECK(fs.makeAbsolute(Path("")) == env.dir());
 }
 
-TEST_CASE("WritableDiskFileSystemTest.createDirectory", "[WritableDiskFileSystemTest]")
+TEST_CASE("WritableDiskFileSystemTest.createDirectory")
 {
   const auto env = makeTestEnvironment();
   WritableDiskFileSystem fs(env.dir(), false);
@@ -420,7 +420,7 @@ TEST_CASE("WritableDiskFileSystemTest.createDirectory", "[WritableDiskFileSystem
   CHECK(fs.directoryExists(Path("newDir/yetAnotherDir")));
 }
 
-TEST_CASE("WritableDiskFileSystemTest.deleteFile", "[WritableDiskFileSystemTest]")
+TEST_CASE("WritableDiskFileSystemTest.deleteFile")
 {
   const auto env = makeTestEnvironment();
   WritableDiskFileSystem fs(env.dir(), false);
@@ -449,7 +449,7 @@ TEST_CASE("WritableDiskFileSystemTest.deleteFile", "[WritableDiskFileSystemTest]
   CHECK_FALSE(fs.fileExists(Path("anotherDir/subDirTest/test2.map")));
 }
 
-TEST_CASE("WritableDiskFileSystemTest.moveFile", "[WritableDiskFileSystemTest]")
+TEST_CASE("WritableDiskFileSystemTest.moveFile")
 {
   const auto env = makeTestEnvironment();
   WritableDiskFileSystem fs(env.dir(), false);
@@ -492,7 +492,7 @@ TEST_CASE("WritableDiskFileSystemTest.moveFile", "[WritableDiskFileSystemTest]")
   CHECK(fs.fileExists(Path("dir1/test2.map")));
 }
 
-TEST_CASE("WritableDiskFileSystemTest.copyFile", "[WritableDiskFileSystemTest]")
+TEST_CASE("WritableDiskFileSystemTest.copyFile")
 {
   const auto env = makeTestEnvironment();
   WritableDiskFileSystem fs(env.dir(), false);

--- a/common/test/src/IO/DkPakFileSystemTest.cpp
+++ b/common/test/src/IO/DkPakFileSystemTest.cpp
@@ -28,7 +28,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("DkPakFileSystemTest.directoryExists", "[DkPakFileSystemTest]")
+TEST_CASE("DkPakFileSystemTest.directoryExists")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/dkpak_test.pak");
@@ -42,7 +42,7 @@ TEST_CASE("DkPakFileSystemTest.directoryExists", "[DkPakFileSystemTest]")
   CHECK_FALSE(fs.directoryExists(Path("pics/tag1.pcx")));
 }
 
-TEST_CASE("DkPakFileSystemTest.fileExists", "[DkPakFileSystemTest]")
+TEST_CASE("DkPakFileSystemTest.fileExists")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/dkpak_test.pak");
@@ -55,7 +55,7 @@ TEST_CASE("DkPakFileSystemTest.fileExists", "[DkPakFileSystemTest]")
   CHECK(fs.fileExists(Path("PICS/TAG1.pcX")));
 }
 
-TEST_CASE("DkPakFileSystemTest.findItems", "[DkPakFileSystemTest]")
+TEST_CASE("DkPakFileSystemTest.findItems")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/dkpak_test.pak");
@@ -84,7 +84,7 @@ TEST_CASE("DkPakFileSystemTest.findItems", "[DkPakFileSystemTest]")
       std::vector<Path>{Path("pics/tag1.pcx"), Path("pics/tag2.pcx")}));
 }
 
-TEST_CASE("DkPakFileSystemTest.findItemsRecursively", "[DkPakFileSystemTest]")
+TEST_CASE("DkPakFileSystemTest.findItemsRecursively")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/dkpak_test.pak");
@@ -140,7 +140,7 @@ TEST_CASE("DkPakFileSystemTest.findItemsRecursively", "[DkPakFileSystemTest]")
     }));
 }
 
-TEST_CASE("DkPakFileSystemTest.openFile", "[DkPakFileSystemTest]")
+TEST_CASE("DkPakFileSystemTest.openFile")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/dkpak_test.pak");

--- a/common/test/src/IO/ELParserTest.cpp
+++ b/common/test/src/IO/ELParserTest.cpp
@@ -38,14 +38,14 @@ static auto evaluate(
   return ELParser::parseStrict(str).evaluate(context);
 }
 
-TEST_CASE("ELParserTest.parseEmptyExpression", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseEmptyExpression")
 {
   CHECK_THROWS_AS(evaluate(""), ParserException);
   CHECK_THROWS_AS(evaluate("    "), ParserException);
   CHECK_THROWS_AS(evaluate("\n"), ParserException);
 }
 
-TEST_CASE("ELParserTest.parseStringLiteral", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseStringLiteral")
 {
   CHECK_THROWS_AS(evaluate("\"asdf"), ParserException);
 
@@ -53,14 +53,14 @@ TEST_CASE("ELParserTest.parseStringLiteral", "[ELParserTest]")
   CHECK(evaluate("\"asdf\"") == EL::Value("asdf"));
 }
 
-TEST_CASE("ELParserTest.parseStringLiteralWithDoubleQuotationMarks", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseStringLiteralWithDoubleQuotationMarks")
 {
   // MSVC complains about an illegal escape sequence if we use a raw string literal for
   // the expression
   CHECK(evaluate("\"asdf\\\" \\\"asdf\"") == EL::Value(R"(asdf" "asdf)"));
 }
 
-TEST_CASE("ELParserTest.parseNumberLiteral", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseNumberLiteral")
 {
   CHECK_THROWS_AS(evaluate("1.123.34"), ParserException);
 
@@ -71,13 +71,13 @@ TEST_CASE("ELParserTest.parseNumberLiteral", "[ELParserTest]")
   CHECK(evaluate("0") == EL::Value(0.0));
 }
 
-TEST_CASE("ELParserTest.parseBooleanLiteral", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBooleanLiteral")
 {
   CHECK(evaluate("true") == EL::Value(true));
   CHECK(evaluate("false") == EL::Value(false));
 }
 
-TEST_CASE("ELParserTest.parseArrayLiteral", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseArrayLiteral")
 {
   EL::ArrayType array, nestedArray;
   array.push_back(EL::Value(1.0));
@@ -102,7 +102,7 @@ TEST_CASE("ELParserTest.parseArrayLiteral", "[ELParserTest]")
       EL::ArrayType({EL::Value(-2.0), EL::Value(-1.0), EL::Value(0.0), EL::Value(1.0)})));
 }
 
-TEST_CASE("ELParserTest.parseMapLiteral", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseMapLiteral")
 {
   EL::MapType map, nestedMap;
   map.insert(std::make_pair("testkey1", EL::Value(1.0)));
@@ -117,7 +117,7 @@ TEST_CASE("ELParserTest.parseMapLiteral", "[ELParserTest]")
     == EL::Value(map));
 }
 
-TEST_CASE("ELParserTest.parseMapLiteralNestedInArray", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseMapLiteralNestedInArray")
 {
   EL::MapType map;
   map.insert(std::make_pair("key", EL::Value("value")));
@@ -128,7 +128,7 @@ TEST_CASE("ELParserTest.parseMapLiteralNestedInArray", "[ELParserTest]")
   CHECK(evaluate(R"([ { "key": "value" } ])") == EL::Value(array));
 }
 
-TEST_CASE("ELParserTest.parseMapLiteralNestedInArrayNestedInMap", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseMapLiteralNestedInArrayNestedInMap")
 {
   EL::MapType inner;
   inner.insert(std::make_pair("key", EL::Value("value")));
@@ -145,7 +145,7 @@ TEST_CASE("ELParserTest.parseMapLiteralNestedInArrayNestedInMap", "[ELParserTest
     == EL::Value(outer));
 }
 
-TEST_CASE("ELParserTest.parseMapLiteralWithTrailingGarbage", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseMapLiteralWithTrailingGarbage")
 {
   CHECK_THROWS_AS(
     evaluate("{\n"
@@ -156,7 +156,7 @@ TEST_CASE("ELParserTest.parseMapLiteralWithTrailingGarbage", "[ELParserTest]")
     ParserException);
 }
 
-TEST_CASE("ELParserTest.parseVariable", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseVariable")
 {
   EL::EvaluationContext context;
   context.declareVariable("test", EL::Value(1.0));
@@ -164,17 +164,17 @@ TEST_CASE("ELParserTest.parseVariable", "[ELParserTest]")
   CHECK(evaluate("test", context) == EL::Value(1.0));
 }
 
-TEST_CASE("ELParserTest.parseUnaryPlus", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseUnaryPlus")
 {
   CHECK(evaluate("+1.0") == EL::Value(1.0));
 }
 
-TEST_CASE("ELParserTest.parseUnaryMinus", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseUnaryMinus")
 {
   CHECK(evaluate("-1.0") == EL::Value(-1.0));
 }
 
-TEST_CASE("ELParserTest.parseLogicalNegation", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseLogicalNegation")
 {
   CHECK(evaluate("!true") == EL::Value(false));
   CHECK(evaluate("!false") == EL::Value(true));
@@ -183,28 +183,28 @@ TEST_CASE("ELParserTest.parseLogicalNegation", "[ELParserTest]")
   CHECK_THROWS_AS(evaluate("!'true'"), EL::EvaluationError);
 }
 
-TEST_CASE("ELParserTest.parseBitwiseNegation", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBitwiseNegation")
 {
   CHECK(evaluate("~393") == EL::Value(~393));
   CHECK_THROWS_AS(evaluate("~"), ParserException);
   CHECK_THROWS_AS(evaluate("~~"), ParserException);
 }
 
-TEST_CASE("ELParserTest.parseAddition", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseAddition")
 {
   CHECK(evaluate("2 + 3") == EL::Value(5.0));
   CHECK(evaluate("\"as\"+\"df\"") == EL::Value("asdf"));
   CHECK(evaluate("2 + 3 + 4") == EL::Value(9.0));
 }
 
-TEST_CASE("ELParserTest.parseSubtraction", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseSubtraction")
 {
   CHECK(evaluate("2 - 3.0") == EL::Value(-1.0));
   CHECK(evaluate("2 - 3 - 4") == EL::Value(-5.0));
   CHECK(evaluate("2 - 3 - 4 - 2") == EL::Value(-7.0));
 }
 
-TEST_CASE("ELParserTest.parseMultiplication", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseMultiplication")
 {
   CHECK(evaluate("2 * 3.0") == EL::Value(6.0));
 
@@ -212,21 +212,21 @@ TEST_CASE("ELParserTest.parseMultiplication", "[ELParserTest]")
   CHECK(evaluate("2 * 3 * 4 * 2") == EL::Value(48.0));
 }
 
-TEST_CASE("ELParserTest.parseDivision", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseDivision")
 {
   CHECK(evaluate("12 / 2.0") == EL::Value(6.0));
   CHECK(evaluate("12 / 2 / 2") == EL::Value(3.0));
   CHECK(evaluate("12 / 2 / 2 / 3") == EL::Value(1.0));
 }
 
-TEST_CASE("ELParserTest.parseModulus", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseModulus")
 {
   CHECK(evaluate("12 % 2.0") == EL::Value(0.0));
   CHECK(evaluate("12 % 5 % 3") == EL::Value(2.0));
   CHECK(evaluate("12 % 5 % 3 % 3") == EL::Value(2.0));
 }
 
-TEST_CASE("ELParserTest.parseLogicalAnd", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseLogicalAnd")
 {
   CHECK(evaluate("true && true") == EL::Value(true));
   CHECK(evaluate("false && true") == EL::Value(false));
@@ -234,7 +234,7 @@ TEST_CASE("ELParserTest.parseLogicalAnd", "[ELParserTest]")
   CHECK(evaluate("false && false") == EL::Value(false));
 }
 
-TEST_CASE("ELParserTest.parseLogicalOr", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseLogicalOr")
 {
   CHECK(evaluate("true || true") == EL::Value(true));
   CHECK(evaluate("false || true") == EL::Value(true));
@@ -242,33 +242,33 @@ TEST_CASE("ELParserTest.parseLogicalOr", "[ELParserTest]")
   CHECK(evaluate("false || false") == EL::Value(false));
 }
 
-TEST_CASE("ELParserTest.parseBitwiseAnd", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBitwiseAnd")
 {
   CHECK(evaluate("23 & 24") == EL::Value(23 & 24));
 }
 
-TEST_CASE("ELParserTest.parseBitwiseOr", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBitwiseOr")
 {
   CHECK(evaluate("23 | 24") == EL::Value(23 | 24));
 }
 
-TEST_CASE("ELParserTest.parseBitwiseXor", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBitwiseXor")
 {
   CHECK(evaluate("23 ^ 24") == EL::Value((23 ^ 24)));
   CHECK_THROWS_AS(evaluate("23 ^^ 23"), ParserException);
 }
 
-TEST_CASE("ELParserTest.parseBitwiseShiftLeft", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBitwiseShiftLeft")
 {
   CHECK(evaluate("1 << 7") == EL::Value(1 << 7));
 }
 
-TEST_CASE("ELParserTest.parseBitwiseShiftRight", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBitwiseShiftRight")
 {
   CHECK(evaluate("8 >> 2") == EL::Value(8 >> 2));
 }
 
-TEST_CASE("ELParserTest.parseSubscript", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseSubscript")
 {
   CHECK(evaluate("[ 1.0, 2.0, \"test\" ][0]") == EL::Value(1.0));
   CHECK(evaluate("[ 1.0, 2.0, \"test\" ][1]") == EL::Value(2.0));
@@ -322,7 +322,7 @@ TEST_CASE("ELParserTest.parseSubscript", "[ELParserTest]")
   CHECK(evaluate("\"test\"[1..]") == EL::Value("est"));
 }
 
-TEST_CASE("ELParserTest.parseCaseOperator", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseCaseOperator")
 {
   CHECK(evaluate("true -> false") == EL::Value(false));
   CHECK(evaluate("true -> true && true") == EL::Value(true));
@@ -330,12 +330,12 @@ TEST_CASE("ELParserTest.parseCaseOperator", "[ELParserTest]")
   CHECK(evaluate("false -> true") == EL::Value(EL::Value::Undefined));
 }
 
-TEST_CASE("ELParserTest.parseBinaryNegation", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseBinaryNegation")
 {
   CHECK(evaluate("~1") == EL::Value(~1l));
 }
 
-TEST_CASE("ELParserTest.parseSwitchExpression", "[ELParserTest]")
+TEST_CASE("ELParserTest.parseSwitchExpression")
 {
   CHECK(evaluate("{{}}") == EL::Value::Undefined);
   CHECK(evaluate("{{'asdf'}}") == EL::Value("asdf"));
@@ -344,7 +344,7 @@ TEST_CASE("ELParserTest.parseSwitchExpression", "[ELParserTest]")
   CHECK(evaluate("{{false -> false}}") == EL::Value::Undefined);
 }
 
-TEST_CASE("ELParserTest.testComparisonOperators", "[ELParserTest]")
+TEST_CASE("ELParserTest.testComparisonOperators")
 {
   CHECK(evaluate("1 < 2") == EL::Value(true));
   CHECK(evaluate("2 < 2") == EL::Value(false));
@@ -364,7 +364,7 @@ TEST_CASE("ELParserTest.testComparisonOperators", "[ELParserTest]")
   CHECK(evaluate("2 >= 3") == EL::Value(false));
 }
 
-TEST_CASE("ELParserTest.testOperatorPrecedence", "[ELParserTest]")
+TEST_CASE("ELParserTest.testOperatorPrecedence")
 {
   CHECK(evaluate("7 + 2 * 3") == evaluate("2 * 3 + 7"));
   CHECK(evaluate("7 + 2 * 3 + 2") == evaluate("2 * 3 + 7 + 2"));
@@ -378,7 +378,7 @@ TEST_CASE("ELParserTest.testOperatorPrecedence", "[ELParserTest]")
   CHECK(evaluate("false && (false || true)") == EL::Value(false));
 }
 
-TEST_CASE("ELParserTest.testParseGrouping", "[ELParserTest]")
+TEST_CASE("ELParserTest.testParseGrouping")
 {
   CHECK_THROWS_AS(evaluate("()"), ParserException);
   CHECK(evaluate("(1)") == EL::Value(1.0));

--- a/common/test/src/IO/EntParserTest.cpp
+++ b/common/test/src/IO/EntParserTest.cpp
@@ -51,7 +51,7 @@ static void assertPropertyDefinition(
   CHECK(propDefinition->type() == expectedType);
 }
 
-TEST_CASE("EntParserTest.parseIncludedEntFiles", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseIncludedEntFiles")
 {
   const Path basePath = Disk::getCurrentWorkingDir() + Path("fixture/games/");
   const std::vector<Path> cfgFiles =
@@ -90,7 +90,7 @@ TEST_CASE("EntParserTest.parseIncludedEntFiles", "[EntParserTest]")
   }
 }
 
-TEST_CASE("EntParserTest.parseEmptyFile", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseEmptyFile")
 {
   const std::string file = "";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -102,7 +102,7 @@ TEST_CASE("EntParserTest.parseEmptyFile", "[EntParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseWhitespaceFile", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseWhitespaceFile")
 {
   const std::string file = "     \n  \t \n  ";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -114,7 +114,7 @@ TEST_CASE("EntParserTest.parseWhitespaceFile", "[EntParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseMalformedXML", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseMalformedXML")
 {
   const std::string file =
     R"(<?xml version="1.0"?>
@@ -128,7 +128,7 @@ TEST_CASE("EntParserTest.parseMalformedXML", "[EntParserTest]")
   CHECK_THROWS_AS(parser.parseDefinitions(status), ParserException);
 }
 
-TEST_CASE("EntParserTest.parseSimplePointEntityDefinition", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseSimplePointEntityDefinition")
 {
   const std::string file = R"(
 <?xml version="1.0"?>
@@ -258,7 +258,7 @@ Updated: 2011-03-02
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseSimpleGroupEntityDefinition", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseSimpleGroupEntityDefinition")
 {
   const std::string file = R"(
 <?xml version="1.0"?>
@@ -346,7 +346,7 @@ Target this entity with a misc_model to have the model attached to the entity (s
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseListPropertyDefinition", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseListPropertyDefinition")
 {
   const std::string file = R"(
 <?xml version="1.0"?>
@@ -426,7 +426,7 @@ TEST_CASE("EntParserTest.parseListPropertyDefinition", "[EntParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition")
 {
   const std::string file = R"(
 <?xml version="1.0"?>
@@ -466,7 +466,7 @@ TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition", "[EntParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseLegacyModelDefinition", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseLegacyModelDefinition")
 {
   const std::string file = R"(
 <?xml version="1.0"?>
@@ -496,7 +496,7 @@ TEST_CASE("EntParserTest.parseLegacyModelDefinition", "[EntParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("EntParserTest.parseELStaticModelDefinition", "[EntParserTest]")
+TEST_CASE("EntParserTest.parseELStaticModelDefinition")
 {
   const std::string file = R"(
             <?xml version="1.0"?>

--- a/common/test/src/IO/EntityDefinitionParserTest.cpp
+++ b/common/test/src/IO/EntityDefinitionParserTest.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("resolveInheritance.filterBaseClasses", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.filterBaseClasses")
 {
   const auto input = std::vector<EntityDefinitionClassInfo>({
     // type                                   l  c  name     description   color size
@@ -97,7 +97,7 @@ TEST_CASE("resolveInheritance.filterBaseClasses", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.filterRedundantClasses", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.filterRedundantClasses")
 {
   const auto input = std::vector<EntityDefinitionClassInfo>({
     // type                                   l  c  name     description   color size
@@ -292,7 +292,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.overrideMembersIfNotPresent", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.overrideMembersIfNotPresent")
 {
   const auto baseModelDef = Assets::ModelDefinition(
     EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
@@ -340,7 +340,7 @@ TEST_CASE("resolveInheritance.overrideMembersIfNotPresent", "[resolveInheritance
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.skipMembersIfPresent", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.skipMembersIfPresent")
 {
   const auto input = std::vector<EntityDefinitionClassInfo>({
     // type                                   l  c  name     description    color size
@@ -385,7 +385,7 @@ TEST_CASE("resolveInheritance.skipMembersIfPresent", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.mergeModelDefinitions", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.mergeModelDefinitions")
 {
   const auto baseModelDef = Assets::ModelDefinition(
     EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
@@ -437,7 +437,7 @@ TEST_CASE("resolveInheritance.mergeModelDefinitions", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.inheritPropertyDefinitions", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.inheritPropertyDefinitions")
 {
   const auto a1_1 =
     std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
@@ -489,7 +489,7 @@ TEST_CASE("resolveInheritance.inheritPropertyDefinitions", "[resolveInheritance]
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.mergeSpawnflagsSimpleInheritance", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.mergeSpawnflagsSimpleInheritance")
 {
   auto a1 = std::make_shared<Assets::FlagsPropertyDefinition>(
     Model::EntityPropertyKeys::Spawnflags);
@@ -552,7 +552,7 @@ TEST_CASE("resolveInheritance.mergeSpawnflagsSimpleInheritance", "[resolveInheri
     })));
 }
 
-TEST_CASE("resolveInheritance.chainOfBaseClasses", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.chainOfBaseClasses")
 {
   const auto a1_1 =
     std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
@@ -624,7 +624,7 @@ TEST_CASE("resolveInheritance.chainOfBaseClasses", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.multipleBaseClasses", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.multipleBaseClasses")
 {
   const auto a1_1 =
     std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
@@ -696,7 +696,7 @@ TEST_CASE("resolveInheritance.multipleBaseClasses", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.diamondInheritance", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.diamondInheritance")
 {
   const auto a1 = std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
   const auto a2_1 =
@@ -788,7 +788,7 @@ TEST_CASE("resolveInheritance.diamondInheritance", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.overloadedSuperClass", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.overloadedSuperClass")
 {
   const auto input = std::vector<EntityDefinitionClassInfo>({
     // type                                   l  c  name      description   color size
@@ -883,7 +883,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass", "[resolveInheritance]")
   CHECK(status.countStatus(LogLevel::Error) == 0u);
 }
 
-TEST_CASE("resolveInheritance.indirectOverloadedSuperClass", "[resolveInheritance]")
+TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
 {
   const auto input = std::vector<EntityDefinitionClassInfo>({
     // type                                   l  c  name      description   color size

--- a/common/test/src/IO/EntityModelTest.cpp
+++ b/common/test/src/IO/EntityModelTest.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("BSP model intersection test", "[EntityModelTest]")
+TEST_CASE("BSP model intersection test")
 {
   auto logger = TestLogger();
   auto [game, gameConfig] = Model::loadGame("Quake");

--- a/common/test/src/IO/FgdParserTest.cpp
+++ b/common/test/src/IO/FgdParserTest.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("FgdParserTest.parseIncludedFgdFiles", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseIncludedFgdFiles")
 {
   const Path basePath = Disk::getCurrentWorkingDir() + Path("fixture/games/");
   const std::vector<Path> cfgFiles =
@@ -78,7 +78,7 @@ TEST_CASE("FgdParserTest.parseIncludedFgdFiles", "[FgdParserTest]")
   }
 }
 
-TEST_CASE("FgdParserTest.parseEmptyFile", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseEmptyFile")
 {
   const std::string file = "";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -90,7 +90,7 @@ TEST_CASE("FgdParserTest.parseEmptyFile", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseWhitespaceFile", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseWhitespaceFile")
 {
   const std::string file = "     \n  \t \n  ";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -102,7 +102,7 @@ TEST_CASE("FgdParserTest.parseWhitespaceFile", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseCommentsFile", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseCommentsFile")
 {
   const std::string file = "// asdfasdfasdf\n//kj3k4jkdjfkjdf\n";
   const Color defaultColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -114,7 +114,7 @@ TEST_CASE("FgdParserTest.parseCommentsFile", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseEmptyFlagDescription", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseEmptyFlagDescription")
 {
   const std::string file =
     "@PointClass color(0 255 0) size(-2 -2 -12, 2 2 12) = light_mine1 : "
@@ -135,7 +135,7 @@ TEST_CASE("FgdParserTest.parseEmptyFlagDescription", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseSolidClass", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseSolidClass")
 {
   const std::string file =
     "@SolidClass = worldspawn : \"World entity\"\n"
@@ -172,7 +172,7 @@ TEST_CASE("FgdParserTest.parseSolidClass", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parsePointClass", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parsePointClass")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -203,7 +203,7 @@ TEST_CASE("FgdParserTest.parsePointClass", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseBaseProperty", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseBaseProperty")
 {
   const std::string file =
     "@baseclass = Appearflags [\n"
@@ -225,7 +225,7 @@ TEST_CASE("FgdParserTest.parseBaseProperty", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parsePointClassWithBaseClasses", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parsePointClassWithBaseClasses")
 {
   const std::string file =
     "@baseclass = Appearflags [\n"
@@ -271,7 +271,7 @@ TEST_CASE("FgdParserTest.parsePointClassWithBaseClasses", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parsePointClassWithUnknownClassProperties", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parsePointClassWithUnknownClassProperties")
 {
   const std::string file =
     "@PointClass unknown1 unknown2(spaghetti) = info_notnull : \"Wildcard entity\" // I "
@@ -303,7 +303,7 @@ TEST_CASE("FgdParserTest.parsePointClassWithUnknownClassProperties", "[FgdParser
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseType_TargetSourcePropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseType_TargetSourcePropertyDefinition")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -373,7 +373,7 @@ TEST_CASE(
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseStringPropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseStringPropertyDefinition")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -436,7 +436,7 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition", "[FgdParserTest]")
  * Technically a type mismatch, but appears in the wild; see:
  * https://github.com/TrenchBroom/TrenchBroom/issues/2833
  */
-TEST_CASE("FgdParserTest.parseStringPropertyDefinition_IntDefault", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseStringPropertyDefinition_IntDefault")
 {
   const std::string file = R"(@PointClass = info_notnull : "Wildcard entity"
 [
@@ -488,7 +488,7 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition_IntDefault", "[FgdParserT
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -543,7 +543,7 @@ TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseReadOnlyPropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseReadOnlyPropertyDefinition")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -574,7 +574,7 @@ TEST_CASE("FgdParserTest.parseReadOnlyPropertyDefinition", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseFloatPropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseFloatPropertyDefinition")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -635,7 +635,7 @@ TEST_CASE("FgdParserTest.parseFloatPropertyDefinition", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseChoicePropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
 {
   const std::string file = R"%(
             @PointClass = info_notnull : "Wildcard entity" // I love you\n
@@ -798,7 +798,7 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseFlagsPropertyDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseFlagsPropertyDefinition")
 {
   const std::string file =
     "@PointClass = info_notnull : \"Wildcard entity\" // I love you\n"
@@ -863,7 +863,7 @@ static const std::string FgdModelDefinitionTemplate =
 
 using Assets::assertModelDefinition;
 
-TEST_CASE("FgdParserTest.parseLegacyStaticModelDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseLegacyStaticModelDefinition")
 {
   static const std::string ModelDefinition =
     "\":maps/b_shell0.bsp\", \":maps/b_shell1.bsp\" spawnflags = 1";
@@ -879,7 +879,7 @@ TEST_CASE("FgdParserTest.parseLegacyStaticModelDefinition", "[FgdParserTest]")
     "{ 'spawnflags': 1 }");
 }
 
-TEST_CASE("FgdParserTest.parseLegacyDynamicModelDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseLegacyDynamicModelDefinition")
 {
   static const std::string ModelDefinition =
     "pathKey = \"model\" skinKey = \"skin\" frameKey = \"frame\"";
@@ -896,7 +896,7 @@ TEST_CASE("FgdParserTest.parseLegacyDynamicModelDefinition", "[FgdParserTest]")
     "{ 'model': 'maps/b_shell1.bsp', 'skin': 1, 'frame': 2 }");
 }
 
-TEST_CASE("FgdParserTest.parseELModelDefinition", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseELModelDefinition")
 {
   static const std::string ModelDefinition =
     "{{ spawnflags == 1 -> 'maps/b_shell1.bsp', 'maps/b_shell0.bsp' }}";
@@ -907,7 +907,7 @@ TEST_CASE("FgdParserTest.parseELModelDefinition", "[FgdParserTest]")
     FgdModelDefinitionTemplate);
 }
 
-TEST_CASE("FgdParserTest.parseLegacyModelWithParseError", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseLegacyModelWithParseError")
 {
   const std::string file =
     "@PointClass base(Monster) size(-16 -16 -24, 16 16 40) model(\":progs/polyp.mdl\" 0 "
@@ -931,7 +931,7 @@ TEST_CASE("FgdParserTest.parseLegacyModelWithParseError", "[FgdParserTest]")
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseInvalidBounds", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseInvalidBounds")
 {
   const std::string file = R"(
 @PointClass size(32 32 0, -32 -32 256) model({"path" : ":progs/goddess-statue.mdl" }) =
@@ -952,7 +952,7 @@ decor_goddess_statue : "Goddess Statue" [])";
   kdl::vec_clear_and_delete(definitions);
 }
 
-TEST_CASE("FgdParserTest.parseInvalidModel", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseInvalidModel")
 {
   const std::string file = R"(@PointClass
 size(-16 -16 -24, 16 16 40)
@@ -971,7 +971,7 @@ decor_goddess_statue : "Goddess Statue" [])";
     Catch::Matchers::StartsWith("At line 3, column 8:"));
 }
 
-TEST_CASE("FgdParserTest.parseErrorAfterModel", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseErrorAfterModel")
 {
   const std::string file = R"(@PointClass
 size(-16 -16 -24, 16 16 40)
@@ -990,7 +990,7 @@ model({"path"
     Catch::Matchers::StartsWith("At line 4, column 64:"));
 }
 
-TEST_CASE("FgdParserTest.parseInclude", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseInclude")
 {
   const Path path =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Fgd/parseInclude/host.fgd");
@@ -1013,7 +1013,7 @@ TEST_CASE("FgdParserTest.parseInclude", "[FgdParserTest]")
   kdl::vec_clear_and_delete(defs);
 }
 
-TEST_CASE("FgdParserTest.parseNestedInclude", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseNestedInclude")
 {
   const Path path = Disk::getCurrentWorkingDir()
                     + Path("fixture/test/IO/Fgd/parseNestedInclude/host.fgd");
@@ -1039,7 +1039,7 @@ TEST_CASE("FgdParserTest.parseNestedInclude", "[FgdParserTest]")
   kdl::vec_clear_and_delete(defs);
 }
 
-TEST_CASE("FgdParserTest.parseRecursiveInclude", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseRecursiveInclude")
 {
   const Path path = Disk::getCurrentWorkingDir()
                     + Path("fixture/test/IO/Fgd/parseRecursiveInclude/host.fgd");
@@ -1059,7 +1059,7 @@ TEST_CASE("FgdParserTest.parseRecursiveInclude", "[FgdParserTest]")
   kdl::vec_clear_and_delete(defs);
 }
 
-TEST_CASE("FgdParserTest.parseStringContinuations", "[FgdParserTest]")
+TEST_CASE("FgdParserTest.parseStringContinuations")
 {
   const std::string file =
     "@PointClass = cont_description :\n"

--- a/common/test/src/IO/FreeImageTextureReaderTest.cpp
+++ b/common/test/src/IO/FreeImageTextureReaderTest.cpp
@@ -60,13 +60,13 @@ static void assertTexture(
   CHECK(texture.type() == Assets::TextureType::Opaque);
 }
 
-TEST_CASE("FreeImageTextureReaderTest.testLoadPngs", "[FreeImageTextureReaderTest]")
+TEST_CASE("FreeImageTextureReaderTest.testLoadPngs")
 {
   assertTexture("5x5.png", 5, 5);
   assertTexture("707x710.png", 707, 710);
 }
 
-TEST_CASE("FreeImageTextureReaderTest.testLoadCorruptPng", "[FreeImageTextureReaderTest]")
+TEST_CASE("FreeImageTextureReaderTest.testLoadCorruptPng")
 {
   const auto texture = loadTexture("corruptPngTest.png");
 
@@ -76,7 +76,7 @@ TEST_CASE("FreeImageTextureReaderTest.testLoadCorruptPng", "[FreeImageTextureRea
   CHECK(texture.height() != 0u);
 }
 
-TEST_CASE("FreeImageTextureReaderTest.testLoad16BitPng", "[FreeImageTextureReaderTest]")
+TEST_CASE("FreeImageTextureReaderTest.testLoad16BitPng")
 {
   const auto texture = loadTexture("16bitGrayscale.png");
 
@@ -121,17 +121,17 @@ static void testImageContents(const Assets::Texture& texture, const ColorMatch m
   }
 }
 
-TEST_CASE("FreeImageTextureReaderTest.testPNGContents", "[FreeImageTextureReaderTest]")
+TEST_CASE("FreeImageTextureReaderTest.testPNGContents")
 {
   testImageContents(loadTexture("pngContentsTest.png"), ColorMatch::Exact);
 }
 
-TEST_CASE("FreeImageTextureReaderTest.testJPGContents", "[FreeImageTextureReaderTest]")
+TEST_CASE("FreeImageTextureReaderTest.testJPGContents")
 {
   testImageContents(loadTexture("jpgContentsTest.jpg"), ColorMatch::Approximate);
 }
 
-TEST_CASE("FreeImageTextureReaderTest.alphaMaskTest", "[FreeImageTextureReaderTest]")
+TEST_CASE("FreeImageTextureReaderTest.alphaMaskTest")
 {
   const auto texture = loadTexture("alphaMaskTest.png");
   const std::size_t w = 25u;

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("GameConfigParserTest.parseIncludedGameConfigs", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseIncludedGameConfigs")
 {
   const Path basePath = Disk::getCurrentWorkingDir() + Path("fixture/games/");
   const std::vector<Path> cfgFiles =
@@ -54,21 +54,21 @@ TEST_CASE("GameConfigParserTest.parseIncludedGameConfigs", "[GameConfigParserTes
   }
 }
 
-TEST_CASE("GameConfigParserTest.parseBlankConfig", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseBlankConfig")
 {
   const std::string config("   ");
   GameConfigParser parser(config);
   CHECK_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("GameConfigParserTest.parseEmptyConfig", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseEmptyConfig")
 {
   const std::string config("  {  } ");
   GameConfigParser parser(config);
   CHECK_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("GameConfigParserTest.parseQuakeConfig", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseQuakeConfig")
 {
   const std::string config(R"(
 {
@@ -185,7 +185,7 @@ TEST_CASE("GameConfigParserTest.parseQuakeConfig", "[GameConfigParserTest]")
     });
 }
 
-TEST_CASE("GameConfigParserTest.parseQuake2Config", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseQuake2Config")
 {
   const std::string config(R"%(
 {
@@ -498,7 +498,7 @@ TEST_CASE("GameConfigParserTest.parseQuake2Config", "[GameConfigParserTest]")
     });
 }
 
-TEST_CASE("GameConfigParserTest.parseExtrasConfig", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseExtrasConfig")
 {
   const std::string config(R"%(
 {
@@ -834,7 +834,7 @@ TEST_CASE("GameConfigParserTest.parseExtrasConfig", "[GameConfigParserTest]")
     });
 }
 
-TEST_CASE("GameConfigParserTest.parseDuplicateTags", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseDuplicateTags")
 {
   const std::string config(R"(
 {
@@ -884,7 +884,7 @@ TEST_CASE("GameConfigParserTest.parseDuplicateTags", "[GameConfigParserTest]")
   REQUIRE_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("GameConfigParserTest.parseSetDefaultProperties", "[GameConfigParserTest]")
+TEST_CASE("GameConfigParserTest.parseSetDefaultProperties")
 {
   const std::string config(R"(
 {

--- a/common/test/src/IO/GameEngineConfigParserTest.cpp
+++ b/common/test/src/IO/GameEngineConfigParserTest.cpp
@@ -35,14 +35,14 @@ static GameEngineConfigParser makeParser(std::string_view config)
   return GameEngineConfigParser(config, Path());
 }
 
-TEST_CASE("GameEngineConfigParserTest.parseBlankConfig", "[GameEngineConfigParserTest]")
+TEST_CASE("GameEngineConfigParserTest.parseBlankConfig")
 {
   const std::string config(R"(   )");
   auto parser = makeParser(config);
   CHECK_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("GameEngineConfigParserTest.parseEmptyConfig", "[GameEngineConfigParserTest]")
+TEST_CASE("GameEngineConfigParserTest.parseEmptyConfig")
 {
   const std::string config(R"( { } )");
   auto parser = makeParser(config);
@@ -74,7 +74,7 @@ TEST_CASE(
   CHECK_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("GameEngineConfigParserTest.parseEmptyProfiles", "[GameEngineConfigParserTest]")
+TEST_CASE("GameEngineConfigParserTest.parseEmptyProfiles")
 {
   const std::string config(R"(  { 'version': 1, 'profiles': [] } )");
   auto parser = makeParser(config);
@@ -99,7 +99,7 @@ TEST_CASE(
   CHECK_THROWS_AS(parser.parse(), ParserException);
 }
 
-TEST_CASE("GameEngineConfigParserTest.parseTwoProfiles", "[GameEngineConfigParserTest]")
+TEST_CASE("GameEngineConfigParserTest.parseTwoProfiles")
 {
   const std::string config(R"(
 {

--- a/common/test/src/IO/HlMipTextureReaderTest.cpp
+++ b/common/test/src/IO/HlMipTextureReaderTest.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("HlMipTextureReaderTest.testLoadWad", "[HlMipTextureReaderTest]")
+TEST_CASE("HlMipTextureReaderTest.testLoadWad")
 {
   using TexInfo = std::tuple<std::string, size_t, size_t>;
 

--- a/common/test/src/IO/IdMipTextureReaderTest.cpp
+++ b/common/test/src/IO/IdMipTextureReaderTest.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("IdMipTextureReaderTest.testLoadWad", "[IdMipTextureReaderTest]")
+TEST_CASE("IdMipTextureReaderTest.testLoadWad")
 {
   using TexInfo = std::tuple<std::string, size_t, size_t>;
 

--- a/common/test/src/IO/IdPakFileSystemTest.cpp
+++ b/common/test/src/IO/IdPakFileSystemTest.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("IdPakFileSystemTest.directoryExists", "[IdPakFileSystemTest]")
+TEST_CASE("IdPakFileSystemTest.directoryExists")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/pak3.pak");
@@ -44,7 +44,7 @@ TEST_CASE("IdPakFileSystemTest.directoryExists", "[IdPakFileSystemTest]")
   CHECK_FALSE(fs.directoryExists(Path("gfx/palette.lmp")));
 }
 
-TEST_CASE("IdPakFileSystemTest.fileExists", "[IdPakFileSystemTest]")
+TEST_CASE("IdPakFileSystemTest.fileExists")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/pak3.pak");
@@ -57,7 +57,7 @@ TEST_CASE("IdPakFileSystemTest.fileExists", "[IdPakFileSystemTest]")
   CHECK(fs.fileExists(Path("GFX/Palette.LMP")));
 }
 
-TEST_CASE("IdPakFileSystemTest.findItems", "[IdPakFileSystemTest]")
+TEST_CASE("IdPakFileSystemTest.findItems")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/pak1.pak");
@@ -86,7 +86,7 @@ TEST_CASE("IdPakFileSystemTest.findItems", "[IdPakFileSystemTest]")
       std::vector<Path>{Path("pics/tag1.pcx"), Path("pics/tag2.pcx")}));
 }
 
-TEST_CASE("IdPakFileSystemTest.findItemsRecursively", "[IdPakFileSystemTest]")
+TEST_CASE("IdPakFileSystemTest.findItemsRecursively")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/pak1.pak");
@@ -142,7 +142,7 @@ TEST_CASE("IdPakFileSystemTest.findItemsRecursively", "[IdPakFileSystemTest]")
     }));
 }
 
-TEST_CASE("IdPakFileSystemTest.openFile", "[IdPakFileSystemTest]")
+TEST_CASE("IdPakFileSystemTest.openFile")
 {
   const Path pakPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Pak/pak1.pak");

--- a/common/test/src/IO/M8TextureReaderTest.cpp
+++ b/common/test/src/IO/M8TextureReaderTest.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("M8TextureReaderTest.testBasicLoading", "[M8TextureReaderTest]")
+TEST_CASE("M8TextureReaderTest.testBasicLoading")
 {
   DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
   const Path filePath = Path("fixture/test/IO/M8/test.m8");

--- a/common/test/src/IO/Md3ParserRegressionTest.cpp
+++ b/common/test/src/IO/Md3ParserRegressionTest.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("Md3ParserTest.loadFailure_2659", "[Md3ParserTest]")
+TEST_CASE("Md3ParserTest.loadFailure_2659")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2659
 

--- a/common/test/src/IO/Md3ParserTest.cpp
+++ b/common/test/src/IO/Md3ParserTest.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("Md3ParserTest.loadValidMd3", "[Md3ParserTest]")
+TEST_CASE("Md3ParserTest.loadValidMd3")
 {
   NullLogger logger;
   const auto shaderSearchPath = Path("scripts");

--- a/common/test/src/IO/MdlParserTest.cpp
+++ b/common/test/src/IO/MdlParserTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("MdlParserTest.loadValidMdl", "[MdlParserTest]")
+TEST_CASE("MdlParserTest.loadValidMdl")
 {
   NullLogger logger;
 
@@ -61,7 +61,7 @@ TEST_CASE("MdlParserTest.loadValidMdl", "[MdlParserTest]")
   CHECK(surface.frameCount() == 1u);
 }
 
-TEST_CASE("MdlParserTest.loadInvalidMdl", "[MdlParserTest]")
+TEST_CASE("MdlParserTest.loadInvalidMdl")
 {
   NullLogger logger;
 

--- a/common/test/src/IO/NodeReaderTest.cpp
+++ b/common/test/src/IO/NodeReaderTest.cpp
@@ -43,7 +43,8 @@ TEST_CASE("NodeReaderTest.parseFaceAsNode")
 
   IO::TestParserStatus status;
 
-  CHECK(IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status).empty());
+  CHECK(
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status).empty());
 }
 
 TEST_CASE("NodeReaderTest.convertValveToStandardMapFormat")
@@ -70,7 +71,7 @@ TEST_CASE("NodeReaderTest.convertValveToStandardMapFormat")
   IO::TestParserStatus status;
 
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   auto* brushNode = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
   REQUIRE(brushNode != nullptr);
 
@@ -106,7 +107,7 @@ TEST_CASE("NodeReaderTest.convertValveToStandardMapFormatInGroups")
   IO::TestParserStatus status;
 
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
 
   auto* groupNode = dynamic_cast<GroupNode*>(nodes.at(0));
   REQUIRE(groupNode != nullptr);

--- a/common/test/src/IO/NodeReaderTest.cpp
+++ b/common/test/src/IO/NodeReaderTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("NodeReaderTest.parseFaceAsNode", "[NodeReaderTest]")
+TEST_CASE("NodeReaderTest.parseFaceAsNode")
 {
   const std::string data(R"(
 ( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
@@ -46,7 +46,7 @@ TEST_CASE("NodeReaderTest.parseFaceAsNode", "[NodeReaderTest]")
   CHECK(IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status).empty());
 }
 
-TEST_CASE("NodeReaderTest.convertValveToStandardMapFormat", "[NodeReaderTest]")
+TEST_CASE("NodeReaderTest.convertValveToStandardMapFormat")
 {
   const std::string data(R"(
 // entity 0
@@ -80,7 +80,7 @@ TEST_CASE("NodeReaderTest.convertValveToStandardMapFormat", "[NodeReaderTest]")
     != nullptr);
 }
 
-TEST_CASE("NodeReaderTest.convertValveToStandardMapFormatInGroups", "[NodeReaderTest]")
+TEST_CASE("NodeReaderTest.convertValveToStandardMapFormatInGroups")
 {
   // Data comes from copying a Group in 2020.2
   const std::string data(R"(// entity 0

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -56,7 +56,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("NodeWriterTest.writeEmptyMap", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeEmptyMap")
 {
   Model::WorldNode map({}, {}, Model::MapFormat::Standard);
 
@@ -74,7 +74,7 @@ TEST_CASE("NodeWriterTest.writeEmptyMap", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeWorldspawn", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeWorldspawn")
 {
   Model::WorldNode map({}, {{"message", "holy damn"}}, Model::MapFormat::Standard);
 
@@ -93,7 +93,7 @@ TEST_CASE("NodeWriterTest.writeWorldspawn", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeDefaultLayerProperties", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeDefaultLayerProperties")
 {
   Model::WorldNode map({}, {}, Model::MapFormat::Standard);
   map.defaultLayer()->setVisibilityState(Model::VisibilityState::Hidden);
@@ -122,7 +122,7 @@ TEST_CASE("NodeWriterTest.writeDefaultLayerProperties", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeDaikatanaMap", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeDaikatanaMap")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -175,7 +175,7 @@ TEST_CASE("NodeWriterTest.writeDaikatanaMap", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeQuake2ValveMap", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeQuake2ValveMap")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -239,7 +239,7 @@ TEST_CASE("NodeWriterTest.writeQuake2ValveMap", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeQuake3ValveMap", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeQuake3ValveMap")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -274,7 +274,7 @@ TEST_CASE("NodeWriterTest.writeQuake3ValveMap", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeWorldspawnWithBrushInDefaultLayer", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeWorldspawnWithBrushInDefaultLayer")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -308,7 +308,7 @@ TEST_CASE("NodeWriterTest.writeWorldspawnWithBrushInDefaultLayer", "[NodeWriterT
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeWorldspawnWithBrushInCustomLayer", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeWorldspawnWithBrushInCustomLayer")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -399,7 +399,7 @@ TEST_CASE(
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeMapWithGroupInDefaultLayer", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeMapWithGroupInDefaultLayer")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -444,7 +444,7 @@ TEST_CASE("NodeWriterTest.writeMapWithGroupInDefaultLayer", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeMapWithGroupInCustomLayer", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeMapWithGroupInCustomLayer")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -501,7 +501,7 @@ TEST_CASE("NodeWriterTest.writeMapWithGroupInCustomLayer", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeMapWithNestedGroupInCustomLayer", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeMapWithNestedGroupInCustomLayer")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -570,7 +570,7 @@ TEST_CASE("NodeWriterTest.writeMapWithNestedGroupInCustomLayer", "[NodeWriterTes
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.ensureLayerAndGroupPersistentIDs", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.ensureLayerAndGroupPersistentIDs")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -650,7 +650,7 @@ TEST_CASE("NodeWriterTest.ensureLayerAndGroupPersistentIDs", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.exportMapWithOmittedLayers", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.exportMapWithOmittedLayers")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -736,7 +736,7 @@ TEST_CASE("NodeWriterTest.exportMapWithOmittedLayers", "[NodeWriterTest]")
   CHECK_THAT(actual, MatchesGlob(expected));
 }
 
-TEST_CASE("NodeWriterTest.writeMapWithInheritedLock", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeMapWithInheritedLock")
 {
   Model::WorldNode map({}, {}, Model::MapFormat::Standard);
 
@@ -773,7 +773,7 @@ TEST_CASE("NodeWriterTest.writeMapWithInheritedLock", "[NodeWriterTest]")
   CHECK_THAT(actual, MatchesGlob(expected));
 }
 
-TEST_CASE("NodeWriterTest.writeNodesWithNestedGroup", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeNodesWithNestedGroup")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -837,7 +837,7 @@ TEST_CASE("NodeWriterTest.writeNodesWithNestedGroup", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeMapWithLinkedGroups", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeMapWithLinkedGroups")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -925,7 +925,7 @@ TEST_CASE("NodeWriterTest.writeMapWithLinkedGroups", "[NodeWriterTest]")
   }
 }
 
-TEST_CASE("NodeWriterTest.writeNodesWithLinkedGroup", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeNodesWithLinkedGroup")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -967,7 +967,7 @@ TEST_CASE("NodeWriterTest.writeNodesWithLinkedGroup", "[NodeWriterTest]")
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeProtectedEntityProperties", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeProtectedEntityProperties")
 {
   auto worldNode = Model::WorldNode{{}, {}, Model::MapFormat::Standard};
 
@@ -1013,7 +1013,7 @@ TEST_CASE("NodeWriterTest.writeProtectedEntityProperties", "[NodeWriterTest]")
   }
 }
 
-TEST_CASE("NodeWriterTest.writeFaces", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeFaces")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -1041,7 +1041,7 @@ TEST_CASE("NodeWriterTest.writeFaces", "[NodeWriterTest]")
   delete brushNode;
 }
 
-TEST_CASE("NodeWriterTest.writePropertiesWithQuotationMarks", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writePropertiesWithQuotationMarks")
 {
   Model::WorldNode map(
     {}, {{"message", "\"holy damn\", he said"}}, Model::MapFormat::Standard);
@@ -1062,7 +1062,7 @@ TEST_CASE("NodeWriterTest.writePropertiesWithQuotationMarks", "[NodeWriterTest]"
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writePropertiesWithEscapedQuotationMarks", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writePropertiesWithEscapedQuotationMarks")
 {
   Model::WorldNode map(
     {}, {{"message", "\\\"holy damn\\\", he said"}}, Model::MapFormat::Standard);
@@ -1084,7 +1084,7 @@ TEST_CASE("NodeWriterTest.writePropertiesWithEscapedQuotationMarks", "[NodeWrite
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/1739
-TEST_CASE("NodeWriterTest.writePropertiesWithNewlineEscapeSequence", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writePropertiesWithNewlineEscapeSequence")
 {
   Model::WorldNode map(
     {}, {{"message", "holy damn\\nhe said"}}, Model::MapFormat::Standard);
@@ -1106,7 +1106,7 @@ TEST_CASE("NodeWriterTest.writePropertiesWithNewlineEscapeSequence", "[NodeWrite
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/2556
-TEST_CASE("NodeWriterTest.writePropertiesWithTrailingBackslash", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writePropertiesWithTrailingBackslash")
 {
   Model::WorldNode map(
     {},
@@ -1135,7 +1135,7 @@ TEST_CASE("NodeWriterTest.writePropertiesWithTrailingBackslash", "[NodeWriterTes
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.writeSmallValuesWithoutScientificNotation", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writeSmallValuesWithoutScientificNotation")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -1187,7 +1187,7 @@ TEST_CASE("NodeWriterTest.writeSmallValuesWithoutScientificNotation", "[NodeWrit
   CHECK(actual == expected);
 }
 
-TEST_CASE("NodeWriterTest.quoteTextureNamesIfNecessary", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.quoteTextureNamesIfNecessary")
 {
   using FormatInfo = std::tuple<Model::MapFormat, std::string>;
 
@@ -1254,7 +1254,7 @@ R"(// entity 0
   CHECK(str.str() == fmt::format(expectedSerializationTemplate, expectedName));
 }
 
-TEST_CASE("NodeWriterTest.writePatch", "[NodeWriterTest]")
+TEST_CASE("NodeWriterTest.writePatch")
 {
   auto patch = Model::BezierPatch{
     5,

--- a/common/test/src/IO/ObjParserTest.cpp
+++ b/common/test/src/IO/ObjParserTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("ObjParserTest.loadValidObj", "[ObjParserTest]")
+TEST_CASE("ObjParserTest.loadValidObj")
 {
   NullLogger logger;
 

--- a/common/test/src/IO/PathSuffixNameStrategyTest.cpp
+++ b/common/test/src/IO/PathSuffixNameStrategyTest.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("PathSuffixNameStrategyTest.getTextureName", "[PathSuffixNameStrategyTest]")
+TEST_CASE("PathSuffixNameStrategyTest.getTextureName")
 {
   CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path()) == "");
   CHECK(

--- a/common/test/src/IO/PathTest.cpp
+++ b/common/test/src/IO/PathTest.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom
 namespace IO
 {
 #ifdef _WIN32
-TEST_CASE("PathTest.constructWithString", "[PathTest]")
+TEST_CASE("PathTest.constructWithString")
 {
   CHECK(Path("").asString() == std::string(""));
   CHECK(Path(" ").asString() == std::string(""));
@@ -44,7 +44,7 @@ TEST_CASE("PathTest.constructWithString", "[PathTest]")
   CHECK(Path(".\\asdf").asString() == std::string(".\\asdf"));
 }
 
-TEST_CASE("PathTest.concatenate", "[PathTest]")
+TEST_CASE("PathTest.concatenate")
 {
   CHECK_THROWS_AS(Path("") + Path("c:\\"), PathException);
   CHECK_THROWS_AS(Path("") + Path("c:\\asdf"), PathException);
@@ -58,7 +58,7 @@ TEST_CASE("PathTest.concatenate", "[PathTest]")
   CHECK(Path("asdf") + Path("hey") == Path("asdf\\hey"));
 }
 
-TEST_CASE("PathTest.isEmpty", "[PathTest]")
+TEST_CASE("PathTest.isEmpty")
 {
   CHECK(Path("").isEmpty());
   CHECK_FALSE(Path("asdf").isEmpty());
@@ -68,7 +68,7 @@ TEST_CASE("PathTest.isEmpty", "[PathTest]")
   CHECK_FALSE(Path("c:\\.").isEmpty());
 }
 
-TEST_CASE("PathTest.getLastComponent", "[PathTest]")
+TEST_CASE("PathTest.getLastComponent")
 {
   CHECK_THROWS_AS(Path("").lastComponent().asString(), PathException);
   CHECK(Path("c:\\asdf").lastComponent().asString() == "asdf");
@@ -77,7 +77,7 @@ TEST_CASE("PathTest.getLastComponent", "[PathTest]")
   CHECK(Path("/").lastComponent() == Path(""));
 }
 
-TEST_CASE("PathTest.deleteLastComponent", "[PathTest]")
+TEST_CASE("PathTest.deleteLastComponent")
 {
   CHECK_THROWS_AS(Path("").deleteLastComponent(), PathException);
   CHECK(Path("c:\\asdf").deleteLastComponent() == Path("c:\\"));
@@ -86,7 +86,7 @@ TEST_CASE("PathTest.deleteLastComponent", "[PathTest]")
     Path("c:\\this\\is\\a\\path.map").deleteLastComponent() == Path("c:\\this\\is\\a"));
 }
 
-TEST_CASE("PathTest.getFirstComponent", "[PathTest]")
+TEST_CASE("PathTest.getFirstComponent")
 {
   CHECK_THROWS_AS(Path("").firstComponent(), PathException);
   CHECK(Path("/asdf").firstComponent().asString() == "\\");
@@ -94,7 +94,7 @@ TEST_CASE("PathTest.getFirstComponent", "[PathTest]")
   CHECK(Path("asdf\\bbab").firstComponent().asString() == "asdf");
 }
 
-TEST_CASE("PathTest.deleteFirstComponent", "[PathTest]")
+TEST_CASE("PathTest.deleteFirstComponent")
 {
   CHECK_THROWS_AS(Path("").deleteFirstComponent(), PathException);
   CHECK(Path("\\").deleteFirstComponent() == Path(""));
@@ -105,7 +105,7 @@ TEST_CASE("PathTest.deleteFirstComponent", "[PathTest]")
   CHECK(Path("asdf/blah").deleteFirstComponent() == Path("blah"));
 }
 
-TEST_CASE("PathTest.subPath", "[PathTest]")
+TEST_CASE("PathTest.subPath")
 {
   CHECK(Path("").subPath(0, 0) == Path(""));
   CHECK_THROWS_AS(Path("test\\blah").subPath(1, 2), PathException);
@@ -116,7 +116,7 @@ TEST_CASE("PathTest.subPath", "[PathTest]")
   CHECK(Path("test\\blah").subPath(1, 1) == Path("blah"));
 }
 
-TEST_CASE("PathTest.getExtension", "[PathTest]")
+TEST_CASE("PathTest.getExtension")
 {
   CHECK_THROWS_AS(Path("").extension(), PathException);
   CHECK(Path("asdf").extension() == std::string(""));
@@ -127,7 +127,7 @@ TEST_CASE("PathTest.getExtension", "[PathTest]")
   CHECK(Path("c:\\").extension() == std::string(""));
 }
 
-TEST_CASE("PathTest.deleteExtension", "[PathTest]")
+TEST_CASE("PathTest.deleteExtension")
 {
   CHECK(Path{}.deleteExtension() == Path{});
   CHECK(Path{"asdf"}.deleteExtension() == Path{"asdf"});
@@ -136,7 +136,7 @@ TEST_CASE("PathTest.deleteExtension", "[PathTest]")
   CHECK(Path{"x\\asdf.jpeg"}.deleteExtension() == Path{"x\\asdf"});
 }
 
-TEST_CASE("PathTest.addExtension", "[PathTest]")
+TEST_CASE("PathTest.addExtension")
 {
   const auto test = Path("c:\\").addExtension("map").asString();
   const auto test2 = test;
@@ -149,14 +149,14 @@ TEST_CASE("PathTest.addExtension", "[PathTest]")
   CHECK(Path("c:\\").addExtension("map") == Path("c:\\.map"));
 }
 
-TEST_CASE("PathTest.makeAbsolute", "[PathTest]")
+TEST_CASE("PathTest.makeAbsolute")
 {
   CHECK_THROWS_AS(Path("c:\\asdf").makeAbsolute(Path("c:\\hello")), PathException);
   CHECK_THROWS_AS(Path("asdf").makeAbsolute(Path("hello")), PathException);
   CHECK(Path("c:\\asdf").makeAbsolute(Path("hello")) == Path("c:\\asdf\\hello"));
 }
 
-TEST_CASE("PathTest.makeRelative", "[PathTest]")
+TEST_CASE("PathTest.makeRelative")
 {
   CHECK_THROWS_AS(Path("").makeRelative(), PathException);
   CHECK_THROWS_AS(Path("models\\barrel\\skin.tga").makeRelative(), PathException);
@@ -167,7 +167,7 @@ TEST_CASE("PathTest.makeRelative", "[PathTest]")
     == Path("models\\barrel\\skin.tga"));
 }
 
-TEST_CASE("PathTest.makeRelativeWithAbsolutePath", "[PathTest]")
+TEST_CASE("PathTest.makeRelativeWithAbsolutePath")
 {
   CHECK_THROWS_AS(Path("c:\\asdf").makeRelative(Path("asdf\\hello")), PathException);
   CHECK_THROWS_AS(Path("asdf").makeRelative(Path("c:\\asdf\\hello")), PathException);
@@ -189,14 +189,14 @@ TEST_CASE("PathTest.makeRelativeWithAbsolutePath", "[PathTest]")
     == Path("hello"));
 }
 
-TEST_CASE("PathTest.makeCanonical", "[PathTest]")
+TEST_CASE("PathTest.makeCanonical")
 {
   CHECK_THROWS_AS(Path("c:\\..").makeCanonical(), PathException);
   CHECK_THROWS_AS(Path("c:\\asdf\\..\\..").makeCanonical(), PathException);
   CHECK(Path("c:\\asdf\\test\\..").makeCanonical() == Path("c:\\asdf"));
 }
 
-TEST_CASE("PathTest.canMakeRelative", "[PathTest]")
+TEST_CASE("PathTest.canMakeRelative")
 {
   // copied from makeRelative test
   CHECK_FALSE(Path("c:\\asdf").canMakeRelative(Path("asdf\\hello")));
@@ -213,19 +213,19 @@ TEST_CASE("PathTest.canMakeRelative", "[PathTest]")
   CHECK(Path("c:\\asdf\\test\\..\\").canMakeRelative(Path("c:\\asdf\\hurr\\..\\hello")));
 }
 
-TEST_CASE("PathTest.pathAsQString", "[PathTest]")
+TEST_CASE("PathTest.pathAsQString")
 {
   CHECK(pathAsQString(Path("c:\\asdf\\test")) == QString::fromLatin1("c:\\asdf\\test"));
   CHECK(pathAsQString(Path("asdf\\test")) == QString::fromLatin1("asdf\\test"));
 }
 
-TEST_CASE("PathTest.pathFromQString", "[PathTest]")
+TEST_CASE("PathTest.pathFromQString")
 {
   CHECK(pathFromQString(QString::fromLatin1("c:\\asdf\\test")) == Path("c:\\asdf\\test"));
   CHECK(pathFromQString(QString::fromLatin1("asdf\\test")) == Path("asdf\\test"));
 }
 #else
-TEST_CASE("PathTest.constructWithString", "[PathTest]")
+TEST_CASE("PathTest.constructWithString")
 {
   CHECK(Path("").asString() == std::string(""));
   CHECK(Path(" ").asString() == std::string(""));
@@ -239,7 +239,7 @@ TEST_CASE("PathTest.constructWithString", "[PathTest]")
   CHECK(Path("./asdf").asString() == std::string("./asdf"));
 }
 
-TEST_CASE("PathTest.concatenate", "[PathTest]")
+TEST_CASE("PathTest.concatenate")
 {
   CHECK_THROWS_AS(Path("") + Path("/"), PathException);
   CHECK_THROWS_AS(Path("") + Path("/asdf"), PathException);
@@ -253,7 +253,7 @@ TEST_CASE("PathTest.concatenate", "[PathTest]")
   CHECK(Path("asdf") + Path("hey") == Path("asdf/hey"));
 }
 
-TEST_CASE("PathTest.isEmpty", "[PathTest]")
+TEST_CASE("PathTest.isEmpty")
 {
   CHECK(Path("").isEmpty());
   CHECK_FALSE(Path("asdf").isEmpty());
@@ -263,7 +263,7 @@ TEST_CASE("PathTest.isEmpty", "[PathTest]")
   CHECK_FALSE(Path("/.").isEmpty());
 }
 
-TEST_CASE("PathTest.getLastComponent", "[PathTest]")
+TEST_CASE("PathTest.getLastComponent")
 {
   CHECK_THROWS_AS(Path("").lastComponent().asString(), PathException);
   CHECK(Path("/asdf").lastComponent().asString() == "asdf");
@@ -272,7 +272,7 @@ TEST_CASE("PathTest.getLastComponent", "[PathTest]")
   CHECK(Path("/").lastComponent() == Path(""));
 }
 
-TEST_CASE("PathTest.deleteLastComponent", "[PathTest]")
+TEST_CASE("PathTest.deleteLastComponent")
 {
   CHECK_THROWS_AS(Path("").deleteLastComponent(), PathException);
   CHECK(Path("/asdf").deleteLastComponent() == Path("/"));
@@ -281,7 +281,7 @@ TEST_CASE("PathTest.deleteLastComponent", "[PathTest]")
   CHECK(Path("/").deleteLastComponent() == Path("/"));
 }
 
-TEST_CASE("PathTest.getFirstComponet", "[PathTest]")
+TEST_CASE("PathTest.getFirstComponet")
 {
   CHECK_THROWS_AS(Path("").firstComponent(), PathException);
   CHECK(Path("/").firstComponent().asString() == "/");
@@ -289,7 +289,7 @@ TEST_CASE("PathTest.getFirstComponet", "[PathTest]")
   CHECK(Path("asdf").firstComponent().asString() == "asdf");
 }
 
-TEST_CASE("PathTest.deleteFirstComponent", "[PathTest]")
+TEST_CASE("PathTest.deleteFirstComponent")
 {
   CHECK_THROWS_AS(Path("").deleteFirstComponent(), PathException);
   CHECK(Path("/").deleteFirstComponent() == Path(""));
@@ -297,7 +297,7 @@ TEST_CASE("PathTest.deleteFirstComponent", "[PathTest]")
   CHECK(Path("asdf/blah").deleteFirstComponent() == Path("blah"));
 }
 
-TEST_CASE("PathTest.subPath", "[PathTest]")
+TEST_CASE("PathTest.subPath")
 {
   CHECK(Path("").subPath(0, 0) == Path(""));
   CHECK_THROWS_AS(Path("test/blah").subPath(1, 2), PathException);
@@ -308,7 +308,7 @@ TEST_CASE("PathTest.subPath", "[PathTest]")
   CHECK(Path("test/blah").subPath(1, 1) == Path("blah"));
 }
 
-TEST_CASE("PathTest.getExtension", "[PathTest]")
+TEST_CASE("PathTest.getExtension")
 {
   CHECK_THROWS_AS(Path("").extension(), PathException);
   CHECK(Path("asdf").extension() == std::string(""));
@@ -318,7 +318,7 @@ TEST_CASE("PathTest.getExtension", "[PathTest]")
   CHECK(Path("/").extension() == std::string(""));
 }
 
-TEST_CASE("PathTest.deleteExtension", "[PathTest]")
+TEST_CASE("PathTest.deleteExtension")
 {
   CHECK(Path{}.deleteExtension() == Path{});
   CHECK(Path{"asdf"}.deleteExtension() == Path{"asdf"});
@@ -327,7 +327,7 @@ TEST_CASE("PathTest.deleteExtension", "[PathTest]")
   CHECK(Path{"x/asdf.jpeg"}.deleteExtension() == Path{"x/asdf"});
 }
 
-TEST_CASE("PathTest.addExtension", "[PathTest]")
+TEST_CASE("PathTest.addExtension")
 {
   CHECK_THROWS_AS(Path("").addExtension("map"), PathException);
   CHECK(Path("/asdf").addExtension("") == Path("/asdf."));
@@ -336,14 +336,14 @@ TEST_CASE("PathTest.addExtension", "[PathTest]")
   CHECK(Path("/").addExtension("map") == Path("/.map"));
 }
 
-TEST_CASE("PathTest.makeAbsolute", "[PathTest]")
+TEST_CASE("PathTest.makeAbsolute")
 {
   CHECK_THROWS_AS(Path("/asdf").makeAbsolute(Path("/hello")), PathException);
   CHECK_THROWS_AS(Path("asdf").makeAbsolute(Path("hello")), PathException);
   CHECK(Path("/asdf").makeAbsolute(Path("hello")) == Path("/asdf/hello"));
 }
 
-TEST_CASE("PathTest.makeRelative", "[PathTest]")
+TEST_CASE("PathTest.makeRelative")
 {
   CHECK_THROWS_AS(Path("").makeRelative(), PathException);
   CHECK_THROWS_AS(Path("models/barrel/skin.tga").makeRelative(), PathException);
@@ -351,7 +351,7 @@ TEST_CASE("PathTest.makeRelative", "[PathTest]")
   CHECK(Path("/models/barrel/skin.tga").makeRelative() == Path("models/barrel/skin.tga"));
 }
 
-TEST_CASE("PathTest.makeRelativeWithAbsolutePath", "[PathTest]")
+TEST_CASE("PathTest.makeRelativeWithAbsolutePath")
 {
   CHECK_THROWS_AS(Path("/asdf").makeRelative(Path("asdf/hello")), PathException);
   CHECK_THROWS_AS(Path("asdf").makeRelative(Path("/asdf/hello")), PathException);
@@ -367,14 +367,14 @@ TEST_CASE("PathTest.makeRelativeWithAbsolutePath", "[PathTest]")
     Path("/asdf/test/../").makeRelative(Path("/asdf/hurr/../hello")) == Path("hello"));
 }
 
-TEST_CASE("PathTest.makeCanonical", "[PathTest]")
+TEST_CASE("PathTest.makeCanonical")
 {
   CHECK_THROWS_AS(Path("/..").makeCanonical(), PathException);
   CHECK_THROWS_AS(Path("/asdf/../..").makeCanonical(), PathException);
   CHECK(Path("/asdf/test/..").makeCanonical() == Path("/asdf"));
 }
 
-TEST_CASE("PathTest.operatorLT", "[PathTest]")
+TEST_CASE("PathTest.operatorLT")
 {
   CHECK_FALSE(Path("") < Path(""));
   CHECK_FALSE(Path("/") < Path(""));
@@ -390,13 +390,13 @@ TEST_CASE("PathTest.operatorLT", "[PathTest]")
   CHECK_FALSE(Path("dir/dir2/dir3") < Path("dir/dir2"));
 }
 
-TEST_CASE("PathTest.pathAsQString", "[PathTest]")
+TEST_CASE("PathTest.pathAsQString")
 {
   CHECK(pathAsQString(Path("/asdf/test")) == QString::fromLatin1("/asdf/test"));
   CHECK(pathAsQString(Path("asdf/test")) == QString::fromLatin1("asdf/test"));
 }
 
-TEST_CASE("PathTest.pathFromQString", "[PathTest]")
+TEST_CASE("PathTest.pathFromQString")
 {
   CHECK(pathFromQString(QString::fromLatin1("/asdf/test")) == Path("/asdf/test"));
   CHECK(pathFromQString(QString::fromLatin1("asdf/test")) == Path("asdf/test"));

--- a/common/test/src/IO/Quake3ShaderFileSystemTest.cpp
+++ b/common/test/src/IO/Quake3ShaderFileSystemTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("Quake3ShaderFileSystemTest.testShaderLinking", "[Quake3ShaderFileSystemTest]")
+TEST_CASE("Quake3ShaderFileSystemTest.testShaderLinking")
 {
   NullLogger logger;
 

--- a/common/test/src/IO/Quake3ShaderParserRegressionTest.cpp
+++ b/common/test/src/IO/Quake3ShaderParserRegressionTest.cpp
@@ -74,7 +74,7 @@ TEST_CASE(
   CHECK_NOTHROW(parser.parse(status));
 }
 
-TEST_CASE("Quake3ShaderParserTest.parseShaderAbsolutePath", "[Quake3ShaderParserTest]")
+TEST_CASE("Quake3ShaderParserTest.parseShaderAbsolutePath")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2633
   // apparently, the Q3 engine can handle this

--- a/common/test/src/IO/Quake3ShaderParserTest.cpp
+++ b/common/test/src/IO/Quake3ShaderParserTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("Quake3ShaderParserTest.parseEmptyShader", "[Quake3ShaderParserTest]")
+TEST_CASE("Quake3ShaderParserTest.parseEmptyShader")
 {
   const std::string data("");
   Quake3ShaderParser parser(data);
@@ -234,7 +234,7 @@ textures/eerie/ironcrosslt2_10000
     }}));
 }
 
-TEST_CASE("Quake3ShaderParserTest.parseTwoShaders", "[Quake3ShaderParserTest]")
+TEST_CASE("Quake3ShaderParserTest.parseTwoShaders")
 {
   const std::string data(R"(
 textures/eerie/ironcrosslt2_10000
@@ -369,7 +369,7 @@ waterBubble
   CHECK_NOTHROW(parser.parse(status));
 }
 
-TEST_CASE("Quake3ShaderParserTest.parseBlendFuncParameters", "[Quake3ShaderParserTest]")
+TEST_CASE("Quake3ShaderParserTest.parseBlendFuncParameters")
 {
   // see
   // https://github.com/id-Software/Quake-III-Arena/blob/master/code/renderer/tr_shader.c#L176

--- a/common/test/src/IO/ReaderTest.cpp
+++ b/common/test/src/IO/ReaderTest.cpp
@@ -57,12 +57,12 @@ static void createEmpty(Reader&& r)
   CHECK_THROWS_AS(r.readChar<char>(), ReaderException);
 }
 
-TEST_CASE("BufferReaderTest.createEmpty", "[BufferReaderTest]")
+TEST_CASE("BufferReaderTest.createEmpty")
 {
   createEmpty(Reader::from(buff(), buff()));
 }
 
-TEST_CASE("FileReaderTest.createEmpty", "[FileReaderTest]")
+TEST_CASE("FileReaderTest.createEmpty")
 {
   const auto emptyFile =
     Disk::openFile(Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Reader/empty"));
@@ -94,12 +94,12 @@ static void createNonEmpty(Reader&& r)
   CHECK_THROWS_AS(r.readChar<char>(), ReaderException);
 }
 
-TEST_CASE("BufferReaderTest.createNonEmpty", "[BufferReaderTest]")
+TEST_CASE("BufferReaderTest.createNonEmpty")
 {
   createNonEmpty(Reader::from(buff(), buff() + 10));
 }
 
-TEST_CASE("FileReaderTest.createNonEmpty", "[FileReaderTest]")
+TEST_CASE("FileReaderTest.createNonEmpty")
 {
   createNonEmpty(file()->reader());
 }
@@ -119,12 +119,12 @@ static void seekFromBegin(Reader&& r)
   CHECK(r.position() == 2U);
 }
 
-TEST_CASE("BufferReaderTest.seekFromBegin", "[BufferReaderTest]")
+TEST_CASE("BufferReaderTest.seekFromBegin")
 {
   seekFromBegin(Reader::from(buff(), buff() + 10));
 }
 
-TEST_CASE("FileReaderTest.seekFromBegin", "[FileReaderTest]")
+TEST_CASE("FileReaderTest.seekFromBegin")
 {
   seekFromBegin(file()->reader());
 }
@@ -144,12 +144,12 @@ static void seekFromEnd(Reader&& r)
   CHECK(r.position() == 0U);
 }
 
-TEST_CASE("BufferReaderTest.seekFromEnd", "[BufferReaderTest]")
+TEST_CASE("BufferReaderTest.seekFromEnd")
 {
   seekFromEnd(Reader::from(buff(), buff() + 10));
 }
 
-TEST_CASE("FileReaderTest.seekFromEnd", "[FileReaderTest]")
+TEST_CASE("FileReaderTest.seekFromEnd")
 {
   seekFromEnd(file()->reader());
 }
@@ -166,12 +166,12 @@ static void seekForward(Reader&& r)
   CHECK(r.position() == 2U);
 }
 
-TEST_CASE("BufferReaderTest.seekForward", "[BufferReaderTest]")
+TEST_CASE("BufferReaderTest.seekForward")
 {
   seekForward(Reader::from(buff(), buff() + 10));
 }
 
-TEST_CASE("FileReaderTest.seekForward", "[FileReaderTest]")
+TEST_CASE("FileReaderTest.seekForward")
 {
   seekForward(file()->reader());
 }
@@ -196,12 +196,12 @@ static void subReader(Reader&& r)
   CHECK(s.position() == 3U);
 }
 
-TEST_CASE("BufferReaderTest.subReader", "[BufferReaderTest]")
+TEST_CASE("BufferReaderTest.subReader")
 {
   subReader(Reader::from(buff(), buff() + 10));
 }
 
-TEST_CASE("FileReaderTest.subReader", "[FileReaderTest]")
+TEST_CASE("FileReaderTest.subReader")
 {
   subReader(file()->reader());
 }

--- a/common/test/src/IO/ResourceUtilsTest.cpp
+++ b/common/test/src/IO/ResourceUtilsTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("ResourceUtilsTest.loadDefaultTexture", "[ResourceUtilsTest]")
+TEST_CASE("ResourceUtilsTest.loadDefaultTexture")
 {
   auto fs = std::make_shared<DiskFileSystem>(
     IO::Disk::getCurrentWorkingDir() + Path("fixture/test/IO/ResourceUtils/assets"));

--- a/common/test/src/IO/TextureLoaderTest.cpp
+++ b/common/test/src/IO/TextureLoaderTest.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("TextureLoaderTest.testLoad", "[TextureLoaderTest]")
+TEST_CASE("TextureLoaderTest.testLoad")
 {
   const std::vector<IO::Path> paths({Path("fixture/test/IO/Wad/cr8_czg.wad")});
 
@@ -92,7 +92,7 @@ TEST_CASE("TextureLoaderTest.testLoad", "[TextureLoaderTest]")
   }
 }
 
-TEST_CASE("TextureLoaderTest.testLoadExclusions", "[TextureLoaderTest]")
+TEST_CASE("TextureLoaderTest.testLoadExclusions")
 {
   const std::vector<IO::Path> paths({Path("fixture/test/IO/Wad/cr8_czg.wad")});
 

--- a/common/test/src/IO/TokenizerTest.cpp
+++ b/common/test/src/IO/TokenizerTest.cpp
@@ -98,21 +98,21 @@ public:
   }
 };
 
-TEST_CASE("TokenizerTest.simpleLanguageEmptyString", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguageEmptyString")
 {
   const std::string testString("");
   SimpleTokenizer tokenizer(testString);
   CHECK(tokenizer.nextToken().type() == SimpleToken::Eof);
 }
 
-TEST_CASE("TokenizerTest.simpleLanguageBlankString", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguageBlankString")
 {
   const std::string testString("\n  \t ");
   SimpleTokenizer tokenizer(testString);
   CHECK(tokenizer.nextToken().type() == SimpleToken::Eof);
 }
 
-TEST_CASE("TokenizerTest.simpleLanguageEmptyBlock", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguageEmptyBlock")
 {
   const std::string testString(
     "{"
@@ -124,7 +124,7 @@ TEST_CASE("TokenizerTest.simpleLanguageEmptyBlock", "[TokenizerTest]")
   CHECK(tokenizer.nextToken().type() == SimpleToken::Eof);
 }
 
-TEST_CASE("TokenizerTest.simpleLanguagePushPeekPopToken", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguagePushPeekPopToken")
 {
   const std::string testString(
     "{\n"
@@ -154,7 +154,7 @@ TEST_CASE(
   CHECK(tokenizer.nextToken().type() == SimpleToken::Eof);
 }
 
-TEST_CASE("TokenizerTest.simpleLanguageBlockWithStringAttribute", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguageBlockWithStringAttribute")
 {
   const std::string testString(
     "{\n"
@@ -176,7 +176,7 @@ TEST_CASE("TokenizerTest.simpleLanguageBlockWithStringAttribute", "[TokenizerTes
   CHECK(tokenizer.nextToken().type() == SimpleToken::Eof);
 }
 
-TEST_CASE("TokenizerTest.simpleLanguageBlockWithIntegerAttribute", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguageBlockWithIntegerAttribute")
 {
   const std::string testString(
     "{"
@@ -217,7 +217,7 @@ TEST_CASE(
   CHECK(tokenizer.nextToken().type() == SimpleToken::Eof);
 }
 
-TEST_CASE("TokenizerTest.simpleLanguageBlockWithDecimalAttribute", "[TokenizerTest]")
+TEST_CASE("TokenizerTest.simpleLanguageBlockWithDecimalAttribute")
 {
   const std::string testString(
     "{"

--- a/common/test/src/IO/WadFileSystemTest.cpp
+++ b/common/test/src/IO/WadFileSystemTest.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("WadFileSystemTest.loadEntries", "[WadFileSystemTest]")
+TEST_CASE("WadFileSystemTest.loadEntries")
 {
   const Path wadPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Wad/cr8_czg.wad");

--- a/common/test/src/IO/WalTextureReaderTest.cpp
+++ b/common/test/src/IO/WalTextureReaderTest.cpp
@@ -33,7 +33,7 @@ namespace IO
 {
 static const auto fixturePath = Path("fixture/test/IO/Wal");
 
-TEST_CASE("WalTextureReaderTest.testLoadQ2WalDir", "[WalTextureReaderTest]")
+TEST_CASE("WalTextureReaderTest.testLoadQ2WalDir")
 {
   DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
   const Assets::Palette palette =

--- a/common/test/src/IO/WorldReaderRegressionTest.cpp
+++ b/common/test/src/IO/WorldReaderRegressionTest.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("WorldReaderTest.parseFailure_1424", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseFailure_1424")
 {
   const std::string data(R"(
 {
@@ -68,7 +68,7 @@ TEST_CASE("WorldReaderTest.parseFailure_1424", "[WorldReaderTest]")
   CHECK(world != nullptr);
 }
 
-TEST_CASE("WorldReaderTest.parseProblematicBrush1", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseProblematicBrush1")
 {
   const std::string data(R"(
 {
@@ -142,7 +142,7 @@ TEST_CASE("WorldReaderTest.parseProblematicBrush1", "[WorldReaderTest]")
     != nullptr);
 }
 
-TEST_CASE("WorldReaderTest.parseProblematicBrush2", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseProblematicBrush2")
 {
   const std::string data(R"(
 {
@@ -171,7 +171,7 @@ TEST_CASE("WorldReaderTest.parseProblematicBrush2", "[WorldReaderTest]")
   checkBrushTexCoordSystem(brush, false);
 }
 
-TEST_CASE("WorldReaderTest.parseProblematicBrush3", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseProblematicBrush3")
 {
   const std::string data(R"(
 {

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -1632,6 +1632,14 @@ TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
 "_tb_linked_group_id" "1"
 "_tb_transformation" "1 0 0 32 0 1 0 16 0 0 1 0 0 0 0 1"
 }
+{
+"classname" "func_group"
+"_tb_type" "_tb_group"
+"_tb_name" "Group 3"
+"_tb_id" "3"
+"_tb_linked_group_id" "1"
+"_tb_transformation" "1 0 0 32 0 1 0 16 0 0 1 0 0 0 0 1"
+}
             )";
 
   const auto worldBounds = vm::bbox3{8192.0};
@@ -1641,22 +1649,29 @@ TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
 
   auto world = reader.read(worldBounds, status);
   REQUIRE(world != nullptr);
-  CHECK(world->defaultLayer()->childCount() == 2u);
+  CHECK(world->defaultLayer()->childCount() == 3u);
 
   auto* groupNode1 =
-    dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children().front());
+    dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children()[0]);
   auto* groupNode2 =
-    dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children().back());
+    dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children()[1]);
+  auto* groupNode3 =
+    dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children()[2]);
 
   CHECK(groupNode1 != nullptr);
   CHECK(groupNode2 != nullptr);
+  CHECK(groupNode3 != nullptr);
 
   CHECK(groupNode1->group().linkedGroupId() == std::nullopt);
   CHECK(groupNode2->group().linkedGroupId() == "1");
+  CHECK(groupNode3->group().linkedGroupId() == "1");
 
-  CHECK(groupNode1->group().transformation() == vm::mat4x4d{});
+  CHECK(groupNode1->group().transformation() == vm::mat4x4d::identity());
   CHECK(
     groupNode2->group().transformation()
+    == vm::translation_matrix(vm::vec3{32.0, 16.0, 0.0}));
+  CHECK(
+    groupNode3->group().transformation()
     == vm::translation_matrix(vm::vec3{32.0, 16.0, 0.0}));
 }
 

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -48,7 +48,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("WorldReaderTest.parseEmptyMap", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseEmptyMap")
 {
   const std::string data("");
   const vm::bbox3 worldBounds(8192.0);
@@ -63,7 +63,7 @@ TEST_CASE("WorldReaderTest.parseEmptyMap", "[WorldReaderTest]")
   CHECK_FALSE(world->children().front()->hasChildren());
 }
 
-TEST_CASE("WorldReaderTest.parseMapWithEmptyEntity", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseMapWithEmptyEntity")
 {
   const std::string data("{}");
   const vm::bbox3 worldBounds(8192.0);
@@ -78,7 +78,7 @@ TEST_CASE("WorldReaderTest.parseMapWithEmptyEntity", "[WorldReaderTest]")
   CHECK(world->children().front()->childCount() == 1u);
 }
 
-TEST_CASE("WorldReaderTest.parseMapWithWorldspawn", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseMapWithWorldspawn")
 {
   const std::string data(R"(
 {
@@ -110,7 +110,7 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawn", "[WorldReaderTest]")
   CHECK(!defaultLayer->layer().omitFromExport());
 }
 
-TEST_CASE("WorldReaderTest.parseDefaultLayerProperties", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseDefaultLayerProperties")
 {
   const std::string data(R"(
 {
@@ -140,7 +140,7 @@ TEST_CASE("WorldReaderTest.parseDefaultLayerProperties", "[WorldReaderTest]")
   CHECK(defaultLayer->layer().omitFromExport());
 }
 
-TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity")
 {
   const std::string data(R"(
 {
@@ -183,7 +183,7 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity", "[WorldReade
   CHECK(*entityNode->entity().property("angle") == " -1 ");
 }
 
-TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneBrush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneBrush")
 {
   const std::string data(R"(
 {
@@ -264,7 +264,7 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneBrush", "[WorldReaderTest
     != nullptr);
 }
 
-TEST_CASE("WorldReaderTest.parseMapAndCheckFaceFlags", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseMapAndCheckFaceFlags")
 {
   const std::string data(R"(
 {
@@ -308,7 +308,7 @@ TEST_CASE("WorldReaderTest.parseMapAndCheckFaceFlags", "[WorldReaderTest]")
   CHECK(face->attributes().yScale() == -0.55f);
 }
 
-TEST_CASE("WorldReaderTest.parseBrushWithCurlyBraceInTextureName", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseBrushWithCurlyBraceInTextureName")
 {
   const std::string data(R"(
 {
@@ -383,7 +383,7 @@ TEST_CASE("WorldReaderTest.parseBrushWithCurlyBraceInTextureName", "[WorldReader
     != nullptr);
 }
 
-TEST_CASE("WorldReaderTest.parseValveBrush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseValveBrush")
 {
   const std::string data(R"(
 {
@@ -412,7 +412,7 @@ TEST_CASE("WorldReaderTest.parseValveBrush", "[WorldReaderTest]")
   checkBrushTexCoordSystem(brush, true);
 }
 
-TEST_CASE("WorldReaderTest.parseQuake2Brush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseQuake2Brush")
 {
   const std::string data(R"(
 {
@@ -480,7 +480,7 @@ TEST_CASE("WorldReaderTest.parseQuake2Brush", "[WorldReaderTest]")
   }
 }
 
-TEST_CASE("WorldReaderTest.parseQuake2ValveBrush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseQuake2ValveBrush")
 {
   const std::string data(R"(
 {
@@ -512,7 +512,7 @@ TEST_CASE("WorldReaderTest.parseQuake2ValveBrush", "[WorldReaderTest]")
   checkBrushTexCoordSystem(brush, true);
 }
 
-TEST_CASE("WorldReaderTest.parseQuake3ValveBrush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseQuake3ValveBrush")
 {
   const std::string data(R"(
 {
@@ -544,7 +544,7 @@ TEST_CASE("WorldReaderTest.parseQuake3ValveBrush", "[WorldReaderTest]")
   checkBrushTexCoordSystem(brush, true);
 }
 
-TEST_CASE("WorldReaderTest.parseDaikatanaBrush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseDaikatanaBrush")
 {
   const std::string data(R"(
 {
@@ -591,7 +591,7 @@ TEST_CASE("WorldReaderTest.parseDaikatanaBrush", "[WorldReaderTest]")
   CHECK_FALSE(brush.face(*c_mf_v3cww_index).attributes().hasColor());
 }
 
-TEST_CASE("WorldReaderTest.parseDaikatanaMapHeader", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseDaikatanaMapHeader")
 {
   const std::string data(R"(
 ////////////////////////////////////////////////////////////
@@ -636,7 +636,7 @@ TEST_CASE("WorldReaderTest.parseDaikatanaMapHeader", "[WorldReaderTest]")
   checkBrushTexCoordSystem(brush, false);
 }
 
-TEST_CASE("WorldReaderTest.parseQuakeBrushWithNumericalTextureName", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseQuakeBrushWithNumericalTextureName")
 {
   const std::string data(R"(
 {
@@ -665,7 +665,7 @@ TEST_CASE("WorldReaderTest.parseQuakeBrushWithNumericalTextureName", "[WorldRead
   checkBrushTexCoordSystem(brush, false);
 }
 
-TEST_CASE("WorldReaderTest.parseBrushesWithLayer", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseBrushesWithLayer")
 {
   const std::string data(R"(
 {
@@ -729,7 +729,7 @@ TEST_CASE("WorldReaderTest.parseBrushesWithLayer", "[WorldReaderTest]")
   CHECK(!myLayerNode->locked());
 }
 
-TEST_CASE("WorldReaderTest.parseLayersWithReverseSort", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseLayersWithReverseSort")
 {
   const std::string data(R"(
 {
@@ -787,8 +787,7 @@ TEST_CASE("WorldReaderTest.parseLayersWithReverseSort", "[WorldReaderTest]")
   CHECK(!sortNode1->layer().omitFromExport());
 }
 
-TEST_CASE(
-  "WorldReaderTest.parseLayersWithReversedSortIndicesWithGaps", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseLayersWithReversedSortIndicesWithGaps")
 {
   const std::string data(R"(
 {
@@ -846,8 +845,7 @@ TEST_CASE(
   CHECK(sortNode5->layer().sortIndex() == 5);
 }
 
-TEST_CASE(
-  "WorldReaderTest.parseLayersWithSortIndicesWithGapsAndDuplicates", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseLayersWithSortIndicesWithGapsAndDuplicates")
 {
   const std::string data = R"end(
 {
@@ -943,7 +941,7 @@ TEST_CASE(
   CHECK(sortNode12->layer().sortIndex() == 12);
 }
 
-TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer")
 {
   const std::string data(R"(
 {
@@ -1004,7 +1002,7 @@ TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer", "[WorldReaderTest]
   CHECK(world->children().back()->children().back()->childCount() == 1u);
 }
 
-TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithGroup", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithGroup")
 {
   const std::string data(R"(
 {
@@ -1086,7 +1084,7 @@ TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithGroup", "[WorldReaderTest]
   CHECK(mySubGroup->childCount() == 1u);
 }
 
-TEST_CASE("WorldReaderTest.parseLayersAndGroupsAndRetainIds", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseLayersAndGroupsAndRetainIds")
 {
   const std::string data(R"(
 {
@@ -1141,7 +1139,7 @@ TEST_CASE("WorldReaderTest.parseLayersAndGroupsAndRetainIds", "[WorldReaderTest]
   CHECK(groupNode2->persistentId() == 22u);
 }
 
-TEST_CASE("WorldReaderTest.parseBrushPrimitive", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseBrushPrimitive")
 {
   const std::string data(R"(
             {
@@ -1170,7 +1168,7 @@ TEST_CASE("WorldReaderTest.parseBrushPrimitive", "[WorldReaderTest]")
   CHECK(world->defaultLayer()->childCount() == 0u);
 }
 
-TEST_CASE("WorldReaderTest.parseBrushPrimitiveAndLegacyBrush", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseBrushPrimitiveAndLegacyBrush")
 {
   const std::string data(R"(
 {
@@ -1207,7 +1205,7 @@ brushDef
   CHECK(world->defaultLayer()->childCount() == 1u);
 }
 
-TEST_CASE("WorldReaderTest.parseQuake3Patch", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseQuake3Patch")
 {
   const std::string data(R"(
 {
@@ -1266,7 +1264,7 @@ common/caulk
     }));
 }
 
-TEST_CASE("WorldReaderTest.parseMultipleClassnames", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseMultipleClassnames")
 {
   // See https://github.com/TrenchBroom/TrenchBroom/issues/1485
 
@@ -1284,7 +1282,7 @@ TEST_CASE("WorldReaderTest.parseMultipleClassnames", "[WorldReaderTest]")
   CHECK_NOTHROW(reader.read(worldBounds, status));
 }
 
-TEST_CASE("WorldReaderTest.parseEscapedDoubleQuotationMarks", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseEscapedDoubleQuotationMarks")
 {
   const std::string data(R"(
 {
@@ -1332,8 +1330,7 @@ TEST_CASE(
   CHECK(*worldNode->entity().property("path") == "c:\\a\\b\\c\\");
 }
 
-TEST_CASE(
-  "WorldReaderTest.parsePropertyWithEscapedPathAndTrailingBackslash", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parsePropertyWithEscapedPathAndTrailingBackslash")
 {
   const std::string data(R"(
 {
@@ -1356,7 +1353,7 @@ TEST_CASE(
   CHECK(*worldNode->entity().property("path") == "c:\\\\a\\\\b\\\\c\\\\");
 }
 
-TEST_CASE("WorldReaderTest.parsePropertyTrailingEscapedBackslash", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parsePropertyTrailingEscapedBackslash")
 {
   const std::string data(R"(
 {
@@ -1380,7 +1377,7 @@ TEST_CASE("WorldReaderTest.parsePropertyTrailingEscapedBackslash", "[WorldReader
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/1739
-TEST_CASE("WorldReaderTest.parsePropertyNewlineEscapeSequence", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parsePropertyNewlineEscapeSequence")
 {
   const std::string data(R"(
 {
@@ -1404,7 +1401,7 @@ TEST_CASE("WorldReaderTest.parsePropertyNewlineEscapeSequence", "[WorldReaderTes
 }
 
 /*
-TEST_CASE("WorldReaderTest.parseIssueIgnoreFlags", "[WorldReaderTest]") {
+TEST_CASE("WorldReaderTest.parseIssueIgnoreFlags") {
     const std::string data("{"
                       "\"classname\" \"worldspawn\""
                       "{\n"
@@ -1450,7 +1447,7 @@ doBrushContentTypes()).WillOnce(ReturnRef(Model::BrushContentType::EmptyList));
 }
  */
 
-TEST_CASE("WorldReaderTest.parseHeretic2QuarkMap", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseHeretic2QuarkMap")
 {
   const IO::Path mapPath =
     IO::Disk::getCurrentWorkingDir() + IO::Path("fixture/test/IO/Map/Heretic2Quark.map");
@@ -1482,7 +1479,7 @@ TEST_CASE("WorldReaderTest.parseHeretic2QuarkMap", "[WorldReaderTest]")
   }
 }
 
-TEST_CASE("WorldReaderTest.parseTBEmptyTextureName", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseTBEmptyTextureName")
 {
   const std::string data(R"(
 // entity 0
@@ -1524,7 +1521,7 @@ TEST_CASE("WorldReaderTest.parseTBEmptyTextureName", "[WorldReaderTest]")
   }
 }
 
-TEST_CASE("WorldReaderTest.parseQuotedTextureNames", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseQuotedTextureNames")
 {
   using NameInfo = std::tuple<std::string, std::string>;
 
@@ -1579,7 +1576,7 @@ TEST_CASE("WorldReaderTest.parseQuotedTextureNames", "[WorldReaderTest]")
   CHECK(brushNode->brush().face(0).attributes().textureName() == expectedName);
 }
 
-TEST_CASE("WorldReaderTest.parseLinkedGroups", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseLinkedGroups")
 {
   const auto data = R"(
 {
@@ -1631,8 +1628,7 @@ TEST_CASE("WorldReaderTest.parseLinkedGroups", "[WorldReaderTest]")
     == vm::translation_matrix(vm::vec3(32.0, 16.0, 0.0)));
 }
 
-TEST_CASE(
-  "WorldReaderTest.parseLinkedGroupsWithMissingTransformation", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
 {
   const auto data = R"(
 {
@@ -1681,7 +1677,7 @@ TEST_CASE(
     == vm::translation_matrix(vm::vec3(32.0, 16.0, 0.0)));
 }
 
-TEST_CASE("WorldReaderTest.parseGroupWithUnnecessaryTransformation", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseGroupWithUnnecessaryTransformation")
 {
   const auto data = R"(
 {
@@ -1713,7 +1709,7 @@ TEST_CASE("WorldReaderTest.parseGroupWithUnnecessaryTransformation", "[WorldRead
   CHECK(groupNode->group().transformation() == vm::mat4x4d{});
 }
 
-TEST_CASE("WorldReaderTest.parseProtectedEntityProperties", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseProtectedEntityProperties")
 {
   const auto data = R"(
 {
@@ -1776,7 +1772,7 @@ TEST_CASE("WorldReaderTest.parseProtectedEntityProperties", "[WorldReaderTest]")
   }
 }
 
-TEST_CASE("WorldReaderTest.parseUnknownFormatEmptyMap", "[WorldReaderTest]")
+TEST_CASE("WorldReaderTest.parseUnknownFormatEmptyMap")
 {
   const auto data = R"(
 {

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -1611,6 +1611,39 @@ TEST_CASE("WorldReaderTest.parseLinkedGroups")
     == vm::translation_matrix(vm::vec3{32.0, 16.0, 0.0}));
 }
 
+TEST_CASE("WorldReaderTest.parseOrphanedLinkedGroups")
+{
+  const auto data = R"(
+{
+"classname" "worldspawn"
+}
+{
+"classname" "func_group"
+"_tb_type" "_tb_group"
+"_tb_name" "Group 1"
+"_tb_id" "1"
+"_tb_linked_group_id" "abcd"
+"_tb_transformation" "1 0 0 32 0 1 0 0 0 0 1 0 0 0 0 1"
+}
+            )";
+
+  const auto worldBounds = vm::bbox3{8192.0};
+
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
+
+  auto world = reader.read(worldBounds, status);
+  REQUIRE(world != nullptr);
+  CHECK(world->defaultLayer()->childCount() == 1);
+
+  auto* groupNode =
+    dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children().front());
+
+  CHECK(groupNode != nullptr);
+  CHECK(groupNode->group().linkedGroupId() == std::nullopt);
+  CHECK(groupNode->group().transformation() == vm::mat4x4::identity());
+}
+
 TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
 {
   const auto data = R"(

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -50,11 +50,11 @@ namespace IO
 {
 TEST_CASE("WorldReaderTest.parseEmptyMap")
 {
-  const std::string data("");
-  const vm::bbox3 worldBounds(8192.0);
+  const auto data = "";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -65,11 +65,11 @@ TEST_CASE("WorldReaderTest.parseEmptyMap")
 
 TEST_CASE("WorldReaderTest.parseMapWithEmptyEntity")
 {
-  const std::string data("{}");
-  const vm::bbox3 worldBounds(8192.0);
+  const auto data = "{}";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -80,17 +80,17 @@ TEST_CASE("WorldReaderTest.parseMapWithEmptyEntity")
 
 TEST_CASE("WorldReaderTest.parseMapWithWorldspawn")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "message" "yay"
 }
-)");
+)";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -112,7 +112,7 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawn")
 
 TEST_CASE("WorldReaderTest.parseDefaultLayerProperties")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "_tb_layer_color" "0.0 1.0 0.0"
@@ -120,12 +120,12 @@ TEST_CASE("WorldReaderTest.parseDefaultLayerProperties")
 "_tb_layer_hidden" "1"
 "_tb_layer_omit_from_export" "1"
 }
-)");
+)";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -142,7 +142,7 @@ TEST_CASE("WorldReaderTest.parseDefaultLayerProperties")
 
 TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "message" "yay"
@@ -152,12 +152,12 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity")
 "origin" "1 22 -3"
 "angle" " -1 "
 }
-)");
+)";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -167,13 +167,12 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity")
   CHECK(*worldNode->entity().property("message") == "yay");
 
   CHECK(worldNode->childCount() == 1u);
-  Model::LayerNode* defaultLayerNode =
-    dynamic_cast<Model::LayerNode*>(worldNode->children().front());
+  auto* defaultLayerNode = dynamic_cast<Model::LayerNode*>(worldNode->children().front());
   CHECK(defaultLayerNode != nullptr);
   CHECK(defaultLayerNode->childCount() == 1u);
   CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
 
-  Model::EntityNode* entityNode =
+  auto* entityNode =
     static_cast<Model::EntityNode*>(defaultLayerNode->children().front());
   CHECK(entityNode->entity().hasProperty("classname"));
   CHECK(*entityNode->entity().property("classname") == "info_player_deathmatch");
@@ -185,7 +184,7 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity")
 
 TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneBrush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -196,29 +195,28 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneBrush")
 ( 64 64  -0 ) ( 64 64 -16 ) ( 64 -0  -0 ) tex5 0 0 0 1 1
 ( 64 64  -0 ) ( 64 -0  -0 ) ( -0 64  -0 ) tex6 0 0 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
 
-  Model::BrushNode* brushNode =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brushNode = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brushNode, false);
   const auto& faces = brushNode->brush().faces();
   CHECK(faces.size() == 6u);
 
-  const Model::BrushFace* face1 = findFaceByPoints(
+  const auto* face1 = findFaceByPoints(
     faces,
-    vm::vec3(0.0, 0.0, -16.0),
-    vm::vec3(0.0, 0.0, 0.0),
-    vm::vec3(64.0, 0.0, -16.0));
+    vm::vec3{0.0, 0.0, -16.0},
+    vm::vec3{0.0, 0.0, 0.0},
+    vm::vec3{64.0, 0.0, -16.0});
   CHECK(face1 != nullptr);
   CHECK(face1->attributes().textureName() == "tex1");
   CHECK(face1->attributes().xOffset() == 1.0);
@@ -230,43 +228,43 @@ TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneBrush")
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(0.0, 0.0, -16.0),
-      vm::vec3(0.0, 64.0, -16.0),
-      vm::vec3(0.0, 0.0, 0.0))
+      vm::vec3{0.0, 0.0, -16.0},
+      vm::vec3{0.0, 64.0, -16.0},
+      vm::vec3{0.0, 0.0, 0.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(0.0, 0.0, -16.0),
-      vm::vec3(64.0, 0.0, -16.0),
-      vm::vec3(0.0, 64.0, -16.0))
+      vm::vec3{0.0, 0.0, -16.0},
+      vm::vec3{64.0, 0.0, -16.0},
+      vm::vec3{0.0, 64.0, -16.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(64.0, 64.0, 0.0),
-      vm::vec3(0.0, 64.0, 0.0),
-      vm::vec3(64.0, 64.0, -16.0))
+      vm::vec3{64.0, 64.0, 0.0},
+      vm::vec3{0.0, 64.0, 0.0},
+      vm::vec3{64.0, 64.0, -16.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(64.0, 64.0, 0.0),
-      vm::vec3(64.0, 64.0, -16.0),
-      vm::vec3(64.0, 0.0, 0.0))
+      vm::vec3{64.0, 64.0, 0.0},
+      vm::vec3{64.0, 64.0, -16.0},
+      vm::vec3{64.0, 0.0, 0.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(64.0, 64.0, 0.0),
-      vm::vec3(64.0, 0.0, 0.0),
-      vm::vec3(0.0, 64.0, 0.0))
+      vm::vec3{64.0, 64.0, 0.0},
+      vm::vec3{64.0, 0.0, 0.0},
+      vm::vec3{0.0, 64.0, 0.0})
     != nullptr);
 }
 
 TEST_CASE("WorldReaderTest.parseMapAndCheckFaceFlags")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -277,29 +275,28 @@ TEST_CASE("WorldReaderTest.parseMapAndCheckFaceFlags")
 ( 64 64  -0 ) ( 64 64 -16 ) ( 64 -0  -0 ) none 0 0 0 1 1
 ( 64 64  -0 ) ( 64 -0  -0 ) ( -0 64  -0 ) none 0 0 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
 
-  Model::BrushNode* brushNode =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brushNode = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brushNode, false);
   const auto& faces = brushNode->brush().faces();
   CHECK(faces.size() == 6u);
 
-  const Model::BrushFace* face = findFaceByPoints(
+  const auto* face = findFaceByPoints(
     faces,
-    vm::vec3(0.0, 0.0, -16.0),
-    vm::vec3(0.0, 0.0, 0.0),
-    vm::vec3(64.0, 0.0, -16.0));
+    vm::vec3{0.0, 0.0, -16.0},
+    vm::vec3{0.0, 0.0, 0.0},
+    vm::vec3{64.0, 0.0, -16.0});
   CHECK(face != nullptr);
   CHECK(face->attributes().xOffset() == 22.0f);
   CHECK(face->attributes().xOffset() == 22.0f);
@@ -310,7 +307,7 @@ TEST_CASE("WorldReaderTest.parseMapAndCheckFaceFlags")
 
 TEST_CASE("WorldReaderTest.parseBrushWithCurlyBraceInTextureName")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -321,20 +318,19 @@ TEST_CASE("WorldReaderTest.parseBrushWithCurlyBraceInTextureName")
 ( 64 64  -0 ) ( 64 64 -16 ) ( 64 -0  -0 ) none 0 0 0 1 1
 ( 64 64  -0 ) ( 64 -0  -0 ) ( -0 64  -0 ) none 0 0 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
 
-  Model::BrushNode* brushNode =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brushNode = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brushNode, false);
   const auto& faces = brushNode->brush().faces();
   CHECK(faces.size() == 6u);
@@ -342,50 +338,50 @@ TEST_CASE("WorldReaderTest.parseBrushWithCurlyBraceInTextureName")
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(0.0, 0.0, -16.0),
-      vm::vec3(0.0, 0.0, 0.0),
-      vm::vec3(64.0, 0.0, -16.0))
+      vm::vec3{0.0, 0.0, -16.0},
+      vm::vec3{0.0, 0.0, 0.0},
+      vm::vec3{64.0, 0.0, -16.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(0.0, 0.0, -16.0),
-      vm::vec3(0.0, 64.0, -16.0),
-      vm::vec3(0.0, 0.0, 0.0))
+      vm::vec3{0.0, 0.0, -16.0},
+      vm::vec3{0.0, 64.0, -16.0},
+      vm::vec3{0.0, 0.0, 0.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(0.0, 0.0, -16.0),
-      vm::vec3(64.0, 0.0, -16.0),
-      vm::vec3(0.0, 64.0, -16.0))
+      vm::vec3{0.0, 0.0, -16.0},
+      vm::vec3{64.0, 0.0, -16.0},
+      vm::vec3{0.0, 64.0, -16.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(64.0, 64.0, 0.0),
-      vm::vec3(0.0, 64.0, 0.0),
-      vm::vec3(64.0, 64.0, -16.0))
+      vm::vec3{64.0, 64.0, 0.0},
+      vm::vec3{0.0, 64.0, 0.0},
+      vm::vec3{64.0, 64.0, -16.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(64.0, 64.0, 0.0),
-      vm::vec3(64.0, 64.0, -16.0),
-      vm::vec3(64.0, 0.0, 0.0))
+      vm::vec3{64.0, 64.0, 0.0},
+      vm::vec3{64.0, 64.0, -16.0},
+      vm::vec3{64.0, 0.0, 0.0})
     != nullptr);
   CHECK(
     findFaceByPoints(
       faces,
-      vm::vec3(64.0, 64.0, 0.0),
-      vm::vec3(64.0, 0.0, 0.0),
-      vm::vec3(0.0, 64.0, 0.0))
+      vm::vec3{64.0, 64.0, 0.0},
+      vm::vec3{64.0, 0.0, 0.0},
+      vm::vec3{0.0, 64.0, 0.0})
     != nullptr);
 }
 
 TEST_CASE("WorldReaderTest.parseValveBrush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -396,25 +392,24 @@ TEST_CASE("WorldReaderTest.parseValveBrush")
 ( -800 224 1024 ) ( -736 224 1024 ) ( -736 224 576 ) METAL4_5 [ 1 0 0 64 ] [ 0 0 -1 0 ] 0 1 1
 ( -800 224 576 ) ( -736 224 576 ) ( -736 288 576 ) METAL4_5 [ 1 0 0 64 ] [ 0 -1 0 0 ] 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Valve, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Valve, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
-  Model::BrushNode* brush =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brush, true);
 }
 
 TEST_CASE("WorldReaderTest.parseQuake2Brush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -425,19 +420,18 @@ TEST_CASE("WorldReaderTest.parseQuake2Brush")
 ( -968 1152 -448 ) ( -920 1152 -448 ) ( -944 1152 -416 ) rtz/c_mf_v3c 56 96 0 1 1 0 0 0
 ( -896 1056 -416 ) ( -896 1056 -448 ) ( -896 1344 -448 ) rtz/c_mf_v3c 16 96 0 1 1 0 0 0
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
-  Model::BrushNode* brush =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brush, false);
 
   SECTION("surface attributes for face attribsExplicit")
@@ -482,7 +476,7 @@ TEST_CASE("WorldReaderTest.parseQuake2Brush")
 
 TEST_CASE("WorldReaderTest.parseQuake2ValveBrush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "mapversion" "220"
@@ -496,25 +490,24 @@ TEST_CASE("WorldReaderTest.parseQuake2ValveBrush")
 ( 224 -52 -176 ) ( 208 -62 -176 ) ( 224 -52 80 ) e1u2/basic1_1 [ 1 0 0 -23.7303 ] [ 0 0 -1 0 ] 35.6251 1 1 0 1 0
 ( 224 -52 80 ) ( 224 200 80 ) ( 224 -52 -176 ) e1u2/basic1_1 [ -0.625 1 0 44 ] [ 0 0 -1 0 ] 32.6509 1 1 0 1 0
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2_Valve, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2_Valve, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
-  Model::BrushNode* brush =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brush, true);
 }
 
 TEST_CASE("WorldReaderTest.parseQuake3ValveBrush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "mapversion" "220"
@@ -528,25 +521,24 @@ TEST_CASE("WorldReaderTest.parseQuake3ValveBrush")
 ( 224 -52 -176 ) ( 208 -62 -176 ) ( 224 -52 80 ) gothic_block/blocks18c_3 [ 1 0 0 -23.7303 ] [ 0 0 -1 0 ] 35.6251 0.25 0.25 0 0 0
 ( 224 -52 80 ) ( 224 200 80 ) ( 224 -52 -176 ) gothic_block/blocks18c_3 [ -0.625 1 0 44 ] [ 0 0 -1 0 ] 32.6509 0.25 0.25 0 0 0
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake3_Valve, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake3_Valve, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
-  Model::BrushNode* brush =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brush, true);
 }
 
 TEST_CASE("WorldReaderTest.parseDaikatanaBrush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -557,16 +549,16 @@ TEST_CASE("WorldReaderTest.parseDaikatanaBrush")
 ( -968 1152 -448 ) ( -920 1152 -448 ) ( -944 1152 -416 ) rtz/c_mf_v3c 56 96 0 1 1 0 0 0
 ( -896 1056 -416 ) ( -896 1056 -448 ) ( -896 1344 -448 ) rtz/c_mf_v3c 16 96 0 1 1 0 0 0
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Daikatana, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Daikatana, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
 
   const auto* brushNode =
@@ -593,7 +585,7 @@ TEST_CASE("WorldReaderTest.parseDaikatanaBrush")
 
 TEST_CASE("WorldReaderTest.parseDaikatanaMapHeader")
 {
-  const std::string data(R"(
+  const auto data = R"(
 ////////////////////////////////////////////////////////////
 // ldef 000 "Base Brush Layer"
 ////////////////////////////////////////////////////////////
@@ -619,26 +611,25 @@ TEST_CASE("WorldReaderTest.parseDaikatanaMapHeader")
 ( 968 2120 -48 ) ( 944 2120 -48 ) ( 956 2120 80 ) e3m1/rooftrim -18 -26 -135 0.999873 -0.499936 134217728 0 0
 }
 }
-)");
+)";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Daikatana, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Daikatana, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
-  Model::BrushNode* brush =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brush, false);
 }
 
 TEST_CASE("WorldReaderTest.parseQuakeBrushWithNumericalTextureName")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -649,25 +640,24 @@ TEST_CASE("WorldReaderTest.parseQuakeBrushWithNumericalTextureName")
 ( -968 1152 -448 ) ( -920 1152 -448 ) ( -944 1152 -416 ) c_mf_v3c 56 96 0 1 1
 ( -896 1056 -416 ) ( -896 1056 -448 ) ( -896 1344 -448 ) c_mf_v3c 16 96 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 1u);
-  Model::BrushNode* brush =
-    static_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = static_cast<Model::BrushNode*>(defaultLayer->children().front());
   checkBrushTexCoordSystem(brush, false);
 }
 
 TEST_CASE("WorldReaderTest.parseBrushesWithLayer")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -700,28 +690,25 @@ TEST_CASE("WorldReaderTest.parseBrushesWithLayer")
 ( -800 224 1024 ) ( -736 224 1024 ) ( -736 224 576 ) rtz/c_mf_v3c 56 -32 0 1 1
 ( -800 224 576 ) ( -736 224 576 ) ( -736 288 576 ) rtz/c_mf_v3c 56 -32 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 2u);
 
-  Model::LayerNode* defaultLayerNode =
-    dynamic_cast<Model::LayerNode*>(world->children().at(0));
-  Model::LayerNode* myLayerNode =
-    dynamic_cast<Model::LayerNode*>(world->children().at(1));
+  auto* defaultLayerNode = dynamic_cast<Model::LayerNode*>(world->children().at(0));
+  auto* myLayerNode = dynamic_cast<Model::LayerNode*>(world->children().at(1));
   CHECK(defaultLayerNode != nullptr);
   CHECK(myLayerNode != nullptr);
 
   CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
-  CHECK(
-    myLayerNode->layer().sortIndex()
-    == 0); // The layer didn't have a sort index (saved in an
-           // older version of TB), so it's assigned 0
+  // The layer didn't have a sort index (saved in an older version of TB), so it's
+  // assigned 0
+  CHECK(myLayerNode->layer().sortIndex() == 0);
 
   CHECK(defaultLayerNode->childCount() == 2u);
   CHECK(myLayerNode->childCount() == 1u);
@@ -731,7 +718,7 @@ TEST_CASE("WorldReaderTest.parseBrushesWithLayer")
 
 TEST_CASE("WorldReaderTest.parseLayersWithReverseSort")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 }
@@ -751,11 +738,11 @@ TEST_CASE("WorldReaderTest.parseLayersWithReverseSort")
 "_tb_layer_sort_index" "0"
 "_tb_layer_hidden" "1"
 "_tb_layer_omit_from_export" "1"
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -789,7 +776,7 @@ TEST_CASE("WorldReaderTest.parseLayersWithReverseSort")
 
 TEST_CASE("WorldReaderTest.parseLayersWithReversedSortIndicesWithGaps")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 }
@@ -813,11 +800,11 @@ TEST_CASE("WorldReaderTest.parseLayersWithReversedSortIndicesWithGaps")
 "_tb_name" "Sort Index 1"
 "_tb_id" "3"
 "_tb_layer_sort_index" "1"
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -893,10 +880,10 @@ TEST_CASE("WorldReaderTest.parseLayersWithSortIndicesWithGapsAndDuplicates")
 "_tb_id" "6"
 "_tb_layer_sort_index" "12"
 })end";
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -927,23 +914,23 @@ TEST_CASE("WorldReaderTest.parseLayersWithSortIndicesWithGapsAndDuplicates")
   CHECK(sortNode12->name() == "Sort Index 12");
 
   CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
-  CHECK(
-    sortMinusOneNode->layer().sortIndex()
-    == 13); // This one was invalid so it got moved to the end
+
+  // This one was invalid so it got moved to the end
+  CHECK(sortMinusOneNode->layer().sortIndex() == 13);
   CHECK(sortNode8->layer().sortIndex() == 8);
-  CHECK(
-    sortNode8second->layer().sortIndex()
-    == 14); // This one was invalid so it got moved to the end
+
+  // This one was invalid so it got moved to the end
+  CHECK(sortNode8second->layer().sortIndex() == 14);
   CHECK(sortNode10->layer().sortIndex() == 10);
-  CHECK(
-    sortNode10second->layer().sortIndex()
-    == 15); // This one was invalid so it got moved to the end
+
+  // This one was invalid so it got moved to the end
+  CHECK(sortNode10second->layer().sortIndex() == 15);
   CHECK(sortNode12->layer().sortIndex() == 12);
 }
 
 TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -988,11 +975,11 @@ TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer")
 ( -800 224 1024 ) ( -736 224 1024 ) ( -736 224 576 ) rtz/c_mf_v3c 56 -32 0 1 1
 ( -800 224 576 ) ( -736 224 576 ) ( -736 288 576 ) rtz/c_mf_v3c 56 -32 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -1004,7 +991,7 @@ TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithLayer")
 
 TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithGroup")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -1064,29 +1051,29 @@ TEST_CASE("WorldReaderTest.parseEntitiesAndBrushesWithGroup")
 ( -800 224 1024 ) ( -736 224 1024 ) ( -736 224 576 ) rtz/c_mf_v3c 56 -32 0 1 1
 ( -800 224 576 ) ( -736 224 576 ) ( -736 288 576 ) rtz/c_mf_v3c 56 -32 0 1 1
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   auto world = reader.read(worldBounds, status);
 
   CHECK(world->childCount() == 1u);
 
-  Model::Node* defaultLayer = world->children().front();
+  auto* defaultLayer = world->children().front();
   CHECK(defaultLayer->childCount() == 3u);
 
-  Model::Node* myGroup = defaultLayer->children().back();
+  auto* myGroup = defaultLayer->children().back();
   CHECK(myGroup->childCount() == 3u);
 
-  Model::Node* mySubGroup = myGroup->children().back();
+  auto* mySubGroup = myGroup->children().back();
   CHECK(mySubGroup->childCount() == 1u);
 }
 
 TEST_CASE("WorldReaderTest.parseLayersAndGroupsAndRetainIds")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 }
@@ -1109,11 +1096,11 @@ TEST_CASE("WorldReaderTest.parseLayersAndGroupsAndRetainIds")
 "_tb_name" "Group 2"
 "_tb_id" "22"
 }
-)");
-  const vm::bbox3 worldBounds(8192.0);
+)";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -1141,7 +1128,7 @@ TEST_CASE("WorldReaderTest.parseLayersAndGroupsAndRetainIds")
 
 TEST_CASE("WorldReaderTest.parseBrushPrimitive")
 {
-  const std::string data(R"(
+  const auto data = R"(
             {
                 "classname" "worldspawn"
                 {
@@ -1155,12 +1142,12 @@ TEST_CASE("WorldReaderTest.parseBrushPrimitive")
                         ( -64 -64 64 ) ( -64 64 -64 ) ( -64 64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
                     }
                 }
-            })");
+            })";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake3, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake3, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -1170,7 +1157,7 @@ TEST_CASE("WorldReaderTest.parseBrushPrimitive")
 
 TEST_CASE("WorldReaderTest.parseBrushPrimitiveAndLegacyBrush")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -1192,12 +1179,12 @@ brushDef
 ( -64 -64 -64 ) ( -64 -64 64 ) ( 64 -64 -64 ) common/caulk 0 0 0 1 1 134217728 0 0
 ( -64 -64 -64 ) ( -64 64 -64 ) ( -64 -64 64 ) common/caulk 0 0 0 1 1 134217728 0 0
 }
-})");
+})";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake3, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake3, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -1207,7 +1194,7 @@ brushDef
 
 TEST_CASE("WorldReaderTest.parseQuake3Patch")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 {
@@ -1224,11 +1211,11 @@ common/caulk
 )
 }
 }
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake3, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake3, {}};
 
   auto world = reader.read(worldBounds, status);
 
@@ -1268,31 +1255,31 @@ TEST_CASE("WorldReaderTest.parseMultipleClassnames")
 {
   // See https://github.com/TrenchBroom/TrenchBroom/issues/1485
 
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "classname" "worldspawn"
-})");
+})";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Quake2, {}};
 
   CHECK_NOTHROW(reader.read(worldBounds, status));
 }
 
 TEST_CASE("WorldReaderTest.parseEscapedDoubleQuotationMarks")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "message" "yay \"Mr. Robot!\""
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -1309,15 +1296,15 @@ TEST_CASE(
   "WorldReaderTest.parsePropertyWithUnescapedPathAndTrailingBackslash",
   "[WorldReaderTest]")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "path" "c:\a\b\c\"
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -1332,15 +1319,15 @@ TEST_CASE(
 
 TEST_CASE("WorldReaderTest.parsePropertyWithEscapedPathAndTrailingBackslash")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "path" "c:\\a\\b\\c\\"
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -1355,15 +1342,15 @@ TEST_CASE("WorldReaderTest.parsePropertyWithEscapedPathAndTrailingBackslash")
 
 TEST_CASE("WorldReaderTest.parsePropertyTrailingEscapedBackslash")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "message" "test\\"
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -1379,15 +1366,15 @@ TEST_CASE("WorldReaderTest.parsePropertyTrailingEscapedBackslash")
 // https://github.com/TrenchBroom/TrenchBroom/issues/1739
 TEST_CASE("WorldReaderTest.parsePropertyNewlineEscapeSequence")
 {
-  const std::string data(R"(
+  const auto data = R"(
 {
 "classname" "worldspawn"
 "message" "vm::line1\nvm::line2"
-})");
-  const vm::bbox3 worldBounds(8192.0);
+})";
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
 
@@ -1402,7 +1389,7 @@ TEST_CASE("WorldReaderTest.parsePropertyNewlineEscapeSequence")
 
 /*
 TEST_CASE("WorldReaderTest.parseIssueIgnoreFlags") {
-    const std::string data("{"
+    const auto data = "{"
                       "\"classname\" \"worldspawn\""
                       "{\n"
                       "/// hideIssues 2\n"
@@ -1449,15 +1436,15 @@ doBrushContentTypes()).WillOnce(ReturnRef(Model::BrushContentType::EmptyList));
 
 TEST_CASE("WorldReaderTest.parseHeretic2QuarkMap")
 {
-  const IO::Path mapPath =
-    IO::Disk::getCurrentWorkingDir() + IO::Path("fixture/test/IO/Map/Heretic2Quark.map");
-  const std::shared_ptr<File> file = IO::Disk::openFile(mapPath);
+  const Path mapPath =
+    Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Map/Heretic2Quark.map");
+  const std::shared_ptr<File> file = Disk::openFile(mapPath);
   auto fileReader = file->reader().buffer();
 
-  IO::TestParserStatus status;
-  IO::WorldReader worldReader(fileReader.stringView(), Model::MapFormat::Quake2, {});
+  auto status = TestParserStatus{};
+  auto worldReader = WorldReader{fileReader.stringView(), Model::MapFormat::Quake2, {}};
 
-  const auto worldBounds = vm::bbox3(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
   auto worldNode = worldReader.read(worldBounds, status);
 
   REQUIRE(worldNode != nullptr);
@@ -1470,10 +1457,8 @@ TEST_CASE("WorldReaderTest.parseHeretic2QuarkMap")
   auto* brushNode = dynamic_cast<Model::BrushNode*>(layerNode->children().at(0));
   REQUIRE(brushNode != nullptr);
 
-  CHECK(
-    vm::bbox3(vm::vec3(-512, -512, -64), vm::vec3(512, 512, 0))
-    == brushNode->logicalBounds());
-  for (const Model::BrushFace& face : brushNode->brush().faces())
+  CHECK(brushNode->logicalBounds() == vm::bbox3{{-512, -512, -64}, {512, 512, 0}});
+  for (const auto& face : brushNode->brush().faces())
   {
     CHECK("general/sand1" == face.attributes().textureName());
   }
@@ -1481,7 +1466,7 @@ TEST_CASE("WorldReaderTest.parseHeretic2QuarkMap")
 
 TEST_CASE("WorldReaderTest.parseTBEmptyTextureName")
 {
-  const std::string data(R"(
+  const auto data = R"(
 // entity 0
 {
 "classname" "worldspawn"
@@ -1494,27 +1479,25 @@ TEST_CASE("WorldReaderTest.parseTBEmptyTextureName")
 ( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty 0 0 0 1 1
 ( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty 0 0 0 1 1
 }
-})");
+})";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
   REQUIRE(world != nullptr);
   REQUIRE(world->childCount() == 1u);
 
-  Model::LayerNode* defaultLayer =
-    dynamic_cast<Model::LayerNode*>(world->children().front());
+  auto* defaultLayer = dynamic_cast<Model::LayerNode*>(world->children().front());
   REQUIRE(defaultLayer != nullptr);
   REQUIRE(defaultLayer->childCount() == 1u);
 
-  Model::BrushNode* brush =
-    dynamic_cast<Model::BrushNode*>(defaultLayer->children().front());
+  auto* brush = dynamic_cast<Model::BrushNode*>(defaultLayer->children().front());
   REQUIRE(brush != nullptr);
 
-  for (const Model::BrushFace& face : brush->brush().faces())
+  for (const auto& face : brush->brush().faces())
   {
     CHECK(!face.attributes().textureName().empty());
     CHECK(face.attributes().textureName() == Model::BrushFaceAttributes::NoTextureName);
@@ -1557,7 +1540,7 @@ TEST_CASE("WorldReaderTest.parseQuotedTextureNames")
 
   const auto worldBounds = vm::bbox3{8192.0};
 
-  auto status = IO::TestParserStatus{};
+  auto status = TestParserStatus{};
   auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto worldNode = reader.read(worldBounds, status);
@@ -1600,10 +1583,10 @@ TEST_CASE("WorldReaderTest.parseLinkedGroups")
 }
             )";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
   REQUIRE(world != nullptr);
@@ -1622,10 +1605,10 @@ TEST_CASE("WorldReaderTest.parseLinkedGroups")
 
   CHECK(
     groupNode1->group().transformation()
-    == vm::translation_matrix(vm::vec3(32.0, 0.0, 0.0)));
+    == vm::translation_matrix(vm::vec3{32.0, 0.0, 0.0}));
   CHECK(
     groupNode2->group().transformation()
-    == vm::translation_matrix(vm::vec3(32.0, 16.0, 0.0)));
+    == vm::translation_matrix(vm::vec3{32.0, 16.0, 0.0}));
 }
 
 TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
@@ -1651,10 +1634,10 @@ TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
 }
             )";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
   REQUIRE(world != nullptr);
@@ -1674,7 +1657,7 @@ TEST_CASE("WorldReaderTest.parseLinkedGroupsWithMissingTransformation")
   CHECK(groupNode1->group().transformation() == vm::mat4x4d{});
   CHECK(
     groupNode2->group().transformation()
-    == vm::translation_matrix(vm::vec3(32.0, 16.0, 0.0)));
+    == vm::translation_matrix(vm::vec3{32.0, 16.0, 0.0}));
 }
 
 TEST_CASE("WorldReaderTest.parseGroupWithUnnecessaryTransformation")
@@ -1692,10 +1675,10 @@ TEST_CASE("WorldReaderTest.parseGroupWithUnnecessaryTransformation")
 }
             )";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
   REQUIRE(world != nullptr);
@@ -1729,10 +1712,10 @@ TEST_CASE("WorldReaderTest.parseProtectedEntityProperties")
 }
             )";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
-  WorldReader reader(data, Model::MapFormat::Standard, {});
+  auto status = TestParserStatus{};
+  auto reader = WorldReader{data, Model::MapFormat::Standard, {}};
 
   auto world = reader.read(worldBounds, status);
   REQUIRE(world != nullptr);
@@ -1780,9 +1763,9 @@ TEST_CASE("WorldReaderTest.parseUnknownFormatEmptyMap")
 }
             )";
 
-  const vm::bbox3 worldBounds(8192.0);
+  const auto worldBounds = vm::bbox3{8192.0};
 
-  IO::TestParserStatus status;
+  auto status = TestParserStatus{};
   auto world = WorldReader::tryRead(
     data, {Model::MapFormat::Standard, Model::MapFormat::Valve}, worldBounds, {}, status);
   REQUIRE(world != nullptr);

--- a/common/test/src/IO/ZipFileSystemTest.cpp
+++ b/common/test/src/IO/ZipFileSystemTest.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom
 {
 namespace IO
 {
-TEST_CASE("ZipFileSystemTest.directoryExists", "[ZipFileSystemTest]")
+TEST_CASE("ZipFileSystemTest.directoryExists")
 {
   const Path zipPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Zip/zip_test.zip");
@@ -46,7 +46,7 @@ TEST_CASE("ZipFileSystemTest.directoryExists", "[ZipFileSystemTest]")
   CHECK_FALSE(fs.directoryExists(Path("pics/tag1.pcx")));
 }
 
-TEST_CASE("ZipFileSystemTest.fileExists", "[ZipFileSystemTest]")
+TEST_CASE("ZipFileSystemTest.fileExists")
 {
   const Path zipPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Zip/zip_test.zip");
@@ -59,7 +59,7 @@ TEST_CASE("ZipFileSystemTest.fileExists", "[ZipFileSystemTest]")
   CHECK(fs.fileExists(Path("PICS/TAG1.pcX")));
 }
 
-TEST_CASE("ZipFileSystemTest.findItems", "[ZipFileSystemTest]")
+TEST_CASE("ZipFileSystemTest.findItems")
 {
   const Path zipPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Zip/zip_test.zip");
@@ -88,7 +88,7 @@ TEST_CASE("ZipFileSystemTest.findItems", "[ZipFileSystemTest]")
       std::vector<Path>{Path("pics/tag1.pcx"), Path("pics/tag2.pcx")}));
 }
 
-TEST_CASE("ZipFileSystemTest.findItemsRecursively", "[ZipFileSystemTest]")
+TEST_CASE("ZipFileSystemTest.findItemsRecursively")
 {
   const Path zipPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Zip/zip_test.zip");
@@ -144,7 +144,7 @@ TEST_CASE("ZipFileSystemTest.findItemsRecursively", "[ZipFileSystemTest]")
     }));
 }
 
-TEST_CASE("ZipFileSystemTest.openFile", "[ZipFileSystemTest]")
+TEST_CASE("ZipFileSystemTest.openFile")
 {
   const Path zipPath =
     Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Zip/zip_test.zip");

--- a/common/test/src/Model/BrushBuilderTest.cpp
+++ b/common/test/src/Model/BrushBuilderTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("BrushBuilderTest.createCube", "[BrushBuilderTest]")
+TEST_CASE("BrushBuilderTest.createCube")
 {
   const vm::bbox3 worldBounds(8192.0);
 
@@ -51,7 +51,7 @@ TEST_CASE("BrushBuilderTest.createCube", "[BrushBuilderTest]")
   }
 }
 
-TEST_CASE("BrushBuilderTest.createCubeDefaults", "[BrushBuilderTest]")
+TEST_CASE("BrushBuilderTest.createCubeDefaults")
 {
   const vm::bbox3 worldBounds(8192.0);
 

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -650,7 +650,7 @@ TEST_CASE("BrushFaceTest.testValveRotation")
 
   IO::TestParserStatus status;
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   BrushNode* pyramidLight = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
   REQUIRE(pyramidLight != nullptr);
 
@@ -719,7 +719,7 @@ TEST_CASE("BrushFaceTest.testCopyTexCoordSystem")
   IO::TestParserStatus status;
 
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   BrushNode* pyramidLight = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
   REQUIRE(pyramidLight != nullptr);
 
@@ -793,7 +793,7 @@ TEST_CASE("BrushFaceTest.move45DegreeFace")
   IO::TestParserStatus status;
 
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   BrushNode* brushNode = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
   CHECK(brushNode != nullptr);
 
@@ -883,7 +883,7 @@ TEST_CASE("BrushFaceTest.flipTexture")
   IO::TestParserStatus status;
 
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   auto* brushNode = dynamic_cast<BrushNode*>(nodes.at(0)->children().at(0));
   REQUIRE(brushNode != nullptr);
 

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("BrushFaceTest.constructWithValidPoints", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.constructWithValidPoints")
 {
   const vm::vec3 p0(0.0, 0.0, 4.0);
   const vm::vec3 p1(1.0, 0.0, 4.0);
@@ -73,7 +73,7 @@ TEST_CASE("BrushFaceTest.constructWithValidPoints", "[BrushFaceTest]")
   CHECK(face.boundary().distance == 4.0);
 }
 
-TEST_CASE("BrushFaceTest.constructWithColinearPoints", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.constructWithColinearPoints")
 {
   const vm::vec3 p0(0.0, 0.0, 4.0);
   const vm::vec3 p1(1.0, 0.0, 4.0);
@@ -86,7 +86,7 @@ TEST_CASE("BrushFaceTest.constructWithColinearPoints", "[BrushFaceTest]")
       .is_success());
 }
 
-TEST_CASE("BrushFaceTest.textureUsageCount", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.textureUsageCount")
 {
   const vm::vec3 p0(0.0, 0.0, 4.0);
   const vm::vec3 p1(1.0, 0.0, 4.0);
@@ -564,7 +564,7 @@ static void checkTextureLockOffWithScale(const Brush& cube)
   CHECK(transformed_U_width.y() == vm::approx(orig_U_width.y()));
 }
 
-TEST_CASE("BrushFaceTest.testSetRotation_Paraxial", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.testSetRotation_Paraxial")
 {
   const vm::bbox3 worldBounds(8192.0);
   Assets::Texture texture("testTexture", 64, 64);
@@ -589,7 +589,7 @@ TEST_CASE("BrushFaceTest.testSetRotation_Paraxial", "[BrushFaceTest]")
   CHECK(face.textureYAxis() == vm::approx(newYAxis));
 }
 
-TEST_CASE("BrushFaceTest.testTextureLock_Paraxial", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.testTextureLock_Paraxial")
 {
   const vm::bbox3 worldBounds(8192.0);
   Assets::Texture texture("testTexture", 64, 64);
@@ -609,7 +609,7 @@ TEST_CASE("BrushFaceTest.testTextureLock_Paraxial", "[BrushFaceTest]")
   checkTextureLockOffWithScale(cube);
 }
 
-TEST_CASE("BrushFaceTest.testTextureLock_Parallel", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.testTextureLock_Parallel")
 {
   const vm::bbox3 worldBounds(8192.0);
   Assets::Texture texture("testTexture", 64, 64);
@@ -630,7 +630,7 @@ TEST_CASE("BrushFaceTest.testTextureLock_Parallel", "[BrushFaceTest]")
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/2001
-TEST_CASE("BrushFaceTest.testValveRotation", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.testValveRotation")
 {
   const std::string data(
     "{\n"
@@ -692,7 +692,7 @@ TEST_CASE("BrushFaceTest.testValveRotation", "[BrushFaceTest]")
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/1995
-TEST_CASE("BrushFaceTest.testCopyTexCoordSystem", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.testCopyTexCoordSystem")
 {
   const std::string data(
     "{\n"
@@ -771,7 +771,7 @@ TEST_CASE("BrushFaceTest.testCopyTexCoordSystem", "[BrushFaceTest]")
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/2315
-TEST_CASE("BrushFaceTest.move45DegreeFace", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.move45DegreeFace")
 {
   const std::string data(R"(
 // entity 0
@@ -815,7 +815,7 @@ TEST_CASE("BrushFaceTest.move45DegreeFace", "[BrushFaceTest]")
   kdl::vec_clear_and_delete(nodes);
 }
 
-TEST_CASE("BrushFaceTest.formatConversion", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.formatConversion")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -859,7 +859,7 @@ TEST_CASE("BrushFaceTest.formatConversion", "[BrushFaceTest]")
   doWithTextureLockTestTransforms(true, testTransform);
 }
 
-TEST_CASE("BrushFaceTest.flipTexture", "[BrushFaceTest]")
+TEST_CASE("BrushFaceTest.flipTexture")
 {
   const std::string data(R"(
 // entity 0

--- a/common/test/src/Model/BrushNodeRegressionTest.cpp
+++ b/common/test/src/Model/BrushNodeRegressionTest.cpp
@@ -85,7 +85,8 @@ TEST_CASE("BrushNodeTest.buildBrush_1186")
 
   auto status = IO::TestParserStatus{};
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+  auto nodes =
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   kdl::vec_clear_and_delete(nodes);
@@ -121,7 +122,8 @@ TEST_CASE("BrushNodeTest.buildBrush_1185")
 
   auto status = IO::TestParserStatus{};
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+  auto nodes =
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   kdl::vec_clear_and_delete(nodes);
@@ -312,7 +314,7 @@ TEST_CASE("BrushNodeTest.buildBrush_1697")
 
   auto status = IO::TestParserStatus{};
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   kdl::vec_clear_and_delete(nodes);
@@ -342,7 +344,8 @@ TEST_CASE("BrushNodeTest.buildBrush_1194")
 
   auto status = IO::TestParserStatus{};
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+  auto nodes =
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.empty());
 
   kdl::vec_clear_and_delete(nodes);
@@ -395,7 +398,7 @@ TEST_CASE("BrushNodeTest.buildBrush_1332")
   auto status = IO::TestParserStatus{};
 
   auto nodes = IO::NodeReader::read(
-    data, MapFormat::Standard, worldBounds, {}, status); // assertion failure
+    data, MapFormat::Standard, worldBounds, {}, {}, status); // assertion failure
   kdl::vec_clear_and_delete(nodes);
 }
 
@@ -446,7 +449,7 @@ TEST_CASE("BrushNodeTest.buildBrush_1395")
   auto status = IO::TestParserStatus{};
 
   auto nodes = IO::NodeReader::read(
-    data, MapFormat::Standard, worldBounds, {}, status); // assertion failure
+    data, MapFormat::Standard, worldBounds, {}, {}, status); // assertion failure
   kdl::vec_clear_and_delete(nodes);
 }
 
@@ -474,7 +477,7 @@ TEST_CASE("BrushNodeTest.buildBrush_1801")
   auto status = IO::TestParserStatus{};
 
   auto nodes = IO::NodeReader::read(
-    data, MapFormat::Standard, worldBounds, {}, status); // assertion failure
+    data, MapFormat::Standard, worldBounds, {}, {}, status); // assertion failure
   kdl::vec_clear_and_delete(nodes);
 }
 
@@ -564,7 +567,8 @@ TEST_CASE("BrushNodeTest.buildBrush_2361")
 
   auto status = IO::TestParserStatus{};
 
-  CHECK_NOTHROW(IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status));
+  CHECK_NOTHROW(
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status));
 }
 
 TEST_CASE("BrushNodeTest.buildBrush_2491")
@@ -586,7 +590,8 @@ TEST_CASE("BrushNodeTest.buildBrush_2491")
 
   auto status = IO::TestParserStatus{};
 
-  CHECK_NOTHROW(IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status));
+  CHECK_NOTHROW(
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status));
 }
 
 TEST_CASE("BrushNodeTest.buildBrush_2686")
@@ -626,7 +631,8 @@ TEST_CASE("BrushNodeTest.buildBrush_2686")
 
   auto status = IO::TestParserStatus{};
 
-  CHECK_NOTHROW(IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status));
+  CHECK_NOTHROW(
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status));
 }
 
 TEST_CASE("BrushNodeTest.buildBrush_4100")
@@ -657,7 +663,8 @@ TEST_CASE("BrushNodeTest.buildBrush_4100")
 
   auto status = IO::TestParserStatus{};
 
-  CHECK_NOTHROW(IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status));
+  CHECK_NOTHROW(
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status));
 }
 
 // https://github.com/TrenchBroom/TrenchBroom/issues/1893
@@ -790,7 +797,7 @@ TEST_CASE("BrushNodeTest.intersects_1893")
 
   auto status = IO::TestParserStatus{};
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
   CHECK(nodes.at(0)->hasChildren());
   CHECK(nodes.at(0)->children().size() == 2u);

--- a/common/test/src/Model/BrushNodeTest.cpp
+++ b/common/test/src/Model/BrushNodeTest.cpp
@@ -58,7 +58,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("BrushNodeTest.entity", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.entity")
 {
   const auto worldBounds = vm::bbox3{4096.0};
 
@@ -72,7 +72,7 @@ TEST_CASE("BrushNodeTest.entity", "[BrushNodeTest]")
   CHECK(brushNode->entity() == &entityNode);
 }
 
-TEST_CASE("BrushNodeTest.hasSelectedFaces", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.hasSelectedFaces")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -167,7 +167,7 @@ TEST_CASE("BrushNodeTest.hasSelectedFaces", "[BrushNodeTest]")
   }
 }
 
-TEST_CASE("BrushNodeTest.containsPatchNode", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.containsPatchNode")
 {
   const auto worldBounds = vm::bbox3d{8192.0};
 
@@ -194,7 +194,7 @@ TEST_CASE("BrushNodeTest.containsPatchNode", "[BrushNodeTest]")
   CHECK_FALSE(brushNode.contains(&patchNode));
 }
 
-TEST_CASE("BrushNodeTest.intersectsPatchNode", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.intersectsPatchNode")
 {
   const auto worldBounds = vm::bbox3d{8192.0};
 
@@ -254,7 +254,7 @@ TEST_CASE("BrushNodeTest.intersectsPatchNode", "[BrushNodeTest]")
   }
 }
 
-TEST_CASE("BrushNodeTest.pick", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.pick")
 {
   const vm::bbox3 worldBounds(4096.0);
   const auto editorContext = EditorContext{};
@@ -298,7 +298,7 @@ TEST_CASE("BrushNodeTest.pick", "[BrushNodeTest]")
   CHECK(hits2.empty());
 }
 
-TEST_CASE("BrushNodeTest.clone", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.clone")
 {
   const vm::bbox3 worldBounds(4096.0);
 

--- a/common/test/src/Model/BrushRegressionTest.cpp
+++ b/common/test/src/Model/BrushRegressionTest.cpp
@@ -64,7 +64,7 @@ namespace Model
  vm::vec3($7, $8, $9)));
  */
 
-TEST_CASE("BrushTest.constructWithFailingFaces", "[BrushTest]")
+TEST_CASE("BrushTest.constructWithFailingFaces")
 {
   /* from rtz_q1
    {
@@ -118,7 +118,7 @@ TEST_CASE("BrushTest.constructWithFailingFaces", "[BrushTest]")
   CHECK(brush.faceCount() == 7u);
 }
 
-TEST_CASE("BrushTest.constructWithFailingFaces2", "[BrushTest]")
+TEST_CASE("BrushTest.constructWithFailingFaces2")
 {
   /* from ne_ruins
    {
@@ -185,7 +185,7 @@ TEST_CASE("BrushTest.constructWithFailingFaces2", "[BrushTest]")
   CHECK(brush.faceCount() == 9u);
 }
 
-TEST_CASE("BrushTest.constructWithFailingFaces3", "[BrushTest]")
+TEST_CASE("BrushTest.constructWithFailingFaces3")
 {
   /* from ne_ruins
    {
@@ -234,7 +234,7 @@ TEST_CASE("BrushTest.constructWithFailingFaces3", "[BrushTest]")
   CHECK(brush.faceCount() == 6u);
 }
 
-TEST_CASE("BrushTest.constructWithFailingFaces4", "[BrushTest]")
+TEST_CASE("BrushTest.constructWithFailingFaces4")
 {
   /* from ne_ruins
    {
@@ -285,7 +285,7 @@ TEST_CASE("BrushTest.constructWithFailingFaces4", "[BrushTest]")
   CHECK(brush.faceCount() == 6u);
 }
 
-TEST_CASE("BrushTest.constructWithFailingFaces5", "[BrushTest]")
+TEST_CASE("BrushTest.constructWithFailingFaces5")
 {
   /* from jam6_ericwtronyn
    Interestingly, the order in which the faces appear in the map file is okay, but when
@@ -338,7 +338,7 @@ TEST_CASE("BrushTest.constructWithFailingFaces5", "[BrushTest]")
   CHECK(brush.faceCount() == 6u);
 }
 
-TEST_CASE("BrushTest.constructWithFailingFaces6", "[BrushTest]")
+TEST_CASE("BrushTest.constructWithFailingFaces6")
 {
   /* from 768_negke
    {
@@ -383,7 +383,7 @@ TEST_CASE("BrushTest.constructWithFailingFaces6", "[BrushTest]")
   CHECK(brush.faceCount() == 5u);
 }
 
-TEST_CASE("BrushTest.constructBrushWithManySides", "[BrushTest]")
+TEST_CASE("BrushTest.constructBrushWithManySides")
 {
   /*
    See https://github.com/TrenchBroom/TrenchBroom/issues/1153
@@ -454,7 +454,7 @@ TEST_CASE("BrushTest.constructBrushWithManySides", "[BrushTest]")
   CHECK(brush.faceCount() == 8u);
 }
 
-TEST_CASE("BrushTest.constructBrushAfterRotateFail", "[BrushTest]")
+TEST_CASE("BrushTest.constructBrushAfterRotateFail")
 {
   /*
    See https://github.com/TrenchBroom/TrenchBroom/issues/1173
@@ -533,7 +533,7 @@ TEST_CASE("BrushTest.constructBrushAfterRotateFail", "[BrushTest]")
   CHECK(brush.fullySpecified());
 }
 
-TEST_CASE("BrushTest.moveVertexFailing1", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexFailing1")
 {
   const vm::vec3d p1(-64.0, -64.0, 0.0);
   const vm::vec3d p2(+64.0, -64.0, 0.0);
@@ -566,7 +566,7 @@ TEST_CASE("BrushTest.moveVertexFailing1", "[BrushTest]")
   }
 }
 
-TEST_CASE("BrushTest.moveVertexFail_2158", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexFail_2158")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2158
   const std::string data(
@@ -605,7 +605,7 @@ TEST_CASE("BrushTest.moveVertexFail_2158", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.moveVerticesFail_2158", "[BrushTest]")
+TEST_CASE("BrushTest.moveVerticesFail_2158")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2158
   const vm::bbox3 worldBounds(4096.0);
@@ -676,7 +676,7 @@ TEST_CASE("BrushTest.moveVerticesFail_2158", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.removeVertexWithCorrectTextures_2082", "[BrushTest]")
+TEST_CASE("BrushTest.removeVertexWithCorrectTextures_2082")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2082
 
@@ -819,7 +819,7 @@ static void assertSnapToInteger(const std::string& data)
   assertSnapTo(data, 1.0);
 }
 
-TEST_CASE("BrushTest.snapIssue1198", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1198")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1198
   const std::string data(
@@ -866,7 +866,7 @@ TEST_CASE("BrushTest.snapIssue1198", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1202", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1202")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1202
   const std::string data(
@@ -893,7 +893,7 @@ TEST_CASE("BrushTest.snapIssue1202", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1203", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1203")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1203
   const std::string data(
@@ -929,7 +929,7 @@ TEST_CASE("BrushTest.snapIssue1203", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1205", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1205")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1205
   const std::string data(
@@ -986,7 +986,7 @@ TEST_CASE("BrushTest.snapIssue1205", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1206", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1206")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1206
   const std::string data(
@@ -1016,7 +1016,7 @@ TEST_CASE("BrushTest.snapIssue1206", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1207", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1207")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1207
   const std::string data(
@@ -1042,7 +1042,7 @@ TEST_CASE("BrushTest.snapIssue1207", "[BrushTest]")
   assertCannotSnap(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1232", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1232")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1232
   const std::string data(
@@ -1106,7 +1106,7 @@ TEST_CASE("BrushTest.snapIssue1232", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1395_24202", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1395_24202")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1395 brush at line 24202
   const std::string data(
@@ -1149,7 +1149,7 @@ TEST_CASE("BrushTest.snapIssue1395_24202", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapIssue1395_18995", "[BrushTest]")
+TEST_CASE("BrushTest.snapIssue1395_18995")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1395 brush at line 24202
   const std::string data(
@@ -1182,7 +1182,7 @@ TEST_CASE("BrushTest.snapIssue1395_18995", "[BrushTest]")
   assertSnapToInteger(data);
 }
 
-TEST_CASE("BrushTest.snapToGrid64", "[BrushTest]")
+TEST_CASE("BrushTest.snapToGrid64")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1415
   const std::string data(
@@ -1201,7 +1201,7 @@ TEST_CASE("BrushTest.snapToGrid64", "[BrushTest]")
   assertCannotSnapTo(data, 64.0);
 }
 
-TEST_CASE("BrushNodeTest.moveEdgesFail_2361", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.moveEdgesFail_2361")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2361
 
@@ -1303,7 +1303,7 @@ TEST_CASE("BrushNodeTest.moveEdgesFail_2361", "[BrushNodeTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.moveFaceFailure_1499", "[BrushTest]")
+TEST_CASE("BrushTest.moveFaceFailure_1499")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1499
 
@@ -1363,7 +1363,7 @@ TEST_CASE("BrushTest.moveFaceFailure_1499", "[BrushTest]")
     worldBounds, std::vector<vm::polygon3>(1, topFace), vm::vec3(0.0, 0.0, -16.0)));
 }
 
-TEST_CASE("BrushTest.convexMergeCrash_2789", "[BrushTest]")
+TEST_CASE("BrushTest.convexMergeCrash_2789")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2789
   const vm::bbox3 worldBounds(4096.0);
@@ -1430,7 +1430,7 @@ TEST_CASE("BrushTest.convexMergeCrash_2789", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.convexMergeIncorrectResult_2789", "[BrushTest]")
+TEST_CASE("BrushTest.convexMergeIncorrectResult_2789")
 {
   // weirdcurvemerge.map from https://github.com/TrenchBroom/TrenchBroom/issues/2789
   const vm::bbox3 worldBounds(8192.0);
@@ -1485,7 +1485,7 @@ TEST_CASE("BrushTest.convexMergeIncorrectResult_2789", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.subtractTruncatedCones", "[BrushTest]")
+TEST_CASE("BrushTest.subtractTruncatedCones")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1469
 
@@ -1567,7 +1567,7 @@ TEST_CASE("BrushTest.subtractTruncatedCones", "[BrushTest]")
   kdl::col_delete_all(subtrahendNodes);
 }
 
-TEST_CASE("BrushTest.subtractDome", "[BrushTest]")
+TEST_CASE("BrushTest.subtractDome")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/2707
 
@@ -1604,7 +1604,7 @@ TEST_CASE("BrushTest.subtractDome", "[BrushTest]")
   kdl::col_delete_all(subtrahendNodes);
 }
 
-TEST_CASE("BrushTest.subtractPipeFromCubeWithMissingFragments", "[BrushTest]")
+TEST_CASE("BrushTest.subtractPipeFromCubeWithMissingFragments")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/pull/1764#issuecomment-296341588
   // subtract creates missing fragments
@@ -1708,7 +1708,7 @@ TEST_CASE("BrushTest.subtractPipeFromCubeWithMissingFragments", "[BrushTest]")
 
 // TODO: add tests for Brush::intersect
 
-TEST_CASE("BrushTest.healEdgesCrash", "[BrushTest]")
+TEST_CASE("BrushTest.healEdgesCrash")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/3711
 
@@ -1760,7 +1760,7 @@ TEST_CASE("BrushTest.healEdgesCrash", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.healEdgesCrash2", "[BrushTest]")
+TEST_CASE("BrushTest.healEdgesCrash2")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/3655
 
@@ -1816,7 +1816,7 @@ TEST_CASE("BrushTest.healEdgesCrash2", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.healEdgesCrash3", "[BrushTest]")
+TEST_CASE("BrushTest.healEdgesCrash3")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/3655
 
@@ -1956,7 +1956,7 @@ TEST_CASE("BrushTest.healEdgesCrash3", "[BrushTest]")
   kdl::col_delete_all(nodes);
 }
 
-TEST_CASE("BrushTest.findInitialEdgeFail", "[BrushTest]")
+TEST_CASE("BrushTest.findInitialEdgeFail")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/3898
 
@@ -2001,7 +2001,7 @@ TEST_CASE("BrushTest.findInitialEdgeFail", "[BrushTest]")
       0.001));
 }
 
-TEST_CASE("BrushTest.headEdgesFail", "[BrushTest]")
+TEST_CASE("BrushTest.headEdgesFail")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/3886
   // this test would previously fail due on an assertion error

--- a/common/test/src/Model/BrushRegressionTest.cpp
+++ b/common/test/src/Model/BrushRegressionTest.cpp
@@ -588,7 +588,7 @@ TEST_CASE("BrushTest.moveVertexFail_2158")
   IO::TestParserStatus status;
 
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -654,7 +654,8 @@ TEST_CASE("BrushTest.moveVerticesFail_2158")
 
   IO::TestParserStatus status;
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+  auto nodes =
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -700,7 +701,7 @@ TEST_CASE("BrushTest.removeVertexWithCorrectTextures_2082")
   IO::TestParserStatus status;
 
   std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -772,7 +773,7 @@ static void assertCannotSnapTo(const std::string& data, const FloatType gridSize
   IO::TestParserStatus status;
 
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -793,7 +794,7 @@ static void assertSnapTo(const std::string& data, const FloatType gridSize)
   IO::TestParserStatus status;
 
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -1284,7 +1285,8 @@ TEST_CASE("BrushNodeTest.moveEdgesFail_2361")
 
   IO::TestParserStatus status;
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status);
+  auto nodes =
+    IO::NodeReader::read(data, MapFormat::Standard, worldBounds, {}, {}, status);
   REQUIRE(nodes.size() == 1u);
 
   Brush brush = static_cast<BrushNode*>(nodes.front())->brush();
@@ -1375,7 +1377,7 @@ TEST_CASE("BrushTest.convexMergeCrash_2789")
 
   IO::TestParserStatus status;
 
-  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   REQUIRE(!nodes.empty());
 
   std::vector<vm::vec3> points;
@@ -1443,7 +1445,7 @@ TEST_CASE("BrushTest.convexMergeIncorrectResult_2789")
   IO::TestParserStatus status;
 
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
   REQUIRE(nodes.size() == 28);
 
   std::vector<vm::vec3> points;
@@ -1551,9 +1553,9 @@ TEST_CASE("BrushTest.subtractTruncatedCones")
 
   IO::TestParserStatus status;
   const std::vector<Node*> minuendNodes =
-    IO::NodeReader::read(minuendStr, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(minuendStr, MapFormat::Valve, worldBounds, {}, {}, status);
   const std::vector<Node*> subtrahendNodes =
-    IO::NodeReader::read(subtrahendStr, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(subtrahendStr, MapFormat::Valve, worldBounds, {}, {}, status);
 
   const Brush& minuend = static_cast<BrushNode*>(minuendNodes.front())->brush();
   const Brush& subtrahend = static_cast<BrushNode*>(subtrahendNodes.front())->brush();
@@ -1590,9 +1592,9 @@ TEST_CASE("BrushTest.subtractDome")
 
   IO::TestParserStatus status;
   const std::vector<Node*> minuendNodes =
-    IO::NodeReader::read(minuendStr, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(minuendStr, MapFormat::Standard, worldBounds, {}, {}, status);
   const std::vector<Node*> subtrahendNodes = IO::NodeReader::read(
-    subtrahendStr.str(), MapFormat::Standard, worldBounds, {}, status);
+    subtrahendStr.str(), MapFormat::Standard, worldBounds, {}, {}, status);
 
   const Brush& minuend = static_cast<BrushNode*>(minuendNodes.front())->brush();
   const Brush& subtrahend = static_cast<BrushNode*>(subtrahendNodes.front())->brush();
@@ -1690,9 +1692,9 @@ TEST_CASE("BrushTest.subtractPipeFromCubeWithMissingFragments")
 
   IO::TestParserStatus status;
   const std::vector<Node*> minuendNodes =
-    IO::NodeReader::read(minuendStr, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(minuendStr, MapFormat::Standard, worldBounds, {}, {}, status);
   const std::vector<Node*> subtrahendNodes =
-    IO::NodeReader::read(subtrahendStr, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(subtrahendStr, MapFormat::Standard, worldBounds, {}, {}, status);
 
   const Brush& minuend = static_cast<BrushNode*>(minuendNodes.front())->brush();
   const Brush& subtrahend = static_cast<BrushNode*>(subtrahendNodes.front())->brush();
@@ -1730,7 +1732,7 @@ TEST_CASE("BrushTest.healEdgesCrash")
 
   IO::TestParserStatus status;
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(brushString, MapFormat::Valve, worldBounds, {}, status);
+    IO::NodeReader::read(brushString, MapFormat::Valve, worldBounds, {}, {}, status);
   const auto* brushNode = dynamic_cast<BrushNode*>(nodes.front());
   REQUIRE(brushNode != nullptr);
   const auto brush = brushNode->brush();
@@ -1790,7 +1792,7 @@ TEST_CASE("BrushTest.healEdgesCrash2")
 
   IO::TestParserStatus status;
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(brushString, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(brushString, MapFormat::Standard, worldBounds, {}, {}, status);
   const auto* brushNode = dynamic_cast<BrushNode*>(nodes.front());
   REQUIRE(brushNode != nullptr);
   const auto brush = brushNode->brush();
@@ -1932,7 +1934,7 @@ TEST_CASE("BrushTest.healEdgesCrash3")
 
   IO::TestParserStatus status;
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(brushString, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(brushString, MapFormat::Standard, worldBounds, {}, {}, status);
   const auto* brushNode = dynamic_cast<BrushNode*>(nodes.front());
   REQUIRE(brushNode != nullptr);
   const auto brush = brushNode->brush();
@@ -1978,7 +1980,7 @@ TEST_CASE("BrushTest.findInitialEdgeFail")
 
   IO::TestParserStatus status;
   const std::vector<Node*> nodes =
-    IO::NodeReader::read(brushString, MapFormat::Standard, worldBounds, {}, status);
+    IO::NodeReader::read(brushString, MapFormat::Standard, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 
   const auto* brushNode = dynamic_cast<BrushNode*>(nodes.front());
@@ -2030,7 +2032,7 @@ TEST_CASE("BrushTest.headEdgesFail")
 
   auto status = IO::TestParserStatus{};
   const auto nodes =
-    IO::NodeReader::read(brushString, MapFormat::Quake2, worldBounds, {}, status);
+    IO::NodeReader::read(brushString, MapFormat::Quake2, worldBounds, {}, {}, status);
   CHECK(nodes.size() == 1u);
 }
 } // namespace Model

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -68,7 +68,7 @@ static bool canMoveBoundary(
       [](const BrushError) { return false; }));
 }
 
-TEST_CASE("BrushTest.constructBrushWithFaces", "[BrushTest]")
+TEST_CASE("BrushTest.constructBrushWithFaces")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -108,7 +108,7 @@ TEST_CASE("BrushTest.constructBrushWithFaces", "[BrushTest]")
   CHECK(brush.findFace(vm::vec3::neg_z()));
 }
 
-TEST_CASE("BrushTest.constructBrushWithRedundantFaces", "[BrushTest]")
+TEST_CASE("BrushTest.constructBrushWithRedundantFaces")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -125,7 +125,7 @@ TEST_CASE("BrushTest.constructBrushWithRedundantFaces", "[BrushTest]")
           .is_error());
 }
 
-TEST_CASE("BrushTest.clip", "[BrushTest]")
+TEST_CASE("BrushTest.clip")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -160,7 +160,7 @@ TEST_CASE("BrushTest.clip", "[BrushTest]")
   CHECK_FALSE(brush.findFace(right.boundary()));
 }
 
-TEST_CASE("BrushTest.moveBoundary", "[BrushTest]")
+TEST_CASE("BrushTest.moveBoundary")
 {
   const vm::bbox3 worldBounds(4096.0);
   Brush brush = Brush::create(
@@ -213,7 +213,7 @@ TEST_CASE("BrushTest.moveBoundary", "[BrushTest]")
   CHECK(brush.bounds().size().z() == 7.0);
 }
 
-TEST_CASE("BrushTest.resizePastWorldBounds", "[BrushTest]")
+TEST_CASE("BrushTest.resizePastWorldBounds")
 {
   const vm::bbox3 worldBounds(8192.0);
   const BrushBuilder builder(MapFormat::Standard, worldBounds);
@@ -237,7 +237,7 @@ TEST_CASE("BrushTest.resizePastWorldBounds", "[BrushTest]")
   CHECK(!canMoveBoundary(brush1, worldBounds, *rightFaceIndex, vm::vec3(8000, 0, 0)));
 }
 
-TEST_CASE("BrushTest.expand", "[BrushTest]")
+TEST_CASE("BrushTest.expand")
 {
   const vm::bbox3 worldBounds(8192.0);
   const BrushBuilder builder(MapFormat::Standard, worldBounds);
@@ -257,7 +257,7 @@ TEST_CASE("BrushTest.expand", "[BrushTest]")
   CHECK_THAT(brush1.vertexPositions(), Catch::UnorderedEquals(expectedVertices));
 }
 
-TEST_CASE("BrushTest.contract", "[BrushTest]")
+TEST_CASE("BrushTest.contract")
 {
   const vm::bbox3 worldBounds(8192.0);
   const BrushBuilder builder(MapFormat::Standard, worldBounds);
@@ -277,7 +277,7 @@ TEST_CASE("BrushTest.contract", "[BrushTest]")
   CHECK_THAT(brush1.vertexPositions(), Catch::UnorderedEquals(expectedVertices));
 }
 
-TEST_CASE("BrushTest.contractToZero", "[BrushTest]")
+TEST_CASE("BrushTest.contractToZero")
 {
   const vm::bbox3 worldBounds(8192.0);
   const BrushBuilder builder(MapFormat::Standard, worldBounds);
@@ -289,7 +289,7 @@ TEST_CASE("BrushTest.contractToZero", "[BrushTest]")
   CHECK(brush1.expand(worldBounds, -64, true).is_error());
 }
 
-TEST_CASE("BrushTest.moveVertex", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertex")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -339,7 +339,7 @@ TEST_CASE("BrushTest.moveVertex", "[BrushTest]")
   assertTexture("bottom", brush, p1, p3, p7, p5);
 }
 
-TEST_CASE("BrushTest.moveTetrahedronVertexToOpposideSide", "[BrushTest]")
+TEST_CASE("BrushTest.moveTetrahedronVertexToOpposideSide")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -364,7 +364,7 @@ TEST_CASE("BrushTest.moveTetrahedronVertexToOpposideSide", "[BrushTest]")
   CHECK(brush.fullySpecified());
 }
 
-TEST_CASE("BrushTest.moveVertexInwardWithoutMerges", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexInwardWithoutMerges")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -439,7 +439,7 @@ TEST_CASE("BrushTest.moveVertexInwardWithoutMerges", "[BrushTest]")
   CHECK(brush.hasFace({p9, p7, p4}));
 }
 
-TEST_CASE("BrushTest.moveVertexOutwardWithoutMerges", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexOutwardWithoutMerges")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -514,7 +514,7 @@ TEST_CASE("BrushTest.moveVertexOutwardWithoutMerges", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p5, p7, p9})));
 }
 
-TEST_CASE("BrushTest.moveVertexWithOneOuterNeighbourMerge", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexWithOneOuterNeighbourMerge")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -587,7 +587,7 @@ TEST_CASE("BrushTest.moveVertexWithOneOuterNeighbourMerge", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p9, p7, p4})));
 }
 
-TEST_CASE("BrushTest.moveVertexWithTwoOuterNeighbourMerges", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexWithTwoOuterNeighbourMerges")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -658,7 +658,7 @@ TEST_CASE("BrushTest.moveVertexWithTwoOuterNeighbourMerges", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p9, p4, p6})));
 }
 
-TEST_CASE("BrushTest.moveVertexWithAllOuterNeighbourMerges", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexWithAllOuterNeighbourMerges")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -727,7 +727,7 @@ TEST_CASE("BrushTest.moveVertexWithAllOuterNeighbourMerges", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p5, p7, p9, p6})));
 }
 
-TEST_CASE("BrushTest.moveVertexWithAllInnerNeighbourMerge", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexWithAllInnerNeighbourMerge")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -795,7 +795,7 @@ TEST_CASE("BrushTest.moveVertexWithAllInnerNeighbourMerge", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p4, p6, p7})));
 }
 
-TEST_CASE("BrushTest.moveVertexUpThroughPlane", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexUpThroughPlane")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -866,7 +866,7 @@ TEST_CASE("BrushTest.moveVertexUpThroughPlane", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p2, p6, p9})));
 }
 
-TEST_CASE("BrushTest.moveVertexOntoEdge", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexOntoEdge")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -934,7 +934,7 @@ TEST_CASE("BrushTest.moveVertexOntoEdge", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p4, p6, p7})));
 }
 
-TEST_CASE("BrushTest.moveVertexOntoIncidentVertex", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexOntoIncidentVertex")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -1002,7 +1002,7 @@ TEST_CASE("BrushTest.moveVertexOntoIncidentVertex", "[BrushTest]")
   CHECK(brush.hasFace(vm::polygon3d({p4, p6, p7})));
 }
 
-TEST_CASE("BrushTest.moveVertexOntoIncidentVertexInOppositeDirection", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexOntoIncidentVertexInOppositeDirection")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -1070,7 +1070,7 @@ TEST_CASE("BrushTest.moveVertexOntoIncidentVertexInOppositeDirection", "[BrushTe
   CHECK(brush.hasFace(vm::polygon3d({p3, p8, p5})));
 }
 
-TEST_CASE("BrushTest.moveVertexAndMergeColinearEdgesWithoutDeletingVertex", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexAndMergeColinearEdgesWithoutDeletingVertex")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -1209,7 +1209,7 @@ TEST_CASE(
   CHECK(brush.hasFace(vm::polygon3d({p5, p7, p9})));
 }
 
-TEST_CASE("BrushTest.moveVertexAndMergeColinearEdgesWithDeletingVertex", "[BrushTest]")
+TEST_CASE("BrushTest.moveVertexAndMergeColinearEdgesWithDeletingVertex")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -1279,7 +1279,7 @@ TEST_CASE("BrushTest.moveVertexAndMergeColinearEdgesWithDeletingVertex", "[Brush
   CHECK(brush.hasFace(vm::polygon3d({p5, p7, p8, p6})));
 }
 
-TEST_CASE("BrushTest.moveVerticesPastWorldBounds", "[BrushTest]")
+TEST_CASE("BrushTest.moveVerticesPastWorldBounds")
 {
   const vm::bbox3 worldBounds(8192.0);
   const BrushBuilder builder(MapFormat::Standard, worldBounds);
@@ -1359,7 +1359,7 @@ static void assertCanNotMoveVertex(
 
 // NOTE: Different than movePolygonRemainingPoint, because in this case we allow
 // point moves that flip the normal of the remaining polygon
-TEST_CASE("BrushTest.movePointRemainingPolygon", "[BrushTest]")
+TEST_CASE("BrushTest.movePointRemainingPolygon")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1422,7 +1422,7 @@ TEST_CASE("BrushTest.movePointRemainingPolygon", "[BrushTest]")
                                                         // quad, without moving through it
 }
 
-TEST_CASE("BrushTest.movePointRemainingPolyhedron", "[BrushTest]")
+TEST_CASE("BrushTest.movePointRemainingPolyhedron")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1461,7 +1461,7 @@ TEST_CASE("BrushTest.movePointRemainingPolyhedron", "[BrushTest]")
 
 // remove vertex tests
 
-TEST_CASE("BrushTest.removeSingleVertex", "[BrushTest]")
+TEST_CASE("BrushTest.removeSingleVertex")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1538,7 +1538,7 @@ TEST_CASE("BrushTest.removeSingleVertex", "[BrushTest]")
     worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, -32.0, -32.0))));
 }
 
-TEST_CASE("BrushTest.removeMultipleVertices", "[BrushTest]")
+TEST_CASE("BrushTest.removeMultipleVertices")
 {
   const vm::bbox3 worldBounds(4096.0);
   BrushBuilder builder(MapFormat::Standard, worldBounds);
@@ -1582,7 +1582,7 @@ TEST_CASE("BrushTest.removeMultipleVertices", "[BrushTest]")
 
 // "Move edge" tests
 
-TEST_CASE("BrushTest.moveEdge", "[BrushTest]")
+TEST_CASE("BrushTest.moveEdge")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1671,7 +1671,7 @@ static void assertCanNotMoveEdges(
   CHECK_FALSE(brush.canMoveEdges(worldBounds, edges, delta));
 }
 
-TEST_CASE("BrushTest.moveEdgeRemainingPolyhedron", "[BrushTest]")
+TEST_CASE("BrushTest.moveEdgeRemainingPolyhedron")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1703,7 +1703,7 @@ TEST_CASE("BrushTest.moveEdgeRemainingPolyhedron", "[BrushTest]")
 }
 
 // Same as above, but moving 2 edges
-TEST_CASE("BrushTest.moveEdgesRemainingPolyhedron", "[BrushTest]")
+TEST_CASE("BrushTest.moveEdgesRemainingPolyhedron")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1734,7 +1734,7 @@ TEST_CASE("BrushTest.moveEdgesRemainingPolyhedron", "[BrushTest]")
 
 // "Move face" tests
 
-TEST_CASE("BrushTest.moveFace", "[BrushTest]")
+TEST_CASE("BrushTest.moveFace")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1776,7 +1776,7 @@ TEST_CASE("BrushTest.moveFace", "[BrushTest]")
     CHECK(newFacePositions[0].hasVertex(face.vertices()[i]));
 }
 
-TEST_CASE("BrushNodeTest.cannotMoveFace", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.cannotMoveFace")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1864,7 +1864,7 @@ static void assertCanNotMoveTopFaceBeyond127UnitsDown(const Brush& brush)
   assertCanNotMoveTopFace(brush, vm::vec3(256, 0, -129));
 }
 
-TEST_CASE("BrushTest.movePolygonRemainingPoint", "[BrushTest]")
+TEST_CASE("BrushTest.movePolygonRemainingPoint")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1885,7 +1885,7 @@ TEST_CASE("BrushTest.movePolygonRemainingPoint", "[BrushTest]")
   assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 }
 
-TEST_CASE("BrushTest.movePolygonRemainingEdge", "[BrushTest]")
+TEST_CASE("BrushTest.movePolygonRemainingEdge")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1906,7 +1906,7 @@ TEST_CASE("BrushTest.movePolygonRemainingEdge", "[BrushTest]")
   assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 }
 
-TEST_CASE("BrushTest.movePolygonRemainingPolygon", "[BrushTest]")
+TEST_CASE("BrushTest.movePolygonRemainingPolygon")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1917,7 +1917,7 @@ TEST_CASE("BrushTest.movePolygonRemainingPolygon", "[BrushTest]")
   assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 }
 
-TEST_CASE("BrushTest.movePolygonRemainingPolygon2", "[BrushTest]")
+TEST_CASE("BrushTest.movePolygonRemainingPolygon2")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1943,7 +1943,7 @@ TEST_CASE("BrushTest.movePolygonRemainingPolygon2", "[BrushTest]")
   assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 }
 
-TEST_CASE("BrushTest.movePolygonRemainingPolygon_DisallowVertexCombining", "[BrushTest]")
+TEST_CASE("BrushTest.movePolygonRemainingPolygon_DisallowVertexCombining")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -1984,7 +1984,7 @@ TEST_CASE("BrushTest.movePolygonRemainingPolygon_DisallowVertexCombining", "[Bru
   assertCanNotMoveFace(brush, topFaceIndex, vm::vec3(0, 0, -129));
 }
 
-TEST_CASE("BrushTest.movePolygonRemainingPolyhedron", "[BrushTest]")
+TEST_CASE("BrushTest.movePolygonRemainingPolyhedron")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -2045,7 +2045,7 @@ TEST_CASE("BrushTest.movePolygonRemainingPolyhedron", "[BrushTest]")
     vm::vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
 }
 
-TEST_CASE("BrushTest.moveTwoFaces", "[BrushTest]")
+TEST_CASE("BrushTest.moveTwoFaces")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -2105,7 +2105,7 @@ TEST_CASE("BrushTest.moveTwoFaces", "[BrushTest]")
 
 // "Move polyhedron" tests
 
-TEST_CASE("BrushNodeTest.movePolyhedronRemainingEdge", "[BrushNodeTest]")
+TEST_CASE("BrushNodeTest.movePolyhedronRemainingEdge")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -2170,7 +2170,7 @@ class UVLockTest
   MapFormat param = F;
 };
 
-TEST_CASE("moveFaceWithUVLock", "[UVLockTest]")
+TEST_CASE("moveFaceWithUVLock")
 {
   auto format = GENERATE(MapFormat::Valve, MapFormat::Standard);
 
@@ -2250,7 +2250,7 @@ TEST_CASE("moveFaceWithUVLock", "[UVLockTest]")
   }
 }
 
-TEST_CASE("BrushTest.subtractCuboidFromCuboid", "[BrushTest]")
+TEST_CASE("BrushTest.subtractCuboidFromCuboid")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -2389,7 +2389,7 @@ TEST_CASE("BrushTest.subtractCuboidFromCuboid", "[BrushTest]")
     == minuendTexture);
 }
 
-TEST_CASE("BrushTest.subtractDisjoint", "[BrushTest]")
+TEST_CASE("BrushTest.subtractDisjoint")
 {
   const vm::bbox3 worldBounds(4096.0);
 
@@ -2412,7 +2412,7 @@ TEST_CASE("BrushTest.subtractDisjoint", "[BrushTest]")
     subtraction.vertexPositions(), Catch::UnorderedEquals(brush1.vertexPositions()));
 }
 
-TEST_CASE("BrushTest.subtractEnclosed", "[BrushTest]")
+TEST_CASE("BrushTest.subtractEnclosed")
 {
   const vm::bbox3 worldBounds(4096.0);
 

--- a/common/test/src/Model/EntityNodeIndexTest.cpp
+++ b/common/test/src/Model/EntityNodeIndexTest.cpp
@@ -44,7 +44,7 @@ static std::vector<EntityNodeBase*> findNumberedExact(
   return index.findEntityNodes(EntityNodeIndexQuery::numbered(name), value);
 }
 
-TEST_CASE("EntityNodeIndexTest.addEntityNode", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.addEntityNode")
 {
   EntityNodeIndex index;
 
@@ -71,7 +71,7 @@ TEST_CASE("EntityNodeIndexTest.addEntityNode", "[EntityNodeIndexTest]")
   delete entity2;
 }
 
-TEST_CASE("EntityNodeIndexTest.removeEntityNode", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.removeEntityNode")
 {
   EntityNodeIndex index;
 
@@ -93,7 +93,7 @@ TEST_CASE("EntityNodeIndexTest.removeEntityNode", "[EntityNodeIndexTest]")
   delete entity2;
 }
 
-TEST_CASE("EntityNodeIndexTest.addProperty", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.addProperty")
 {
   EntityNodeIndex index;
 
@@ -131,7 +131,7 @@ TEST_CASE("EntityNodeIndexTest.addProperty", "[EntityNodeIndexTest]")
   delete entity2;
 }
 
-TEST_CASE("EntityNodeIndexTest.removeProperty", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.removeProperty")
 {
   EntityNodeIndex index;
 
@@ -156,7 +156,7 @@ TEST_CASE("EntityNodeIndexTest.removeProperty", "[EntityNodeIndexTest]")
   delete entity2;
 }
 
-TEST_CASE("EntityNodeIndexTest.addNumberedEntityProperty", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.addNumberedEntityProperty")
 {
   EntityNodeIndex index;
 
@@ -174,7 +174,7 @@ TEST_CASE("EntityNodeIndexTest.addNumberedEntityProperty", "[EntityNodeIndexTest
   delete entity1;
 }
 
-TEST_CASE("EntityNodeIndexTest.addRemoveFloatProperty", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.addRemoveFloatProperty")
 {
   EntityNodeIndex index;
 
@@ -191,7 +191,7 @@ TEST_CASE("EntityNodeIndexTest.addRemoveFloatProperty", "[EntityNodeIndexTest]")
   delete entity1;
 }
 
-TEST_CASE("EntityNodeIndexTest.allKeys", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.allKeys")
 {
   EntityNodeIndex index;
 
@@ -207,7 +207,7 @@ TEST_CASE("EntityNodeIndexTest.allKeys", "[EntityNodeIndexTest]")
     index.allKeys(), Catch::UnorderedEquals(std::vector<std::string>{"test", "other"}));
 }
 
-TEST_CASE("EntityNodeIndexTest.allValuesForKeys", "[EntityNodeIndexTest]")
+TEST_CASE("EntityNodeIndexTest.allValuesForKeys")
 {
   EntityNodeIndex index;
 

--- a/common/test/src/Model/EntityNodeLinkTest.cpp
+++ b/common/test/src/Model/EntityNodeLinkTest.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("EntityNodeLinkTest.testCreateLink", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testCreateLink")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(Model::Entity());
@@ -55,7 +55,7 @@ TEST_CASE("EntityNodeLinkTest.testCreateLink", "[EntityNodeLinkTest]")
   CHECK(sources.front() == sourceNode);
 }
 
-TEST_CASE("EntityNodeLinkTest.testCreateMultiSourceLink", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testCreateMultiSourceLink")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode1 = new Model::EntityNode(Model::Entity());
@@ -85,7 +85,7 @@ TEST_CASE("EntityNodeLinkTest.testCreateMultiSourceLink", "[EntityNodeLinkTest]"
   CHECK(kdl::vec_contains(sources, sourceNode2));
 }
 
-TEST_CASE("EntityNodeLinkTest.testCreateMultiTargetLink", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testCreateMultiTargetLink")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(Model::Entity());
@@ -120,7 +120,7 @@ TEST_CASE("EntityNodeLinkTest.testCreateMultiTargetLink", "[EntityNodeLinkTest]"
   CHECK(sources2.front() == sourceNode);
 }
 
-TEST_CASE("EntityNodeLinkTest.testLoadLink", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testLoadLink")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -140,7 +140,7 @@ TEST_CASE("EntityNodeLinkTest.testLoadLink", "[EntityNodeLinkTest]")
   CHECK(sources.front() == sourceNode);
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveLinkByChangingSource", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveLinkByChangingSource")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -160,7 +160,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveLinkByChangingSource", "[EntityNodeLinkT
   CHECK(sources.empty());
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveLinkByChangingTarget", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveLinkByChangingTarget")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -180,7 +180,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveLinkByChangingTarget", "[EntityNodeLinkT
   CHECK(sources.empty());
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveLinkByRemovingSource", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveLinkByRemovingSource")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -202,7 +202,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveLinkByRemovingSource", "[EntityNodeLinkT
   delete sourceNode;
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveLinkByRemovingTarget", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveLinkByRemovingTarget")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -224,7 +224,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveLinkByRemovingTarget", "[EntityNodeLinkT
   delete targetNode;
 }
 
-TEST_CASE("EntityNodeLinkTest.testCreateKillLink", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testCreateKillLink")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(Model::Entity());
@@ -245,7 +245,7 @@ TEST_CASE("EntityNodeLinkTest.testCreateKillLink", "[EntityNodeLinkTest]")
   CHECK(sources.front() == sourceNode);
 }
 
-TEST_CASE("EntityNodeLinkTest.testLoadKillLink", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testLoadKillLink")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -265,7 +265,7 @@ TEST_CASE("EntityNodeLinkTest.testLoadKillLink", "[EntityNodeLinkTest]")
   CHECK(sources.front() == sourceNode);
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByChangingSource", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByChangingSource")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -285,7 +285,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByChangingSource", "[EntityNodeL
   CHECK(sources.empty());
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByChangingTarget", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByChangingTarget")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -305,7 +305,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByChangingTarget", "[EntityNodeL
   CHECK(sources.empty());
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByRemovingSource", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByRemovingSource")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(
@@ -327,7 +327,7 @@ TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByRemovingSource", "[EntityNodeL
   delete sourceNode;
 }
 
-TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByRemovingTarget", "[EntityNodeLinkTest]")
+TEST_CASE("EntityNodeLinkTest.testRemoveKillLinkByRemovingTarget")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   EntityNode* sourceNode = new Model::EntityNode(

--- a/common/test/src/Model/GameTest.cpp
+++ b/common/test/src/Model/GameTest.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("GameTest.findTextureCollections", "[GameTest]")
+TEST_CASE("GameTest.findTextureCollections")
 {
   auto config = GameConfig{
     "Quake2",
@@ -70,7 +70,7 @@ TEST_CASE("GameTest.findTextureCollections", "[GameTest]")
       IO::Path("textures"), IO::Path("textures/e1m1"), IO::Path("textures/e1m1/f1")}));
 }
 
-TEST_CASE("GameTest.loadCorruptPackages", "[GameTest]")
+TEST_CASE("GameTest.loadCorruptPackages")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/2496
 
@@ -94,7 +94,7 @@ TEST_CASE("GameTest.loadCorruptPackages", "[GameTest]")
   }
 }
 
-TEST_CASE("GameTest.loadQuake3Shaders", "[GameTest]")
+TEST_CASE("GameTest.loadQuake3Shaders")
 {
   const auto configPath =
     IO::Disk::getCurrentWorkingDir() + IO::Path("fixture/games//Quake3/GameConfig.cfg");

--- a/common/test/src/Model/GroupNodeTest.cpp
+++ b/common/test/src/Model/GroupNodeTest.cpp
@@ -160,7 +160,7 @@ TEST_CASE("GroupNodeTest.canRemoveChild")
   CHECK(groupNode.canRemoveChild(&patchNode));
 }
 
-TEST_CASE("GroupNodeTest.updateLinkedGroups", "[GroupNodeTest]")
+TEST_CASE("GroupNodeTest.updateLinkedGroups")
 {
   const auto worldBounds = vm::bbox3(8192.0);
 
@@ -232,7 +232,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups", "[GroupNodeTest]")
   }
 }
 
-TEST_CASE("GroupNodeTest.updateNestedLinkedGroups", "[GroupNodeTest]")
+TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
 {
   const auto worldBounds = vm::bbox3(8192.0);
 
@@ -320,7 +320,7 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups", "[GroupNodeTest]")
   }
 }
 
-TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively", "[GroupNodeTest]")
+TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively")
 {
   const auto worldBounds = vm::bbox3(8192.0);
 
@@ -393,7 +393,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively", "[GroupNodeTest]")
     [](const auto&) { FAIL(); }));
 }
 
-TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds", "[GroupNodeTest]")
+TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds")
 {
   const auto worldBounds = vm::bbox3(8192.0);
 

--- a/common/test/src/Model/GroupNodeTest.cpp
+++ b/common/test/src/Model/GroupNodeTest.cpp
@@ -131,6 +131,18 @@ TEST_CASE("GroupNodeTest.canAddChild")
   CHECK(groupNode.canAddChild(&entityNode));
   CHECK(groupNode.canAddChild(&brushNode));
   CHECK(groupNode.canAddChild(&patchNode));
+
+  SECTION("Recursive linked groups")
+  {
+    auto linkedGroupNode = std::make_unique<GroupNode>(Group{"group"});
+    setLinkedGroupId(groupNode, "linked_group_id");
+    setLinkedGroupId(*linkedGroupNode, *groupNode.group().linkedGroupId());
+    CHECK_FALSE(groupNode.canAddChild(linkedGroupNode.get()));
+
+    auto outerGroupNode = GroupNode{Group{"outer_group"}};
+    outerGroupNode.addChild(linkedGroupNode.release());
+    CHECK_FALSE(groupNode.canAddChild(&outerGroupNode));
+  }
 }
 
 TEST_CASE("GroupNodeTest.canRemoveChild")

--- a/common/test/src/Model/GroupTest.cpp
+++ b/common/test/src/Model/GroupTest.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("GroupTest.transform", "[GroupNodeTest]")
+TEST_CASE("GroupTest.transform")
 {
   auto group = Group{"name"};
   REQUIRE(group.transformation() == vm::mat4x4());

--- a/common/test/src/Model/NodeTest.cpp
+++ b/common/test/src/Model/NodeTest.cpp
@@ -274,7 +274,7 @@ public:
   ~DestroyableNode() override { m_destroyed = true; }
 };
 
-TEST_CASE("NodeTest.destroyChild", "[NodeTest]")
+TEST_CASE("NodeTest.destroyChild")
 {
   TestNode* root = new TestNode();
   bool childDestroyed = false;
@@ -286,7 +286,7 @@ TEST_CASE("NodeTest.destroyChild", "[NodeTest]")
   CHECK(childDestroyed);
 }
 
-TEST_CASE("NodeTest.addRemoveChild", "[NodeTest]")
+TEST_CASE("NodeTest.addRemoveChild")
 {
   MockNode root;
   MockNode* child = new MockNode();
@@ -406,7 +406,7 @@ TEST_CASE("NodeTest.replaceChildren")
   CHECK(child3->parent() == &root);
 }
 
-TEST_CASE("NodeTest.partialSelection", "[NodeTest]")
+TEST_CASE("NodeTest.partialSelection")
 {
   TestNode root;
   TestNode* child1 = new TestNode();
@@ -447,7 +447,7 @@ TEST_CASE("NodeTest.partialSelection", "[NodeTest]")
   CHECK(root.descendantSelectionCount() == 2u);
 }
 
-TEST_CASE("NodeTest.isAncestorOf", "[NodeTest]")
+TEST_CASE("NodeTest.isAncestorOf")
 {
   TestNode root;
   TestNode* child1 = new TestNode();
@@ -502,7 +502,7 @@ TEST_CASE("NodeTest.isAncestorOf", "[NodeTest]")
     std::vector<Node*>{&root, child1, child2, grandChild1_1, grandChild1_2}));
 }
 
-TEST_CASE("NodeTest.isDescendantOf", "[NodeTest]")
+TEST_CASE("NodeTest.isDescendantOf")
 {
   TestNode root;
   TestNode* child1 = new TestNode();
@@ -603,7 +603,7 @@ const auto constNodeTestVisitor = kdl::overload(
   [](const BrushNode*) { return Visited::Brush; },
   [](const PatchNode*) { return Visited::Patch; });
 
-TEST_CASE("NodeTest.accept", "[NodeTest]")
+TEST_CASE("NodeTest.accept")
 {
   const auto worldBounds = vm::bbox3(8192.0);
 
@@ -661,7 +661,7 @@ TEST_CASE("NodeTest.accept", "[NodeTest]")
   }
 }
 
-TEST_CASE("NodeTest.acceptAndVisitChildren", "[NodeTest]")
+TEST_CASE("NodeTest.acceptAndVisitChildren")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   auto* layer = world.defaultLayer();
@@ -711,7 +711,7 @@ TEST_CASE("NodeTest.acceptAndVisitChildren", "[NodeTest]")
     collectRecursively(*entityNode1), Catch::Equals(std::vector<Node*>{entityNode1}));
 }
 
-TEST_CASE("NodeTest.visitParent", "[NodeTest]")
+TEST_CASE("NodeTest.visitParent")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   auto* layer = world.defaultLayer();
@@ -737,7 +737,7 @@ static auto makeCollectVisitedNodesVisitor(std::vector<Node*>& visited)
     [&](PatchNode* patch) { visited.push_back(patch); });
 }
 
-TEST_CASE("NodeTest.visitAll", "[NodeTest]")
+TEST_CASE("NodeTest.visitAll")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   LayerNode layer(Layer("name"));
@@ -751,7 +751,7 @@ TEST_CASE("NodeTest.visitAll", "[NodeTest]")
   CHECK_THAT(visited, Catch::Equals(toVisit));
 }
 
-TEST_CASE("NodeTest.visitChildren", "[NodeTest]")
+TEST_CASE("NodeTest.visitChildren")
 {
   WorldNode world({}, {}, MapFormat::Standard);
   auto* layer = world.defaultLayer();
@@ -783,7 +783,7 @@ TEST_CASE("NodeTest.visitChildren", "[NodeTest]")
   }
 }
 
-TEST_CASE("NodeTest.pathFrom", "[NodeTest]")
+TEST_CASE("NodeTest.pathFrom")
 {
   auto root = TestNode{};
   auto& child1 = root.addChild(new TestNode{});
@@ -802,7 +802,7 @@ TEST_CASE("NodeTest.pathFrom", "[NodeTest]")
   CHECK(root.pathFrom(root) == NodePath{{}});
 }
 
-TEST_CASE("Nodepath.resolvePath", "[NodeTest]")
+TEST_CASE("Nodepath.resolvePath")
 {
   auto root = TestNode{};
   auto& child1 = root.addChild(new TestNode{});

--- a/common/test/src/Model/PolyhedronRegressionTest.cpp
+++ b/common/test/src/Model/PolyhedronRegressionTest.cpp
@@ -50,7 +50,7 @@ using PFace = Polyhedron3d::Face;
 using EdgeInfo = std::pair<vm::vec3d, vm::vec3d>;
 using EdgeInfoList = std::vector<EdgeInfo>;
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(-64.0, -45.5049, -34.4752),
@@ -67,7 +67,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 7u);
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints2", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints2")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(-64.0, 48.7375, -34.4752),
@@ -88,7 +88,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints2", "[PolyhedronTest]")
   }
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints3", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints3")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(-64, -64, -48),
@@ -104,7 +104,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints3", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 5u);
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints4", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints4")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(-64, 64, -48),
@@ -127,7 +127,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints4", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 13);
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints5", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints5")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(-64, -64, -64),
@@ -146,7 +146,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints5", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 8u);
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints6", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints6")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(-32, -16, -32),
@@ -163,7 +163,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints6", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 7u);
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints7", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints7")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(12.8616, -36.5751, 32),
@@ -180,7 +180,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints7", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 6u);
 }
 
-TEST_CASE("PolyhedronTest.convexHullWithFailingPoints8", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.convexHullWithFailingPoints8")
 {
   // Cause of https://github.com/TrenchBroom/TrenchBroom/issues/1469
   // See also BrushTest.subtractTruncatedCones
@@ -202,7 +202,7 @@ TEST_CASE("PolyhedronTest.convexHullWithFailingPoints8", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 9u);
 }
 
-TEST_CASE("PolyhedronTest.testAddManyPointsCrash", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.testAddManyPointsCrash")
 {
   const vm::vec3d p1(8, 10, 0);
   const vm::vec3d p2(0, 24, 0);
@@ -368,7 +368,7 @@ TEST_CASE("PolyhedronTest.testAddManyPointsCrash", "[PolyhedronTest]")
   CHECK(p.hasFace({p7, p5, p6}));
 }
 
-TEST_CASE("PolyhedronTest.testAdd8PointsCrash", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.testAdd8PointsCrash")
 {
   const auto vertices = std::vector<vm::vec3>({
     // a horizontal rectangle
@@ -388,7 +388,7 @@ TEST_CASE("PolyhedronTest.testAdd8PointsCrash", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 6u);
 }
 
-TEST_CASE("PolyhedronTest.crashWhileAddingPoints1", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.crashWhileAddingPoints1")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(224, 336, 0),
@@ -404,7 +404,7 @@ TEST_CASE("PolyhedronTest.crashWhileAddingPoints1", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 6u);
 }
 
-TEST_CASE("PolyhedronTest.crashWhileAddingPoints2", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.crashWhileAddingPoints2")
 {
   const vm::vec3d p1(256, 39, 160);
   const vm::vec3d p4(256, 39, 64);
@@ -444,7 +444,7 @@ TEST_CASE("PolyhedronTest.crashWhileAddingPoints2", "[PolyhedronTest]")
   CHECK(p.hasFace({p6, p14, p15, p9}));
 }
 
-TEST_CASE("PolyhedronTest.crashWhileAddingPoints3", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.crashWhileAddingPoints3")
 {
   const auto vertices = std::vector<vm::vec3>({
     vm::vec3d(256, 39, 160),
@@ -468,7 +468,7 @@ TEST_CASE("PolyhedronTest.crashWhileAddingPoints3", "[PolyhedronTest]")
   CHECK(p.vertexCount() == 9u);
 }
 
-TEST_CASE("PolyhedronTest.crashWhileAddingPoints4", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.crashWhileAddingPoints4")
 {
   //
   // p2 .  |  . p3
@@ -487,7 +487,7 @@ TEST_CASE("PolyhedronTest.crashWhileAddingPoints4", "[PolyhedronTest]")
   CHECK(p.hasFace({p1, p2, p3, p4}));
 }
 
-TEST_CASE("PolyhedronTest.badClip", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.badClip")
 {
   std::vector<vm::vec3d> polyVertices;
   vm::parse_all<double, 3>(
@@ -522,7 +522,7 @@ TEST_CASE("PolyhedronTest.badClip", "[PolyhedronTest]")
   CHECK_NOTHROW(poly.clip(plane));
 }
 
-TEST_CASE("PolyhedronTest.clipWithInvalidSeam", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipWithInvalidSeam")
 {
   // see https://github.com/TrenchBroom/TrenchBroom/issues/1801
   // see BrushTest::invalidBrush1801
@@ -577,7 +577,7 @@ TEST_CASE("PolyhedronTest.clipWithInvalidSeam", "[PolyhedronTest]")
     vm::vec3d(-184.0, 1428.0, 237.0))));
 }
 
-TEST_CASE("PolyhedronTest.subtractFailWithMissingFragments", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractFailWithMissingFragments")
 {
   const std::vector<vm::vec3d> minuendVertices{
     vm::vec3d(-1056, 864, -192),
@@ -630,7 +630,7 @@ TEST_CASE(
   CHECK(result.size() == 3u);
 }
 
-TEST_CASE("PolyhedronTest.addVertexToPolygonAndAllFacesCoplanar", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.addVertexToPolygonAndAllFacesCoplanar")
 {
   auto p = Polyhedron3d{
     vm::vec3{-64.0, 64.0, -16.0},

--- a/common/test/src/Model/PolyhedronTest.cpp
+++ b/common/test/src/Model/PolyhedronTest.cpp
@@ -88,13 +88,13 @@ static bool mutuallyNotIntersects(const Polyhedron3d& lhs, const Polyhedron3d& r
   return !lhs.intersects(rhs) && !rhs.intersects(lhs);
 }
 
-TEST_CASE("PolyhedronTest.constructEmpty", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructEmpty")
 {
   Polyhedron3d p;
   CHECK(p.empty());
 }
 
-TEST_CASE("PolyhedronTest.constructWithOnePoint", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWithOnePoint")
 {
   const vm::vec3d p1(-8.0, -8.0, -8.0);
 
@@ -112,7 +112,7 @@ TEST_CASE("PolyhedronTest.constructWithOnePoint", "[PolyhedronTest]")
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructWithTwoIdenticalPoints", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWithTwoIdenticalPoints")
 {
   const vm::vec3d p1(-8.0, -8.0, -8.0);
 
@@ -130,7 +130,7 @@ TEST_CASE("PolyhedronTest.constructWithTwoIdenticalPoints", "[PolyhedronTest]")
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructWithTwoPoints", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWithTwoPoints")
 {
   const vm::vec3d p1(0.0, 0.0, 0.0);
   const vm::vec3d p2(3.0, 0.0, 0.0);
@@ -150,7 +150,7 @@ TEST_CASE("PolyhedronTest.constructWithTwoPoints", "[PolyhedronTest]")
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructWithThreeColinearPoints", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWithThreeColinearPoints")
 {
   const vm::vec3d p1(0.0, 0.0, 0.0);
   const vm::vec3d p2(3.0, 0.0, 0.0);
@@ -171,7 +171,7 @@ TEST_CASE("PolyhedronTest.constructWithThreeColinearPoints", "[PolyhedronTest]")
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructWithThreePoints", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWithThreePoints")
 {
   const vm::vec3d p1(0.0, 0.0, 0.0);
   const vm::vec3d p2(3.0, 0.0, 0.0);
@@ -193,7 +193,7 @@ TEST_CASE("PolyhedronTest.constructWithThreePoints", "[PolyhedronTest]")
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructTriangleWithContainedPoint", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructTriangleWithContainedPoint")
 {
   const vm::vec3d p1(0.0, 0.0, 0.0);
   const vm::vec3d p2(6.0, 0.0, 0.0);
@@ -216,7 +216,7 @@ TEST_CASE("PolyhedronTest.constructTriangleWithContainedPoint", "[PolyhedronTest
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructWithFourCoplanarPoints", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWithFourCoplanarPoints")
 {
   const vm::vec3d p1(0.0, 0.0, 0.0);
   const vm::vec3d p2(6.0, 0.0, 0.0);
@@ -239,7 +239,7 @@ TEST_CASE("PolyhedronTest.constructWithFourCoplanarPoints", "[PolyhedronTest]")
   CHECK(hasVertices(p, points));
 }
 
-TEST_CASE("PolyhedronTest.constructWith4Points", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructWith4Points")
 {
   const vm::vec3d p1(0.0, 0.0, 8.0);
   const vm::vec3d p2(8.0, 0.0, 0.0);
@@ -272,7 +272,7 @@ TEST_CASE("PolyhedronTest.constructWith4Points", "[PolyhedronTest]")
   CHECK(p.hasFace({p1, p4, p3}));
 }
 
-TEST_CASE("PolyhedronTest.constructRectangleWithRedundantPoint", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructRectangleWithRedundantPoint")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1659
   /*
@@ -299,7 +299,7 @@ TEST_CASE("PolyhedronTest.constructRectangleWithRedundantPoint", "[PolyhedronTes
   CHECK_FALSE(p.hasVertex(p5));
 }
 
-TEST_CASE("PolyhedronTest.constructTrapezoidWithRedundantPoint", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructTrapezoidWithRedundantPoint")
 {
   /*
    p4    p3 p5
@@ -325,7 +325,7 @@ TEST_CASE("PolyhedronTest.constructTrapezoidWithRedundantPoint", "[PolyhedronTes
   CHECK_FALSE(p.hasVertex(p3));
 }
 
-TEST_CASE("PolyhedronTest.constructPolygonWithRedundantPoint", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructPolygonWithRedundantPoint")
 {
   auto p = Polyhedron3d{
     vm::vec3{-64.0, 64.0, -16.0},
@@ -348,7 +348,7 @@ TEST_CASE("PolyhedronTest.constructPolygonWithRedundantPoint", "[PolyhedronTest]
     0.0));
 }
 
-TEST_CASE("PolyhedronTest.constructTetrahedonWithRedundantPoint", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructTetrahedonWithRedundantPoint")
 {
   const vm::vec3d p1(0.0, 4.0, 8.0);
   const vm::vec3d p2(8.0, 0.0, 0.0);
@@ -382,7 +382,7 @@ TEST_CASE("PolyhedronTest.constructTetrahedonWithRedundantPoint", "[PolyhedronTe
   CHECK(p.hasFace({p5, p4, p3}));
 }
 
-TEST_CASE("PolyhedronTest.constructTetrahedonWithCoplanarFaces", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructTetrahedonWithCoplanarFaces")
 {
   const vm::vec3d p1(0.0, 0.0, 8.0);
   const vm::vec3d p2(8.0, 0.0, 0.0);
@@ -414,7 +414,7 @@ TEST_CASE("PolyhedronTest.constructTetrahedonWithCoplanarFaces", "[PolyhedronTes
   CHECK(p.hasFace({p5, p4, p3}));
 }
 
-TEST_CASE("PolyhedronTest.constructCube", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.constructCube")
 {
   const vm::vec3d p1(-8.0, -8.0, -8.0);
   const vm::vec3d p2(-8.0, -8.0, +8.0);
@@ -465,7 +465,7 @@ TEST_CASE("PolyhedronTest.constructCube", "[PolyhedronTest]")
   CHECK(p.hasFace({p2, p6, p8, p4}));
 }
 
-TEST_CASE("PolyhedronTest.copy", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.copy")
 {
   const vm::vec3d p1(0.0, 0.0, 8.0);
   const vm::vec3d p2(8.0, 0.0, 0.0);
@@ -480,7 +480,7 @@ TEST_CASE("PolyhedronTest.copy", "[PolyhedronTest]")
     Polyhedron3d({p1, p2, p3, p4}) == (Polyhedron3d() = Polyhedron3d({p1, p2, p3, p4})));
 }
 
-TEST_CASE("PolyhedronTest.swap", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.swap")
 {
   const vm::vec3d p1(0.0, 0.0, 8.0);
   const vm::vec3d p2(8.0, 0.0, 0.0);
@@ -507,7 +507,7 @@ TEST_CASE("PolyhedronTest.swap", "[PolyhedronTest]")
   CHECK(rhs.bounds() == original.bounds());
 }
 
-TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlane", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlane")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -556,7 +556,7 @@ TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlane", "[PolyhedronTest]")
   CHECK(p.hasFace({p5, p7, p8 + d, p6 + d}));
 }
 
-TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAtTop", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAtTop")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -604,7 +604,7 @@ TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAtTop", "[PolyhedronTest]")
   CHECK(p.hasFace({p5, p7, p8, p6}));
 }
 
-TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAboveTop", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAboveTop")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -652,7 +652,7 @@ TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAboveTop", "[PolyhedronTest
   CHECK(p.hasFace({p5, p7, p8, p6}));
 }
 
-TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAtBottom", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAtBottom")
 {
   const vm::vec3d p1(-64.0, -64.0, -64.0);
   const vm::vec3d p2(-64.0, -64.0, +64.0);
@@ -679,7 +679,7 @@ TEST_CASE("PolyhedronTest.clipCubeWithHorizontalPlaneAtBottom", "[PolyhedronTest
   CHECK(p.clip(plane).empty());
 }
 
-TEST_CASE("PolyhedronTest.clipCubeWithSlantedPlane", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeWithSlantedPlane")
 {
   Polyhedron3d p(vm::bbox3d(64.0));
 
@@ -737,7 +737,7 @@ TEST_CASE("PolyhedronTest.clipCubeWithSlantedPlane", "[PolyhedronTest]")
   CHECK(p.hasFace({p9, p11, p10}, 0.0001));
 }
 
-TEST_CASE("PolyhedronTest.clipCubeDiagonally", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeDiagonally")
 {
   Polyhedron3d p(vm::bbox3d(64.0));
 
@@ -778,7 +778,7 @@ TEST_CASE("PolyhedronTest.clipCubeDiagonally", "[PolyhedronTest]")
   CHECK(p.hasFace({p2, p6, p4}));
 }
 
-TEST_CASE("PolyhedronTest.clipCubeWithVerticalSlantedPlane", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.clipCubeWithVerticalSlantedPlane")
 {
   Polyhedron3d p(vm::bbox3d(64.0));
 
@@ -838,7 +838,7 @@ bool findAndRemove(
   return false;
 }
 
-TEST_CASE("PolyhedronTest.subtractInnerCuboidFromCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractInnerCuboidFromCuboid")
 {
   const Polyhedron3d minuend(vm::bbox3d(32.0));
   const Polyhedron3d subtrahend(vm::bbox3d(16.0));
@@ -891,7 +891,7 @@ TEST_CASE("PolyhedronTest.subtractInnerCuboidFromCuboid", "[PolyhedronTest]")
   CHECK(result.empty());
 }
 
-TEST_CASE("PolyhedronTest.subtractDisjointCuboidFromCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractDisjointCuboidFromCuboid")
 {
   const Polyhedron3d minuend(vm::bbox3d(64.0));
   const Polyhedron3d subtrahend(
@@ -904,7 +904,7 @@ TEST_CASE("PolyhedronTest.subtractDisjointCuboidFromCuboid", "[PolyhedronTest]")
   CHECK(resultPolyhedron == minuend);
 }
 
-TEST_CASE("PolyhedronTest.subtractCuboidFromInnerCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractCuboidFromInnerCuboid")
 {
   const Polyhedron3d minuend(vm::bbox3d(32.0));
   const Polyhedron3d subtrahend(vm::bbox3d(64.0));
@@ -913,7 +913,7 @@ TEST_CASE("PolyhedronTest.subtractCuboidFromInnerCuboid", "[PolyhedronTest]")
   CHECK(result.empty());
 }
 
-TEST_CASE("PolyhedronTest.subtractCuboidFromIdenticalCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractCuboidFromIdenticalCuboid")
 {
   const Polyhedron3d minuend(vm::bbox3d(64.0));
   const Polyhedron3d subtrahend(vm::bbox3d(64.0));
@@ -922,7 +922,7 @@ TEST_CASE("PolyhedronTest.subtractCuboidFromIdenticalCuboid", "[PolyhedronTest]"
   CHECK(result.empty());
 }
 
-TEST_CASE("PolyhedronTest.subtractCuboidProtrudingThroughCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractCuboidProtrudingThroughCuboid")
 {
   const Polyhedron3d minuend(
     vm::bbox3d(vm::vec3d(-32.0, -32.0, -16.0), vm::vec3d(32.0, 32.0, 16.0)));
@@ -981,7 +981,7 @@ TEST_CASE("PolyhedronTest.subtractCuboidProtrudingThroughCuboid", "[PolyhedronTe
   CHECK(result.empty());
 }
 
-TEST_CASE("PolyhedronTest.subtractCuboidProtrudingFromCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractCuboidProtrudingFromCuboid")
 {
   /*
    ____________
@@ -1002,7 +1002,7 @@ TEST_CASE("PolyhedronTest.subtractCuboidProtrudingFromCuboid", "[PolyhedronTest]
   CHECK(result.size() == 3u);
 }
 
-TEST_CASE("PolyhedronTest.subtractCuboidProtrudingFromCuboid2", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractCuboidProtrudingFromCuboid2")
 {
   /*
    ____________
@@ -1021,7 +1021,7 @@ TEST_CASE("PolyhedronTest.subtractCuboidProtrudingFromCuboid2", "[PolyhedronTest
   CHECK(result.size() == 3u);
 }
 
-TEST_CASE("PolyhedronTest.subtractCuboidFromCuboidWithCutCorners", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractCuboidFromCuboidWithCutCorners")
 {
 
   /*
@@ -1074,7 +1074,7 @@ TEST_CASE("PolyhedronTest.subtractCuboidFromCuboidWithCutCorners", "[PolyhedronT
   CHECK(result.empty());
 }
 
-TEST_CASE("PolyhedronTest.subtractRhombusFromCuboid", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.subtractRhombusFromCuboid")
 {
 
   /*
@@ -1123,7 +1123,7 @@ TEST_CASE("PolyhedronTest.subtractRhombusFromCuboid", "[PolyhedronTest]")
   CHECK(result.size() == 0u);
 }
 
-TEST_CASE("PolyhedronTest.intersection_empty_polyhedron", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_empty_polyhedron")
 {
   const Polyhedron3d empty;
   const Polyhedron3d point{vm::vec3d(1.0, 0.0, 0.0)};
@@ -1143,7 +1143,7 @@ TEST_CASE("PolyhedronTest.intersection_empty_polyhedron", "[PolyhedronTest]")
   CHECK(mutuallyNotIntersects(empty, polyhedron));
 }
 
-TEST_CASE("PolyhedronTest.intersection_point_point", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_point_point")
 {
   const Polyhedron3d point{vm::vec3d(0.0, 0.0, 0.0)};
 
@@ -1151,7 +1151,7 @@ TEST_CASE("PolyhedronTest.intersection_point_point", "[PolyhedronTest]")
   CHECK(mutuallyNotIntersects(point, Polyhedron3d{vm::vec3d(0.0, 0.0, 1.0)}));
 }
 
-TEST_CASE("PolyhedronTest.intersection_point_edge", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_point_edge")
 {
   const vm::vec3d pointPos(0.0, 0.0, 0.0);
   const Polyhedron3d point{pointPos};
@@ -1171,7 +1171,7 @@ TEST_CASE("PolyhedronTest.intersection_point_edge", "[PolyhedronTest]")
       vm::vec3d(-1.0, 0.0, 1.0), vm::vec3d(1.0, 0.0, 1.0)})); // point / unrelated edge
 }
 
-TEST_CASE("PolyhedronTest.intersection_point_polygon", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_point_polygon")
 {
   const vm::vec3d pointPos(0.0, 0.0, 0.0);
   const Polyhedron3d point{pointPos};
@@ -1203,7 +1203,7 @@ TEST_CASE("PolyhedronTest.intersection_point_polygon", "[PolyhedronTest]")
       vm::vec3d(0.0, 1.0, 1.0)})); // point / triangle above point
 }
 
-TEST_CASE("PolyhedronTest.intersection_point_polyhedron", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_point_polyhedron")
 {
   const vm::vec3d pointPos(0.0, 0.0, 0.0);
   const Polyhedron3d point{pointPos};
@@ -1246,7 +1246,7 @@ TEST_CASE("PolyhedronTest.intersection_point_polyhedron", "[PolyhedronTest]")
       vm::vec3d(0.0, 0.0, 2.0)})); // point / tetrahedron above point
 }
 
-TEST_CASE("PolyhedronTest.intersection_edge_edge", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_edge_edge")
 {
   const vm::vec3d point1(-1.0, 0.0, 0.0);
   const vm::vec3d point2(+1.0, 0.0, 0.0);
@@ -1266,7 +1266,7 @@ TEST_CASE("PolyhedronTest.intersection_edge_edge", "[PolyhedronTest]")
     edge, Polyhedron3d{point1 + vm::vec3d::pos_z(), point2 + vm::vec3d::pos_z()}));
 }
 
-TEST_CASE("PolyhedronTest.intersection_edge_polygon_same_plane", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_edge_polygon_same_plane")
 {
   const vm::vec3d point1(-1.0, 0.0, 0.0);
   const vm::vec3d point2(+1.0, 0.0, 0.0);
@@ -1324,7 +1324,7 @@ TEST_CASE("PolyhedronTest.intersection_edge_polygon_same_plane", "[PolyhedronTes
       vm::vec3d(+3.0, 1.0, 0.0)})); // no intersection
 }
 
-TEST_CASE("PolyhedronTest.intersection_edge_polygon_different_plane", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_edge_polygon_different_plane")
 {
   const vm::vec3d point1(0.0, 0.0, 1.0);
   const vm::vec3d point2(0.0, 0.0, -1.0);
@@ -1403,7 +1403,7 @@ TEST_CASE("PolyhedronTest.intersection_edge_polygon_different_plane", "[Polyhedr
       vm::vec3d(0.0, 2.0, 0.0)}));
 }
 
-TEST_CASE("PolyhedronTest.intersection_edge_polyhedron", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_edge_polyhedron")
 {
   const Polyhedron3d tetrahedron{
     vm::vec3d(-1.0, -1.0, 0.0),
@@ -1438,7 +1438,7 @@ TEST_CASE("PolyhedronTest.intersection_edge_polyhedron", "[PolyhedronTest]")
     tetrahedron)); // no intersection
 }
 
-TEST_CASE("PolyhedronTest.intersection_polygon_polygon_same_plane", "[PolyhedronTest]")
+TEST_CASE("PolyhedronTest.intersection_polygon_polygon_same_plane")
 {
   const Polyhedron3d square{
     vm::vec3d(-1.0, -1.0, 0.0),

--- a/common/test/src/Model/PortalFileTest.cpp
+++ b/common/test/src/Model/PortalFileTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("PortalFileTest.parseInvalidPRT1", "[PortalFileTest]")
+TEST_CASE("PortalFileTest.parseInvalidPRT1")
 {
   const auto path = IO::Path("fixture/test/Model/PortalFile/portaltest_prt1_invalid.prt");
 
@@ -59,28 +59,28 @@ static const std::vector<vm::polygon3f> ExpectedPortals{
    {0, 64, 64}},
   {{-64, -32, 0}, {-32, -32, 0}, {-48, -32, 64}}};
 
-TEST_CASE("PortalFileTest.parsePRT1", "[PortalFileTest]")
+TEST_CASE("PortalFileTest.parsePRT1")
 {
   const auto path = IO::Path{"fixture/test/Model/PortalFile/portaltest_prt1.prt"};
   const auto portalFile = Model::PortalFile{path};
   CHECK(portalFile.portals() == ExpectedPortals);
 }
 
-TEST_CASE("PortalFileTest.parsePRT1Q3", "[PortalFileTest]")
+TEST_CASE("PortalFileTest.parsePRT1Q3")
 {
   const auto path = IO::Path{"fixture/test/Model/PortalFile/portaltest_prt1q3.prt"};
   const auto portalFile = Model::PortalFile{path};
   CHECK(portalFile.portals() == ExpectedPortals);
 }
 
-TEST_CASE("PortalFileTest.parsePRT1AM", "[PortalFileTest]")
+TEST_CASE("PortalFileTest.parsePRT1AM")
 {
   const auto path = IO::Path{"fixture/test/Model/PortalFile/portaltest_prt1am.prt"};
   const auto portalFile = Model::PortalFile{path};
   CHECK(portalFile.portals() == ExpectedPortals);
 }
 
-TEST_CASE("PortalFileTest.parsePRT2", "[PortalFileTest]")
+TEST_CASE("PortalFileTest.parsePRT2")
 {
   const auto path = IO::Path{"fixture/test/Model/PortalFile/portaltest_prt2.prt"};
   const auto portalFile = Model::PortalFile{path};

--- a/common/test/src/Model/TaggingTest.cpp
+++ b/common/test/src/Model/TaggingTest.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom
 {
 namespace Model
 {
-TEST_CASE("TaggingTest.testTagBrush", "[TaggingTest]")
+TEST_CASE("TaggingTest.testTagBrush")
 {
   const vm::bbox3 worldBounds{4096.0};
   WorldNode world{{}, {}, MapFormat::Standard};

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -164,10 +164,12 @@ std::vector<Node*> TestGame::doParseNodes(
   const std::string& str,
   const MapFormat mapFormat,
   const vm::bbox3& worldBounds,
+  const std::vector<std::string>& linkedGroupsToKeep,
   Logger& /* logger */) const
 {
   IO::TestParserStatus status;
-  return IO::NodeReader::read(str, mapFormat, worldBounds, {}, status);
+  return IO::NodeReader::read(
+    str, mapFormat, worldBounds, {}, linkedGroupsToKeep, status);
 }
 
 std::vector<BrushFace> TestGame::doParseBrushFaces(

--- a/common/test/src/Model/TestGame.h
+++ b/common/test/src/Model/TestGame.h
@@ -83,6 +83,7 @@ private:
     const std::string& str,
     MapFormat mapFormat,
     const vm::bbox3& worldBounds,
+    const std::vector<std::string>& linkedGroupsToKeep,
     Logger& logger) const override;
   std::vector<BrushFace> doParseBrushFaces(
     const std::string& str,

--- a/common/test/src/Model/TexCoordSystemTest.cpp
+++ b/common/test/src/Model/TexCoordSystemTest.cpp
@@ -37,7 +37,7 @@ namespace Model
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #endif
 
-TEST_CASE("TexCoordSystemTest.testSnapshotTypeSafety", "[TexCoordSystemTest]")
+TEST_CASE("TexCoordSystemTest.testSnapshotTypeSafety")
 {
   BrushFaceAttributes attribs("");
 

--- a/common/test/src/Model/WorldNodeTest.cpp
+++ b/common/test/src/Model/WorldNodeTest.cpp
@@ -323,13 +323,13 @@ TEST_CASE("WorldNodeTest.disableNodeTreeUpdates")
   CHECK(nodeTree.contains(patchNode));
 }
 
-TEST_CASE("WorldNodeTest.persistentIdOfDefaultLayer", "[WorldNodeTest]")
+TEST_CASE("WorldNodeTest.persistentIdOfDefaultLayer")
 {
   auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
   CHECK(worldNode.defaultLayer()->persistentId() == std::nullopt);
 }
 
-TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingLayer", "[WorldNodeTest]")
+TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingLayer")
 {
   auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
   auto* initialLayerNode = new LayerNode{Layer{"name"}};
@@ -373,7 +373,7 @@ TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingLayer", "[WorldNodeTest]")
   }
 }
 
-TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingGroup", "[WorldNodeTest]")
+TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingGroup")
 {
   auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
   auto* initialGroupNode = new GroupNode{Group{"name"}};
@@ -417,7 +417,7 @@ TEST_CASE("WorldNodeTest.setPersistentIdWhenAddingGroup", "[WorldNodeTest]")
   }
 }
 
-TEST_CASE("WorldNodeTest.setPersistentIdsWhenAddingLayersAndGroups", "[WorldNodeTest]")
+TEST_CASE("WorldNodeTest.setPersistentIdsWhenAddingLayersAndGroups")
 {
   auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 

--- a/common/test/src/NotifierTest.cpp
+++ b/common/test/src/NotifierTest.cpp
@@ -59,7 +59,7 @@ public:
   void notify2(const int& a1, const int& a2) { notify2Calls.push_back({a1, a2}); }
 };
 
-TEST_CASE("NotifierTest.testAddRemoveObservers", "[NotifierTest]")
+TEST_CASE("NotifierTest.testAddRemoveObservers")
 {
   auto o1 = Observer{};
   auto o2 = Observer{};
@@ -82,7 +82,7 @@ TEST_CASE("NotifierTest.testAddRemoveObservers", "[NotifierTest]")
   CHECK(o2.notify0Calls == 1);
 }
 
-TEST_CASE("NotifierTest.testNotifyObservers", "[NotifierTest]")
+TEST_CASE("NotifierTest.testNotifyObservers")
 {
   auto o1 = Observer{};
   auto o2 = Observer{};

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -52,7 +52,7 @@ static QJsonValue getValue(const std::map<IO::Path, QJsonValue>& map, const IO::
   return it->second;
 }
 
-TEST_CASE("PreferencesTest.migrateLocalV1Settings", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.migrateLocalV1Settings")
 {
   const std::map<IO::Path, QJsonValue> reg = readV1Settings();
 
@@ -62,7 +62,7 @@ TEST_CASE("PreferencesTest.migrateLocalV1Settings", "[PreferencesTest]")
   // has any settings on it.
 }
 
-TEST_CASE("PreferencesTest.parseV1", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.parseV1")
 {
   const std::map<IO::Path, QJsonValue> parsed =
     getINISettingsV1("fixture/test/preferences-v1.ini");
@@ -374,7 +374,7 @@ static void testV2Prefs(const std::map<IO::Path, QJsonValue>& v2)
   CHECK(getValue(v2, IO::Path("RecentDocuments/0")) == QJsonValue(QJsonValue::Undefined));
 }
 
-TEST_CASE("PreferencesTest.migrateV1", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.migrateV1")
 {
   const std::map<IO::Path, QJsonValue> v1 =
     getINISettingsV1("fixture/test/preferences-v1.ini");
@@ -385,7 +385,7 @@ TEST_CASE("PreferencesTest.migrateV1", "[PreferencesTest]")
   // CHECK(writeV2SettingsToPath("C:\\Users\\Eric\\Desktop\\Preferences.json", v2));
 }
 
-TEST_CASE("PreferencesTest.readV2", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.readV2")
 {
   // Invalid JSON -> parse error -> parseV2SettingsFromJSON() is expected to return
   // nullopt
@@ -409,7 +409,7 @@ TEST_CASE("PreferencesTest.readV2", "[PreferencesTest]")
     [](const PreferenceErrors::FileReadError&) { FAIL_CHECK(); }));
 }
 
-TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.testWriteReadV2")
 {
   const std::map<IO::Path, QJsonValue> v1 =
     getINISettingsV1("fixture/test/preferences-v1.ini");
@@ -460,7 +460,7 @@ static void testSerialize(const QJsonValue& str, const PrimitiveType& value)
   CHECK(testSerialize == str);
 }
 
-TEST_CASE("PreferencesTest.serializeV1Bool", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV1Bool")
 {
   CHECK_FALSE((maybeDeserialize<PreferenceSerializerV1, bool>("").has_value()));
   CHECK_FALSE((maybeDeserialize<PreferenceSerializerV1, bool>("-1").has_value()));
@@ -469,7 +469,7 @@ TEST_CASE("PreferencesTest.serializeV1Bool", "[PreferencesTest]")
   testSerialize<PreferenceSerializerV1, bool>(QJsonValue("1"), true);
 }
 
-TEST_CASE("PreferencesTest.serializeV1Color", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV1Color")
 {
   CHECK_FALSE(
     (maybeDeserialize<PreferenceSerializerV1, Color>(QJsonValue("0.921569 0.666667"))
@@ -480,19 +480,19 @@ TEST_CASE("PreferencesTest.serializeV1Color", "[PreferencesTest]")
     Color(0.921569f, 0.666667f, 0.45098f, 0.5f));
 }
 
-TEST_CASE("PreferencesTest.serializeV1float", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV1float")
 {
   testSerialize<PreferenceSerializerV1, float>(QJsonValue("0.921569"), 0.921569f);
 }
 
-TEST_CASE("PreferencesTest.serializeV1int", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV1int")
 {
   testSerialize<PreferenceSerializerV1, int>(QJsonValue("0"), 0);
   testSerialize<PreferenceSerializerV1, int>(QJsonValue("-1"), -1);
   testSerialize<PreferenceSerializerV1, int>(QJsonValue("1000"), 1000);
 }
 
-TEST_CASE("PreferencesTest.serializeV1Path", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV1Path")
 {
 #ifdef _WIN32
   testSerialize<PreferenceSerializerV1, IO::Path>(
@@ -516,7 +516,7 @@ TEST_CASE("PreferencesTest.serializeV1Path", "[PreferencesTest]")
   testSerialize<PreferenceSerializerV1, IO::Path>(QJsonValue(""), IO::Path());
 }
 
-TEST_CASE("PreferencesTest.serializeV1KeyboardShortcut", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV1KeyboardShortcut")
 {
   // These come from wxWidgets TrenchBroom 2019.6, on Windows
   testSerialize<PreferenceSerializerV1, QKeySequence>(
@@ -543,7 +543,7 @@ TEST_CASE("PreferencesTest.serializeV1KeyboardShortcut", "[PreferencesTest]")
     QKeySequence::fromString("Alt+P")); // "Alt" in Qt = Alt in macOS
 }
 
-TEST_CASE("PreferencesTest.serializeV2Bool", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV2Bool")
 {
   CHECK_FALSE(
     (maybeDeserialize<PreferenceSerializerV2, bool>(QJsonValue("")).has_value()));
@@ -554,7 +554,7 @@ TEST_CASE("PreferencesTest.serializeV2Bool", "[PreferencesTest]")
   testSerialize<PreferenceSerializerV2, bool>(QJsonValue(true), true);
 }
 
-TEST_CASE("PreferencesTest.serializeV2float", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV2float")
 {
   CHECK_FALSE(
     (maybeDeserialize<PreferenceSerializerV2, float>(QJsonValue("1.25")).has_value()));
@@ -562,7 +562,7 @@ TEST_CASE("PreferencesTest.serializeV2float", "[PreferencesTest]")
   testSerialize<PreferenceSerializerV2, float>(QJsonValue(1.25), 1.25f);
 }
 
-TEST_CASE("PreferencesTest.serializeV2int", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV2int")
 {
   CHECK_FALSE(
     (maybeDeserialize<PreferenceSerializerV2, int>(QJsonValue("0")).has_value()));
@@ -574,7 +574,7 @@ TEST_CASE("PreferencesTest.serializeV2int", "[PreferencesTest]")
   testSerialize<PreferenceSerializerV2, int>(QJsonValue(1000), 1000);
 }
 
-TEST_CASE("PreferencesTest.serializeV2KeyboardShortcut", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.serializeV2KeyboardShortcut")
 {
   testSerialize<PreferenceSerializerV2, QKeySequence>(
     QJsonValue("Alt+Shift+W"), QKeySequence::fromString("Alt+Shift+W"));
@@ -755,7 +755,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE("PreferencesTest.testWxEntityShortcuts", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.testWxEntityShortcuts")
 {
   auto hellKnight = Assets::PointEntityDefinition(
     "monster_hell_knight",
@@ -789,7 +789,7 @@ TEST_CASE("PreferencesTest.testWxEntityShortcuts", "[PreferencesTest]")
   }
 }
 
-TEST_CASE("PreferencesTest.testWxTagShortcuts", "[PreferencesTest]")
+TEST_CASE("PreferencesTest.testWxTagShortcuts")
 {
   const auto tags = std::vector<Model::SmartTag>{Model::SmartTag(
     "Detail", {}, std::make_unique<Model::ContentFlagsTagMatcher>(1 << 27))};

--- a/common/test/src/Renderer/AllocationTrackerTest.cpp
+++ b/common/test/src/Renderer/AllocationTrackerTest.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom
 {
 namespace Renderer
 {
-TEST_CASE("AllocationTrackerTest.constructor", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.constructor")
 {
   AllocationTracker t(100);
   CHECK(t.capacity() == 100u);
@@ -39,7 +39,7 @@ TEST_CASE("AllocationTrackerTest.constructor", "[AllocationTrackerTest]")
   CHECK_FALSE(t.hasAllocations());
 }
 
-TEST_CASE("AllocationTrackerTest.emptyConstructor", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.emptyConstructor")
 {
   AllocationTracker t;
   CHECK(t.capacity() == 0u);
@@ -50,7 +50,7 @@ TEST_CASE("AllocationTrackerTest.emptyConstructor", "[AllocationTrackerTest]")
   CHECK_FALSE(t.hasAllocations());
 }
 
-TEST_CASE("AllocationTrackerTest.constructWithZeroCapacity", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.constructWithZeroCapacity")
 {
   AllocationTracker t(0);
   CHECK(t.capacity() == 0u);
@@ -61,7 +61,7 @@ TEST_CASE("AllocationTrackerTest.constructWithZeroCapacity", "[AllocationTracker
   CHECK_FALSE(t.hasAllocations());
 }
 
-TEST_CASE("AllocationTrackerTest.invalidAllocate", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.invalidAllocate")
 {
   AllocationTracker t(100);
 
@@ -72,7 +72,7 @@ TEST_CASE("AllocationTrackerTest.invalidAllocate", "[AllocationTrackerTest]")
   CHECK_FALSE(t.hasAllocations());
 }
 
-TEST_CASE("AllocationTrackerTest.fiveAllocations", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.fiveAllocations")
 {
   AllocationTracker t(500);
 
@@ -160,7 +160,7 @@ TEST_CASE("AllocationTrackerTest.fiveAllocations", "[AllocationTrackerTest]")
   CHECK(t.freeBlocks() == (std::vector<AllocationTracker::Range>{}));
 }
 
-TEST_CASE("AllocationTrackerTest.freeMergeRight", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.freeMergeRight")
 {
   AllocationTracker t(400);
 
@@ -188,7 +188,7 @@ TEST_CASE("AllocationTrackerTest.freeMergeRight", "[AllocationTrackerTest]")
   CHECK(t.largestPossibleAllocation() == 200u);
 }
 
-TEST_CASE("AllocationTrackerTest.freeMergeLeft", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.freeMergeLeft")
 {
   AllocationTracker t(400);
 
@@ -216,7 +216,7 @@ TEST_CASE("AllocationTrackerTest.freeMergeLeft", "[AllocationTrackerTest]")
   CHECK(t.largestPossibleAllocation() == 200u);
 }
 
-TEST_CASE("AllocationTrackerTest.expandEmpty", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.expandEmpty")
 {
   AllocationTracker t;
 
@@ -230,7 +230,7 @@ TEST_CASE("AllocationTrackerTest.expandEmpty", "[AllocationTrackerTest]")
   CHECK_FALSE(t.hasAllocations());
 }
 
-TEST_CASE("AllocationTrackerTest.expandWithFreeSpaceAtEnd", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.expandWithFreeSpaceAtEnd")
 {
   AllocationTracker t(200);
 
@@ -249,7 +249,7 @@ TEST_CASE("AllocationTrackerTest.expandWithFreeSpaceAtEnd", "[AllocationTrackerT
   CHECK(t.usedBlocks() == (std::vector<AllocationTracker::Range>{{0, 100}}));
 }
 
-TEST_CASE("AllocationTrackerTest.expandWithUsedSpaceAtEnd", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.expandWithUsedSpaceAtEnd")
 {
   AllocationTracker t(200);
 
@@ -310,7 +310,7 @@ static void shuffle(std::vector<T>& vec, std::mt19937& engine)
   }
 }
 
-TEST_CASE("AllocationTrackerTest.testShuffle", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.testShuffle")
 {
   std::vector<int> ints;
   for (int i = 0; i < 10; ++i)
@@ -324,7 +324,7 @@ TEST_CASE("AllocationTrackerTest.testShuffle", "[AllocationTrackerTest]")
   CHECK(ints == (std::vector<int>{8, 0, 7, 6, 4, 3, 5, 1, 2, 9}));
 }
 
-TEST_CASE("AllocationTrackerTest.benchmarkAllocOnly", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.benchmarkAllocOnly")
 {
   std::mt19937 randEngine;
 
@@ -337,7 +337,7 @@ TEST_CASE("AllocationTrackerTest.benchmarkAllocOnly", "[AllocationTrackerTest]")
   }
 }
 
-TEST_CASE("AllocationTrackerTest.benchmarkAllocFreeAlloc", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.benchmarkAllocFreeAlloc")
 {
   std::mt19937 randEngine;
 
@@ -374,7 +374,7 @@ TEST_CASE("AllocationTrackerTest.benchmarkAllocFreeAlloc", "[AllocationTrackerTe
   }
 }
 
-TEST_CASE("AllocationTrackerTest.benchmarkAllocAndExpand", "[AllocationTrackerTest]")
+TEST_CASE("AllocationTrackerTest.benchmarkAllocAndExpand")
 {
   std::mt19937 randEngine;
 

--- a/common/test/src/Renderer/CameraTest.cpp
+++ b/common/test/src/Renderer/CameraTest.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom
 {
 namespace Renderer
 {
-TEST_CASE("CameraTest.testInvalidUp", "[CameraTest]")
+TEST_CASE("CameraTest.testInvalidUp")
 {
   PerspectiveCamera c;
   c.setDirection(vm::vec3f(0, 0, 1), vm::vec3f(0, 0, 1));
@@ -36,7 +36,7 @@ TEST_CASE("CameraTest.testInvalidUp", "[CameraTest]")
   CHECK_FALSE(vm::is_nan(c.up()));
 }
 
-TEST_CASE("CameraTest.testOrbitDown", "[CameraTest]")
+TEST_CASE("CameraTest.testOrbitDown")
 {
   PerspectiveCamera c;
   c.setDirection(vm::vec3f(1, 0, 0), vm::vec3f(0, 0, 1));
@@ -48,7 +48,7 @@ TEST_CASE("CameraTest.testOrbitDown", "[CameraTest]")
   CHECK_FALSE(vm::is_nan(c.up()));
 }
 
-TEST_CASE("CameraTest.testOrbitWhileInverted", "[CameraTest]")
+TEST_CASE("CameraTest.testOrbitWhileInverted")
 {
   PerspectiveCamera c;
   c.setDirection(vm::vec3f(1, 0, 0), vm::vec3f(0, 0, -1));
@@ -60,7 +60,7 @@ TEST_CASE("CameraTest.testOrbitWhileInverted", "[CameraTest]")
   CHECK_FALSE(vm::is_nan(c.up()));
 }
 
-TEST_CASE("CameraTest.testYawWhenPitchedDown", "[CameraTest]")
+TEST_CASE("CameraTest.testYawWhenPitchedDown")
 {
   PerspectiveCamera c;
   c.setDirection(vm::vec3f::neg_z(), vm::vec3f::pos_x());

--- a/common/test/src/Renderer/VertexTest.cpp
+++ b/common/test/src/Renderer/VertexTest.cpp
@@ -38,7 +38,7 @@ struct TestVertex
   vm::vec4f color;
 };
 
-TEST_CASE("VertexTest.memoryLayoutSingleVertex", "[VertexTest]")
+TEST_CASE("VertexTest.memoryLayoutSingleVertex")
 {
   using Vertex = GLVertexTypes::P3T2C4::Vertex;
 
@@ -53,7 +53,7 @@ TEST_CASE("VertexTest.memoryLayoutSingleVertex", "[VertexTest]")
   REQUIRE(std::memcmp(&expected, &actual, sizeof(expected)) == 0);
 }
 
-TEST_CASE("VertexTest.memoryLayoutVertexList", "[VertexTest]")
+TEST_CASE("VertexTest.memoryLayoutVertexList")
 {
   using Vertex = GLVertexTypes::P3T2C4::Vertex;
 

--- a/common/test/src/StackWalkerTest.cpp
+++ b/common/test/src/StackWalkerTest.cpp
@@ -23,7 +23,7 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 namespace TrenchBroom
 {
-TEST_CASE("StackWalkerTest.testStackTraceSymbols", "[StackWalkerTest]")
+TEST_CASE("StackWalkerTest.testStackTraceSymbols")
 {
   const std::string stackTrace = TrenchBroomStackWalker::getStackTrace();
 

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -109,7 +109,7 @@ bool UVListsEqual(
   return true;
 }
 
-TEST_CASE("TestUtilsTest.testTexCoordsEqual", "[TestUtilsTest]")
+TEST_CASE("TestUtilsTest.testTexCoordsEqual")
 {
   CHECK(texCoordsEqual(vm::vec2f(0.0, 0.0), vm::vec2f(0.0, 0.0)));
   CHECK(texCoordsEqual(vm::vec2f(0.0, 0.0), vm::vec2f(1.0, 0.0)));
@@ -125,7 +125,7 @@ TEST_CASE("TestUtilsTest.testTexCoordsEqual", "[TestUtilsTest]")
   CHECK_FALSE(texCoordsEqual(vm::vec2f(-0.25, 0.0), vm::vec2f(0.25, 0.0)));
 }
 
-TEST_CASE("TestUtilsTest.UVListsEqual", "[TestUtilsTest]")
+TEST_CASE("TestUtilsTest.UVListsEqual")
 {
   CHECK(UVListsEqual({{0, 0}, {1, 0}, {0, 1}}, {{0, 0}, {1, 0}, {0, 1}}));
   CHECK(UVListsEqual(
@@ -143,7 +143,7 @@ TEST_CASE("TestUtilsTest.UVListsEqual", "[TestUtilsTest]")
     UVListsEqual({{0, 0}, {1, 0}, {0, 1}}, {{0, 0}, {2, 0}, {0, 2}})); // unwanted scaling
 }
 
-TEST_CASE("TestUtilsTest.pointExactlyIntegral", "[TestUtilsTest]")
+TEST_CASE("TestUtilsTest.pointExactlyIntegral")
 {
   CHECK(pointExactlyIntegral(vm::vec3d(0.0, 0.0, 0.0)));
   CHECK(pointExactlyIntegral(vm::vec3d(1024.0, 1204.0, 1024.0)));
@@ -513,7 +513,7 @@ GlobMatcher MatchesGlob(const std::string& glob)
   return GlobMatcher(glob);
 }
 
-TEST_CASE("TestUtilsTest.testUnorderedApproxVecMatcher", "[TestUtilsTest]")
+TEST_CASE("TestUtilsTest.testUnorderedApproxVecMatcher")
 {
   using V = std::vector<vm::vec3>;
   CHECK_THAT((V{{1, 1, 1}}), UnorderedApproxVecMatches(V{{1.01, 1.01, 1.01}}, 0.02));

--- a/common/test/src/View/AutosaverTest.cpp
+++ b/common/test/src/View/AutosaverTest.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-TEST_CASE("AutosaverTest.backupFileMatcher", "[AutosaverTest]")
+TEST_CASE("AutosaverTest.backupFileMatcher")
 {
   Autosaver::BackupFileMatcher matcher(IO::Path("test"));
 

--- a/common/test/src/View/CommandProcessorTest.cpp
+++ b/common/test/src/View/CommandProcessorTest.cpp
@@ -242,7 +242,7 @@ public:
   }
 };
 
-TEST_CASE("CommandProcessorTest.doAndUndoSuccessfulCommand", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.doAndUndoSuccessfulCommand")
 {
   /*
    * Execute a successful command, then undo it successfully.
@@ -329,7 +329,7 @@ TEST_CASE(
     }));
 }
 
-TEST_CASE("CommandProcessorTest.doFailingCommand", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.doFailingCommand")
 {
   /*
    * Execute a failing command.
@@ -356,7 +356,7 @@ TEST_CASE("CommandProcessorTest.doFailingCommand", "[CommandProcessorTest]")
     }));
 }
 
-TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction")
 {
   /*
    * Execute two successful commands in a transaction, then undo the transaction
@@ -438,7 +438,7 @@ TEST_CASE("CommandProcessorTest.commitUndoRedoTransaction", "[CommandProcessorTe
     }));
 }
 
-TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.rollbackTransaction")
 {
   /*
    * Execute two successful commands in a transaction, then rollback the transaction and
@@ -502,7 +502,7 @@ TEST_CASE("CommandProcessorTest.rollbackTransaction", "[CommandProcessorTest]")
   REQUIRE(observer.popNotifications().empty());
 }
 
-TEST_CASE("CommandProcessorTest.nestedTransactions", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.nestedTransactions")
 {
   /*
    * Execute a command in a transaction, start a nested transaction, execute a command,
@@ -662,7 +662,7 @@ TEST_CASE("CommandProceossor.isCurrentDocumentStateObservable")
   }
 }
 
-TEST_CASE("CommandProcessorTest.collateCommands", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.collateCommands")
 {
   /*
    * Execute a command and collate the next command, then undo.
@@ -720,7 +720,7 @@ TEST_CASE("CommandProcessorTest.collateCommands", "[CommandProcessorTest]")
     }));
 }
 
-TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.collationInterval")
 {
   /*
    * Execute two commands, with time passing between their execution exceeding the
@@ -783,7 +783,7 @@ TEST_CASE("CommandProcessorTest.collationInterval", "[CommandProcessorTest]")
   REQUIRE(commandProcessor.redoCommandName() == commandName2);
 }
 
-TEST_CASE("CommandProcessorTest.collateTransactions", "[CommandProcessorTest]")
+TEST_CASE("CommandProcessorTest.collateTransactions")
 {
   auto commandProcessor = CommandProcessor{nullptr};
   auto observer = TestObserver{commandProcessor};

--- a/common/test/src/View/CopyPasteTest.cpp
+++ b/common/test/src/View/CopyPasteTest.cpp
@@ -313,7 +313,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteAndTranslateGroup")
   CHECK(document->selectionBounds() == box.translate(delta));
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteInGroup", "[CopyPasteTest]")
+TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteInGroup")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/1734
 
@@ -338,7 +338,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteInGroup", "[CopyPasteTest]
   CHECK(light->parent() == group);
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.undoRedo", "[CopyPasteTest]")
+TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.undoRedo")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/4174
 

--- a/common/test/src/View/CopyPasteTest.cpp
+++ b/common/test/src/View/CopyPasteTest.cpp
@@ -338,6 +338,79 @@ TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.pasteInGroup")
   CHECK(light->parent() == group);
 }
 
+TEST_CASE_METHOD(
+  MapDocumentTest, "CopyPasteTest.copyPasteGroupResetsDuplicatedLinkedGroupId")
+{
+  auto* brushNode = createBrushNode();
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
+  document->selectNodes({brushNode});
+
+  auto* groupNode = document->groupSelection("test");
+
+  document->deselectAll();
+  document->selectNodes({groupNode});
+  auto* linkedGroup = document->createLinkedDuplicate();
+
+  document->deselectAll();
+  document->selectNodes({linkedGroup});
+  const auto data = document->serializeSelectedNodes();
+
+  document->deselectAll();
+
+  SECTION("Pasting unknown linked group ID")
+  {
+    const auto linkedGroupId = groupNode->group().linkedGroupId();
+    REQUIRE(linkedGroupId);
+
+    document->selectAllNodes();
+    document->deleteObjects();
+
+    CHECK(document->paste(data) == PasteType::Node);
+    CHECK(document->world()->defaultLayer()->childCount() == 1);
+
+    const auto* pastedGroup = dynamic_cast<Model::GroupNode*>(
+      document->world()->defaultLayer()->children().back());
+    REQUIRE(pastedGroup);
+
+    CHECK(pastedGroup->group().linkedGroupId() == std::nullopt);
+  }
+
+  SECTION("Pasting duplicate linked group ID")
+  {
+    const auto linkedGroupId = groupNode->group().linkedGroupId();
+    REQUIRE(linkedGroupId);
+
+    CHECK(document->paste(data) == PasteType::Node);
+    CHECK(document->world()->defaultLayer()->childCount() == 3);
+
+    const auto* pastedGroup = dynamic_cast<Model::GroupNode*>(
+      document->world()->defaultLayer()->children().back());
+    REQUIRE(pastedGroup);
+
+    CHECK(pastedGroup->group().linkedGroupId() == linkedGroupId);
+  }
+
+  SECTION("Pasting recursive linked group")
+  {
+    document->openGroup(groupNode);
+
+    CHECK(document->paste(data) == PasteType::Node);
+    CHECK(groupNode->childCount() == 2);
+    CHECK(linkedGroup->childCount() == 2);
+
+    auto* pastedGroup = dynamic_cast<Model::GroupNode*>(groupNode->children().back());
+    REQUIRE(pastedGroup);
+
+    CHECK(pastedGroup->group().linkedGroupId() == std::nullopt);
+
+    auto* linkedPastedGroup =
+      dynamic_cast<Model::GroupNode*>(linkedGroup->children().back());
+    REQUIRE(linkedPastedGroup);
+
+    CHECK(linkedPastedGroup->group().linkedGroupId() == std::nullopt);
+  }
+}
+
 TEST_CASE_METHOD(MapDocumentTest, "CopyPasteTest.undoRedo")
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/4174

--- a/common/test/src/View/CsgTest.cpp
+++ b/common/test/src/View/CsgTest.cpp
@@ -265,7 +265,7 @@ TEST_CASE_METHOD(MapDocumentTest, "CsgTest.csgSubtractAndUndoRestoresSelection")
 }
 
 // Test for https://github.com/TrenchBroom/TrenchBroom/issues/3755
-TEST_CASE("CsgTest.csgSubtractFailure", "[MapDocumentTest]")
+TEST_CASE("CsgTest.csgSubtractFailure")
 {
   auto [document, game, gameConfig] = View::loadMapDocument(
     IO::Path("fixture/test/View/MapDocumentTest/csgSubtractFailure.map"),
@@ -301,7 +301,7 @@ TEST_CASE("CsgTest.csgSubtractFailure", "[MapDocumentTest]")
       0.001));
 }
 
-TEST_CASE("CsgTest.csgHollow", "[MapDocumentTest]")
+TEST_CASE("CsgTest.csgHollow")
 {
   auto [document, game, gameConfig] = View::loadMapDocument(
     IO::Path("fixture/test/View/MapDocumentTest/csgHollow.map"),

--- a/common/test/src/View/ExtrudeToolTest.cpp
+++ b/common/test/src/View/ExtrudeToolTest.cpp
@@ -219,7 +219,7 @@ static Model::PickResult performPick(
 /**
  * Test for https://github.com/TrenchBroom/TrenchBroom/issues/3726
  */
-TEST_CASE("ExtrudeToolTest.findDragFaces", "[ExtrudeToolTest]")
+TEST_CASE("ExtrudeToolTest.findDragFaces")
 {
   using T = std::tuple<IO::Path, std::vector<std::string>>;
 
@@ -274,7 +274,7 @@ TEST_CASE("ExtrudeToolTest.findDragFaces", "[ExtrudeToolTest]")
     Catch::UnorderedEquals(expectedDragFaceTextureNames));
 }
 
-TEST_CASE("ExtrudeToolTest.splitBrushes", "[ExtrudeToolTest]")
+TEST_CASE("ExtrudeToolTest.splitBrushes")
 {
   using namespace Model::HitFilters;
 

--- a/common/test/src/View/GridTest.cpp
+++ b/common/test/src/View/GridTest.cpp
@@ -43,13 +43,13 @@ namespace View
 {
 static const vm::bbox3 worldBounds(8192.0);
 
-TEST_CASE("GridTest.size", "[GridTest]")
+TEST_CASE("GridTest.size")
 {
   for (int i = Grid::MinSize; i < Grid::MaxSize; ++i)
     CHECK(Grid(i).size() == i);
 }
 
-TEST_CASE("GridTest.actualSizeInteger", "[GridTest]")
+TEST_CASE("GridTest.actualSizeInteger")
 {
   for (int i = 0; i < Grid::MaxSize; ++i)
   {
@@ -58,14 +58,14 @@ TEST_CASE("GridTest.actualSizeInteger", "[GridTest]")
   }
 }
 
-TEST_CASE("GridTest.actualSizeSubInteger", "[GridTest]")
+TEST_CASE("GridTest.actualSizeSubInteger")
 {
   CHECK(Grid(-1).actualSize() == 0.5);
   CHECK(Grid(-2).actualSize() == 0.25);
   CHECK(Grid(-3).actualSize() == 0.125);
 }
 
-TEST_CASE("GridTest.changeSize", "[GridTest]")
+TEST_CASE("GridTest.changeSize")
 {
   Grid g(0);
   g.incSize();
@@ -79,7 +79,7 @@ TEST_CASE("GridTest.changeSize", "[GridTest]")
   CHECK(g.size() == 4);
 }
 
-TEST_CASE("GridTest.offsetScalars", "[GridTest]")
+TEST_CASE("GridTest.offsetScalars")
 {
   CHECK(Grid(2u).offset(0.0) == vm::approx(0.0));
   CHECK(Grid(2u).offset(0.3) == vm::approx(0.3));
@@ -93,7 +93,7 @@ TEST_CASE("GridTest.offsetScalars", "[GridTest]")
   CHECK(Grid(2u).offset(5.0) == vm::approx(1.0));
 }
 
-TEST_CASE("GridTest.snapScalars", "[GridTest]")
+TEST_CASE("GridTest.snapScalars")
 {
   CHECK(Grid(-1).snap(0.0) == vm::approx(0.0));
   CHECK(Grid(-1).snap(0.1) == vm::approx(0.0));
@@ -129,7 +129,7 @@ TEST_CASE("GridTest.snapScalars", "[GridTest]")
   CHECK(Grid(2u).snapUp(-4.0, true) == vm::approx(0.0));
 }
 
-TEST_CASE("GridTest.snapOnLine", "[GridTest]")
+TEST_CASE("GridTest.snapOnLine")
 {
   const vm::line3d X(vm::vec3d(5.0, 0.0, 0.0), vm::vec3d::pos_x());
 
@@ -150,7 +150,7 @@ TEST_CASE("GridTest.snapOnLine", "[GridTest]")
     Grid(2u).snap(vm::vec3(7.5, 0.0, 0.0), L) == vm::approx(vm::vec3d(2.0, 4.0, 0.0)));
 }
 
-TEST_CASE("GridTest.snapOnEdge", "[GridTest]")
+TEST_CASE("GridTest.snapOnEdge")
 {
   const vm::segment3d E(vm::vec3d::zero(), vm::vec3d(1.0, 2.0, 0.0) * 2.0);
   CHECK(Grid(2u).snap(vm::vec3d::zero(), E) == vm::approx(vm::vec3d::zero()));
@@ -163,7 +163,7 @@ TEST_CASE("GridTest.snapOnEdge", "[GridTest]")
   CHECK(vm::is_nan(Grid(2u).snap(vm::vec3(-10.0, 0.0, 0.0), E)));
 }
 
-TEST_CASE("GridTest.snapOnQuad", "[GridTest]")
+TEST_CASE("GridTest.snapOnQuad")
 {
   const vm::polygon3d quad{
     vm::vec3d(-9.0, -9.0, 0.0),
@@ -189,7 +189,7 @@ TEST_CASE("GridTest.snapOnQuad", "[GridTest]")
     == vm::approx(vm::vec3d(9.0, -4.0, 0.0)));
 }
 
-TEST_CASE("GridTest.moveDeltaForPoint", "[GridTest]")
+TEST_CASE("GridTest.moveDeltaForPoint")
 {
   const auto grid16 = Grid(4);
 
@@ -200,7 +200,7 @@ TEST_CASE("GridTest.moveDeltaForPoint", "[GridTest]")
   CHECK(pointOffGrid + grid16.moveDeltaForPoint(pointOffGrid, inputDelta) == pointOnGrid);
 }
 
-TEST_CASE("GridTest.moveDeltaForPoint_SubInteger", "[GridTest]")
+TEST_CASE("GridTest.moveDeltaForPoint_SubInteger")
 {
   const auto grid05 = Grid(-1);
 
@@ -212,7 +212,7 @@ TEST_CASE("GridTest.moveDeltaForPoint_SubInteger", "[GridTest]")
   CHECK(pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, inputDelta) == pointOnGrid);
 }
 
-TEST_CASE("GridTest.moveDeltaForPoint_SubInteger2", "[GridTest]")
+TEST_CASE("GridTest.moveDeltaForPoint_SubInteger2")
 {
   const auto grid05 = Grid(-1);
 
@@ -229,7 +229,7 @@ static vm::ray3 make_ray_from_to(const vm::vec3& from, const vm::vec3& to)
   return vm::ray3(from, vm::normalize(to - from));
 }
 
-TEST_CASE("GridTest.moveDeltaForBounds", "[GridTest]")
+TEST_CASE("GridTest.moveDeltaForBounds")
 {
   const auto grid16 = Grid(4);
 

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -48,7 +48,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.createEmptyGroup", "[GroupNodesTest]")
+TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.createEmptyGroup")
 {
   CHECK(document->groupSelection("test") == nullptr);
 }
@@ -213,7 +213,7 @@ TEST_CASE_METHOD(
   CHECK_FALSE(entityNode->entity().hasProperty("origin"));
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.renameGroup", "[GroupNodesTest]")
+TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.renameGroup")
 {
   Model::BrushNode* brush1 = createBrushNode();
   document->addNodes({{document->parentForNodes(), {brush1}}});
@@ -529,7 +529,7 @@ TEST_CASE_METHOD(
   CHECK(linkedGroupNode->group().linkedGroupId() == groupNode->group().linkedGroupId());
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.selectLinkedGroups", "[GroupNodesTest]")
+TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.selectLinkedGroups")
 {
   auto* entityNode = new Model::EntityNode{Model::Entity{}};
   auto* brushNode = createBrushNode();
@@ -584,7 +584,7 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.selectLinkedGroups", "[GroupNo
   }
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups", "[GroupNodesTest]")
+TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
 {
   auto* brushNode = createBrushNode();
   document->addNodes({{document->parentForNodes(), {brushNode}}});

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -529,6 +529,42 @@ TEST_CASE_METHOD(
   CHECK(linkedGroupNode->group().linkedGroupId() == groupNode->group().linkedGroupId());
 }
 
+TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.recursiveLinkedGroups")
+{
+  auto* brushNode = createBrushNode();
+  document->addNodes({{document->parentForNodes(), {brushNode}}});
+  document->selectNodes({brushNode});
+
+  auto* groupNode = document->groupSelection("test");
+  REQUIRE(groupNode != nullptr);
+
+  document->deselectAll();
+  document->selectNodes({groupNode});
+  auto* linkedGroupNode = document->createLinkedDuplicate();
+  document->deselectAll();
+
+  REQUIRE(linkedGroupNode != nullptr);
+  REQUIRE(groupNode->group().linkedGroupId() != std::nullopt);
+  REQUIRE(linkedGroupNode->group().linkedGroupId() == groupNode->group().linkedGroupId());
+
+  SECTION("Adding a linked group to its linked sibling does nothing")
+  {
+    CHECK_FALSE(document->reparentNodes({{groupNode, {linkedGroupNode}}}));
+  }
+
+  SECTION(
+    "Adding a group containing a nested linked sibling to a linked group does nothing")
+  {
+    document->selectNodes({linkedGroupNode});
+
+    auto* outerGroupNode = document->groupSelection("outer");
+    REQUIRE(outerGroupNode != nullptr);
+
+    document->deselectAll();
+    CHECK_FALSE(document->reparentNodes({{groupNode, {outerGroupNode}}}));
+  }
+}
+
 TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.selectLinkedGroups")
 {
   auto* entityNode = new Model::EntityNode{Model::Entity{}};

--- a/common/test/src/View/InputEventTest.cpp
+++ b/common/test/src/View/InputEventTest.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-TEST_CASE("KeyEventTest.collateWith", "[KeyEventTest]")
+TEST_CASE("KeyEventTest.collateWith")
 {
   static const std::array<KeyEvent::Type, 2> eventTypes = {
     KeyEvent::Type::Down, KeyEvent::Type::Up};
@@ -52,7 +52,7 @@ TEST_CASE("KeyEventTest.collateWith", "[KeyEventTest]")
   }
 }
 
-TEST_CASE("MouseEventTest.collateWith", "[MouseEventTest]")
+TEST_CASE("MouseEventTest.collateWith")
 {
   static const std::array<MouseEvent::Type, 9> eventTypes = {
     MouseEvent::Type::Down,
@@ -267,7 +267,7 @@ inline QWheelEvent makeWheelEvent(const QPoint& angleDelta)
 #endif
 }
 
-TEST_CASE("InputEventRecorderTest.recordKeyEvents", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordKeyEvents")
 {
   InputEventRecorder r;
 
@@ -277,7 +277,7 @@ TEST_CASE("InputEventRecorderTest.recordKeyEvents", "[InputEventRecorderTest]")
   checkEventQueue(r, KeyEvent(KeyEvent::Type::Down), KeyEvent(KeyEvent::Type::Up));
 }
 
-TEST_CASE("InputEventRecorderTest.recordLeftClick", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordLeftClick")
 {
   InputEventRecorder r;
 
@@ -311,7 +311,7 @@ TEST_CASE("InputEventRecorderTest.recordLeftClick", "[InputEventRecorderTest]")
       0.0f));
 }
 
-TEST_CASE("InputEventRecorderTest.recordLeftDoubleClick", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordLeftDoubleClick")
 {
   InputEventRecorder r;
 
@@ -376,7 +376,7 @@ TEST_CASE("InputEventRecorderTest.recordLeftDoubleClick", "[InputEventRecorderTe
       0.0f));
 }
 
-TEST_CASE("InputEventRecorderTest.recordCtrlLeftClick", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordCtrlLeftClick")
 {
   InputEventRecorder r;
 
@@ -416,7 +416,7 @@ TEST_CASE("InputEventRecorderTest.recordCtrlLeftClick", "[InputEventRecorderTest
       0.0f));
 }
 
-TEST_CASE("InputEventRecorderTest.recordRightClick", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordRightClick")
 {
   InputEventRecorder r;
 
@@ -456,7 +456,7 @@ TEST_CASE("InputEventRecorderTest.recordRightClick", "[InputEventRecorderTest]")
       0.0f));
 }
 
-TEST_CASE("InputEventRecorderTest.recordMotionWithCollation", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordMotionWithCollation")
 {
   InputEventRecorder r;
 
@@ -477,7 +477,7 @@ TEST_CASE("InputEventRecorderTest.recordMotionWithCollation", "[InputEventRecord
       0.0f));
 }
 
-TEST_CASE("InputEventRecorderTest.recordHScrollWithCollation", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordHScrollWithCollation")
 {
   InputEventRecorder r;
   const auto qWheel1 = makeWheelEvent({2, 0});
@@ -504,7 +504,7 @@ TEST_CASE("InputEventRecorderTest.recordHScrollWithCollation", "[InputEventRecor
       expectedScrollLines));
 }
 
-TEST_CASE("InputEventRecorderTest.recordVScrollWithCollation", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordVScrollWithCollation")
 {
   InputEventRecorder r;
   const auto qWheel1 = makeWheelEvent({0, 3});
@@ -531,7 +531,7 @@ TEST_CASE("InputEventRecorderTest.recordVScrollWithCollation", "[InputEventRecor
       expectedScrollLines));
 }
 
-TEST_CASE("InputEventRecorderTest.recordDiagonalScroll", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordDiagonalScroll")
 {
   InputEventRecorder r;
   const auto qWheel1 = makeWheelEvent({1, 3});
@@ -712,7 +712,7 @@ TEST_CASE(
       0.0f));
 }
 
-TEST_CASE("InputEventRecorderTest.recordLeftDrag", "[InputEventRecorderTest]")
+TEST_CASE("InputEventRecorderTest.recordLeftDrag")
 {
   InputEventRecorder r;
 

--- a/common/test/src/View/LayerNodesTest.cpp
+++ b/common/test/src/View/LayerNodesTest.cpp
@@ -53,7 +53,7 @@ TEST_CASE_METHOD(
   CHECK(defaultLayerNode->layer().sortIndex() == Model::Layer::defaultLayerSortIndex());
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.renameLayer", "[LayerNodesTest]")
+TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.renameLayer")
 {
   // delete default brush
   document->selectAllNodes();
@@ -323,7 +323,7 @@ TEST_CASE_METHOD(
   CHECK(!entity1->locked());
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.moveLayer", "[LayerNodesTest]")
+TEST_CASE_METHOD(MapDocumentTest, "LayerNodeTest.moveLayer")
 {
   // delete default brush
   document->selectAllNodes();

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -118,7 +118,7 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.throwExceptionDuringCommand")
   CHECK_THROWS_AS(document->throwExceptionDuringCommand(), CommandProcessorException);
 }
 
-TEST_CASE("MapDocumentTest.detectValveFormatMap", "[MapDocumentTest]")
+TEST_CASE("MapDocumentTest.detectValveFormatMap")
 {
   auto [document, game, gameConfig] = View::loadMapDocument(
     IO::Path("fixture/test/View/MapDocumentTest/valveFormatMapWithoutFormatTag.map"),
@@ -128,7 +128,7 @@ TEST_CASE("MapDocumentTest.detectValveFormatMap", "[MapDocumentTest]")
   CHECK(document->world()->defaultLayer()->childCount() == 1);
 }
 
-TEST_CASE("MapDocumentTest.detectStandardFormatMap", "[MapDocumentTest]")
+TEST_CASE("MapDocumentTest.detectStandardFormatMap")
 {
   auto [document, game, gameConfig] = View::loadMapDocument(
     IO::Path("fixture/test/View/MapDocumentTest/standardFormatMapWithoutFormatTag.map"),
@@ -138,7 +138,7 @@ TEST_CASE("MapDocumentTest.detectStandardFormatMap", "[MapDocumentTest]")
   CHECK(document->world()->defaultLayer()->childCount() == 1);
 }
 
-TEST_CASE("MapDocumentTest.detectEmptyMap", "[MapDocumentTest]")
+TEST_CASE("MapDocumentTest.detectEmptyMap")
 {
   auto [document, game, gameConfig] = View::loadMapDocument(
     IO::Path("fixture/test/View/MapDocumentTest/emptyMapWithoutFormatTag.map"),
@@ -149,7 +149,7 @@ TEST_CASE("MapDocumentTest.detectEmptyMap", "[MapDocumentTest]")
   CHECK(document->world()->defaultLayer()->childCount() == 0);
 }
 
-TEST_CASE("MapDocumentTest.mixedFormats", "[MapDocumentTest]")
+TEST_CASE("MapDocumentTest.mixedFormats")
 {
   // map has both Standard and Valve brushes
   CHECK_THROWS_AS(

--- a/common/test/src/View/ScaleObjectsToolTest.cpp
+++ b/common/test/src/View/ScaleObjectsToolTest.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-TEST_CASE("ScaleObjectsToolTest.moveBBoxFace_NonProportional", "[ScaleObjectsToolTest]")
+TEST_CASE("ScaleObjectsToolTest.moveBBoxFace_NonProportional")
 {
   const auto input1 = vm::bbox3(vm::vec3(-100, -100, -100), vm::vec3(100, 100, 100));
 
@@ -84,7 +84,7 @@ TEST_CASE("ScaleObjectsToolTest.moveBBoxFace_NonProportional", "[ScaleObjectsToo
           .is_empty());
 }
 
-TEST_CASE("ScaleObjectsToolTest.moveBBoxFace_Proportional", "[ScaleObjectsToolTest]")
+TEST_CASE("ScaleObjectsToolTest.moveBBoxFace_Proportional")
 {
   const auto input1 = vm::bbox3(vm::vec3(-100, -100, -100), vm::vec3(100, 100, 100));
 
@@ -144,7 +144,7 @@ TEST_CASE("ScaleObjectsToolTest.moveBBoxFace_Proportional", "[ScaleObjectsToolTe
           .is_empty());
 }
 
-TEST_CASE("ScaleObjectsToolTest.moveBBoxCorner", "[ScaleObjectsToolTest]")
+TEST_CASE("ScaleObjectsToolTest.moveBBoxCorner")
 {
   const auto input1 = vm::bbox3(vm::vec3(-100, -100, -100), vm::vec3(100, 100, 100));
 
@@ -180,7 +180,7 @@ TEST_CASE("ScaleObjectsToolTest.moveBBoxCorner", "[ScaleObjectsToolTest]")
           .is_empty());
 }
 
-TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge_NonProportional", "[ScaleObjectsToolTest]")
+TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge_NonProportional")
 {
   const auto input1 = vm::bbox3(vm::vec3(-100, -100, -100), vm::vec3(100, 100, 100));
 
@@ -270,7 +270,7 @@ TEST_CASE(
     == exp2);
 }
 
-TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge_Proportional", "[ScaleObjectsToolTest]")
+TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge_Proportional")
 {
   const auto input1 = vm::bbox3(vm::vec3(-100, -100, -100), vm::vec3(100, 100, 100));
 
@@ -329,7 +329,7 @@ TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge_Proportional", "[ScaleObjectsToolTe
           .is_empty());
 }
 
-TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge", "[ScaleObjectsToolTest]")
+TEST_CASE("ScaleObjectsToolTest.moveBBoxEdge")
 {
   const auto input1 = vm::bbox3(vm::vec3(-64, -64, -16), vm::vec3(64, 64, 16));
 

--- a/common/test/src/View/TextOutputAdapterTest.cpp
+++ b/common/test/src/View/TextOutputAdapterTest.cpp
@@ -27,7 +27,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-TEST_CASE("TextOutputAdapterTest.test", "[TextOutputAdapterTest]")
+TEST_CASE("TextOutputAdapterTest.test")
 {
   QTextEdit textEdit;
   TextOutputAdapter adapter(&textEdit);

--- a/common/test/src/View/UndoTest.cpp
+++ b/common/test/src/View/UndoTest.cpp
@@ -41,7 +41,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-TEST_CASE_METHOD(MapDocumentTest, "UndoTest.setTexturesAfterRestore", "[UndoTest]")
+TEST_CASE_METHOD(MapDocumentTest, "UndoTest.setTexturesAfterRestore")
 {
   document->setEnabledTextureCollections(
     std::vector<IO::Path>{IO::Path("fixture/test/IO/Wad/cr8_czg.wad")});
@@ -104,7 +104,7 @@ TEST_CASE_METHOD(MapDocumentTest, "UndoTest.setTexturesAfterRestore", "[UndoTest
   }
 }
 
-TEST_CASE_METHOD(MapDocumentTest, "UndoTest.undoRotation", "[UndoTest]")
+TEST_CASE_METHOD(MapDocumentTest, "UndoTest.undoRotation")
 {
   auto* entityNode =
     new Model::EntityNode{{}, {{Model::EntityPropertyKeys::Classname, "test"}}};

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -996,6 +996,44 @@ auto set_intersection(const S1& s1, const S2& s2)
 }
 
 /**
+ * Checks if the given sets have a shared element.
+ *
+ * @tparam S1 the type of the first set
+ * @tparam S2 the type of the second set
+ * @tparam C the comparator to use when comparing set elements
+ * @param s1 the first set
+ * @param s2 the second set
+ * @return true if the given sets have a shared element and false otherwise
+ */
+template <
+  typename S1,
+  typename S2,
+  typename C =
+    std::less<std::common_type_t<typename S1::value_type, typename S2::value_type>>>
+auto set_has_shared_element(const S1& s1, const S2& s2, const C& cmp = C{})
+{
+  auto it1 = std::begin(s1);
+  auto it2 = std::begin(s2);
+  while (it1 != std::end(s1) && it2 != std::end(s2))
+  {
+    if (cmp(*it1, *it2))
+    {
+      ++it1;
+    }
+    else if (cmp(*it2, *it1))
+    {
+      ++it2;
+    }
+    else
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Clears the given vector and ensures that it has a capacity of 0 afterwards.
  *
  * @tparam T the type of the vector elements

--- a/lib/kdl/test/src/binary_relation_test.cpp
+++ b/lib/kdl/test/src/binary_relation_test.cpp
@@ -33,7 +33,7 @@ bool checkRelation(
   return std::equal(std::begin(act), std::end(act), std::begin(exp), std::end(exp));
 }
 
-TEST_CASE("binary_relation_test.constructor_default", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.constructor_default")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -41,7 +41,7 @@ TEST_CASE("binary_relation_test.constructor_default", "[binary_relation_test]")
   CHECK(r.empty());
 }
 
-TEST_CASE("binary_relation_test.constructor_intializer_list", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.constructor_intializer_list")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -65,7 +65,7 @@ TEST_CASE("binary_relation_test.constructor_intializer_list", "[binary_relation_
     }));
 }
 
-TEST_CASE("binary_relation_test.empty", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.empty")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -73,7 +73,7 @@ TEST_CASE("binary_relation_test.empty", "[binary_relation_test]")
   CHECK_FALSE(relation({{1, "a"}}).empty());
 }
 
-TEST_CASE("binary_relation_test.size", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.size")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -83,7 +83,7 @@ TEST_CASE("binary_relation_test.size", "[binary_relation_test]")
   CHECK(relation({{1, "a"}, {1, "b"}, {2, "c"}}).size() == 3u);
 }
 
-TEST_CASE("binary_relation_test.contains", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.contains")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -93,7 +93,7 @@ TEST_CASE("binary_relation_test.contains", "[binary_relation_test]")
   CHECK(relation({{1, "a"}}).contains(1, "a"));
 }
 
-TEST_CASE("binary_relation_test.count_left", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.count_left")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -104,7 +104,7 @@ TEST_CASE("binary_relation_test.count_left", "[binary_relation_test]")
   CHECK(relation({{1, "a"}, {1, "b"}, {2, "a"}}).count_left("a") == 2u);
 }
 
-TEST_CASE("binary_relation_test.count_right", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.count_right")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -115,7 +115,7 @@ TEST_CASE("binary_relation_test.count_right", "[binary_relation_test]")
   CHECK(relation({{1, "a"}, {1, "b"}, {2, "a"}}).count_right(1) == 2u);
 }
 
-TEST_CASE("binary_relation_test.iterator", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.iterator")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -161,7 +161,7 @@ void assertRange(const std::vector<T>& exp, const std::pair<I, I>& act)
   CHECK(std::equal(std::begin(exp), std::end(exp), act.first, act.second));
 }
 
-TEST_CASE("binary_relation_test.left_range", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.left_range")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -171,7 +171,7 @@ TEST_CASE("binary_relation_test.left_range", "[binary_relation_test]")
   assertRange<int>({1, 2}, relation({{1, "a"}, {2, "a"}, {3, "b"}}).left_range("a"));
 }
 
-TEST_CASE("binary_relation_test.right_range", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.right_range")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -182,7 +182,7 @@ TEST_CASE("binary_relation_test.right_range", "[binary_relation_test]")
     {"a", "b"}, relation({{1, "a"}, {1, "b"}, {2, "c"}}).right_range(1));
 }
 
-TEST_CASE("binary_relation_test.insert_relation", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.insert_relation")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -207,7 +207,7 @@ TEST_CASE("binary_relation_test.insert_relation", "[binary_relation_test]")
     }));
 }
 
-TEST_CASE("binary_relation_test.insert_right_range", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.insert_right_range")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -254,7 +254,7 @@ TEST_CASE("binary_relation_test.insert_right_range", "[binary_relation_test]")
   CHECK(std::equal(std::begin(right_3), std::end(right_3), r.right_begin(left_3)));
 }
 
-TEST_CASE("binary_relation_test.insert_left_range", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.insert_left_range")
 {
   using relation = binary_relation<std::string, size_t>;
 
@@ -301,7 +301,7 @@ TEST_CASE("binary_relation_test.insert_left_range", "[binary_relation_test]")
   CHECK(std::equal(std::begin(left_3), std::end(left_3), r.left_begin(right_3)));
 }
 
-TEST_CASE("binary_relation_test.insert_values", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.insert_values")
 {
   using relation = binary_relation<int, std::string>;
 
@@ -332,7 +332,7 @@ TEST_CASE("binary_relation_test.insert_values", "[binary_relation_test]")
   CHECK(r.count_right(2) == 1u);
 }
 
-TEST_CASE("binary_relation_test.erase", "[binary_relation_test]")
+TEST_CASE("binary_relation_test.erase")
 {
   using relation = binary_relation<int, std::string>;
 

--- a/lib/kdl/test/src/collection_utils_test.cpp
+++ b/lib/kdl/test/src/collection_utils_test.cpp
@@ -54,7 +54,7 @@ TEST_CASE("collection_utils_test.compare_cmp")
     combine_cmp(cmpInt, cmpChr)(std::make_tuple(1, 'a'), std::make_tuple(1, 'a')));
 }
 
-TEST_CASE("collection_utils_test.col_total_size", "[collection_utils_test]")
+TEST_CASE("collection_utils_test.col_total_size")
 {
   using vec = std::vector<int>;
 
@@ -74,7 +74,7 @@ void test_range_remove_all(
   CHECK(std::vector<T>(std::begin(col), it) == exp1);
 }
 
-TEST_CASE("collection_utils_test.range_remove_all", "[collection_utils_test]")
+TEST_CASE("collection_utils_test.range_remove_all")
 {
   test_range_remove_all<int>(
     {1, 2, 3, 4, 5, 6, 7, 8, 9}, {}, {1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -82,7 +82,7 @@ TEST_CASE("collection_utils_test.range_remove_all", "[collection_utils_test]")
   test_range_remove_all<int>({1, 2, 3, 4, 5, 6, 7, 8, 9}, {7, 3, 4}, {1, 2, 5, 6, 8, 9});
 }
 
-TEST_CASE("collection_utils_test.range_delete_all", "[collection_utils_test]")
+TEST_CASE("collection_utils_test.range_delete_all")
 {
   bool d1 = false;
   bool d2 = false;
@@ -118,13 +118,13 @@ TEST_CASE(
   test_range_lexicographical_compare<int>({1, 2, 3}, {3}, -1);
 }
 
-TEST_CASE("collection_utils_test.col_size", "[collection_utils_test]")
+TEST_CASE("collection_utils_test.col_size")
 {
   CHECK(col_size<int>(std::vector<int>({1, 2})) == 2);
   CHECK(col_size<unsigned>(std::vector<int>({1, 2})) == 2u);
 }
 
-TEST_CASE("collection_utils_test.col_delete_all", "[collection_utils_test]")
+TEST_CASE("collection_utils_test.col_delete_all")
 {
   bool d1 = false;
   bool d2 = false;
@@ -145,7 +145,7 @@ void test_col_is_equivalent(
   CHECK(col_is_equivalent(lhs, rhs) == exp);
 }
 
-TEST_CASE("collection_utils_test.col_is_equivalent", "[collection_utils_test]")
+TEST_CASE("collection_utils_test.col_is_equivalent")
 {
   test_col_is_equivalent<int>({}, {}, true);
   test_col_is_equivalent<int>({}, {1}, false);

--- a/lib/kdl/test/src/compact_trie_test.cpp
+++ b/lib/kdl/test/src/compact_trie_test.cpp
@@ -40,7 +40,7 @@ static void assertMatches(
   CHECK_THAT(matches, Catch::UnorderedEquals(expectedMatches));
 }
 
-TEST_CASE("compact_trie_test.insert", "[compact_trie_test]")
+TEST_CASE("compact_trie_test.insert")
 {
   test_index index;
   index.insert("key", "value");
@@ -76,7 +76,7 @@ TEST_CASE("compact_trie_test.insert", "[compact_trie_test]")
   assertMatches(index, "*", {"value", "value", "value2", "value3", "value4", "value4"});
 }
 
-TEST_CASE("compact_trie_test.remove", "[compact_trie_test]")
+TEST_CASE("compact_trie_test.remove")
 {
   test_index index;
   index.insert("andrew", "value");
@@ -113,7 +113,7 @@ TEST_CASE("compact_trie_test.remove", "[compact_trie_test]")
   assertMatches(index, "*", {});
 }
 
-TEST_CASE("compact_trie_test.find_matches_with_exact_pattern", "[compact_trie_test]")
+TEST_CASE("compact_trie_test.find_matches_with_exact_pattern")
 {
   test_index index;
   index.insert("key", "value");
@@ -133,7 +133,7 @@ TEST_CASE("compact_trie_test.find_matches_with_exact_pattern", "[compact_trie_te
   assertMatches(index, "", {});
 }
 
-TEST_CASE("compact_trie_test.find_matches_with_wildcards", "[compact_trie_test]")
+TEST_CASE("compact_trie_test.find_matches_with_wildcards")
 {
   test_index index;
   index.insert("key", "value");
@@ -172,7 +172,7 @@ TEST_CASE("compact_trie_test.find_matches_with_wildcards", "[compact_trie_test]"
   assertMatches(index, "t*%*", {});
 }
 
-TEST_CASE("compact_trie_test.find_matches_with_digit_suffix", "[compact_trie_test]")
+TEST_CASE("compact_trie_test.find_matches_with_digit_suffix")
 {
   test_index index;
   index.insert("key", "value");
@@ -191,7 +191,7 @@ TEST_CASE("compact_trie_test.find_matches_with_digit_suffix", "[compact_trie_tes
   assertMatches(index, "k%*", {});
 }
 
-TEST_CASE("compact_trie_test.get_keys", "[compact_trie_test]")
+TEST_CASE("compact_trie_test.get_keys")
 {
   test_index index;
   index.insert("key", "value");

--- a/lib/kdl/test/src/intrusive_circular_list_test.cpp
+++ b/lib/kdl/test/src/intrusive_circular_list_test.cpp
@@ -164,7 +164,7 @@ TEST_CASE(
   CHECK(t3_deleted);
 }
 
-TEST_CASE("intrusive_circular_list_test.iterators", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.iterators")
 {
   list l;
 
@@ -228,7 +228,7 @@ TEST_CASE(
   CHECK(end == it);
 }
 
-TEST_CASE("intrusive_circular_list_test.empty", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.empty")
 {
   list l;
   CHECK(l.empty());
@@ -238,7 +238,7 @@ TEST_CASE("intrusive_circular_list_test.empty", "[intrusive_circular_list_test]"
   CHECK_FALSE(l.empty());
 }
 
-TEST_CASE("intrusive_circular_list_test.size", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.size")
 {
   list l;
   CHECK(l.size() == 0u);
@@ -248,7 +248,7 @@ TEST_CASE("intrusive_circular_list_test.size", "[intrusive_circular_list_test]")
   CHECK(l.size() == 1u);
 }
 
-TEST_CASE("intrusive_circular_list_test.front", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.front")
 {
   list l;
 
@@ -268,7 +268,7 @@ TEST_CASE("intrusive_circular_list_test.front", "[intrusive_circular_list_test]"
   CHECK(l.front() == e1);
 }
 
-TEST_CASE("intrusive_circular_list_test.back", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.back")
 {
   list l;
 
@@ -288,7 +288,7 @@ TEST_CASE("intrusive_circular_list_test.back", "[intrusive_circular_list_test]")
   CHECK(l.back() == e3);
 }
 
-TEST_CASE("intrusive_circular_list_test.contains", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.contains")
 {
   list l;
 
@@ -307,7 +307,7 @@ TEST_CASE("intrusive_circular_list_test.contains", "[intrusive_circular_list_tes
   CHECK(l.contains(e3));
 }
 
-TEST_CASE("intrusive_circular_list_test.push_back", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.push_back")
 {
   list l;
   auto* e1 = new element();
@@ -365,7 +365,7 @@ TEST_CASE(
   assertList({e1, e2}, l);
 }
 
-TEST_CASE("intrusive_circular_list_test.remove_single", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.remove_single")
 {
   auto e1_deleted = false;
   auto e2_deleted = false;
@@ -445,7 +445,7 @@ TEST_CASE(
   assertList({e2, e3}, l);
 }
 
-TEST_CASE("intrusive_circular_list_test.remove_all", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.remove_all")
 {
   auto e1_deleted = false;
   auto e2_deleted = false;
@@ -464,7 +464,7 @@ TEST_CASE("intrusive_circular_list_test.remove_all", "[intrusive_circular_list_t
   assertList({}, l);
 }
 
-TEST_CASE("intrusive_circular_list_test.release_single", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.release_single")
 {
   auto e1_deleted = false;
   auto e2_deleted = false;
@@ -549,7 +549,7 @@ TEST_CASE(
   assertLinks(e4, {e1, e4});
 }
 
-TEST_CASE("intrusive_circular_list_test.release_all", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.release_all")
 {
   auto e1_deleted = false;
   auto e2_deleted = false;
@@ -569,7 +569,7 @@ TEST_CASE("intrusive_circular_list_test.release_all", "[intrusive_circular_list_
   assertLinks(e1, {e1, e2});
 }
 
-TEST_CASE("intrusive_circular_list_test.emplace_back", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.emplace_back")
 {
   list l;
 
@@ -595,7 +595,7 @@ TEST_CASE(
   CHECK(e1_deleted);
 }
 
-TEST_CASE("intrusive_circular_list_test.reverse", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.reverse")
 {
   auto* e1 = new element();
   auto* e2 = new element();
@@ -606,7 +606,7 @@ TEST_CASE("intrusive_circular_list_test.reverse", "[intrusive_circular_list_test
   assertList({e3, e2, e1}, l);
 }
 
-TEST_CASE("intrusive_circular_list_test.append_list", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.append_list")
 {
   list from;
   list to;
@@ -1557,7 +1557,7 @@ TEST_CASE(
   CHECK(t3_deleted);
 }
 
-TEST_CASE("intrusive_circular_list_test.release", "[intrusive_circular_list_test]")
+TEST_CASE("intrusive_circular_list_test.release")
 {
   auto e1_deleted = false;
   auto e2_deleted = false;

--- a/lib/kdl/test/src/invoke_test.cpp
+++ b/lib/kdl/test/src/invoke_test.cpp
@@ -24,7 +24,7 @@
 
 namespace kdl
 {
-TEST_CASE("invoke_test.invoke_later_lvalue", "[invoke_test]")
+TEST_CASE("invoke_test.invoke_later_lvalue")
 {
   bool invoked = false;
   auto lambda = [&invoked]() { invoked = true; };
@@ -36,7 +36,7 @@ TEST_CASE("invoke_test.invoke_later_lvalue", "[invoke_test]")
   CHECK(invoked);
 }
 
-TEST_CASE("invoke_test.invoke_later_rvalue", "[invoke_test]")
+TEST_CASE("invoke_test.invoke_later_rvalue")
 {
   bool invoked = false;
 

--- a/lib/kdl/test/src/map_utils_test.cpp
+++ b/lib/kdl/test/src/map_utils_test.cpp
@@ -36,7 +36,7 @@ void test_map_keys(const std::vector<K>& keys, const std::map<K, V>& map)
   CHECK(map_keys(map) == keys);
 }
 
-TEST_CASE("map_utils_test.map_keys", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_keys")
 {
   test_map_keys<int, int>({}, {});
   test_map_keys<int, std::string>({1, 2, 3}, {{1, "one"}, {2, "two"}, {3, "three "}});
@@ -48,7 +48,7 @@ void test_map_values(const std::vector<V>& values, const std::map<K, V>& map)
   CHECK(map_values(map) == values);
 }
 
-TEST_CASE("map_utils_test.map_values", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_values")
 {
   test_map_values<int, int>({}, {});
   test_map_values<int, std::string>(
@@ -62,7 +62,7 @@ void test_map_lexicographical_compare(
   CHECK(map_lexicographical_compare(lhs, rhs) == exp);
 }
 
-TEST_CASE("map_utils_test.map_lexicographical_compare", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_lexicographical_compare")
 {
   test_map_lexicographical_compare<int, int>(0, {}, {});
   test_map_lexicographical_compare<int, int>(0, {{1, 2}, {2, 3}}, {{1, 2}, {2, 3}});
@@ -95,7 +95,7 @@ void test_map_is_equivalent(
   CHECK(map_is_equivalent(lhs, rhs) == exp);
 }
 
-TEST_CASE("map_utils_test.map_is_equivalent", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_is_equivalent")
 {
   test_map_is_equivalent<int, int>(true, {}, {});
   test_map_is_equivalent<int, int>(true, {{1, 2}, {2, 3}}, {{1, 2}, {2, 3}});
@@ -127,7 +127,7 @@ void test_map_find_or_default(
   CHECK(map_find_or_default(m, key, defaultValue) == exp);
 }
 
-TEST_CASE("map_utils_test.map_find_or_default", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_find_or_default")
 {
   test_map_find_or_default<int, std::string>("default", {}, 1, "default");
   test_map_find_or_default<int, std::string>("value", {{1, "value"}}, 1, "default");
@@ -140,7 +140,7 @@ void test_map_union(
   CHECK(map_union(m1, m2) == exp);
 }
 
-TEST_CASE("map_utils_test.map_union", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_union")
 {
   test_map_union<int, int>({}, {}, {});
   test_map_union<int, int>({{1, 2}}, {{1, 2}}, {});
@@ -160,7 +160,7 @@ void test_map_merge(
   CHECK(map_merge(m1, m2) == exp);
 }
 
-TEST_CASE("map_utils_test.map_merge", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_merge")
 {
   test_map_merge<int, int>({}, {}, {});
   test_map_merge<int, int>({{1, {1, 2}}}, {{1, {1, 2}}}, {});
@@ -169,7 +169,7 @@ TEST_CASE("map_utils_test.map_merge", "[map_utils_test]")
   test_map_merge<int, int>({{1, {1, 2, 3, 4}}}, {{1, {1, 2}}}, {{1, {3, 4}}});
 }
 
-TEST_CASE("map_utils_test.map_clear_and_delete", "[map_utils_test]")
+TEST_CASE("map_utils_test.map_clear_and_delete")
 {
   bool d1 = false;
   bool d2 = false;

--- a/lib/kdl/test/src/meta_utils_test.cpp
+++ b/lib/kdl/test/src/meta_utils_test.cpp
@@ -24,7 +24,7 @@
 
 namespace kdl
 {
-TEST_CASE("meta_utils_test.contains", "[meta_utils_test]")
+TEST_CASE("meta_utils_test.contains")
 {
   static_assert(meta_contains_v<int, int>);
   static_assert(!meta_contains_v<int, float>);
@@ -32,7 +32,7 @@ TEST_CASE("meta_utils_test.contains", "[meta_utils_test]")
   static_assert(!meta_contains_v<int, float, double>);
 }
 
-TEST_CASE("meta_utils_test.append", "[meta_utils_test]")
+TEST_CASE("meta_utils_test.append")
 {
   static_assert(std::is_same_v<
                 meta_append<int, float, double>::result,
@@ -42,7 +42,7 @@ TEST_CASE("meta_utils_test.append", "[meta_utils_test]")
                 meta_type_list<int, float, double, int>>);
 }
 
-TEST_CASE("meta_utils_test.append_if", "[meta_utils_test]")
+TEST_CASE("meta_utils_test.append_if")
 {
   static_assert(std::is_same_v<
                 meta_append_if<true, int, float, double>::result,
@@ -52,7 +52,7 @@ TEST_CASE("meta_utils_test.append_if", "[meta_utils_test]")
                 meta_type_list<float, double>>);
 }
 
-TEST_CASE("meta_utils_test.front", "[meta_utils_test]")
+TEST_CASE("meta_utils_test.front")
 {
   static_assert(std::is_same_v<meta_front<int>::front, int>);
   static_assert(std::is_same_v<meta_front<int>::remainder, meta_type_list<>>);
@@ -62,7 +62,7 @@ TEST_CASE("meta_utils_test.front", "[meta_utils_test]")
                 meta_type_list<float, double>>);
 }
 
-TEST_CASE("meta_utils_test.remove_duplicates", "[meta_utils_test]")
+TEST_CASE("meta_utils_test.remove_duplicates")
 {
   static_assert(std::is_same_v<
                 meta_remove_duplicates<int, float, double>::result,

--- a/lib/kdl/test/src/parallel_test.cpp
+++ b/lib/kdl/test/src/parallel_test.cpp
@@ -33,14 +33,14 @@
 
 namespace kdl
 {
-TEST_CASE("for 0", "[parallel_test]")
+TEST_CASE("for 0")
 {
   bool ran = false;
   kdl::parallel_for(0, [&](size_t) { ran = true; });
   CHECK(!ran);
 }
 
-TEST_CASE("for 10000", "[parallel_test]")
+TEST_CASE("for 10000")
 {
   constexpr size_t TestSize = 10'000;
 
@@ -73,7 +73,7 @@ TEST_CASE("for 10000", "[parallel_test]")
   }
 }
 
-TEST_CASE("transform", "[parallel_test]")
+TEST_CASE("transform")
 {
   const auto L = [](const int& v) { return v * 10; };
 
@@ -83,7 +83,7 @@ TEST_CASE("transform", "[parallel_test]")
     == kdl::vec_parallel_transform(std::vector<int>{1, 2, 3}, L));
 }
 
-TEST_CASE("transform_many", "[parallel_test]")
+TEST_CASE("transform_many")
 {
   std::vector<int> input;
   std::vector<std::string> expected;
@@ -99,7 +99,7 @@ TEST_CASE("transform_many", "[parallel_test]")
         }));
 }
 
-TEST_CASE("overhead for small work batches", "[parallel_test]")
+TEST_CASE("overhead for small work batches")
 {
   constexpr size_t OuterLoop = 1'000;
   constexpr size_t InnerLoop = 10;

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -373,7 +373,7 @@ void test_visit_error_rvalue_ref_with_opt_value(E&& e)
   CHECK(y.copies == 0u);
 }
 
-TEST_CASE("result_test.void_success", "[result_test]")
+TEST_CASE("result_test.void_success")
 {
   kdl::result<void, Error1> r1 =
     result<int, Error1>(1).and_then([](int) { return void_success; });
@@ -381,7 +381,7 @@ TEST_CASE("result_test.void_success", "[result_test]")
   CHECK(r1.is_success());
 }
 
-TEST_CASE("result_test.constructor", "[result_test]")
+TEST_CASE("result_test.constructor")
 {
   CHECK((result<int, float, std::string>(1).is_success()));
   CHECK((result<int, float, std::string>(1.0f).is_error()));
@@ -403,7 +403,7 @@ TEST_CASE("result_test.constructor", "[result_test]")
   test_construct_error<result<const int, Error1, Error2>>(Error2{});
 }
 
-TEST_CASE("result_test.converting_constructor", "[result_test]")
+TEST_CASE("result_test.converting_constructor")
 {
   CHECK(result<int, std::string, float>{result<int, std::string, float>{1}}.is_success());
   CHECK(
@@ -423,7 +423,7 @@ TEST_CASE("result_test.converting_constructor", "[result_test]")
   // CHECK(result<int, std::string, float>{result<int, float, double>{1.0f}}.is_error());
 }
 
-TEST_CASE("result_test.visit", "[result_test]")
+TEST_CASE("result_test.visit")
 {
   test_visit_success_const_lvalue_ref<const result<int, Error1, Error2>>(1);
   test_visit_success_const_lvalue_ref<result<int, Error1, Error2>>(1);
@@ -438,7 +438,7 @@ TEST_CASE("result_test.visit", "[result_test]")
   test_visit_error_rvalue_ref<result<int, Counter, Error2>>(Counter{});
 }
 
-TEST_CASE("result_test.and_then", "[result_test]")
+TEST_CASE("result_test.and_then")
 {
   test_and_then_const_lvalue_ref<const result<int, Error1, Error2>, float>(1);
   test_and_then_const_lvalue_ref<result<int, Error1, Error2>, float>(1);
@@ -447,7 +447,7 @@ TEST_CASE("result_test.and_then", "[result_test]")
   test_and_then_rvalue_ref<result<Counter, Error1, Error2>, Counter>(Counter{});
 }
 
-TEST_CASE("result_test.map_errors", "[result_test]")
+TEST_CASE("result_test.map_errors")
 {
   SECTION("map error of success result by const lvalue")
   {
@@ -484,7 +484,7 @@ TEST_CASE("result_test.map_errors", "[result_test]")
   }
 }
 
-TEST_CASE("void_result_test.constructor", "[void_result_test]")
+TEST_CASE("void_result_test.constructor")
 {
   CHECK((result<void, float, std::string>().is_success()));
   CHECK((result<void, float, std::string>(1.0f).is_error()));
@@ -500,7 +500,7 @@ TEST_CASE("void_result_test.constructor", "[void_result_test]")
   test_construct_error<result<void, Error1, Error2>>(Error2{});
 }
 
-TEST_CASE("void_result_test.converting_constructor", "[result_test]")
+TEST_CASE("void_result_test.converting_constructor")
 {
   CHECK(
     result<void, std::string, float>{result<void, std::string, float>{}}.is_success());
@@ -523,7 +523,7 @@ TEST_CASE("void_result_test.converting_constructor", "[result_test]")
   // double>{1.0f}}.is_error());
 }
 
-TEST_CASE("void_result_test.visit", "[void_result_test]")
+TEST_CASE("void_result_test.visit")
 {
   test_visit_success_with_opt_value<const result<void, Error1, Error2>>();
   test_visit_success_with_opt_value<result<void, Error1, Error2>>();
@@ -535,7 +535,7 @@ TEST_CASE("void_result_test.visit", "[void_result_test]")
   test_visit_error_rvalue_ref_with_opt_value<result<void, Counter, Error2>>(Counter{});
 }
 
-TEST_CASE("void_result_test.and_then", "[void_result_test]")
+TEST_CASE("void_result_test.and_then")
 {
   const auto r_success = result<void, Error1, Error2>();
   const auto r_error = result<void, Error1, Error2>(Error2{});

--- a/lib/kdl/test/src/set_adapter_test.cpp
+++ b/lib/kdl/test/src/set_adapter_test.cpp
@@ -26,13 +26,13 @@
 
 namespace kdl
 {
-TEST_CASE("const_set_adapter_test.wrap_set", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.wrap_set")
 {
   const auto v = std::vector<int>{1, 2, 3, 4};
   CHECK_THAT(wrap_set(v).get_data(), Catch::Equals(v));
 }
 
-TEST_CASE("const_set_adapter_test.iterators", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.iterators")
 {
   const auto v = std::vector<int>{1, 2, 3, 4};
   const auto s = wrap_set(v);
@@ -46,7 +46,7 @@ TEST_CASE("const_set_adapter_test.iterators", "[const_set_adapter_test]")
   CHECK(it == std::end(s));
 }
 
-TEST_CASE("const_set_adapter_test.reverse_iterators", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.reverse_iterators")
 {
   const auto v = std::vector<int>{1, 2, 3, 4};
   const auto s = wrap_set(v);
@@ -60,7 +60,7 @@ TEST_CASE("const_set_adapter_test.reverse_iterators", "[const_set_adapter_test]"
   CHECK(it == std::rend(s));
 }
 
-TEST_CASE("const_set_adapter_test.empty", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.empty")
 {
   const auto v1 = std::vector<int>();
   CHECK(wrap_set(v1).empty());
@@ -69,7 +69,7 @@ TEST_CASE("const_set_adapter_test.empty", "[const_set_adapter_test]")
   CHECK_FALSE(wrap_set(v2).empty());
 }
 
-TEST_CASE("const_set_adapter_test.col_total_size", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.col_total_size")
 {
   const auto v1 = std::vector<int>();
   CHECK(wrap_set(v1).size() == 0u);
@@ -78,13 +78,13 @@ TEST_CASE("const_set_adapter_test.col_total_size", "[const_set_adapter_test]")
   CHECK(wrap_set(v2).size() == 2u);
 }
 
-TEST_CASE("const_set_adapter_test.max_size", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.max_size")
 {
   const auto v = std::vector<int>();
   CHECK(wrap_set(v).max_size() == v.max_size());
 }
 
-TEST_CASE("const_set_adapter_test.count", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.count")
 {
   const auto v1 = std::vector<int>();
   CHECK(wrap_set(v1).count(1) == 0u);
@@ -97,7 +97,7 @@ TEST_CASE("const_set_adapter_test.count", "[const_set_adapter_test]")
   CHECK(wrap_set(v2).count(4) == 0u);
 }
 
-TEST_CASE("const_set_adapter_test.find", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.find")
 {
   const auto v1 = std::vector<int>();
   const auto s1 = wrap_set(v1);
@@ -112,7 +112,7 @@ TEST_CASE("const_set_adapter_test.find", "[const_set_adapter_test]")
   CHECK(s2.find(4) == std::end(s2));
 }
 
-TEST_CASE("const_set_adapter_test.equal_range", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.equal_range")
 {
   const auto v1 = std::vector<int>();
   const auto s1 = wrap_set(v1);
@@ -137,7 +137,7 @@ TEST_CASE("const_set_adapter_test.equal_range", "[const_set_adapter_test]")
     == std::make_pair(std::next(std::begin(s2), 3), std::next(std::begin(s2), 3)));
 }
 
-TEST_CASE("const_set_adapter_test.lower_bound", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.lower_bound")
 {
   const auto v1 = std::vector<int>();
   const auto s1 = wrap_set(v1);
@@ -152,7 +152,7 @@ TEST_CASE("const_set_adapter_test.lower_bound", "[const_set_adapter_test]")
   CHECK(s2.lower_bound(4) == std::next(std::begin(s2), 3));
 }
 
-TEST_CASE("const_set_adapter_test.upper_bound", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.upper_bound")
 {
   const auto v1 = std::vector<int>();
   const auto s1 = wrap_set(v1);
@@ -167,14 +167,14 @@ TEST_CASE("const_set_adapter_test.upper_bound", "[const_set_adapter_test]")
   CHECK(s2.upper_bound(4) == std::next(std::begin(s2), 3));
 }
 
-TEST_CASE("const_set_adapter_test.capacity", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.capacity")
 {
   const auto v1 = std::vector<int>();
   const auto s1 = wrap_set(v1);
   CHECK(s1.capacity() == v1.capacity());
 }
 
-TEST_CASE("const_set_adapter_test.get_data", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.get_data")
 {
   const auto v1 = std::vector<int>();
   const auto s1 = wrap_set(v1);
@@ -182,7 +182,7 @@ TEST_CASE("const_set_adapter_test.get_data", "[const_set_adapter_test]")
   CHECK(&d == &v1);
 }
 
-TEST_CASE("const_set_adapter_test.operator_equal", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.operator_equal")
 {
   CHECK(wrap_set(std::vector<int>({})) == wrap_set(std::vector<int>({})));
   CHECK(wrap_set(std::vector<int>({1, 2, 3})) == wrap_set(std::vector<int>({1, 2, 3})));
@@ -194,7 +194,7 @@ TEST_CASE("const_set_adapter_test.operator_equal", "[const_set_adapter_test]")
   CHECK_FALSE(wrap_set(std::vector<int>({1, 2, 3})) == wrap_set(std::vector<int>({3})));
 }
 
-TEST_CASE("const_set_adapter_test.operator_not_equal", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.operator_not_equal")
 {
   CHECK_FALSE(wrap_set(std::vector<int>({})) != wrap_set(std::vector<int>({})));
   CHECK_FALSE(
@@ -205,7 +205,7 @@ TEST_CASE("const_set_adapter_test.operator_not_equal", "[const_set_adapter_test]
   CHECK(wrap_set(std::vector<int>({1, 2, 3})) != wrap_set(std::vector<int>({3})));
 }
 
-TEST_CASE("const_set_adapter_test.operator_less_than", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.operator_less_than")
 {
   CHECK_FALSE(wrap_set(std::vector<int>({})) < wrap_set(std::vector<int>({})));
   CHECK(wrap_set(std::vector<int>({})) < wrap_set(std::vector<int>({1})));
@@ -234,7 +234,7 @@ TEST_CASE(
   CHECK(wrap_set(std::vector<int>({1, 2, 3})) <= wrap_set(std::vector<int>({2, 3})));
 }
 
-TEST_CASE("const_set_adapter_test.operator_greater_than", "[const_set_adapter_test]")
+TEST_CASE("const_set_adapter_test.operator_greater_than")
 {
   CHECK_FALSE(wrap_set(std::vector<int>({})) > wrap_set(std::vector<int>({})));
   CHECK_FALSE(wrap_set(std::vector<int>({})) > wrap_set(std::vector<int>({1})));
@@ -264,19 +264,19 @@ TEST_CASE(
     wrap_set(std::vector<int>({1, 2, 3})) >= wrap_set(std::vector<int>({2, 3})));
 }
 
-TEST_CASE("set_adapter_test.wrap_set", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.wrap_set")
 {
   auto v = std::vector<int>{1, 2, 3};
   CHECK_THAT(wrap_set(v).get_data(), Catch::Equals(v));
 }
 
-TEST_CASE("set_adapter_test.create_set", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.create_set")
 {
   auto v = std::vector<int>{1, 2, 3, 2, 5};
   CHECK_THAT(create_set(v).get_data(), Catch::Equals(std::vector<int>{1, 2, 3, 5}));
 }
 
-TEST_CASE("set_adapter_test.operator_assign_with_initializer_list", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.operator_assign_with_initializer_list")
 {
   auto v = std::vector<int>{1, 2, 3, 2, 5};
   auto s = create_set(v);
@@ -285,7 +285,7 @@ TEST_CASE("set_adapter_test.operator_assign_with_initializer_list", "[set_adapte
   CHECK_THAT(s.get_data(), Catch::Equals(std::vector<int>{3, 5, 6, 7}));
 }
 
-TEST_CASE("set_adapter_test.clear", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.clear")
 {
   auto v = std::vector<int>{1, 2, 3};
   auto s = wrap_set(v);
@@ -295,7 +295,7 @@ TEST_CASE("set_adapter_test.clear", "[set_adapter_test]")
   CHECK(v.empty());
 }
 
-TEST_CASE("set_adapter_test.insert_with_value", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.insert_with_value")
 {
   auto v = std::vector<int>();
   auto s = wrap_set(v);
@@ -323,7 +323,7 @@ TEST_CASE("set_adapter_test.insert_with_value", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{1, 2, 3}));
 }
 
-TEST_CASE("set_adapter_test.insert_with_value_and_hint", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.insert_with_value_and_hint")
 {
   auto v = std::vector<int>();
   auto s = wrap_set(v);
@@ -343,7 +343,7 @@ TEST_CASE("set_adapter_test.insert_with_value_and_hint", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{1, 2, 3}));
 }
 
-TEST_CASE("set_adapter_test.insert_with_range", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.insert_with_range")
 {
   auto v = std::vector<int>();
   auto s = wrap_set(v);
@@ -354,7 +354,7 @@ TEST_CASE("set_adapter_test.insert_with_range", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{1, 2, 3, 4}));
 }
 
-TEST_CASE("set_adapter_test.insert_with_range_and_count", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.insert_with_range_and_count")
 {
   auto v = std::vector<int>();
   auto s = wrap_set(v);
@@ -365,7 +365,7 @@ TEST_CASE("set_adapter_test.insert_with_range_and_count", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{1, 2, 3, 4}));
 }
 
-TEST_CASE("set_adapter_test.emplace", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.emplace")
 {
   auto v = std::vector<int>();
   auto s = wrap_set(v);
@@ -396,7 +396,7 @@ TEST_CASE("set_adapter_test.emplace", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{1, 2, 3}));
 }
 
-TEST_CASE("set_adapter_test.emplace_hint", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.emplace_hint")
 {
   auto v = std::vector<int>();
   auto s = wrap_set(v);
@@ -419,7 +419,7 @@ TEST_CASE("set_adapter_test.emplace_hint", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{1, 2, 3}));
 }
 
-TEST_CASE("set_adapter_test.erase_with_iterator", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.erase_with_iterator")
 {
   auto v = std::vector<int>{1, 2, 3};
   auto s = wrap_set(v);
@@ -434,7 +434,7 @@ TEST_CASE("set_adapter_test.erase_with_iterator", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{}));
 }
 
-TEST_CASE("set_adapter_test.erase_with_range", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.erase_with_range")
 {
   auto v = std::vector<int>{1, 2, 3};
   auto s = wrap_set(v);
@@ -448,7 +448,7 @@ TEST_CASE("set_adapter_test.erase_with_range", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{}));
 }
 
-TEST_CASE("set_adapter_test.erase_with_value", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.erase_with_value")
 {
   auto v = std::vector<int>{1, 2, 3};
   auto s = wrap_set(v);
@@ -469,7 +469,7 @@ TEST_CASE("set_adapter_test.erase_with_value", "[set_adapter_test]")
   CHECK_THAT(v, Catch::Equals(std::vector<int>{}));
 }
 
-TEST_CASE("set_adapter_test.swap", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.swap")
 {
   // swap only works if the underlying collection is stored by value
   auto s = set_adapter<std::vector<int>, std::less<int>>(std::vector<int>({1, 2, 3}));
@@ -485,7 +485,7 @@ TEST_CASE("set_adapter_test.swap", "[set_adapter_test]")
   CHECK_THAT(t.get_data(), Catch::Equals(std::vector<int>{1, 2, 3}));
 }
 
-TEST_CASE("set_adapter_test.release_data", "[set_adapter_test]")
+TEST_CASE("set_adapter_test.release_data")
 {
   auto v = std::vector<int>{1, 2, 3};
   auto s = wrap_set(v);

--- a/lib/kdl/test/src/set_temp_test.cpp
+++ b/lib/kdl/test/src/set_temp_test.cpp
@@ -24,7 +24,7 @@
 
 namespace kdl
 {
-TEST_CASE("set_temp_test.set_unset", "[set_temp_test]")
+TEST_CASE("set_temp_test.set_unset")
 {
   int value = 0;
   {
@@ -34,7 +34,7 @@ TEST_CASE("set_temp_test.set_unset", "[set_temp_test]")
   CHECK(value == 0);
 }
 
-TEST_CASE("set_temp_test.set_unset_bool", "[set_temp_test]")
+TEST_CASE("set_temp_test.set_unset_bool")
 {
   bool value = false;
   {
@@ -56,7 +56,7 @@ TEST_CASE("set_temp_test.set_unset_bool", "[set_temp_test]")
   CHECK_FALSE(value);
 }
 
-TEST_CASE("set_later_test.set", "[set_later_test]")
+TEST_CASE("set_later_test.set")
 {
   int value = 0;
 
@@ -67,7 +67,7 @@ TEST_CASE("set_later_test.set", "[set_later_test]")
   CHECK(value == 1);
 }
 
-TEST_CASE("inc_temp.inc_dec", "[inc_temp]")
+TEST_CASE("inc_temp.inc_dec")
 {
   int value = 0;
 
@@ -78,7 +78,7 @@ TEST_CASE("inc_temp.inc_dec", "[inc_temp]")
   CHECK(value == 0);
 }
 
-TEST_CASE("dec_temp.dec_inc", "[dec_temp]")
+TEST_CASE("dec_temp.dec_inc")
 {
   int value = 0;
   {

--- a/lib/kdl/test/src/skip_iterator_test.cpp
+++ b/lib/kdl/test/src/skip_iterator_test.cpp
@@ -26,7 +26,7 @@
 
 namespace kdl
 {
-TEST_CASE("skip_iterator_test.prefix_increment", "[skip_iterator_test]")
+TEST_CASE("skip_iterator_test.prefix_increment")
 {
   std::vector<int> vec({1, 2, 3, 4, 5});
   auto it = skip_iterator(std::begin(vec), std::end(vec), 1, 2);
@@ -36,7 +36,7 @@ TEST_CASE("skip_iterator_test.prefix_increment", "[skip_iterator_test]")
   CHECK(std::end(vec) == ++it);
 }
 
-TEST_CASE("skip_iterator_test.postfix_increment", "[skip_iterator_test]")
+TEST_CASE("skip_iterator_test.postfix_increment")
 {
   std::vector<int> vec({1, 2, 3, 4, 5});
   auto it = skip_iterator(std::begin(vec), std::end(vec), 1, 2);
@@ -46,7 +46,7 @@ TEST_CASE("skip_iterator_test.postfix_increment", "[skip_iterator_test]")
   CHECK(std::end(vec) == it);
 }
 
-TEST_CASE("skip_iterator_test.empty_sequence", "[skip_iterator_test]")
+TEST_CASE("skip_iterator_test.empty_sequence")
 {
   std::vector<size_t> vec;
 
@@ -56,7 +56,7 @@ TEST_CASE("skip_iterator_test.empty_sequence", "[skip_iterator_test]")
   CHECK(skip_iterator(std::begin(vec), std::end(vec), 1) == std::end(vec));
 }
 
-TEST_CASE("skip_iterator_test.zero_stride", "[skip_iterator_test]")
+TEST_CASE("skip_iterator_test.zero_stride")
 {
   std::vector<size_t> vec({1});
 
@@ -65,7 +65,7 @@ TEST_CASE("skip_iterator_test.zero_stride", "[skip_iterator_test]")
     std::next(skip_iterator(std::begin(vec), std::end(vec), 0, 0)) == std::begin(vec));
 }
 
-TEST_CASE("skip_iterator_test.oneElement_sequence", "[skip_iterator_test]")
+TEST_CASE("skip_iterator_test.oneElement_sequence")
 {
   std::vector<size_t> vec({1});
 

--- a/lib/kdl/test/src/string_compare_test.cpp
+++ b/lib/kdl/test/src/string_compare_test.cpp
@@ -27,7 +27,7 @@ namespace kdl
 {
 namespace cs
 {
-TEST_CASE("string_utils_cs_test.str_mismatch", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_mismatch")
 {
   CHECK(str_mismatch("", "") == 0u);
   CHECK(str_mismatch("asdf", "asdf") == 4u);
@@ -44,7 +44,7 @@ TEST_CASE("string_utils_cs_test.str_mismatch", "[string_utils_cs_test]")
   CHECK(str_mismatch("asDf", "asdf") == 2u);
 }
 
-TEST_CASE("string_utils_cs_test.str_contains", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_contains")
 {
   CHECK_FALSE(str_contains("", ""));
   CHECK(str_contains("asdf", ""));
@@ -72,7 +72,7 @@ TEST_CASE("string_utils_cs_test.str_contains", "[string_utils_cs_test]")
   CHECK_FALSE(str_contains("asdf", "ASDF"));
 }
 
-TEST_CASE("string_utils_cs_test.str_is_prefix", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_is_prefix")
 {
   CHECK(str_is_prefix("asdf", ""));
   CHECK(str_is_prefix("asdf", "a"));
@@ -89,7 +89,7 @@ TEST_CASE("string_utils_cs_test.str_is_prefix", "[string_utils_cs_test]")
   CHECK_FALSE(str_is_prefix("asdf", "asDF"));
 }
 
-TEST_CASE("string_utils_cs_test.str_is_suffix", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_is_suffix")
 {
   CHECK(str_is_suffix("asdf", ""));
   CHECK(str_is_suffix("asdf", "f"));
@@ -105,7 +105,7 @@ TEST_CASE("string_utils_cs_test.str_is_suffix", "[string_utils_cs_test]")
   CHECK_FALSE(str_is_suffix("asdf", "ASDf"));
 }
 
-TEST_CASE("string_utils_cs_test.str_compare", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_compare")
 {
   CHECK(str_compare("", "") == 0);
   CHECK(str_compare("a", "a") == 0);
@@ -118,7 +118,7 @@ TEST_CASE("string_utils_cs_test.str_compare", "[string_utils_cs_test]")
   CHECK(str_compare("Asdf", "Wxyt") == -1);
 }
 
-TEST_CASE("string_utils_cs_test.str_is_equal", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_is_equal")
 {
   CHECK(str_is_equal("", ""));
   CHECK(str_is_equal("asdf", "asdf"));
@@ -126,7 +126,7 @@ TEST_CASE("string_utils_cs_test.str_is_equal", "[string_utils_cs_test]")
   CHECK_FALSE(str_is_equal("AsdF", "Asdf"));
 }
 
-TEST_CASE("string_utils_cs_test.str_matches_glob", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.str_matches_glob")
 {
   CHECK(str_matches_glob("", ""));
   CHECK(str_matches_glob("", "*"));
@@ -179,7 +179,7 @@ C sorted(C c)
   return kdl::col_sort(std::move(c), string_less());
 }
 
-TEST_CASE("string_utils_cs_test.sort", "[string_utils_cs_test]")
+TEST_CASE("string_utils_cs_test.sort")
 {
   CHECK_THAT(
     sorted(std::vector<std::string>{}), Catch::Equals(std::vector<std::string>{}));
@@ -206,7 +206,7 @@ TEST_CASE("string_utils_cs_test.sort", "[string_utils_cs_test]")
 
 namespace ci
 {
-TEST_CASE("string_utils_ci_test.str_mismatch", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_mismatch")
 {
   CHECK(str_mismatch("", "") == 0u);
   CHECK(str_mismatch("asdf", "asdf") == 4u);
@@ -223,7 +223,7 @@ TEST_CASE("string_utils_ci_test.str_mismatch", "[string_utils_ci_test]")
   CHECK(str_mismatch("asDf", "asdf") == 4u);
 }
 
-TEST_CASE("string_utils_ci_test.str_contains", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_contains")
 {
   CHECK_FALSE(str_contains("", ""));
   CHECK(str_contains("asdf", ""));
@@ -251,7 +251,7 @@ TEST_CASE("string_utils_ci_test.str_contains", "[string_utils_ci_test]")
   CHECK(str_contains("asdf", "ASDF"));
 }
 
-TEST_CASE("string_utils_ci_test.str_is_prefix", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_is_prefix")
 {
   CHECK(str_is_prefix("asdf", ""));
   CHECK(str_is_prefix("asdf", "a"));
@@ -270,7 +270,7 @@ TEST_CASE("string_utils_ci_test.str_is_prefix", "[string_utils_ci_test]")
   CHECK_FALSE(str_is_prefix("asdf", "DF"));
 }
 
-TEST_CASE("string_utils_ci_test.str_is_suffix", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_is_suffix")
 {
   CHECK(str_is_suffix("asdf", ""));
   CHECK(str_is_suffix("asdf", "f"));
@@ -288,7 +288,7 @@ TEST_CASE("string_utils_ci_test.str_is_suffix", "[string_utils_ci_test]")
   CHECK(str_is_suffix("asdf", "ASDf"));
 }
 
-TEST_CASE("string_utils_ci_test.str_compare", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_compare")
 {
   CHECK(str_compare("", "") == 0);
   CHECK(str_compare("a", "a") == 0);
@@ -301,7 +301,7 @@ TEST_CASE("string_utils_ci_test.str_compare", "[string_utils_ci_test]")
   CHECK(str_compare("Asdf", "Wxyt") == -1);
 }
 
-TEST_CASE("string_utils_ci_test.str_is_equal", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_is_equal")
 {
   CHECK(str_is_equal("", ""));
   CHECK(str_is_equal("asdf", "asdf"));
@@ -311,7 +311,7 @@ TEST_CASE("string_utils_ci_test.str_is_equal", "[string_utils_ci_test]")
   CHECK_FALSE(str_is_equal("dfdd", "Asdf"));
 }
 
-TEST_CASE("string_utils_ci_test.str_matches_glob", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.str_matches_glob")
 {
   CHECK(str_matches_glob("ASdf", "asdf"));
   CHECK(str_matches_glob("AsdF", "*"));
@@ -333,7 +333,7 @@ C sorted(C c)
   return kdl::col_sort(std::move(c), string_less());
 }
 
-TEST_CASE("string_utils_ci_test.sort", "[string_utils_ci_test]")
+TEST_CASE("string_utils_ci_test.sort")
 {
   CHECK_THAT(
     sorted(std::vector<std::string>{}), Catch::Equals(std::vector<std::string>{}));

--- a/lib/kdl/test/src/string_format_test.cpp
+++ b/lib/kdl/test/src/string_format_test.cpp
@@ -24,27 +24,27 @@
 
 namespace kdl
 {
-TEST_CASE("string_format_test.str_select", "[string_format_test]")
+TEST_CASE("string_format_test.str_select")
 {
   CHECK(str_select(true, "yes", "no") == "yes");
   CHECK(str_select(false, "yes", "no") == "no");
 }
 
-TEST_CASE("string_format_test.str_plural", "[string_format_test]")
+TEST_CASE("string_format_test.str_plural")
 {
   CHECK(str_plural(0, "one", "many") == "many");
   CHECK(str_plural(1, "one", "many") == "one");
   CHECK(str_plural(2, "one", "many") == "many");
 }
 
-TEST_CASE("string_format_test.str_plural_with_prefix_suffix", "[string_format_test]")
+TEST_CASE("string_format_test.str_plural_with_prefix_suffix")
 {
   CHECK(str_plural("prefix ", 0, "one", "many", " suffix") == "prefix many suffix");
   CHECK(str_plural("prefix ", 1, "one", "many", " suffix") == "prefix one suffix");
   CHECK(str_plural("prefix ", 2, "one", "many", " suffix") == "prefix many suffix");
 }
 
-TEST_CASE("string_format_test.str_trim", "[string_format_test]")
+TEST_CASE("string_format_test.str_trim")
 {
   CHECK(str_trim("") == "");
   CHECK(str_trim("abc") == "abc");
@@ -55,7 +55,7 @@ TEST_CASE("string_format_test.str_trim", "[string_format_test]")
   CHECK(str_trim("xyxxabczzxzyz", "xyz") == "abc");
 }
 
-TEST_CASE("string_format_test.str_to_lower_char", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_lower_char")
 {
   constexpr auto input =
     " !\"#$%&\\'()*+,-./"
@@ -69,7 +69,7 @@ TEST_CASE("string_format_test.str_to_lower_char", "[string_format_test]")
   }
 }
 
-TEST_CASE("string_format_test.str_to_upper_char", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_upper_char")
 {
   constexpr auto input =
     " !\"#$%&\\'()*+,-./"
@@ -83,7 +83,7 @@ TEST_CASE("string_format_test.str_to_upper_char", "[string_format_test]")
   }
 }
 
-TEST_CASE("string_format_test.str_to_lower", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_lower")
 {
   CHECK(str_to_lower("") == "");
   CHECK(str_to_lower("#?\"abc73474") == "#?\"abc73474");
@@ -92,7 +92,7 @@ TEST_CASE("string_format_test.str_to_lower", "[string_format_test]")
   CHECK(str_to_lower("XYZ") == "xyz");
 }
 
-TEST_CASE("string_format_test.str_to_upper", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_upper")
 {
   CHECK(str_to_lower("") == "");
   CHECK(str_to_upper("#?\"ABC73474") == "#?\"ABC73474");
@@ -101,14 +101,14 @@ TEST_CASE("string_format_test.str_to_upper", "[string_format_test]")
   CHECK(str_to_upper("xyz") == "XYZ");
 }
 
-TEST_CASE("string_format_test.str_capitalize", "[string_format_test]")
+TEST_CASE("string_format_test.str_capitalize")
 {
   CHECK(
     str_capitalize("the quick brown fOX, .he jumped!")
     == "The Quick Brown FOX, .he Jumped!");
 }
 
-TEST_CASE("string_format_test.str_escape", "[string_format_test]")
+TEST_CASE("string_format_test.str_escape")
 {
   CHECK(str_escape("", "") == "");
   CHECK(str_escape("", ";") == "");
@@ -124,7 +124,7 @@ TEST_CASE("string_format_test.str_escape", "[string_format_test]")
   CHECK(str_escape("asdf", "f") == "asd\\f");
 }
 
-TEST_CASE("string_format_test.str_escape_if_necessary", "[string_format_test]")
+TEST_CASE("string_format_test.str_escape_if_necessary")
 {
   CHECK(
     str_escape_if_necessary(
@@ -132,7 +132,7 @@ TEST_CASE("string_format_test.str_escape_if_necessary", "[string_format_test]")
     == "this \\# should be escaped, but not this \\#; this \\\\\\# however, should!");
 }
 
-TEST_CASE("string_format_test.str_unescape", "[string_format_test]")
+TEST_CASE("string_format_test.str_unescape")
 {
   CHECK(str_unescape("", "") == "");
   CHECK(str_unescape("", ";") == "");
@@ -151,7 +151,7 @@ TEST_CASE("string_format_test.str_unescape", "[string_format_test]")
   CHECK(str_unescape("asdf\\\\\\\\", "") == "asdf\\\\");
 }
 
-TEST_CASE("string_format_test.str_is_blank", "[string_format_test]")
+TEST_CASE("string_format_test.str_is_blank")
 {
   CHECK(str_is_blank(""));
   CHECK(str_is_blank(" "));
@@ -161,7 +161,7 @@ TEST_CASE("string_format_test.str_is_blank", "[string_format_test]")
   CHECK_FALSE(str_is_blank(" another one bites    "));
 }
 
-TEST_CASE("string_format_test.str_is_numeric", "[string_format_test]")
+TEST_CASE("string_format_test.str_is_numeric")
 {
   CHECK(str_is_numeric(""));
   CHECK_FALSE(str_is_numeric("a"));

--- a/lib/kdl/test/src/string_utils_test.cpp
+++ b/lib/kdl/test/src/string_utils_test.cpp
@@ -27,7 +27,7 @@
 
 namespace kdl
 {
-TEST_CASE("string_utils_test.str_split", "[string_utils_test]")
+TEST_CASE("string_utils_test.str_split")
 {
   CHECK_THAT(str_split("", " "), Catch::Equals(std::vector<std::string>{}));
   CHECK_THAT(str_split(" ", " "), Catch::Equals(std::vector<std::string>{}));
@@ -67,7 +67,7 @@ TEST_CASE("string_utils_test.str_split", "[string_utils_test]")
     str_split("c:\\x\\y", "\\"), Catch::Equals(std::vector<std::string>{"c:", "x", "y"}));
 }
 
-TEST_CASE("string_utils_test.str_join", "[string_utils_test]")
+TEST_CASE("string_utils_test.str_join")
 {
   CHECK(str_join(std::vector<std::string_view>{}, ", ", " and ", ", and ") == "");
   CHECK(str_join(std::vector<std::string_view>{"one"}, ", ", " and ", ", and ") == "one");
@@ -87,7 +87,7 @@ TEST_CASE("string_utils_test.str_join", "[string_utils_test]")
     == "one, two, three");
 }
 
-TEST_CASE("string_utils_test.str_replace_every", "[string_utils_test]")
+TEST_CASE("string_utils_test.str_replace_every")
 {
   CHECK(str_replace_every("", "", "haha") == "");
   CHECK(str_replace_every("asdf", "", "haha") == "asdf");
@@ -113,7 +113,7 @@ inline std::ostream& operator<<(std::ostream& o, const to_string& t)
   return o;
 }
 
-TEST_CASE("string_format_test.str_to_string", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_string")
 {
   CHECK(str_to_string("abc") == "abc");
   CHECK(str_to_string(1234) == "1234");
@@ -121,7 +121,7 @@ TEST_CASE("string_format_test.str_to_string", "[string_format_test]")
   CHECK(str_to_string(to_string{"xyz"}) == "xyz;");
 }
 
-TEST_CASE("string_format_test.str_to_int", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_int")
 {
   CHECK(str_to_int("0") == std::optional<int>{0});
   CHECK(str_to_int("1") == std::optional<int>{1});
@@ -134,7 +134,7 @@ TEST_CASE("string_format_test.str_to_int", "[string_format_test]")
   CHECK(str_to_int("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_long", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_long")
 {
   CHECK(str_to_long("0") == std::optional<long>{0l});
   CHECK(str_to_long("1") == std::optional<long>{1l});
@@ -149,7 +149,7 @@ TEST_CASE("string_format_test.str_to_long", "[string_format_test]")
   CHECK(str_to_long("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_long_long", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_long_long")
 {
   CHECK(str_to_long_long("0") == std::optional<long long>{0ll});
   CHECK(str_to_long_long("1") == std::optional<long long>{1ll});
@@ -170,7 +170,7 @@ TEST_CASE("string_format_test.str_to_long_long", "[string_format_test]")
   CHECK(str_to_long_long("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_u_long", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_u_long")
 {
 
   CHECK(str_to_u_long("0") == std::optional<unsigned long>{0ul});
@@ -184,7 +184,7 @@ TEST_CASE("string_format_test.str_to_u_long", "[string_format_test]")
   CHECK(str_to_u_long("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_u_long_long", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_u_long_long")
 {
   CHECK(str_to_u_long_long("0") == std::optional<unsigned long long>{0ull});
   CHECK(str_to_u_long_long("1") == std::optional<unsigned long long>{1ull});
@@ -202,7 +202,7 @@ TEST_CASE("string_format_test.str_to_u_long_long", "[string_format_test]")
   CHECK(str_to_u_long_long("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_size", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_size")
 {
   CHECK(str_to_size("0") == std::optional<std::size_t>{0u});
   CHECK(str_to_size("1") == std::optional<std::size_t>{1u});
@@ -215,7 +215,7 @@ TEST_CASE("string_format_test.str_to_size", "[string_format_test]")
   CHECK(str_to_size("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_float", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_float")
 {
   CHECK(str_to_float("0") == std::optional<float>{0.0f});
   CHECK(str_to_float("1.0") == std::optional<float>{1.0f});
@@ -224,7 +224,7 @@ TEST_CASE("string_format_test.str_to_float", "[string_format_test]")
   CHECK(str_to_float("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_double", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_double")
 {
   CHECK(str_to_double("0") == std::optional<double>{0.0});
   CHECK(str_to_double("1.0") == std::optional<double>{1.0});
@@ -233,7 +233,7 @@ TEST_CASE("string_format_test.str_to_double", "[string_format_test]")
   CHECK(str_to_double("") == std::nullopt);
 }
 
-TEST_CASE("string_format_test.str_to_long_double", "[string_format_test]")
+TEST_CASE("string_format_test.str_to_long_double")
 {
   CHECK(str_to_long_double("0") == std::optional<long double>{0.0L});
   CHECK(str_to_long_double("1.0") == std::optional<long double>{1.0L});

--- a/lib/kdl/test/src/transform_range_test.cpp
+++ b/lib/kdl/test/src/transform_range_test.cpp
@@ -26,7 +26,7 @@
 
 namespace kdl
 {
-TEST_CASE("transform_iterator_test.operator_less_than", "[transform_iterator_test]")
+TEST_CASE("transform_iterator_test.operator_less_than")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -43,7 +43,7 @@ TEST_CASE("transform_iterator_test.operator_less_than", "[transform_iterator_tes
   CHECK_FALSE(it < end);
 }
 
-TEST_CASE("transform_iterator_test.operator_greater_than", "[transform_iterator_test]")
+TEST_CASE("transform_iterator_test.operator_greater_than")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -60,7 +60,7 @@ TEST_CASE("transform_iterator_test.operator_greater_than", "[transform_iterator_
   CHECK_FALSE(end > it);
 }
 
-TEST_CASE("transform_iterator_test.operator_equal", "[transform_iterator_test]")
+TEST_CASE("transform_iterator_test.operator_equal")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -77,7 +77,7 @@ TEST_CASE("transform_iterator_test.operator_equal", "[transform_iterator_test]")
   CHECK(it == end);
 }
 
-TEST_CASE("transform_iterator_test.operator_not_equal", "[transform_iterator_test]")
+TEST_CASE("transform_iterator_test.operator_not_equal")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -132,14 +132,14 @@ TEST_CASE(
   CHECK(it == std::begin(t));
 }
 
-TEST_CASE("transform_iterator_test.operator_star", "[transform_iterator_test]")
+TEST_CASE("transform_iterator_test.operator_star")
 {
   const auto v = std::vector<int>({1});
   const auto t = transform_adapter(v, [](const auto& i) { return i + 2; });
   CHECK(*std::begin(t) == 3);
 }
 
-TEST_CASE("transform_adapter_test.empty", "[transform_adapter_test]")
+TEST_CASE("transform_adapter_test.empty")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -150,7 +150,7 @@ TEST_CASE("transform_adapter_test.empty", "[transform_adapter_test]")
   CHECK_FALSE(t2.empty());
 }
 
-TEST_CASE("transform_adapter_test.size", "[transform_adapter_test]")
+TEST_CASE("transform_adapter_test.size")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -161,7 +161,7 @@ TEST_CASE("transform_adapter_test.size", "[transform_adapter_test]")
   CHECK(t2.size() == 3u);
 }
 
-TEST_CASE("transform_adapter_test.iterators", "[transform_adapter_test]")
+TEST_CASE("transform_adapter_test.iterators")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });
@@ -187,7 +187,7 @@ TEST_CASE("transform_adapter_test.iterators", "[transform_adapter_test]")
   CHECK(end == it);
 }
 
-TEST_CASE("transform_adapter_test.reverse_iterators", "[transform_adapter_test]")
+TEST_CASE("transform_adapter_test.reverse_iterators")
 {
   const auto v1 = std::vector<int>({});
   const auto t1 = transform_adapter(v1, [](const auto& i) { return i + 2; });

--- a/lib/kdl/test/src/vector_set_test.cpp
+++ b/lib/kdl/test/src/vector_set_test.cpp
@@ -65,14 +65,14 @@ static void assertVset(
   CHECK(actual == create_vset_from_range(expected));
 }
 
-TEST_CASE("vector_set_test.constructor_default", "[vector_set_test]")
+TEST_CASE("vector_set_test.constructor_default")
 {
   vset s;
   CHECK(s.empty());
   CHECK(s.size() == 0u);
 }
 
-TEST_CASE("vector_set_test.constructor_default_with_capacity", "[vector_set_test]")
+TEST_CASE("vector_set_test.constructor_default_with_capacity")
 {
   vset s(7u);
   CHECK(s.empty());
@@ -80,7 +80,7 @@ TEST_CASE("vector_set_test.constructor_default_with_capacity", "[vector_set_test
   CHECK(s.capacity() == 7u);
 }
 
-TEST_CASE("vector_set_test.constructor_with_range", "[vector_set_test]")
+TEST_CASE("vector_set_test.constructor_with_range")
 {
   assertVset(create_vset_from_range({}), {});
   assertVset(create_vset_from_range({1}), {1});
@@ -90,7 +90,7 @@ TEST_CASE("vector_set_test.constructor_with_range", "[vector_set_test]")
   assertVset(create_vset_from_range({2, 1, 3, 1, 2}), {1, 2, 3});
 }
 
-TEST_CASE("vector_set_test.constructor_with_range_and_capacity", "[vector_set_test]")
+TEST_CASE("vector_set_test.constructor_with_range_and_capacity")
 {
   assertVset(create_vset_from_range(10u, {}), {}, 10u);
   assertVset(create_vset_from_range(10u, {1}), {1}, 10u);
@@ -100,7 +100,7 @@ TEST_CASE("vector_set_test.constructor_with_range_and_capacity", "[vector_set_te
   assertVset(create_vset_from_range(10u, {2, 1, 3, 1, 2}), {1, 2, 3}, 10u);
 }
 
-TEST_CASE("vector_set_test.constructor_with_initializer_list", "[vector_set_test]")
+TEST_CASE("vector_set_test.constructor_with_initializer_list")
 {
   assertVset(create_vset_from_list({}), {});
   assertVset(create_vset_from_list({1}), {1});
@@ -121,7 +121,7 @@ TEST_CASE(
   assertVset(create_vset_from_list(10u, {2, 1, 3, 1, 2}), {1, 2, 3}, 10u);
 }
 
-TEST_CASE("vector_set_test.constructor_with_vector", "[vector_set_test]")
+TEST_CASE("vector_set_test.constructor_with_vector")
 {
   assertVset(create_vset_from_vector({}), {});
   assertVset(create_vset_from_vector({1}), {1});
@@ -131,7 +131,7 @@ TEST_CASE("vector_set_test.constructor_with_vector", "[vector_set_test]")
   assertVset(create_vset_from_vector({2, 1, 3, 1, 2}), {1, 2, 3});
 }
 
-TEST_CASE("vector_set_test.assignment_from_initializer_list", "[vector_set_test]")
+TEST_CASE("vector_set_test.assignment_from_initializer_list")
 {
   assertVset(vset() = {}, {});
   assertVset(vset() = {1}, {1});
@@ -148,7 +148,7 @@ TEST_CASE("vector_set_test.assignment_from_initializer_list", "[vector_set_test]
   assertVset(vset({7, 8, 9}) = {2, 1, 3, 1, 2}, {1, 2, 3});
 }
 
-TEST_CASE("vector_set_test.assignment_from_vector", "[vector_set_test]")
+TEST_CASE("vector_set_test.assignment_from_vector")
 {
   assertVset(vset() = std::vector<int>({}), {});
   assertVset(vset() = std::vector<int>({1}), {1});
@@ -165,13 +165,13 @@ TEST_CASE("vector_set_test.assignment_from_vector", "[vector_set_test]")
   assertVset(vset({7, 8, 9}) = std::vector<int>({2, 1, 3, 1, 2}), {1, 2, 3});
 }
 
-TEST_CASE("vector_set_test.deduction_guide_range", "[vector_set_test]")
+TEST_CASE("vector_set_test.deduction_guide_range")
 {
   std::vector<int> v({1, 2, 3});
   vector_set s(std::begin(v), std::end(v));
 }
 
-TEST_CASE("vector_set_test.deduction_guide_range_and_capacity", "[vector_set_test]")
+TEST_CASE("vector_set_test.deduction_guide_range_and_capacity")
 {
   std::vector<int> v({1, 2, 3});
   vector_set s(3u, std::begin(v), std::end(v));

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -30,7 +30,7 @@
 
 namespace kdl
 {
-TEST_CASE("vector_utils_test.vec_at", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_at")
 {
   const auto cv = std::vector<int>{1, 2, 3};
   for (std::size_t i = 0u; i < cv.size(); ++i)
@@ -43,7 +43,7 @@ TEST_CASE("vector_utils_test.vec_at", "[vector_utils_test]")
   CHECK(mv[2] == 4);
 }
 
-TEST_CASE("vector_utils_test.vec_pop_back", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_pop_back")
 {
   auto v = std::vector<int>{1, 2, 3};
   CHECK(vec_pop_back(v) == 3);
@@ -68,7 +68,7 @@ struct derived : public base
 
 derived::~derived() = default;
 
-TEST_CASE("vector_utils_test.vec_element_cast", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_element_cast")
 {
   auto vd = std::vector<derived*>{new derived(), new derived()};
   auto vb = vec_element_cast<base*>(vd);
@@ -89,7 +89,7 @@ TEST_CASE("vector_utils_test.vec_element_cast", "[vector_utils_test]")
   vec_clear_and_delete(vd);
 }
 
-TEST_CASE("vector_utils_test.vec_index_of", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_index_of")
 {
   using vec = std::vector<int>;
 
@@ -112,7 +112,7 @@ TEST_CASE("vector_utils_test.vec_index_of", "[vector_utils_test]")
   CHECK(vec_index_of(vec{1, 2, 3}, [](const auto& i) { return i == 4; }) == std::nullopt);
 }
 
-TEST_CASE("vector_utils_test.vec_contains", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_contains")
 {
   using vec = std::vector<int>;
 
@@ -142,7 +142,7 @@ static auto makeVec(T&& t, R... r)
   return result;
 }
 
-TEST_CASE("vector_utils_test.vec_concat", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_concat")
 {
   using vec = std::vector<int>;
 
@@ -152,7 +152,7 @@ TEST_CASE("vector_utils_test.vec_concat", "[vector_utils_test]")
   CHECK_THAT(vec_concat(vec{1}, vec{2}), Catch::Equals(vec{1, 2}));
 }
 
-TEST_CASE("vector_utils_test.vec_concat_move", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_concat_move")
 {
   auto v = makeVec(std::make_unique<int>(1));
   v = vec_concat(std::move(v), makeVec(std::make_unique<int>(2)));
@@ -161,7 +161,7 @@ TEST_CASE("vector_utils_test.vec_concat_move", "[vector_utils_test]")
   CHECK(*v[1] == 2);
 }
 
-TEST_CASE("vector_utils_test.vec_slice", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_slice")
 {
   using vec = std::vector<int>;
 
@@ -178,7 +178,7 @@ TEST_CASE("vector_utils_test.vec_slice", "[vector_utils_test]")
   CHECK_THAT(vec_slice(vec{1, 2, 3}, 0, 3), Catch::Equals(vec{1, 2, 3}));
 }
 
-TEST_CASE("vector_utils_test.vec_slice_prefix", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_slice_prefix")
 {
   using vec = std::vector<int>;
 
@@ -191,7 +191,7 @@ TEST_CASE("vector_utils_test.vec_slice_prefix", "[vector_utils_test]")
   CHECK_THAT(vec_slice_prefix(vec{1, 2, 3}, 0), Catch::Equals(vec{}));
 }
 
-TEST_CASE("vector_utils_test.vec_slice_suffix", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_slice_suffix")
 {
   using vec = std::vector<int>;
 
@@ -213,7 +213,7 @@ void test_erase(std::vector<T> from, const T& x, const std::vector<T>& exp)
   CHECK_THAT(vec_erase(std::move(from), x), Catch::Equals(exp));
 }
 
-TEST_CASE("vector_utils_test.vec_erase", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_erase")
 {
   test_erase<int>({}, 1, {});
   test_erase<int>({1}, 1, {});
@@ -231,7 +231,7 @@ void test_erase_if(std::vector<T> from, const P& pred, const std::vector<T>& exp
   CHECK_THAT(vec_erase_if(std::move(from), pred), Catch::Equals(exp));
 }
 
-TEST_CASE("vector_utils_test.vec_erase_if", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_erase_if")
 {
   const auto pred = [](const int n) { return n % 2 == 0; };
 
@@ -250,7 +250,7 @@ void test_erase_at(std::vector<T> from, const std::size_t i, const std::vector<T
   CHECK_THAT(vec_erase_at(std::move(from), i), Catch::Equals(exp));
 }
 
-TEST_CASE("vector_utils_test.vec_erase_at", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_erase_at")
 {
   test_erase_at<int>({1}, 0u, {});
   test_erase_at<int>({1, 2, 1}, 1u, {1, 1});
@@ -267,7 +267,7 @@ void test_erase_all(
   CHECK_THAT(vec_erase_all(std::move(from), which), Catch::Equals(exp));
 }
 
-TEST_CASE("vector_utils_test.vec_erase_all", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_erase_all")
 {
   test_erase_all<int>({}, {}, {});
   test_erase_all<int>({1, 2, 3}, {}, {1, 2, 3});
@@ -277,14 +277,14 @@ TEST_CASE("vector_utils_test.vec_erase_all", "[vector_utils_test]")
   test_erase_all<int>({1, 2, 2, 3}, {2}, {1, 3});
 }
 
-TEST_CASE("vector_utils_test.vec_sort", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_sort")
 {
   // just a smoke test since we're just forwarding to std::sort
   CHECK_THAT(
     vec_sort(std::vector<int>{2, 3, 2, 1}), Catch::Equals(std::vector<int>{1, 2, 2, 3}));
 }
 
-TEST_CASE("vector_utils_test.vec_sort_and_remove_duplicates", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_sort_and_remove_duplicates")
 {
   // just a smoke test since we're just forwarding to std::sort and std::unique
   CHECK_THAT(
@@ -292,7 +292,7 @@ TEST_CASE("vector_utils_test.vec_sort_and_remove_duplicates", "[vector_utils_tes
     Catch::Equals(std::vector<int>{1, 2, 3}));
 }
 
-TEST_CASE("vector_utils_test.vec_filter", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_filter")
 {
   CHECK_THAT(
     vec_filter(std::vector<int>{}, [](auto) { return false; }),
@@ -323,7 +323,7 @@ struct MoveOnly
   MoveOnly& operator=(MoveOnly&& other) = default;
 };
 
-TEST_CASE("vector_utils_test.vec_filter_rvalue", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_filter_rvalue")
 {
   const auto makeVec = []() {
     auto vec = std::vector<MoveOnly>{};
@@ -337,7 +337,7 @@ TEST_CASE("vector_utils_test.vec_filter_rvalue", "[vector_utils_test]")
     vec_filter(makeVec(), [](const auto&, auto i) { return i % 2u == 1u; }).size() == 1u);
 }
 
-TEST_CASE("vector_utils_test.vec_transform", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_transform")
 {
   CHECK_THAT(
     vec_transform(std::vector<int>{}, [](auto x) { return x + 10; }),
@@ -359,7 +359,7 @@ struct X
 {
 };
 
-TEST_CASE("vector_utils_test.vec_transform_lvalue", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_transform_lvalue")
 {
   std::vector<X> v{X{}, X{}, X{}};
 
@@ -367,7 +367,7 @@ TEST_CASE("vector_utils_test.vec_transform_lvalue", "[vector_utils_test]")
   CHECK(vec_transform(v, [](X& x, std::size_t) { return x; }).size() == 3u);
 }
 
-TEST_CASE("vector_utils_test.vec_transform_rvalue", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_transform_rvalue")
 {
   CHECK(
     vec_transform(std::vector<X>{X()}, [](X&& x) { return std::move(x); }).size() == 1u);
@@ -377,7 +377,7 @@ TEST_CASE("vector_utils_test.vec_transform_rvalue", "[vector_utils_test]")
     == 1u);
 }
 
-TEST_CASE("vector_utils_test.vec_flatten", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_flatten")
 {
   CHECK_THAT(
     vec_flatten(std::vector<std::vector<int>>{}), Catch::Equals(std::vector<int>{}));
@@ -406,7 +406,7 @@ TEST_CASE("vector_utils_test.vec_flatten", "[vector_utils_test]")
     Catch::Equals(std::vector<int>{1, 2, 2, 3}));
 }
 
-TEST_CASE("vector_utils_test.set_difference", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.set_difference")
 {
   using vec = std::vector<int>;
   using set = std::set<int>;
@@ -420,7 +420,7 @@ TEST_CASE("vector_utils_test.set_difference", "[vector_utils_test]")
   CHECK_THAT(set_difference(set({1, 2, 3}), set({2})), Catch::Equals(vec{1, 3}));
 }
 
-TEST_CASE("vector_utils_test.set_union", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.set_union")
 {
   using vec = std::vector<int>;
   using set = std::set<int>;
@@ -432,7 +432,7 @@ TEST_CASE("vector_utils_test.set_union", "[vector_utils_test]")
   CHECK_THAT(set_union(set({1, 2, 3}), set({2, 4})), Catch::Equals(vec{1, 2, 3, 4}));
 }
 
-TEST_CASE("vector_utils_test.set_intersection", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.set_intersection")
 {
   using vec = std::vector<int>;
   using set = std::set<int>;
@@ -446,7 +446,7 @@ TEST_CASE("vector_utils_test.set_intersection", "[vector_utils_test]")
     set_intersection(set({1, 2, 3, 4}), set({1, 3, 5})), Catch::Equals(vec{1, 3}));
 }
 
-TEST_CASE("vector_utils_test.vec_clear_to_zero", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_clear_to_zero")
 {
   auto v = std::vector<int>{1, 2, 3};
   CHECK(v.capacity() > 0u);
@@ -456,7 +456,7 @@ TEST_CASE("vector_utils_test.vec_clear_to_zero", "[vector_utils_test]")
   CHECK(v.capacity() == 0u);
 }
 
-TEST_CASE("vector_utils_test.vec_clear_and_delete", "[vector_utils_test]")
+TEST_CASE("vector_utils_test.vec_clear_and_delete")
 {
   bool d1 = false;
   bool d2 = false;

--- a/lib/kdl/test/src/vector_utils_test.cpp
+++ b/lib/kdl/test/src/vector_utils_test.cpp
@@ -446,6 +446,22 @@ TEST_CASE("vector_utils_test.set_intersection")
     set_intersection(set({1, 2, 3, 4}), set({1, 3, 5})), Catch::Equals(vec{1, 3}));
 }
 
+TEST_CASE("vector_utils_test.set_has_shared_element")
+{
+  using vec = std::vector<int>;
+  CHECK_FALSE(set_has_shared_element(vec{}, vec{}));
+  CHECK_FALSE(set_has_shared_element(vec{}, vec{4}));
+  CHECK_FALSE(set_has_shared_element(vec{1}, vec{4}));
+  CHECK_FALSE(set_has_shared_element(vec{1, 2, 3}, vec{4}));
+  CHECK(set_has_shared_element(vec{1}, vec{1}));
+  CHECK(set_has_shared_element(vec{1, 2, 3}, vec{1}));
+  CHECK(set_has_shared_element(vec{1}, vec{1, 2, 3}));
+  CHECK(set_has_shared_element(vec{1, 2, 3}, vec{2}));
+  CHECK(set_has_shared_element(vec{2}, vec{1, 2, 3}));
+  CHECK(set_has_shared_element(vec{1, 2, 3}, vec{3}));
+  CHECK(set_has_shared_element(vec{3}, vec{1, 2, 3}));
+}
+
 TEST_CASE("vector_utils_test.vec_clear_to_zero")
 {
   auto v = std::vector<int>{1, 2, 3};

--- a/lib/kdl/test/src/zip_iterator_test.cpp
+++ b/lib/kdl/test/src/zip_iterator_test.cpp
@@ -27,7 +27,7 @@
 
 namespace kdl
 {
-TEST_CASE("zip_iterator_test.construct", "[zip_iterator_test]")
+TEST_CASE("zip_iterator_test.construct")
 {
   using Catch::Matchers::Equals;
 
@@ -41,7 +41,7 @@ TEST_CASE("zip_iterator_test.construct", "[zip_iterator_test]")
   CHECK_THAT(vz, Equals(std::vector<std::tuple<int, int>>{{1, 4}, {2, 5}, {3, 6}}));
 }
 
-TEST_CASE("zip_iterator_test.make_zip_range", "[zip_iterator_test]")
+TEST_CASE("zip_iterator_test.make_zip_range")
 {
   using Catch::Matchers::Equals;
 


### PR DESCRIPTION
Closes #4177.

Recursive linked groups make no sense, and it should not be possible to create them. This PR makes two changes: When loading a map, the linked groups are validated and nested recursive linked groups are unlinked. Furthermore, the editor cannot create recursive linked groups anymore since the corresponding menu item is disabled.