### PR TITLE
4162: Don't crash if an ENT file is missing the box property

### DIFF
--- a/common/src/IO/EntParser.h
+++ b/common/src/IO/EntParser.h
@@ -143,11 +143,11 @@ private:
     PropertyDefinitionList& propertyDeclarations,
     ParserStatus& status);
 
-  vm::bbox3 parseBounds(
+  std::optional<vm::bbox3> parseBounds(
     const tinyxml2::XMLElement& element,
     const std::string& attributeName,
     ParserStatus& status);
-  Color parseColor(
+  std::optional<Color> parseColor(
     const tinyxml2::XMLElement& element,
     const std::string& attributeName,
     ParserStatus& status);

--- a/common/test/src/IO/EntParserTest.cpp
+++ b/common/test/src/IO/EntParserTest.cpp
@@ -525,5 +525,29 @@ TEST_CASE("EntParserTest.parseELStaticModelDefinition")
 
   kdl::vec_clear_and_delete(definitions);
 }
+
+TEST_CASE("EntParserTest.parsePointEntityWithMissingBoxAttribute")
+{
+  const auto file = R"(
+<?xml version="1.0"?>
+  <classes>
+    <point name= "linkEmitter" color="0.2 0.5 0.2 ">
+      <target key="target" name="target"></target>
+    </point>
+  </classes>
+)";
+
+  const auto defaultColor = Color{1.0f, 1.0f, 1.0f, 1.0f};
+  auto parser = EntParser{file, defaultColor};
+
+  auto status = TestParserStatus{};
+  auto definitions = parser.parseDefinitions(status);
+  CHECK(definitions.size() == 1u);
+
+  const auto definition = static_cast<Assets::PointEntityDefinition*>(definitions[0]);
+  CHECK(definition->bounds() == vm::bbox3d{{-8.0, -8.0, -8.0}, {8.0, 8.0, 8.0}});
+
+  kdl::vec_clear_and_delete(definitions);
+}
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/IO/FgdParserTest.cpp
+++ b/common/test/src/IO/FgdParserTest.cpp
@@ -931,6 +931,26 @@ TEST_CASE("FgdParserTest.parseLegacyModelWithParseError")
   kdl::vec_clear_and_delete(definitions);
 }
 
+TEST_CASE("FgdParserTest.parseMissingBounds")
+{
+  const std::string file = R"(
+@PointClass model({"path" : ":progs/goddess-statue.mdl" }) =
+decor_goddess_statue : "Goddess Statue" []
+)";
+
+  const auto defaultColor = Color{1.0f, 1.0f, 1.0f, 1.0f};
+  auto parser = FgdParser(file, defaultColor);
+
+  auto status = TestParserStatus{};
+  auto definitions = parser.parseDefinitions(status);
+  CHECK(definitions.size() == 1u);
+
+  const auto definition = static_cast<Assets::PointEntityDefinition*>(definitions[0]);
+  CHECK(definition->bounds() == vm::bbox3d{{-8.0, -8.0, -8.0}, {8.0, 8.0, 8.0}});
+
+  kdl::vec_clear_and_delete(definitions);
+}
+
 TEST_CASE("FgdParserTest.parseInvalidBounds")
 {
   const std::string file = R"(


### PR DESCRIPTION
Closes #4162.