### PR TITLE
Fix clearing the test fixtures before copying

### DIFF
--- a/common/benchmark/CMakeLists.txt
+++ b/common/benchmark/CMakeLists.txt
@@ -45,10 +45,7 @@ if(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsVistaStylePlugin>" "$<TARGET_FILE_DIR:common-benchmark>/styles")
 endif()
 
-# Clear all fixtures
-add_custom_command(TARGET common-benchmark POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${BENCHMARK_FIXTURE_DEST_DIR}")
-
 # Copy test fixtures
 add_custom_command(TARGET common-benchmark POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${BENCHMARK_FIXTURE_DEST_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_directory "${BENCHMARK_FIXTURE_SOURCE_DIR}" "${BENCHMARK_FIXTURE_DEST_DIR}/benchmark")

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -201,19 +201,11 @@ macro(configure_test_target TARGET)
     add_custom_command(TARGET ${TARGET} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${APP_RESOURCE_DIR}/graphics/images" "${TEST_RESOURCE_DEST_DIR}/images")
 
-    # Clear all fixtures
+    # Copy fixtures
     add_custom_command(TARGET ${TARGET} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E rm -rf "${TEST_FIXTURE_DEST_DIR}")
-
-    # Copy test fixtures
-    add_custom_command(TARGET ${TARGET} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory "${TEST_FIXTURE_SOURCE_DIR}" "${TEST_FIXTURE_DEST_DIR}/test")
-
-    # Copy game config files
-    add_custom_command(TARGET ${TARGET} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory "${APP_RESOURCE_DIR}/games" "${TEST_FIXTURE_DEST_DIR}/games")
-
-    add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E rm -rf "${TEST_FIXTURE_DEST_DIR}"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "${TEST_FIXTURE_SOURCE_DIR}" "${TEST_FIXTURE_DEST_DIR}/test"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "${APP_RESOURCE_DIR}/games" "${TEST_FIXTURE_DEST_DIR}/games"
             COMMAND ${CMAKE_COMMAND} -E copy_directory "${APP_RESOURCE_DIR}/games-testing" "${TEST_FIXTURE_DEST_DIR}/games")
 endmacro()
 


### PR DESCRIPTION
On mac, there is a problem that cmake cannot clear the test fixtures before copying them. I don't exactly know what's causing it, but this change seems to fix it.