### PR TITLE
Add support for _external_map.

### DIFF
--- a/common/src/Assets/ModelDefinition.cpp
+++ b/common/src/Assets/ModelDefinition.cpp
@@ -88,7 +88,8 @@ static IO::Path path(const EL::Value& value)
     return IO::Path();
   }
   const std::string& path = value.stringValue();
-  return IO::Path{kdl::cs::str_is_prefix(path, ":") ? path.substr(1) : path};
+  auto p = IO::Path{kdl::cs::str_is_prefix(path, ":") ? path.substr(1) : path};
+  return p.hasExtension("map", false) ? p.replaceExtension("bsp") : p;
 }
 
 static size_t index(const EL::Value& value)

--- a/common/src/Model/EntityProperties.cpp
+++ b/common/src/Model/EntityProperties.cpp
@@ -47,6 +47,7 @@ const std::string Mangle = "mangle";
 const std::string Target = "target";
 const std::string Targetname = "targetname";
 const std::string Killtarget = "killtarget";
+const std::string ExternalMapAngles = "_external_map_angles";
 const std::string ProtectedEntityProperties = "_tb_protected_properties";
 const std::string GroupType = "_tb_type";
 const std::string LayerId = "_tb_id";

--- a/common/src/Model/EntityProperties.h
+++ b/common/src/Model/EntityProperties.h
@@ -46,6 +46,7 @@ extern const std::string Mangle;
 extern const std::string Target;
 extern const std::string Targetname;
 extern const std::string Killtarget;
+extern const std::string ExternalMapAngles;
 extern const std::string ProtectedEntityProperties;
 extern const std::string GroupType;
 extern const std::string LayerId;

--- a/common/src/Model/EntityRotation.cpp
+++ b/common/src/Model/EntityRotation.cpp
@@ -197,6 +197,7 @@ EntityRotationInfo entityRotationInfo(const Entity& entity)
             entity,
             {{EntityPropertyKeys::Angles, eulerType},
              {EntityPropertyKeys::Mangle, eulerType},
+             {EntityPropertyKeys::ExternalMapAngles, eulerType},
              {EntityPropertyKeys::Angle, EntityRotationType::AngleUpDown}})
             .value_or(std::make_tuple(
               EntityPropertyKeys::Angle, EntityRotationType::AngleUpDown));


### PR DESCRIPTION
Perhaps not merge-worthy, but a starting point from someone who enjoys C++ and wants #2810 to happen.

Define the following in FGD file:

```
@PointClass base() model({ "path": {{ _external_map }}, "scale": {{ _external_map_scale }} }) = misc_external_map : "Each misc_external_map imports brushes from an external .map file, applies rotations specified by the _external_map_angles key, then translates them to the origin key of the misc_external_map entity. Finally, the classname of the misc_external_map is switched to the one provided by the mapper in the _external_map_classname key. (The origin key is also cleared to 0 0 0 before saving the .bsp).

The external .map file should consist of worldspawn brushes only, although you can use func_group for editing convenience. Brush entities are merged with the worldspawn brushes during import. All worldspawn keys, and any point entities are ignored. Currently, this means that the wad key is not handled, so you need to add any texture wads required by the external .map file to your main map.

Note that you can set other entity keys on the misc_external_map configure the final entity type. e.g. if you set _external_map_classname to func_door, you can also set a targetname key on the misc_external_map, or any other keys for func_door."
[
    _external_map(string) : "Specifies the filename of the .map to import."
    _external_map_scale(string) : "Scale factor for the prefab, defaults to 1. Either specify a single value or three scales, x y z."
    _external_map_angles(string) : "Rotation for the prefab, pitch yaw roll format. Negative pitch is down."
    _external_map_classname(string) : "What entity you want the external map to turn in to. You can use internal qbsp entity types such as func_detail, or a regular bmodel classname like func_wall or func_door."
]
```

Will result in something like this:

![image](https://user-images.githubusercontent.com/302027/213916865-b5904dfb-4b73-42be-9120-0dd0aacac846.png)

The prefab in the above image is accessed from `Quake/id1/table.bsp` which is not really ideal.

A continuation of this functionality would be to either extend the entity browser, or have some other content drawer like Unreal Editor where all prefabs from some prefab directory would be picked up, and you just drag in a misc_external_map entity with the correct settings. Depending on how qbsp works, perhaps this would also require a compile step to copy the .map file into the same directory as the current map, or qbsp be extended with some .map search path parameter.

....some way of opening up the external map in a TB session by interacting with the misc_external_map would be neat.

....a further continuation of this would be to define a REST API, and TB users could provide a base URL that implements this API, such that slipseer.com could have a library of shared assets.

....a further further qbsp continuation of this would be if external maps could have scoped target-names and full entity support so you for example could effortlessly pull in a really complex func_rotate_door and it would get its unique wiring at compile time without having to update all the gazillion ents.

....a further further further continuation would be to never have to produce the bsp, but have TB call qbsp and put it in some prefab-build directory whenever a map referred to in a misc_external_map changes.

As can be seen in the screenshot, the entity bounding box is not set to the size of the imported bsp. No idea how to resize that, would also be nice.