### PR TITLE
Refactor result types

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -584,7 +584,7 @@ static CreateNodeResult createBrushNode(
         std::move(brushNode), std::move(parentInfo), {} // issues
       };
     })
-    .map_errors([&](const Model::BrushError e) {
+    .or_else([&](const Model::BrushError e) {
       return CreateNodeResult{NodeError{brushInfo.startLine, kdl::str_to_string(e)}};
     });
 }

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -648,14 +648,14 @@ static std::vector<std::optional<NodeInfo>> createNodesFromObjectInfos(
       assert(createNodeResult.has_value());
 
       return std::move(*createNodeResult)
-        .visit(kdl::overload(
-          [&](NodeInfo&& nodeInfo) -> std::optional<NodeInfo> {
-            return std::move(nodeInfo);
-          },
-          [&](const NodeError& e) -> std::optional<NodeInfo> {
-            status.error(e.line, e.msg);
-            return std::nullopt;
-          }));
+        .and_then([&](NodeInfo&& nodeInfo) -> std::optional<NodeInfo> {
+          return std::move(nodeInfo);
+        })
+        .or_else([&](const NodeError& e) -> std::optional<NodeInfo> {
+          status.error(e.line, e.msg);
+          return std::nullopt;
+        })
+        .value();
     });
 }
 

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -141,7 +141,7 @@ void MapReader::onStandardBrushFace(
       face.setFilePosition(line, 1u);
       onBrushFace(std::move(face), status);
     })
-    .handle_errors([&](const Model::BrushError e) {
+    .or_else([&](const Model::BrushError e) {
       status.error(line, kdl::str_to_string("Skipping face: ", e));
     });
 }
@@ -163,7 +163,7 @@ void MapReader::onValveBrushFace(
       face.setFilePosition(line, 1u);
       onBrushFace(std::move(face), status);
     })
-    .handle_errors([&](const Model::BrushError e) {
+    .or_else([&](const Model::BrushError e) {
       status.error(line, kdl::str_to_string("Skipping face: ", e));
     });
 }

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -137,7 +137,7 @@ void MapReader::onStandardBrushFace(
   ParserStatus& status)
 {
   Model::BrushFace::createFromStandard(point1, point2, point3, attribs, targetMapFormat)
-    .and_then([&](Model::BrushFace&& face) {
+    .transform([&](Model::BrushFace&& face) {
       face.setFilePosition(line, 1u);
       onBrushFace(std::move(face), status);
     })
@@ -159,7 +159,7 @@ void MapReader::onValveBrushFace(
 {
   Model::BrushFace::createFromValve(
     point1, point2, point3, attribs, texAxisX, texAxisY, targetMapFormat)
-    .and_then([&](Model::BrushFace&& face) {
+    .transform([&](Model::BrushFace&& face) {
       face.setFilePosition(line, 1u);
       onBrushFace(std::move(face), status);
     })
@@ -574,7 +574,7 @@ static CreateNodeResult createBrushNode(
   MapReader::BrushInfo brushInfo, const vm::bbox3& worldBounds)
 {
   return Model::Brush::create(worldBounds, std::move(brushInfo.faces))
-    .and_then([&](Model::Brush&& brush) {
+    .transform([&](Model::Brush&& brush) {
       auto brushNode = std::make_unique<Model::BrushNode>(std::move(brush));
       brushNode->setFilePosition(brushInfo.startLine, brushInfo.lineCount);
 
@@ -648,7 +648,7 @@ static std::vector<std::optional<NodeInfo>> createNodesFromObjectInfos(
       assert(createNodeResult.has_value());
 
       return std::move(*createNodeResult)
-        .and_then([&](NodeInfo&& nodeInfo) -> std::optional<NodeInfo> {
+        .transform([&](NodeInfo&& nodeInfo) -> std::optional<NodeInfo> {
           return std::move(nodeInfo);
         })
         .or_else([&](const NodeError& e) -> std::optional<NodeInfo> {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -400,7 +400,7 @@ kdl::result<void, BrushError> Brush::expand(
   for (auto& face : m_faces)
   {
     const vm::vec3 moveAmount = face.boundary().normal * delta;
-    if (!face.transform(vm::translation_matrix(moveAmount), lockTexture))
+    if (!face.transform(vm::translation_matrix(moveAmount), lockTexture).is_success())
     {
       return BrushError::InvalidFace;
     }
@@ -1191,8 +1191,7 @@ kdl::result<void, BrushError> Brush::transform(
 {
   for (auto& face : m_faces)
   {
-    if (const auto transformResult = face.transform(transformation, lockTextures);
-        !transformResult)
+    if (!face.transform(transformation, lockTextures).is_success())
     {
       return BrushError::InvalidFace;
     }

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1096,7 +1096,7 @@ void Brush::applyUVLock(
       }
       rightFace.resetTexCoordSystemCache();
     })
-    .handle_errors([](const BrushError) {
+    .or_else([](const BrushError) {
       // do nothing
     });
 }
@@ -1125,7 +1125,7 @@ kdl::result<void, BrushError> Brush::updateFacesFromGeometry(
             applyUVLock(matcher, leftFace, rightFace);
           }
         })
-        .handle_errors([&](const BrushError e) {
+        .or_else([&](const BrushError e) {
           if (!error)
           {
             error = e;

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -116,7 +116,7 @@ kdl::result<Brush, BrushError> Brush::create(
   const vm::bbox3& worldBounds, std::vector<BrushFace> faces)
 {
   Brush brush(std::move(faces));
-  return brush.updateGeometryFromFaces(worldBounds).and_then([&]() {
+  return brush.updateGeometryFromFaces(worldBounds).transform([&]() {
     return std::move(brush);
   });
 }
@@ -1083,7 +1083,7 @@ void Brush::applyUVLock(
   // identical plane to `rightFace` within FP error) to `rightFace`.
   BrushFace leftClone = leftFace;
   leftClone.transform(M, true)
-    .and_then([&]() {
+    .transform([&]() {
       auto snapshot =
         std::unique_ptr<TexCoordSystemSnapshot>(leftClone.takeTexCoordSystemSnapshot());
       rightFace.setAttributes(leftClone.attributes());
@@ -1119,7 +1119,7 @@ kdl::result<void, BrushError> Brush::updateFacesFromGeometry(
 
       rightFace.setGeometry(right);
       rightFace.updatePointsFromVertices()
-        .and_then([&]() {
+        .transform([&]() {
           if (uvLock)
           {
             applyUVLock(matcher, leftFace, rightFace);
@@ -1257,7 +1257,7 @@ kdl::result<Brush, BrushError> Brush::createBrush(
     .and_then([&](std::vector<BrushFace>&& faces) {
       return Brush::create(worldBounds, std::move(faces));
     })
-    .and_then([&](Brush&& brush) {
+    .transform([&](Brush&& brush) {
       brush.cloneFaceAttributesFrom(*this);
       for (const auto* subtrahend : subtrahends)
       {

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -665,7 +665,7 @@ kdl::result<void, BrushError> BrushFace::transform(
     swap(m_points[1], m_points[2]);
   }
 
-  return setPoints(m_points[0], m_points[1], m_points[2]).and_then([&]() {
+  return setPoints(m_points[0], m_points[1], m_points[2]).transform([&]() {
     m_texCoordSystem->transform(
       oldBoundary,
       m_boundary,
@@ -695,7 +695,7 @@ kdl::result<void, BrushError> BrushFace::updatePointsFromVertices()
            first->next()->origin()->position(),
            first->origin()->position(),
            first->previous()->origin()->position())
-    .and_then([&]() {
+    .transform([&]() {
       // Get a line, and a reference point, that are on both the old plane
       // (before moving the face) and after moving the face.
       const auto seam = vm::intersect_plane_plane(oldPlane, m_boundary);

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -196,7 +196,7 @@ std::unique_ptr<WorldNode> GameImpl::doNewMap(
   const auto builder =
     Model::BrushBuilder{worldNode->mapFormat(), worldBounds, defaultFaceAttribs()};
   builder.createCuboid({128.0, 128.0, 32.0}, Model::BrushFaceAttributes::NoTextureName)
-    .and_then([&](Brush&& b) {
+    .transform([&](Brush&& b) {
       worldNode->defaultLayer()->addChild(new BrushNode{std::move(b)});
     })
     .or_else([&](const Model::BrushError e) {

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -196,13 +196,12 @@ std::unique_ptr<WorldNode> GameImpl::doNewMap(
   const auto builder =
     Model::BrushBuilder{worldNode->mapFormat(), worldBounds, defaultFaceAttribs()};
   builder.createCuboid({128.0, 128.0, 32.0}, Model::BrushFaceAttributes::NoTextureName)
-    .visit(kdl::overload(
-      [&](Brush&& b) {
-        worldNode->defaultLayer()->addChild(new BrushNode{std::move(b)});
-      },
-      [&](const Model::BrushError e) {
-        logger.error() << "Could not create default brush: " << e;
-      }));
+    .and_then([&](Brush&& b) {
+      worldNode->defaultLayer()->addChild(new BrushNode{std::move(b)});
+    })
+    .or_else([&](const Model::BrushError e) {
+      logger.error() << "Could not create default brush: " << e;
+    });
 
   return worldNode;
 }

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -335,7 +335,7 @@ kdl::result<UpdateLinkedGroupsResult, UpdateLinkedGroupsError> updateLinkedGroup
     const auto transformation =
       targetGroupNode->group().transformation() * _invertedSourceTransformation;
     return cloneAndTransformChildren(sourceGroupNode, worldBounds, transformation)
-      .and_then([&](std::vector<std::unique_ptr<Node>>&& newChildren) {
+      .transform([&](std::vector<std::unique_ptr<Node>>&& newChildren) {
         preserveGroupNames(newChildren, targetGroupNode->children());
         preserveEntityProperties(newChildren, targetGroupNode->children());
 

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -345,7 +345,7 @@ void AppPreferenceManager::initialize()
           });
       }
     })
-    .handle_errors(kdl::overload(
+    .or_else(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath
@@ -400,7 +400,7 @@ void AppPreferenceManager::discardChanges()
 void AppPreferenceManager::saveChangesImmediately()
 {
   writeV2SettingsToPath(m_preferencesFilePath, m_cache)
-    .handle_errors(kdl::overload(
+    .or_else(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath
@@ -498,7 +498,7 @@ void AppPreferenceManager::loadCacheFromDisk()
   // Reload m_cache
   readV2SettingsFromPath(m_preferencesFilePath)
     .and_then([&](std::map<IO::Path, QJsonValue>&& prefs) { m_cache = std::move(prefs); })
-    .handle_errors(kdl::overload(
+    .or_else(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -329,7 +329,7 @@ void AppPreferenceManager::initialize()
   m_preferencesFilePath = v2SettingsPath();
 
   migrateSettingsFromV1IfPathDoesNotExist(m_preferencesFilePath)
-    .and_then([&]() {
+    .transform([&]() {
       loadCacheFromDisk();
 
       m_fileSystemWatcher = new QFileSystemWatcher{this};
@@ -497,7 +497,8 @@ void AppPreferenceManager::loadCacheFromDisk()
 
   // Reload m_cache
   readV2SettingsFromPath(m_preferencesFilePath)
-    .and_then([&](std::map<IO::Path, QJsonValue>&& prefs) { m_cache = std::move(prefs); })
+    .transform(
+      [&](std::map<IO::Path, QJsonValue>&& prefs) { m_cache = std::move(prefs); })
     .or_else(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -994,7 +994,7 @@ void ClipTool::updateBrushes()
           setFaceAttributes(brush.faces(), clipFace);
           return brush.clip(worldBounds, std::move(clipFace));
         })
-        .and_then([&]() {
+        .transform([&]() {
           brushMap[node->parent()].push_back(new Model::BrushNode(std::move(brush)));
         })
         .or_else([&](const Model::BrushError e) {

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -997,7 +997,7 @@ void ClipTool::updateBrushes()
         .and_then([&]() {
           brushMap[node->parent()].push_back(new Model::BrushNode(std::move(brush)));
         })
-        .handle_errors([&](const Model::BrushError e) {
+        .or_else([&](const Model::BrushError e) {
           document->error() << "Could not clip brush: " << e;
         });
     };

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -60,7 +60,7 @@ void CreateComplexBrushTool::update(const Model::Polyhedron3& polyhedron)
       game->defaultFaceAttribs());
 
     builder.createBrush(*m_polyhedron, document->currentTextureName())
-      .and_then(
+      .transform(
         [&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
       .or_else([&](const Model::BrushError e) {
         updateBrush(nullptr);

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -62,7 +62,7 @@ void CreateComplexBrushTool::update(const Model::Polyhedron3& polyhedron)
     builder.createBrush(*m_polyhedron, document->currentTextureName())
       .and_then(
         [&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
-      .handle_errors([&](const Model::BrushError e) {
+      .or_else([&](const Model::BrushError e) {
         updateBrush(nullptr);
         document->error() << "Could not update brush: " << e;
       });

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -50,7 +50,7 @@ void CreateSimpleBrushTool::update(const vm::bbox3& bounds)
 
   builder.createCuboid(bounds, document->currentTextureName())
     .and_then([&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
-    .handle_errors([&](const Model::BrushError e) {
+    .or_else([&](const Model::BrushError e) {
       updateBrush(nullptr);
       document->error() << "Could not update brush: " << e;
     });

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -49,7 +49,7 @@ void CreateSimpleBrushTool::update(const vm::bbox3& bounds)
     document->world()->mapFormat(), document->worldBounds(), game->defaultFaceAttribs());
 
   builder.createCuboid(bounds, document->currentTextureName())
-    .and_then([&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
+    .transform([&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
     .or_else([&](const Model::BrushError e) {
       updateBrush(nullptr);
       document->error() << "Could not update brush: " << e;

--- a/common/src/View/ExtrudeTool.cpp
+++ b/common/src/View/ExtrudeTool.cpp
@@ -450,14 +450,12 @@ bool splitBrushesOutward(
       document.selectNodes(addedNodes);
       dragState.currentDragFaces = std::move(newDragFaces);
       dragState.totalDelta = delta;
-      return true;
     })
-    .or_else([&](const Model::BrushError e) {
+    .if_error([&](const Model::BrushError e) {
       document.error() << "Could not extrude brush: " << e;
       kdl::map_clear_and_delete(newNodes);
-      return false;
     })
-    .value();
+    .is_success();
 }
 
 /**

--- a/common/src/View/ExtrudeTool.cpp
+++ b/common/src/View/ExtrudeTool.cpp
@@ -427,7 +427,7 @@ bool splitBrushesOutward(
                  clipFace.invert();
                  return newBrush.clip(worldBounds, std::move(clipFace));
                })
-               .and_then([&]() {
+               .transform([&]() {
                  auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                  newNodes[brushNode->parent()].push_back(newBrushNode);
 
@@ -441,7 +441,7 @@ bool splitBrushesOutward(
                  }
                });
            })
-    .and_then([&]() {
+    .transform([&]() {
       // Apply the changes calculated above
       document.rollbackTransaction();
 

--- a/common/src/View/ExtrudeTool.cpp
+++ b/common/src/View/ExtrudeTool.cpp
@@ -450,11 +450,14 @@ bool splitBrushesOutward(
       document.selectNodes(addedNodes);
       dragState.currentDragFaces = std::move(newDragFaces);
       dragState.totalDelta = delta;
+      return true;
     })
-    .handle_errors([&](const Model::BrushError e) {
+    .or_else([&](const Model::BrushError e) {
       document.error() << "Could not extrude brush: " << e;
       kdl::map_clear_and_delete(newNodes);
-    });
+      return false;
+    })
+    .value();
 }
 
 /**

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3046,7 +3046,8 @@ bool MapDocument::createBrush(const std::vector<vm::vec3>& points)
 
       return kdl::void_success;
     })
-    .or_else([&](const auto& e) { error() << "Could not create brush: " << e; });
+    .if_error([&](const auto& e) { error() << "Could not create brush: " << e; })
+    .is_success();
 }
 
 bool MapDocument::csgConvexMerge()
@@ -3125,8 +3126,9 @@ bool MapDocument::csgConvexMerge()
       selectNodes({brushNode});
       transaction.commit();
     })
-    .or_else(
-      [&](const Model::BrushError e) { error() << "Could not create brush: " << e; });
+    .if_error(
+      [&](const Model::BrushError e) { error() << "Could not create brush: " << e; })
+    .is_success();
 }
 
 bool MapDocument::csgSubtract()
@@ -3196,9 +3198,10 @@ bool MapDocument::csgIntersect()
     auto* brushNode = *it;
     const auto& brush = brushNode->brush();
     valid = intersection.intersect(m_worldBounds, brush)
-              .or_else([&](const Model::BrushError e) {
+              .if_error([&](const Model::BrushError e) {
                 error() << "Could not intersect brushes: " << e;
-              });
+              })
+              .is_success();
   }
 
   const auto toRemove = std::vector<Model::Node*>{std::begin(brushes), std::end(brushes)};
@@ -3350,9 +3353,10 @@ bool MapDocument::clipBrushes(const vm::vec3& p1, const vm::vec3& p2, const vm::
         {
           return ReplaceClippedBrushesError{};
         }
-        return {};
+        return kdl::void_success;
       })
-    .or_else([&](const auto& e) { error() << "Could not clip brushes: " << e; });
+    .if_error([&](const auto& e) { error() << "Could not clip brushes: " << e; })
+    .is_success();
 }
 
 bool MapDocument::setProperty(
@@ -3848,7 +3852,7 @@ MapDocument::MoveVerticesResult MapDocument::moveVertices(
             newVertexPositions =
               kdl::vec_concat(std::move(newVertexPositions), std::move(newPositions));
           })
-          .or_else([&](const Model::BrushError e) {
+          .if_error([&](const Model::BrushError e) {
             error() << "Could not move brush vertices: " << e;
           })
           .is_success();
@@ -3929,7 +3933,7 @@ bool MapDocument::moveEdges(
             newEdgePositions =
               kdl::vec_concat(std::move(newEdgePositions), std::move(newPositions));
           })
-          .or_else([&](const Model::BrushError e) {
+          .if_error([&](const Model::BrushError e) {
             error() << "Could not move brush edges: " << e;
           })
           .is_success();
@@ -3997,7 +4001,7 @@ bool MapDocument::moveFaces(
             newFacePositions =
               kdl::vec_concat(std::move(newFacePositions), std::move(newPositions));
           })
-          .or_else([&](const Model::BrushError e) {
+          .if_error([&](const Model::BrushError e) {
             error() << "Could not move brush faces: " << e;
           })
           .is_success();
@@ -4049,7 +4053,7 @@ bool MapDocument::addVertex(const vm::vec3& vertexPosition)
         }
 
         return brush.addVertex(m_worldBounds, vertexPosition)
-          .or_else([&](const Model::BrushError e) {
+          .if_error([&](const Model::BrushError e) {
             error() << "Could not add brush vertex: " << e;
           })
           .is_success();
@@ -4106,7 +4110,7 @@ bool MapDocument::removeVertices(
         }
 
         return brush.removeVertices(m_worldBounds, verticesToRemove)
-          .or_else([&](const Model::BrushError e) {
+          .if_error([&](const Model::BrushError e) {
             error() << "Could not remove brush vertices: " << e;
           })
           .is_success();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1429,11 +1429,11 @@ void MapDocument::selectTall(const vm::axis::type cameraAxis)
 
       return brushBuilder
         .createBrush(tallVertices, Model::BrushFaceAttributes::NoTextureName)
-        .and_then([](Model::Brush&& brush) {
+        .transform([](Model::Brush&& brush) {
           return std::make_unique<Model::BrushNode>(std::move(brush));
         });
     })
-    .and_then([&](const std::vector<std::unique_ptr<Model::BrushNode>>& tallBrushes) {
+    .transform([&](const std::vector<std::unique_ptr<Model::BrushNode>>& tallBrushes) {
       // delete the original selection brushes before searching for the objects to select
       auto transaction = Transaction{*this, "Select Tall"};
       deleteObjects();
@@ -3089,7 +3089,7 @@ bool MapDocument::csgConvexMerge()
   const auto builder = Model::BrushBuilder{
     m_world->mapFormat(), m_worldBounds, m_game->defaultFaceAttribs()};
   return builder.createBrush(polyhedron, currentTextureName())
-    .and_then([&](Model::Brush&& b) {
+    .transform([&](Model::Brush&& b) {
       b.cloneFaceAttributesFrom(kdl::vec_transform(
         selectedNodes().brushes(),
         [](const auto* brushNode) { return &brushNode->brush(); }));
@@ -3245,7 +3245,7 @@ bool MapDocument::csgHollow()
       auto fragments = std::vector<Model::Brush>{};
       shrunkenBrush
         .expand(m_worldBounds, -1.0 * static_cast<FloatType>(m_grid->actualSize()), true)
-        .and_then([&]() {
+        .transform([&]() {
           didHollowAnything = true;
 
           auto subtractionResults = originalBrush.subtract(
@@ -3669,7 +3669,7 @@ bool MapDocument::extrudeBrushes(
 
         return brush
           .moveBoundary(m_worldBounds, *faceIndex, delta, pref(Preferences::TextureLock))
-          .and_then([&]() { return m_worldBounds.contains(brush.bounds()); })
+          .transform([&]() { return m_worldBounds.contains(brush.bounds()); })
           .or_else([&](const Model::BrushError e) {
             error() << "Could not resize brush: " << e;
             return false;
@@ -3784,7 +3784,7 @@ bool MapDocument::snapVertices(const FloatType snapTo)
         if (originalBrush.canSnapVertices(m_worldBounds, snapTo))
         {
           originalBrush.snapVertices(m_worldBounds, snapTo, pref(Preferences::UVLock))
-            .and_then([&]() { succeededBrushCount += 1; })
+            .transform([&]() { succeededBrushCount += 1; })
             .or_else([&](const Model::BrushError e) {
               error() << "Could not snap vertices: " << e;
               failedBrushCount += 1;
@@ -3847,7 +3847,7 @@ MapDocument::MoveVerticesResult MapDocument::moveVertices(
 
         return brush
           .moveVertices(m_worldBounds, verticesToMove, delta, pref(Preferences::UVLock))
-          .and_then([&]() {
+          .transform([&]() {
             auto newPositions = brush.findClosestVertexPositions(verticesToMove + delta);
             newVertexPositions =
               kdl::vec_concat(std::move(newVertexPositions), std::move(newPositions));
@@ -3927,7 +3927,7 @@ bool MapDocument::moveEdges(
 
         return brush
           .moveEdges(m_worldBounds, edgesToMove, delta, pref(Preferences::UVLock))
-          .and_then([&]() {
+          .transform([&]() {
             auto newPositions = brush.findClosestEdgePositions(kdl::vec_transform(
               edgesToMove, [&](const auto& edge) { return edge.translate(delta); }));
             newEdgePositions =
@@ -3995,7 +3995,7 @@ bool MapDocument::moveFaces(
 
         return brush
           .moveFaces(m_worldBounds, facesToMove, delta, pref(Preferences::UVLock))
-          .and_then([&]() {
+          .transform([&]() {
             auto newPositions = brush.findClosestFacePositions(kdl::vec_transform(
               facesToMove, [&](const auto& face) { return face.translate(delta); }));
             newFacePositions =

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -3665,12 +3665,12 @@ bool MapDocument::extrudeBrushes(
 
         return brush
           .moveBoundary(m_worldBounds, *faceIndex, delta, pref(Preferences::TextureLock))
-          .visit(kdl::overload(
-            [&]() { return m_worldBounds.contains(brush.bounds()); },
-            [&](const Model::BrushError e) {
-              error() << "Could not resize brush: " << e;
-              return false;
-            }));
+          .and_then([&]() { return m_worldBounds.contains(brush.bounds()); })
+          .or_else([&](const Model::BrushError e) {
+            error() << "Could not resize brush: " << e;
+            return false;
+          })
+          .value();
       },
       [](Model::BezierPatch&) { return true; }));
 }

--- a/common/src/View/UpdateLinkedGroupsCommandBase.cpp
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<CommandResult> UpdateLinkedGroupsCommandBase::performDo(
   }
 
   return m_updateLinkedGroupsHelper.applyLinkedGroupUpdates(*document)
-    .and_then([&]() {
+    .transform([&]() {
       setModificationCount(document);
       return std::move(commandResult);
     })

--- a/common/src/View/UpdateLinkedGroupsHelper.cpp
+++ b/common/src/View/UpdateLinkedGroupsHelper.cpp
@@ -67,7 +67,7 @@ UpdateLinkedGroupsHelper::~UpdateLinkedGroupsHelper() = default;
 kdl::result<void, Model::UpdateLinkedGroupsError> UpdateLinkedGroupsHelper::
   applyLinkedGroupUpdates(MapDocumentCommandFacade& document)
 {
-  return computeLinkedGroupUpdates(document).and_then(
+  return computeLinkedGroupUpdates(document).transform(
     [&]() { doApplyOrUndoLinkedGroupUpdates(document); });
 }
 
@@ -117,8 +117,9 @@ kdl::result<void, Model::UpdateLinkedGroupsError> UpdateLinkedGroupsHelper::
     kdl::overload(
       [&](const ChangedLinkedGroups& changedLinkedGroups) {
         return computeLinkedGroupUpdates(changedLinkedGroups, document)
-          .and_then(
-            [&](auto&& linkedGroupUpdates) { m_state = std::move(linkedGroupUpdates); });
+          .transform([&](auto&& linkedGroupUpdates) {
+            m_state = std::forward<decltype(linkedGroupUpdates)>(linkedGroupUpdates);
+          });
       },
       [](const LinkedGroupUpdates&) -> kdl::result<void, Model::UpdateLinkedGroupsError> {
         return kdl::void_success;

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -354,7 +354,7 @@ public: // csg convex merge
         }
         transaction.commit();
       })
-      .handle_errors([&](const Model::BrushError e) {
+      .or_else([&](const Model::BrushError e) {
         document->error() << "Could not create brush: " << e;
       });
   }

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -337,7 +337,7 @@ public: // csg convex merge
       document->worldBounds(),
       game->defaultFaceAttribs()};
     builder.createBrush(polyhedron, document->currentTextureName())
-      .and_then([&](Model::Brush&& b) {
+      .transform([&](Model::Brush&& b) {
         for (const auto* selectedBrushNode : document->selectedNodes().brushes())
         {
           b.cloneFaceAttributesFrom(selectedBrushNode->brush());

--- a/common/test/src/Model/tst_Brush.cpp
+++ b/common/test/src/Model/tst_Brush.cpp
@@ -63,9 +63,8 @@ static bool canMoveBoundary(
   const vm::vec3& delta)
 {
   return brush.moveBoundary(worldBounds, faceIndex, delta, false)
-    .visit(kdl::overload(
-      [&]() { return worldBounds.contains(brush.bounds()); },
-      [](const BrushError) { return false; }));
+    .and_then([&]() { return worldBounds.contains(brush.bounds()); })
+    .value_or(false);
 }
 
 TEST_CASE("BrushTest.constructBrushWithFaces")

--- a/common/test/src/Model/tst_Brush.cpp
+++ b/common/test/src/Model/tst_Brush.cpp
@@ -63,7 +63,7 @@ static bool canMoveBoundary(
   const vm::vec3& delta)
 {
   return brush.moveBoundary(worldBounds, faceIndex, delta, false)
-    .and_then([&]() { return worldBounds.contains(brush.bounds()); })
+    .transform([&]() { return worldBounds.contains(brush.bounds()); })
     .value_or(false);
 }
 

--- a/common/test/src/Model/tst_BrushFace.cpp
+++ b/common/test/src/Model/tst_BrushFace.cpp
@@ -825,7 +825,7 @@ TEST_CASE("BrushFaceTest.formatConversion")
   Assets::Texture texture("testTexture", 64, 64);
 
   const Brush startingCube = standardBuilder.createCube(128.0, "")
-                               .and_then([&](Brush&& brush) {
+                               .transform([&](Brush&& brush) {
                                  for (size_t i = 0; i < brush.faceCount(); ++i)
                                  {
                                    BrushFace& face = brush.face(i);

--- a/common/test/src/Model/tst_BrushFace.cpp
+++ b/common/test/src/Model/tst_BrushFace.cpp
@@ -218,14 +218,14 @@ static void checkTextureLockOffWithTransform(
   // reset alignment, transform the face (texture lock off)
   BrushFace face = origFace;
   resetFaceTextureAlignment(face);
-  REQUIRE(face.transform(transform, false));
+  REQUIRE(face.transform(transform, false).is_success());
   face.resetTexCoordSystemCache();
 
   // reset alignment, transform the face (texture lock off), then reset the alignment
   // again
   BrushFace resetFace = origFace;
   resetFaceTextureAlignment(resetFace);
-  REQUIRE(resetFace.transform(transform, false));
+  REQUIRE(resetFace.transform(transform, false).is_success());
   resetFaceTextureAlignment(resetFace);
 
   // UVs of the verts of `face` and `resetFace` should be the same now
@@ -296,7 +296,7 @@ static void checkTextureLockOnWithTransform(
 
   // transform the face
   BrushFace face = origFace;
-  REQUIRE(face.transform(transform, true));
+  REQUIRE(face.transform(transform, true).is_success());
   face.resetTexCoordSystemCache();
 
   // transform the verts
@@ -511,7 +511,7 @@ static void checkTextureLockOffWithVerticalFlip(const Brush& cube)
 
   // transform the face (texture lock off)
   BrushFace face = origFace;
-  REQUIRE(face.transform(transform, false));
+  REQUIRE(face.transform(transform, false).is_success());
   face.resetTexCoordSystemCache();
 
   // UVs of the verts of `face` and `origFace` should be the same now
@@ -541,7 +541,7 @@ static void checkTextureLockOffWithScale(const Brush& cube)
 
   // transform the face (texture lock off)
   BrushFace face = origFace;
-  REQUIRE(face.transform(transform, false));
+  REQUIRE(face.transform(transform, false).is_success());
   face.resetTexCoordSystemCache();
 
   // get UV at mins; should be equal

--- a/common/test/src/Model/tst_GroupNode.cpp
+++ b/common/test/src/Model/tst_GroupNode.cpp
@@ -189,14 +189,14 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
   SECTION("Target group list is empty")
   {
     updateLinkedGroups(groupNode, {}, worldBounds)
-      .and_then([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
+      .transform([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
       .or_else([](const auto&) { FAIL(); });
   }
 
   SECTION("Target group list contains only source group")
   {
     updateLinkedGroups(groupNode, {&groupNode}, worldBounds)
-      .and_then([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
+      .transform([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
       .or_else([](const auto&) { FAIL(); });
   }
 
@@ -222,7 +222,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
     REQUIRE(entityNode->entity().origin() == vm::vec3(1.0, 0.0, 3.0));
 
     updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds)
-      .and_then([&](const UpdateLinkedGroupsResult& r) {
+      .transform([&](const UpdateLinkedGroupsResult& r) {
         CHECK(r.size() == 1u);
 
         const auto& p = r.front();
@@ -275,7 +275,7 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
       == vm::translation_matrix(vm::vec3(0.0, 2.0, 0.0)));
 
     updateLinkedGroups(*innerGroupNode, {innerGroupNodeClone.get()}, worldBounds)
-      .and_then([&](const UpdateLinkedGroupsResult& r) {
+      .transform([&](const UpdateLinkedGroupsResult& r) {
         CHECK(r.size() == 1u);
 
         const auto& p = r.front();
@@ -306,7 +306,7 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
       == vm::translation_matrix(vm::vec3(0.0, 2.0, 0.0)));
 
     updateLinkedGroups(*innerGroupNode, {innerGroupNodeClone.get()}, worldBounds)
-      .and_then([&](const UpdateLinkedGroupsResult& r) {
+      .transform([&](const UpdateLinkedGroupsResult& r) {
         CHECK(r.size() == 1u);
 
         const auto& p = r.front();
@@ -375,7 +375,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively")
   REQUIRE(innerGroupEntityNodeClone != nullptr);
 
   updateLinkedGroups(outerGroupNode, {outerGroupNodeClone.get()}, worldBounds)
-    .and_then([&](const UpdateLinkedGroupsResult& r) {
+    .transform([&](const UpdateLinkedGroupsResult& r) {
       REQUIRE(r.size() == 1u);
       const auto& [groupNodeToUpdate, newChildren] = r.front();
 
@@ -419,7 +419,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds")
   REQUIRE(entityNode->entity().origin() == vm::vec3(1.0, 0.0, 0.0));
 
   updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds)
-    .and_then([&](const UpdateLinkedGroupsResult&) { FAIL(); })
+    .transform([&](const UpdateLinkedGroupsResult&) { FAIL(); })
     .or_else(kdl::overload(
       [](const BrushError&) { FAIL(); },
       [](const UpdateLinkedGroupsError& e) {
@@ -467,7 +467,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveNestedGroupNames")
     "group")
   {
     updateLinkedGroups(outerGroupNode, {outerGroupNodeClone.get()}, worldBounds)
-      .and_then([&](const UpdateLinkedGroupsResult& r) {
+      .transform([&](const UpdateLinkedGroupsResult& r) {
         REQUIRE(r.size() == 1u);
 
         const auto& [groupNodeToUpdate, newChildren] = r.front();
@@ -603,7 +603,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveEntityProperties")
   const auto expectedTargetProperties = expectedProperties;
 
   updateLinkedGroups(sourceGroupNode, {targetGroupNode.get()}, worldBounds)
-    .and_then([&](const UpdateLinkedGroupsResult& r) {
+    .transform([&](const UpdateLinkedGroupsResult& r) {
       REQUIRE(r.size() == 1u);
       const auto& p = r.front();
 

--- a/common/test/src/Model/tst_GroupNode.cpp
+++ b/common/test/src/Model/tst_GroupNode.cpp
@@ -188,18 +188,16 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
 
   SECTION("Target group list is empty")
   {
-    const auto updateResult = updateLinkedGroups(groupNode, {}, worldBounds);
-    updateResult.visit(kdl::overload(
-      [&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); },
-      [](const auto&) { FAIL(); }));
+    updateLinkedGroups(groupNode, {}, worldBounds)
+      .and_then([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
+      .or_else([](const auto&) { FAIL(); });
   }
 
   SECTION("Target group list contains only source group")
   {
-    const auto updateResult = updateLinkedGroups(groupNode, {&groupNode}, worldBounds);
-    updateResult.visit(kdl::overload(
-      [&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); },
-      [](const auto&) { FAIL(); }));
+    updateLinkedGroups(groupNode, {&groupNode}, worldBounds)
+      .and_then([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
+      .or_else([](const auto&) { FAIL(); });
   }
 
   SECTION("Update a single target group")
@@ -223,10 +221,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
       *entityNode, vm::translation_matrix(vm::vec3(0.0, 0.0, 3.0)), worldBounds);
     REQUIRE(entityNode->entity().origin() == vm::vec3(1.0, 0.0, 3.0));
 
-    const auto updateResult =
-      updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds);
-    updateResult.visit(kdl::overload(
-      [&](const UpdateLinkedGroupsResult& r) {
+    updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds)
+      .and_then([&](const UpdateLinkedGroupsResult& r) {
         CHECK(r.size() == 1u);
 
         const auto& p = r.front();
@@ -239,8 +235,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
         CHECK(newEntityNode != nullptr);
 
         CHECK(newEntityNode->entity().origin() == vm::vec3(1.0, 2.0, 3.0));
-      },
-      [](const auto&) { FAIL(); }));
+      })
+      .or_else([](const auto&) { FAIL(); });
   }
 }
 
@@ -278,10 +274,8 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
       innerGroupNodeClone->group().transformation()
       == vm::translation_matrix(vm::vec3(0.0, 2.0, 0.0)));
 
-    const auto updateResult =
-      updateLinkedGroups(*innerGroupNode, {innerGroupNodeClone.get()}, worldBounds);
-    updateResult.visit(kdl::overload(
-      [&](const UpdateLinkedGroupsResult& r) {
+    updateLinkedGroups(*innerGroupNode, {innerGroupNodeClone.get()}, worldBounds)
+      .and_then([&](const UpdateLinkedGroupsResult& r) {
         CHECK(r.size() == 1u);
 
         const auto& p = r.front();
@@ -294,8 +288,8 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
         CHECK(newEntityNode != nullptr);
 
         CHECK(newEntityNode->entity().origin() == vm::vec3(0.0, 2.0, 0.0));
-      },
-      [](const auto&) { FAIL(); }));
+      })
+      .or_else([](const auto&) { FAIL(); });
   }
 
   SECTION("Transforming the inner group node's entity and updating the linked group")
@@ -311,10 +305,8 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
       innerGroupNodeClone->group().transformation()
       == vm::translation_matrix(vm::vec3(0.0, 2.0, 0.0)));
 
-    const auto updateResult =
-      updateLinkedGroups(*innerGroupNode, {innerGroupNodeClone.get()}, worldBounds);
-    updateResult.visit(kdl::overload(
-      [&](const UpdateLinkedGroupsResult& r) {
+    updateLinkedGroups(*innerGroupNode, {innerGroupNodeClone.get()}, worldBounds)
+      .and_then([&](const UpdateLinkedGroupsResult& r) {
         CHECK(r.size() == 1u);
 
         const auto& p = r.front();
@@ -327,8 +319,8 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
         CHECK(newEntityNode != nullptr);
 
         CHECK(newEntityNode->entity().origin() == vm::vec3(1.0, 2.0, 0.0));
-      },
-      [](const auto&) { FAIL(); }));
+      })
+      .or_else([](const auto&) { FAIL(); });
   }
 }
 
@@ -382,10 +374,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively")
     dynamic_cast<EntityNode*>(innerGroupNodeClone->children().front());
   REQUIRE(innerGroupEntityNodeClone != nullptr);
 
-  const auto updateResult =
-    updateLinkedGroups(outerGroupNode, {outerGroupNodeClone.get()}, worldBounds);
-  updateResult.visit(kdl::overload(
-    [&](const UpdateLinkedGroupsResult& r) {
+  updateLinkedGroups(outerGroupNode, {outerGroupNodeClone.get()}, worldBounds)
+    .and_then([&](const UpdateLinkedGroupsResult& r) {
       REQUIRE(r.size() == 1u);
       const auto& [groupNodeToUpdate, newChildren] = r.front();
 
@@ -401,8 +391,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively")
         dynamic_cast<EntityNode*>(newInnerGroupNodeClone->children().front());
       CHECK(newInnerGroupEntityNodeClone != nullptr);
       CHECK(newInnerGroupEntityNodeClone->entity() == innerGroupEntityNode->entity());
-    },
-    [](const auto&) { FAIL(); }));
+    })
+    .or_else([](const auto&) { FAIL(); });
 }
 
 TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds")
@@ -428,14 +418,13 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds")
     *entityNode, vm::translation_matrix(vm::vec3(1.0, 0.0, 0.0)), worldBounds);
   REQUIRE(entityNode->entity().origin() == vm::vec3(1.0, 0.0, 0.0));
 
-  const auto updateResult =
-    updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds);
-  updateResult.visit(kdl::overload(
-    [&](const UpdateLinkedGroupsResult&) { FAIL(); },
-    [](const BrushError&) { FAIL(); },
-    [](const UpdateLinkedGroupsError& e) {
-      CHECK(e == UpdateLinkedGroupsError::UpdateExceedsWorldBounds);
-    }));
+  updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds)
+    .and_then([&](const UpdateLinkedGroupsResult&) { FAIL(); })
+    .or_else(kdl::overload(
+      [](const BrushError&) { FAIL(); },
+      [](const UpdateLinkedGroupsError& e) {
+        CHECK(e == UpdateLinkedGroupsError::UpdateExceedsWorldBounds);
+      }));
 }
 
 static void setGroupName(GroupNode& groupNode, const std::string& name)
@@ -477,10 +466,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveNestedGroupNames")
     "Updating outerGroupNode retains the names of its linked group and the nested linked "
     "group")
   {
-    const auto updateResult =
-      updateLinkedGroups(outerGroupNode, {outerGroupNodeClone.get()}, worldBounds);
-    updateResult.visit(kdl::overload(
-      [&](const UpdateLinkedGroupsResult& r) {
+    updateLinkedGroups(outerGroupNode, {outerGroupNodeClone.get()}, worldBounds)
+      .and_then([&](const UpdateLinkedGroupsResult& r) {
         REQUIRE(r.size() == 1u);
 
         const auto& [groupNodeToUpdate, newChildren] = r.front();
@@ -488,8 +475,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveNestedGroupNames")
 
         const auto* innerReplacement = static_cast<GroupNode*>(newChildren.front().get());
         CHECK(innerReplacement->name() == innerGroupNodeNestedClone->name());
-      },
-      [](const auto&) { FAIL(); }));
+      })
+      .or_else([](const auto&) { FAIL(); });
   }
 }
 
@@ -615,10 +602,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveEntityProperties")
   // lambda can't capture structured bindings
   const auto expectedTargetProperties = expectedProperties;
 
-  const auto updateResult =
-    updateLinkedGroups(sourceGroupNode, {targetGroupNode.get()}, worldBounds);
-  updateResult.visit(kdl::overload(
-    [&](const UpdateLinkedGroupsResult& r) {
+  updateLinkedGroups(sourceGroupNode, {targetGroupNode.get()}, worldBounds)
+    .and_then([&](const UpdateLinkedGroupsResult& r) {
       REQUIRE(r.size() == 1u);
       const auto& p = r.front();
 
@@ -634,8 +619,8 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveEntityProperties")
       CHECK_THAT(
         newEntityNode->entity().protectedProperties(),
         Catch::UnorderedEquals(targetEntityNode->entity().protectedProperties()));
-    },
-    [](const auto&) { FAIL(); }));
+    })
+    .or_else([](const auto&) { FAIL(); });
 }
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/test/src/View/tst_UpdateLinkedGroupsHelper.cpp
+++ b/common/test/src/View/tst_UpdateLinkedGroupsHelper.cpp
@@ -103,8 +103,10 @@ TEST_CASE_METHOD(UpdateLinkedGroupsHelperTest, "UpdateLinkedGroupsHelperTest.own
   {
     {
       auto helper = UpdateLinkedGroupsHelper{{linkedNode}};
-      REQUIRE(helper.applyLinkedGroupUpdates(
-        *static_cast<MapDocumentCommandFacade*>(document.get())));
+      REQUIRE(helper
+                .applyLinkedGroupUpdates(
+                  *static_cast<MapDocumentCommandFacade*>(document.get()))
+                .is_success());
     }
     CHECK(deleted);
   }
@@ -113,8 +115,10 @@ TEST_CASE_METHOD(UpdateLinkedGroupsHelperTest, "UpdateLinkedGroupsHelperTest.own
   {
     {
       auto helper = UpdateLinkedGroupsHelper{{linkedNode}};
-      REQUIRE(helper.applyLinkedGroupUpdates(
-        *static_cast<MapDocumentCommandFacade*>(document.get())));
+      REQUIRE(helper
+                .applyLinkedGroupUpdates(
+                  *static_cast<MapDocumentCommandFacade*>(document.get()))
+                .is_success());
       helper.undoLinkedGroupUpdates(
         *static_cast<MapDocumentCommandFacade*>(document.get()));
     }
@@ -183,8 +187,10 @@ TEST_CASE_METHOD(
 
   // propagate changes
   auto helper = UpdateLinkedGroupsHelper{{groupNode}};
-  REQUIRE(helper.applyLinkedGroupUpdates(
-    *static_cast<MapDocumentCommandFacade*>(document.get())));
+  REQUIRE(
+    helper
+      .applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()))
+      .is_success());
 
   /*
   world
@@ -413,8 +419,10 @@ TEST_CASE_METHOD(
   SECTION("First propagate changes to innerGroupNode, then outerGroupNode")
   {
     auto helper1 = UpdateLinkedGroupsHelper{{innerGroupNode}};
-    CHECK(helper1.applyLinkedGroupUpdates(
-      *static_cast<MapDocumentCommandFacade*>(document.get())));
+    CHECK(
+      helper1
+        .applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()))
+        .is_success());
 
     /*
     world
@@ -451,8 +459,10 @@ TEST_CASE_METHOD(
       == originalBrushBounds.translate(vm::vec3(32.0, 0.0, 8.0)));
 
     auto helper2 = UpdateLinkedGroupsHelper{{outerGroupNode}};
-    CHECK(helper2.applyLinkedGroupUpdates(
-      *static_cast<MapDocumentCommandFacade*>(document.get())));
+    CHECK(
+      helper2
+        .applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()))
+        .is_success());
 
     // see end of test for assertions of final state
   }
@@ -460,8 +470,10 @@ TEST_CASE_METHOD(
   SECTION("First propagate changes to outerGroupNode, then innerGroupNode")
   {
     auto helper1 = UpdateLinkedGroupsHelper{{outerGroupNode}};
-    REQUIRE(helper1.applyLinkedGroupUpdates(
-      *static_cast<MapDocumentCommandFacade*>(document.get())));
+    REQUIRE(
+      helper1
+        .applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()))
+        .is_success());
 
     /*
     world
@@ -496,8 +508,10 @@ TEST_CASE_METHOD(
       == originalBrushBounds.translate(vm::vec3(32.0, 16.0, 8.0)));
 
     auto helper2 = UpdateLinkedGroupsHelper{{innerGroupNode}};
-    REQUIRE(helper2.applyLinkedGroupUpdates(
-      *static_cast<MapDocumentCommandFacade*>(document.get())));
+    REQUIRE(
+      helper2
+        .applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()))
+        .is_success());
 
     // see end of test for assertions of final state
   }
@@ -515,8 +529,10 @@ TEST_CASE_METHOD(
     }
 
     auto helper = UpdateLinkedGroupsHelper{groupNodes};
-    REQUIRE(helper.applyLinkedGroupUpdates(
-      *static_cast<MapDocumentCommandFacade*>(document.get())));
+    REQUIRE(
+      helper
+        .applyLinkedGroupUpdates(*static_cast<MapDocumentCommandFacade*>(document.get()))
+        .is_success());
   }
 
   /*

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -401,7 +401,7 @@ TEST_CASE("PreferencesTest.readV2")
   CHECK(parseV2SettingsFromJSON(QByteArray("{}")).is_success());
 
   readV2SettingsFromPath("fixture/test/preferences-v2.json")
-    .and_then([](const std::map<IO::Path, QJsonValue>& prefs) { testV2Prefs(prefs); })
+    .transform([](const std::map<IO::Path, QJsonValue>& prefs) { testV2Prefs(prefs); })
     .or_else([](const auto&) { FAIL_CHECK(); });
 }
 
@@ -413,7 +413,7 @@ TEST_CASE("PreferencesTest.testWriteReadV2")
 
   const QByteArray v2Serialized = writeV2SettingsToJSON(v2);
   parseV2SettingsFromJSON(v2Serialized)
-    .and_then([&](const std::map<IO::Path, QJsonValue>& prefs) { CHECK(v2 == prefs); })
+    .transform([&](const std::map<IO::Path, QJsonValue>& prefs) { CHECK(v2 == prefs); })
     .or_else([](const auto&) { FAIL_CHECK(); });
 }
 

--- a/lib/kdl/include/kdl/meta_utils.h
+++ b/lib/kdl/include/kdl/meta_utils.h
@@ -99,6 +99,12 @@ struct meta_front
   using remainder = meta_type_list<Remainder...>;
 };
 
+template <typename... T>
+using meta_front_v = typename meta_front<T...>::front;
+
+template <typename... T>
+using meta_remainder_v = typename meta_front<T...>::remainder;
+
 template <typename Subset, typename Superset>
 struct meta_is_subset
 {

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -484,51 +484,6 @@ public:
   }
 
   /**
-   * Applies the given function to the error contained in this result.
-   *
-   * Does nothing if this result does not contain an error.
-   *
-   * Passes the error contained in this result by rvalue reference to the given function.
-   *
-   * @tparam F the type of the function
-   * @param f the function
-   * @return true if this result is successful and false otherwise
-   */
-  template <typename F>
-  bool handle_errors(F&& f) &&
-  {
-    return std::move(*this).visit(kdl::overload(
-      [](const value_type&) { return true; },
-      [&](auto&& error) {
-        f(std::forward<decltype(error)>(error));
-        return false;
-      }));
-  }
-
-  /**
-   * Applies the given function to the error contained in this result.
-   *
-   * Does nothing if this result does not contain an error.
-   *
-   * Passes the error contained in this result by const lvalue reference to the given
-   * function.
-   *
-   * @tparam F the type of the function
-   * @param f the function
-   * @return true if this result is successful and false otherwise
-   */
-  template <typename F>
-  bool handle_errors(F&& f) const&
-  {
-    return visit(kdl::overload(
-      [](const value_type&) { return true; },
-      [&](const auto& error) {
-        f(error);
-        return false;
-      }));
-  }
-
-  /**
    * Returns the value contained in this result if it is successful. Otherwise, throws
    * `bad_result_access`.
    *
@@ -1052,34 +1007,6 @@ public:
         kdl::overload([]() {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
       return result<void>{};
     }
-  }
-
-  /**
-   * See result<Value, Errors...>::handle_errors.
-   */
-  template <typename F>
-  bool handle_errors(F&& f) &&
-  {
-    return std::move(*this).visit(kdl::overload(
-      []() { return true; },
-      [&](auto&& error) {
-        f(std::forward<decltype(error)>(error));
-        return false;
-      }));
-  }
-
-  /**
-   * See result<Value, Errors...>::handle_errors.
-   */
-  template <typename F>
-  bool handle_errors(F&& f) const&
-  {
-    return visit(kdl::overload(
-      []() { return true; },
-      [&](const auto& error) {
-        f(error);
-        return false;
-      }));
   }
 
   /**

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -543,6 +543,34 @@ public:
       [](const auto&) -> value_type { throw bad_result_access{}; }));
   }
 
+  auto value_or(const Value& x) const&
+  {
+    return visit(kdl::overload(
+      [](const value_type& v) -> value_type { return v; },
+      [&](const auto&) -> value_type { return x; }));
+  }
+
+  auto value_or(Value&& x) const&
+  {
+    return visit(kdl::overload(
+      [](const value_type& v) -> value_type { return v; },
+      [&](const auto&) -> value_type { return std::move(x); }));
+  }
+
+  auto value_or(const Value& x) &&
+  {
+    return std::move(*this).visit(kdl::overload(
+      [](value_type&& v) -> value_type { return std::move(v); },
+      [&](const auto&) -> value_type { return x; }));
+  }
+
+  auto value_or(Value&& x) &&
+  {
+    return std::move(*this).visit(kdl::overload(
+      [](value_type&& v) -> value_type { return std::move(v); },
+      [&](const auto&) -> value_type { return std::move(x); }));
+  }
+
   /**
    * Returns the value contained in this result if it is successful. Otherwise, throws
    * `bad_result_access`.

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -637,6 +637,93 @@ struct void_success_value_type
 } // namespace detail
 
 /**
+ * Wrapper class that can contain only nothing.
+ *
+ * An instance of this class represents an expectation for the result of applying a
+ * function if that function returns void.
+ *
+ * This result is always considered successful.
+ */
+template <>
+class result<void>
+{
+public:
+  using value_type = void;
+
+  template <typename OtherValue>
+  using with_value_type = result<OtherValue>;
+
+public:
+  /**
+   * Applies the given visitor this result.
+   *
+   * The given visitor must accept void.
+   *
+   * @tparam Visitor the type of the visitor
+   * @param visitor the visitor to apply
+   * @return the value returned by the given visitor or void if the given visitor does not
+   * return anything
+   */
+  template <typename Visitor>
+  auto visit(Visitor&& visitor) const&
+  {
+    return visitor();
+  }
+
+  /**
+   * Applies the given visitor this result.
+   *
+   * See above.
+   */
+  template <typename Visitor>
+  auto visit(Visitor&& visitor) &&
+  {
+    return visitor();
+  }
+
+  /**
+   * See result<Value, Errors...>::and_then.
+   */
+  template <typename F>
+  auto and_then(F&& f) const&
+  {
+    return f();
+  }
+
+  /**
+   * See result<Value, Errors...>::and_then.
+   */
+  template <typename F>
+  auto and_then(F&& f) &&
+  {
+    return f();
+  }
+
+  /**
+   * Indicates whether this result is empty. Always true.
+   */
+  bool is_success() const { return true; }
+
+  /**
+   * Indicates whether this result contains an error. Always false.
+   */
+  bool is_error() const { return !is_success(); }
+
+  /**
+   * Indicates whether this result is empty.
+   */
+  // NOLINTNEXTLINE
+  operator bool() const { return is_success(); }
+
+  friend bool operator==(const result&, const result&) { return true; }
+
+  friend bool operator!=(const result& lhs, const result& rhs) { return !(lhs == rhs); }
+};
+
+
+constexpr auto void_success = kdl::result<void>{};
+
+/**
  * Wrapper class that can contain either nothing or one of several errors.
  *
  * An instance of this class represents an expectation for the result of applying a
@@ -1009,6 +1096,4 @@ public:
 
   friend bool operator!=(const result& lhs, const result& rhs) { return !(lhs == rhs); }
 };
-
-constexpr auto void_success = kdl::result<void>{};
 } // namespace kdl

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -696,7 +696,7 @@ public:
   template <typename F>
   auto and_then(F&& f) const&
   {
-    using Fn_Result = std::invoke_result_t<F, void>;
+    using Fn_Result = std::invoke_result_t<F>;
 
     static_assert(
       detail::is_result<Fn_Result>::value, "Function must return a result type");
@@ -710,7 +710,7 @@ public:
   template <typename F>
   auto and_then(F&& f) &&
   {
-    using Fn_Result = std::invoke_result_t<F, void>;
+    using Fn_Result = std::invoke_result_t<F>;
 
     static_assert(
       detail::is_result<Fn_Result>::value, "Function must return a result type");
@@ -724,7 +724,7 @@ public:
   template <typename F>
   auto transform(F&& f) const
   {
-    using Fn_Result = std::invoke_result_t<F, void>;
+    using Fn_Result = std::invoke_result_t<F>;
     using Cm_Result = result<Fn_Result>;
 
     return Cm_Result{f()};

--- a/lib/kdl/include/kdl/result_combine.h
+++ b/lib/kdl/include/kdl/result_combine.h
@@ -73,9 +73,9 @@ auto combine_results(Result&& result)
   using value_type = typename std::remove_reference_t<Result>::value_type;
 
   return result.visit(kdl::overload(
-    [](value_type&& v) { return result_type(std::make_tuple(std::move(v))); },
-    [](const value_type& v) { return result_type(std::make_tuple(v)); },
-    [](auto&& e) { return result_type(std::forward<decltype(e)>(e)); }));
+    [](value_type&& v) { return result_type{std::make_tuple(std::move(v))}; },
+    [](const value_type& v) { return result_type{std::make_tuple(v)}; },
+    [](auto&& e) { return result_type{std::forward<decltype(e)>(e)}; }));
 }
 
 /**
@@ -121,34 +121,33 @@ auto combine_results(FirstResult&& firstResult, MoreResults&&... moreResults)
         return combine_results(std::forward<MoreResults>(moreResults)...)
           .visit(kdl::overload(
             [&](typename combined_more_result_type::value_type&& remainingValues) {
-              return result_type(std::tuple_cat(
-                std::make_tuple(std::move(firstValue)), std::move(remainingValues)));
+              return result_type{std::tuple_cat(
+                std::tuple{std::move(firstValue)}, std::move(remainingValues))};
             },
             [&](const typename combined_more_result_type::value_type& remainingValues) {
-              return result_type(
-                std::tuple_cat(std::make_tuple(std::move(firstValue)), remainingValues));
+              return result_type{
+                std::tuple_cat(std::tuple{std::move(firstValue)}, remainingValues)};
             },
             [](auto&& combinedError) {
-              return result_type(std::forward<decltype(combinedError)>(combinedError));
+              return result_type{std::forward<decltype(combinedError)>(combinedError)};
             }));
       },
       [&](const first_value_type& firstValue) {
         return combine_results(std::forward<MoreResults>(moreResults)...)
           .visit(kdl::overload(
             [&](typename combined_more_result_type::value_type&& remainingValues) {
-              return result_type(
-                std::tuple_cat(std::make_tuple(firstValue), std::move(remainingValues)));
+              return result_type{
+                std::tuple_cat(std::tuple{firstValue}, std::move(remainingValues))};
             },
             [&](const typename combined_more_result_type::value_type& remainingValues) {
-              return result_type(
-                std::tuple_cat(std::make_tuple(firstValue), remainingValues));
+              return result_type{std::tuple_cat(std::tuple{firstValue}, remainingValues)};
             },
             [](auto&& combinedError) {
-              return result_type(std::forward<decltype(combinedError)>(combinedError));
+              return result_type{std::forward<decltype(combinedError)>(combinedError)};
             }));
       },
       [&](auto&& firstError) {
-        return result_type(std::forward<decltype(firstError)>(firstError));
+        return result_type{std::forward<decltype(firstError)>(firstError)};
       }));
 }
 } // namespace kdl

--- a/lib/kdl/include/kdl/result_for_each.h
+++ b/lib/kdl/include/kdl/result_for_each.h
@@ -58,7 +58,7 @@ auto collect_values(I cur, I end, E errorHandler)
       .and_then([&](auto&& value) {
         result_vector.push_back(std::forward<decltype(value)>(value));
       })
-      .handle_errors(errorHandler);
+      .or_else(errorHandler);
     ++cur;
   }
 

--- a/lib/kdl/include/kdl/result_for_each.h
+++ b/lib/kdl/include/kdl/result_for_each.h
@@ -55,7 +55,9 @@ auto collect_values(I cur, I end, E errorHandler)
   while (cur != end)
   {
     std::move(*cur)
-      .and_then([&](auto&& value) { result_vector.push_back(std::move(value)); })
+      .and_then([&](auto&& value) {
+        result_vector.push_back(std::forward<decltype(value)>(value));
+      })
       .handle_errors(errorHandler);
     ++cur;
   }
@@ -127,7 +129,7 @@ auto for_each_result(I cur, I end, F f)
       if (f_result.is_error())
       {
         return std::visit(
-          [](auto&& e) { return result_type{std::move(e)}; },
+          [](auto&& e) { return result_type{std::forward<decltype(e)>(e)}; },
           std::move(f_result).error());
       }
 

--- a/lib/kdl/include/kdl/result_for_each.h
+++ b/lib/kdl/include/kdl/result_for_each.h
@@ -57,6 +57,7 @@ auto collect_values(I cur, I end, E errorHandler)
     std::move(*cur)
       .and_then([&](auto&& value) {
         result_vector.push_back(std::forward<decltype(value)>(value));
+        return void_success;
       })
       .or_else(errorHandler);
     ++cur;

--- a/lib/kdl/include/kdl/result_io.h
+++ b/lib/kdl/include/kdl/result_io.h
@@ -22,6 +22,7 @@
 
 #include "kdl/overload.h"
 #include "kdl/result.h"
+#include "kdl/std_io.h"
 
 #include <iostream>
 
@@ -30,14 +31,15 @@ namespace kdl
 template <typename Value, typename... Errors>
 std::ostream& operator<<(std::ostream& str, const result<Value, Errors...>& result)
 {
-  result.visit([&](const auto& x) { str << x; });
+  result.visit([&](const auto& x) { str << make_streamable(x); });
   return str;
 }
 
 template <typename... Errors>
 std::ostream& operator<<(std::ostream& str, const result<void, Errors...>& result)
 {
-  result.visit(kdl::overload([&]() { str << "void"; }, [&](const auto& e) { str << e; }));
+  result.visit(kdl::overload(
+    [&]() { str << "void"; }, [&](const auto& e) { str << make_streamable(e); }));
   return str;
 }
 } // namespace kdl

--- a/lib/kdl/test/src/tst_result.cpp
+++ b/lib/kdl/test/src/tst_result.cpp
@@ -96,7 +96,6 @@ void test_construct_success(V&&... v)
   auto result = ResultType(std::forward<V>(v)...);
   CHECK(result.is_success());
   CHECK_FALSE(result.is_error());
-  CHECK(result);
 }
 
 /**
@@ -108,7 +107,6 @@ void test_construct_error(E&& e)
   auto result = ResultType(std::forward<E>(e));
   CHECK_FALSE(result.is_success());
   CHECK(result.is_error());
-  CHECK_FALSE(result);
 }
 
 /**
@@ -196,7 +194,6 @@ void test_and_then_const_lvalue_ref(V&& v)
     });
     CHECK(to.is_success());
     CHECK_FALSE(to.is_error());
-    CHECK(to);
 
     CHECK(to.visit(overload(
       [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
@@ -209,7 +206,6 @@ void test_and_then_const_lvalue_ref(V&& v)
     });
     CHECK(to.is_success());
     CHECK_FALSE(to.is_error());
-    CHECK(to);
 
     CHECK(to.visit(overload(
       [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
@@ -232,7 +228,6 @@ void test_and_then_rvalue_ref(V&& v)
     });
     CHECK(to.is_success());
     CHECK_FALSE(to.is_error());
-    CHECK(to);
 
     CHECK(to.visit(overload(
       [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
@@ -250,7 +245,6 @@ void test_and_then_rvalue_ref(V&& v)
     });
     CHECK(to.is_success());
     CHECK_FALSE(to.is_error());
-    CHECK(to);
 
     CHECK(to.visit(overload(
       [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
@@ -516,6 +510,44 @@ TEST_CASE("result_test.or_else")
     CHECK(result<void, Error1, Error2>{Error1{}}.or_else([](auto&&) {
       return result<void, Error3>{Error3{}};
     }) == result<void, Error3>{Error3{}});
+  }
+}
+
+TEST_CASE("result_test.if_error")
+{
+  auto called = false;
+  SECTION("non-void result")
+  {
+    called = false;
+    const auto constLValueSuccess = result<int, Error1, Error2>{1};
+    CHECK(constLValueSuccess.if_error([&](const auto&) {
+      called = true;
+    }) == result<int, Error1, Error2>{1});
+    CHECK_FALSE(called);
+
+    called = false;
+    const auto constLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(constLValueError.if_error([&](const auto&) {
+      called = true;
+    }) == result<int, Error1, Error2>{Error1{}});
+    CHECK(called);
+  }
+
+  SECTION("void result")
+  {
+    called = false;
+    const auto constLValueSuccess = result<void, Error1, Error2>{};
+    CHECK(constLValueSuccess.if_error([&](const auto&) {
+      called = true;
+    }) == result<void, Error1, Error2>{});
+    CHECK_FALSE(called);
+
+    called = false;
+    const auto constLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(constLValueError.if_error([&](const auto&) {
+      called = true;
+    }) == result<void, Error1, Error2>{Error1{}});
+    CHECK(called);
   }
 }
 

--- a/lib/kdl/test/src/tst_result.cpp
+++ b/lib/kdl/test/src/tst_result.cpp
@@ -519,43 +519,6 @@ TEST_CASE("result_test.or_else")
   }
 }
 
-TEST_CASE("result_test.map_errors")
-{
-  SECTION("map error of success result by const lvalue")
-  {
-    const auto r = result<int, Error1>{1};
-    const auto rm =
-      r.map_errors([](const Error1&) { return result<int, Error2>{Error2{}}; });
-    CHECK(rm.is_success());
-    CHECK(rm.value() == 1);
-  }
-
-  SECTION("map error of success result by rvalue")
-  {
-    const auto rm = result<int, Error1>{1}.map_errors(
-      [](Error1&&) { return result<int, Error2>{Error2{}}; });
-    CHECK(rm.is_success());
-    CHECK(rm.value() == 1);
-  }
-
-  SECTION("map error of error result by const lvalue")
-  {
-    const auto r = result<int, Error1>{Error1{}};
-    const auto rm =
-      r.map_errors([](const Error1&) { return result<int, Error2>{Error2{}}; });
-    CHECK(rm.is_error());
-    CHECK(rm.error() == std::variant<Error2>{Error2{}});
-  }
-
-  SECTION("map error of error result by rvalue")
-  {
-    const auto rm = result<int, Error1>{Error1{}}.map_errors(
-      [](Error1&&) { return result<int, Error2>{Error2{}}; });
-    CHECK(rm.is_error());
-    CHECK(rm.error() == std::variant<Error2>{Error2{}});
-  }
-}
-
 TEST_CASE("void_result_test.constructor")
 {
   CHECK((result<void, float, std::string>().is_success()));

--- a/lib/kdl/test/src/tst_result.cpp
+++ b/lib/kdl/test/src/tst_result.cpp
@@ -201,7 +201,7 @@ void test_and_then_const_lvalue_ref(V&& v)
 
   SECTION("mapping function returns some other type")
   {
-    const auto to = from.and_then([](const typename FromResult::value_type& x) {
+    const auto to = from.transform([](const typename FromResult::value_type& x) {
       return static_cast<ToValueType>(x);
     });
     CHECK(to.is_success());
@@ -240,7 +240,7 @@ void test_and_then_rvalue_ref(V&& v)
 
   SECTION("mapping function returns some other type")
   {
-    const auto to = std::move(from).and_then([](typename FromResult::value_type&& x) {
+    const auto to = std::move(from).transform([](typename FromResult::value_type&& x) {
       return std::move(static_cast<ToValueType>(x));
     });
     CHECK(to.is_success());
@@ -624,9 +624,9 @@ TEST_CASE("void_result_test.and_then")
     const auto f_success = []() { return true; };
     const auto f_void = []() {};
 
-    CHECK(r_success.and_then(f_success) == result<bool, Error1, Error2>(true));
-    CHECK(r_error.and_then(f_success) == result<bool, Error1, Error2>(Error2{}));
-    CHECK(r_success.and_then(f_void) == result<void, Error1, Error2>());
+    CHECK(r_success.transform(f_success) == result<bool, Error1, Error2>(true));
+    CHECK(r_error.transform(f_success) == result<bool, Error1, Error2>(Error2{}));
+    CHECK(r_success.transform(f_void) == result<void, Error1, Error2>());
   }
 }
 

--- a/lib/kdl/test/src/tst_result.cpp
+++ b/lib/kdl/test/src/tst_result.cpp
@@ -87,331 +87,443 @@ inline std::ostream& operator<<(std::ostream& str, const Counter&)
   return str;
 }
 
-/**
- * Tests construction of a successful result.
- */
-template <typename ResultType, typename... V>
-void test_construct_success(V&&... v)
-{
-  auto result = ResultType(std::forward<V>(v)...);
-  CHECK(result.is_success());
-  CHECK_FALSE(result.is_error());
-}
-
-/**
- * Tests construction of an error result.
- */
-template <typename ResultType, typename E>
-void test_construct_error(E&& e)
-{
-  auto result = ResultType(std::forward<E>(e));
-  CHECK_FALSE(result.is_success());
-  CHECK(result.is_error());
-}
-
-/**
- * Tests visiting a successful result and passing by const lvalue reference to the
- * visitor.
- */
-template <typename ResultType, typename V>
-void test_visit_success_const_lvalue_ref(V&& v)
-{
-  auto result = ResultType(std::forward<V>(v));
-
-  CHECK(result.visit(overload(
-    [&](const auto& x) { return x == v; },
-    [](const Error1&) { return false; },
-    [](const Error2&) { return false; })));
-}
-
-/**
- * Tests visiting a successful result and passing by rvalue reference to the visitor.
- */
-template <typename ResultType, typename V>
-void test_visit_success_rvalue_ref(V&& v)
-{
-  auto result = ResultType(std::forward<V>(v));
-
-  CHECK(std::move(result).visit(overload(
-    [&](auto&&) { return true; },
-    [](Error1&&) { return false; },
-    [](Error2&&) { return false; })));
-
-  typename ResultType::value_type y;
-  std::move(result).visit(
-    overload([&](auto&& x) { y = std::move(x); }, [](Error1&&) {}, [](Error2&&) {}));
-
-  CHECK(y.copies == 0u);
-}
-
-/**
- * Tests visiting an error result and passing by const lvalue reference to the visitor.
- */
-template <typename ResultType, typename E>
-void test_visit_error_const_lvalue_ref(E&& e)
-{
-  auto result = ResultType(std::forward<E>(e));
-
-  CHECK(result.visit(overload(
-    [](const auto&) { return false; },
-    [&](const E& x) { return x == e; },
-    [](const Error2&) { return false; })));
-}
-
-/**
- * Tests visiting an error result and passing by rvalue reference to the visitor.
- */
-template <typename ResultType, typename E>
-void test_visit_error_rvalue_ref(E&& e)
-{
-  auto result = ResultType(std::forward<E>(e));
-
-  CHECK(std::move(result).visit(overload(
-    [](auto&&) { return false; },
-    [&](E&&) { return true; },
-    [](Error2&&) { return false; })));
-
-  E y;
-  std::move(result).visit(
-    overload([](auto&&) {}, [&](E&& x) { y = std::move(x); }, [](Error2&&) {}));
-
-  CHECK(y.copies == 0u);
-}
-
-/**
- * Tests mapping a successful result and passing by const lvalue reference to the mapping
- * function.
- */
-template <typename FromResult, typename ToValueType, typename V>
-void test_and_then_const_lvalue_ref(V&& v)
-{
-  auto from = FromResult(std::forward<V>(v));
-
-  SECTION("mapping function returns a result type")
-  {
-    const auto to = from.and_then([](const typename FromResult::value_type& x) {
-      return kdl::result<ToValueType, Error3>(static_cast<ToValueType>(x));
-    });
-    CHECK(to.is_success());
-    CHECK_FALSE(to.is_error());
-
-    CHECK(to.visit(overload(
-      [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
-  }
-
-  SECTION("mapping function returns some other type")
-  {
-    const auto to = from.transform([](const typename FromResult::value_type& x) {
-      return static_cast<ToValueType>(x);
-    });
-    CHECK(to.is_success());
-    CHECK_FALSE(to.is_error());
-
-    CHECK(to.visit(overload(
-      [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
-  }
-}
-
-/**
- * Tests mapping a successful result and passing by rvalue reference to the mapping
- * function.
- */
-template <typename FromResult, typename ToValueType, typename V>
-void test_and_then_rvalue_ref(V&& v)
-{
-  auto from = FromResult(std::forward<V>(v));
-
-  SECTION("mapping function returns a result type")
-  {
-    const auto to = std::move(from).and_then([](typename FromResult::value_type&& x) {
-      return kdl::result<ToValueType, Error3>(std::move(static_cast<ToValueType>(x)));
-    });
-    CHECK(to.is_success());
-    CHECK_FALSE(to.is_error());
-
-    CHECK(to.visit(overload(
-      [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
-
-    ToValueType y;
-    std::move(to).visit(overload([&](ToValueType&& x) { y = x; }, [](auto&&) {}));
-
-    CHECK(y.copies == 0u);
-  }
-
-  SECTION("mapping function returns some other type")
-  {
-    const auto to = std::move(from).transform([](typename FromResult::value_type&& x) {
-      return std::move(static_cast<ToValueType>(x));
-    });
-    CHECK(to.is_success());
-    CHECK_FALSE(to.is_error());
-
-    CHECK(to.visit(overload(
-      [](const ToValueType&) { return true; }, [](const auto&) { return false; })));
-
-    ToValueType y;
-    std::move(to).visit(overload([&](ToValueType&& x) { y = x; }, [](auto&&) {}));
-
-    CHECK(y.copies == 0u);
-  }
-}
-
-/**
- * Tests visiting a successful result when there is no value.
- */
-template <typename ResultType>
-void test_visit_success_with_opt_value()
-{
-  auto result = ResultType();
-
-  CHECK(result.visit(overload([]() { return true; }, [](const auto&) { return false; })));
-}
-
-/**
- * Tests visiting a successful result and passing by const lvalue reference to the visitor
- * when the value is optional (or void).
- */
-template <typename ResultType, typename V>
-void test_visit_success_const_lvalue_ref_with_opt_value(V&& v)
-{
-  auto result = ResultType(std::forward<V>(v));
-
-  CHECK(result.visit(overload(
-    []() { return false; },
-    [&](const auto& x) { return x == v; },
-    [](const Error1&) { return false; },
-    [](const Error2&) { return false; })));
-}
-
-/**
- * Tests visiting a successful result and passing by rvalue reference to the visitor
- * when the value is optional (or void).
- */
-template <typename ResultType, typename V>
-void test_visit_success_rvalue_ref_with_opt_value(V&& v)
-{
-  auto result = ResultType(std::forward<V>(v));
-
-  CHECK(std::move(result).visit(overload(
-    []() { return false; },
-    [&](auto&&) { return true; },
-    [](Error1&&) { return false; },
-    [](Error2&&) { return false; })));
-
-  typename ResultType::value_type y;
-  std::move(result).visit(overload(
-    []() {}, [&](auto&& x) { y = std::move(x); }, [](Error1&&) {}, [](Error2&&) {}));
-
-  CHECK(y.copies == 0u);
-}
-
-/**
- * Tests visiting an error result and passing by const lvalue reference to the visitor
- * when the value is optional (or void).
- */
-template <typename ResultType, typename E>
-void test_visit_error_const_lvalue_ref_with_opt_value(E&& e)
-{
-  auto result = ResultType(std::forward<E>(e));
-  REQUIRE(result.is_error());
-
-  CHECK(result.visit(overload(
-    []() { return false; },
-    [](const auto&) { return false; },
-    [&](const E& x) { return x == e; })));
-}
-
-/**
- * Tests visiting an error result and passing by rvalue reference to the visitor
- * when the value is optional (or void).
- */
-template <typename ResultType, typename E>
-void test_visit_error_rvalue_ref_with_opt_value(E&& e)
-{
-  auto result = ResultType(std::forward<E>(e));
-
-  CHECK(std::move(result).visit(overload(
-    []() { return false; }, [](auto&&) { return false; }, [&](E&&) { return true; })));
-
-  E y;
-  std::move(result).visit(
-    overload([]() {}, [](auto&&) {}, [&](E&& x) { y = std::move(x); }));
-
-  CHECK(y.copies == 0u);
-}
-
 TEST_CASE("result_test.void_success")
 {
-  kdl::result<void, Error1> r1 =
-    result<int, Error1>(1).and_then([](int) { return void_success; });
-
-  CHECK(r1.is_success());
+  CHECK(void_success == result<void>{});
+  CHECK(void_success.is_success());
+  CHECK_FALSE(void_success.is_error());
 }
 
 TEST_CASE("result_test.constructor")
 {
-  CHECK((result<int, float, std::string>(1).is_success()));
-  CHECK((result<int, float, std::string>(1.0f).is_error()));
-  CHECK((result<int, float, std::string>("").is_error()));
+  SECTION("non-void result")
+  {
+    CHECK((result<int, float, std::string>{1}.value() == 1));
+    CHECK(
+      (result<int, float, std::string>{1.0f}.error()
+       == std::variant<float, std::string>{1.0f}));
+    CHECK(
+      (result<int, float, std::string>{""}.error()
+       == std::variant<float, std::string>{""}));
+  }
 
-  test_construct_success<const result<int, Error1, Error2>>(1);
-  test_construct_success<result<int, Error1, Error2>>(1);
-  test_construct_success<const result<const int, Error1, Error2>>(1);
-  test_construct_success<result<const int, Error1, Error2>>(1);
+  SECTION("void result with errors")
+  {
+    CHECK((result<void, float, std::string>{}.is_success()));
+    CHECK(
+      (result<void, float, std::string>{1.0f}.error()
+       == std::variant<float, std::string>{1.0f}));
+    CHECK(
+      (result<void, float, std::string>{""}.error()
+       == std::variant<float, std::string>{""}));
+  }
 
-  test_construct_error<const result<int, Error1, Error2>>(Error1{});
-  test_construct_error<result<int, Error1, Error2>>(Error1{});
-  test_construct_error<const result<const int, Error1, Error2>>(Error1{});
-  test_construct_error<result<const int, Error1, Error2>>(Error1{});
-
-  test_construct_error<const result<int, Error1, Error2>>(Error2{});
-  test_construct_error<result<int, Error1, Error2>>(Error2{});
-  test_construct_error<const result<const int, Error1, Error2>>(Error2{});
-  test_construct_error<result<const int, Error1, Error2>>(Error2{});
+  SECTION("void result without errors") { CHECK((result<void>{}.is_success())); }
 }
 
 TEST_CASE("result_test.converting_constructor")
 {
-  CHECK(result<int, std::string, float>{result<int, std::string, float>{1}}.is_success());
-  CHECK(
-    result<int, std::string, float>{result<int, std::string, float>{"asdf"}}.is_error());
+  SECTION("non-void result")
+  {
+    CHECK(
+      result<int, std::string, float>{result<int, std::string, float>{1}}
+      == result<int, std::string, float>{1});
+    CHECK(
+      result<int, std::string, float>{result<int, std::string, float>{"asdf"}}
+      == result<int, std::string, float>{"asdf"});
 
-  CHECK(result<int, std::string, float>{result<int, float, std::string>{1}}.is_success());
-  CHECK(
-    result<int, std::string, float>{result<int, float, std::string>{"asdf"}}.is_error());
+    CHECK(
+      result<int, std::string, float>{result<int, float, std::string>{1}}
+      == result<int, std::string, float>{1});
+    CHECK(
+      result<int, std::string, float>{result<int, float, std::string>{"asdf"}}
+      == result<int, std::string, float>{"asdf"});
 
-  CHECK(result<int, std::string, float>{result<int, std::string>{1}}.is_success());
-  CHECK(result<int, std::string, float>{result<int, std::string>{"asdf"}}.is_error());
+    CHECK(
+      result<int, std::string, float>{result<int, std::string>{1}}
+      == result<int, std::string, float>{1});
+    CHECK(
+      result<int, std::string, float>{result<int, std::string>{"asdf"}}
+      == result<int, std::string, float>{"asdf"});
 
-  CHECK(result<int, std::string, float>{result<int, float>{1}}.is_success());
-  CHECK(result<int, std::string, float>{result<int, float>{1.0f}}.is_error());
+    CHECK(
+      result<int, std::string, float>{result<int, float>{1}}
+      == result<int, std::string, float>{1});
+    CHECK(
+      result<int, std::string, float>{result<int, float>{1.0f}}
+      == result<int, std::string, float>{1.0f});
+  }
 
-  // must trigger static assert
-  // CHECK(result<int, std::string, float>{result<int, float, double>{1.0f}}.is_error());
+  SECTION("void result with errors")
+  {
+    CHECK(
+      result<void, std::string, float>{result<void, std::string, float>{}}
+      == result<void, std::string, float>{});
+    CHECK(
+      result<void, std::string, float>{result<void, std::string, float>{"asdf"}}
+      == result<void, std::string, float>{"asdf"});
+
+    CHECK(
+      result<void, std::string, float>{result<void, float, std::string>{}}
+      == result<void, std::string, float>{});
+    CHECK(
+      result<void, std::string, float>{result<void, float, std::string>{"asdf"}}
+      == result<void, std::string, float>{"asdf"});
+
+    CHECK(
+      result<void, std::string, float>{result<void, std::string>{}}
+      == result<void, std::string, float>{});
+    CHECK(
+      result<void, std::string, float>{result<void, std::string>{"asdf"}}
+      == result<void, std::string, float>{"asdf"});
+
+    CHECK(
+      result<void, std::string, float>{result<void, float>{}}
+      == result<void, std::string, float>{});
+    CHECK(
+      result<void, std::string, float>{result<void, float>{1.0f}}
+      == result<void, std::string, float>{1.0f});
+  }
+
+  SECTION("void result without errors")
+  {
+    CHECK(result<void>{result<void>{}} == result<void>{});
+  }
 }
 
 TEST_CASE("result_test.visit")
 {
-  test_visit_success_const_lvalue_ref<const result<int, Error1, Error2>>(1);
-  test_visit_success_const_lvalue_ref<result<int, Error1, Error2>>(1);
-  test_visit_success_const_lvalue_ref<const result<const int, Error1, Error2>>(1);
-  test_visit_success_const_lvalue_ref<result<const int, Error1, Error2>>(1);
-  test_visit_success_rvalue_ref<result<Counter, Error1, Error2>>(Counter{});
+  SECTION("non-void result")
+  {
+    const auto constLValueSuccess = result<int, Error1, Error2>{1};
+    CHECK(constLValueSuccess.visit(kdl::overload(
+      [](const int& x) { return x == 1; }, [](const auto&) { return false; })));
 
-  test_visit_error_const_lvalue_ref<const result<int, Error1, Error2>>(Error1{});
-  test_visit_error_const_lvalue_ref<result<int, Error1, Error2>>(Error1{});
-  test_visit_error_const_lvalue_ref<const result<const int, Error1, Error2>>(Error1{});
-  test_visit_error_const_lvalue_ref<result<const int, Error1, Error2>>(Error1{});
-  test_visit_error_rvalue_ref<result<int, Counter, Error2>>(Counter{});
+    const auto constLValueError1 = result<int, Error1, Error2>{Error1{}};
+    CHECK(constLValueError1.visit(kdl::overload(
+      [](const int&) { return false; },
+      [](const Error1&) { return true; },
+      [](const Error2&) { return false; })));
+
+    const auto constLValueError2 = result<int, Error1, Error2>{Error2{}};
+    CHECK(constLValueError2.visit(kdl::overload(
+      [](const int&) { return false; },
+      [](const Error1&) { return false; },
+      [](const Error2&) { return true; })));
+
+    auto nonConstLValueSuccess = result<int, Error1, Error2>{1};
+    CHECK(nonConstLValueSuccess.visit(kdl::overload(
+      [](const int& x) { return x == 1; }, [](const auto&) { return false; })));
+
+    auto nonConstLValueError1 = result<int, Error1, Error2>{Error1{}};
+    CHECK(nonConstLValueError1.visit(kdl::overload(
+      [](const int&) { return false; },
+      [](const Error1&) { return true; },
+      [](const Error2&) { return false; })));
+
+    auto nonConstLValueError2 = result<int, Error1, Error2>{Error2{}};
+    CHECK(nonConstLValueError2.visit(kdl::overload(
+      [](const int&) { return false; },
+      [](const Error1&) { return false; },
+      [](const Error2&) { return true; })));
+
+    CHECK(result<int, Error1, Error2>{1}.visit(
+      kdl::overload([](int&& x) { return x == 1; }, [](auto&&) { return false; })));
+
+    CHECK(result<int, Error1, Error2>{Error1{}}.visit(kdl::overload(
+      [](int&&) { return false; },
+      [](Error1&&) { return true; },
+      [](Error2&&) { return false; })));
+
+    CHECK(result<int, Error1, Error2>{Error2{}}.visit(kdl::overload(
+      [](int&&) { return false; },
+      [](Error1&&) { return false; },
+      [](Error2&&) { return true; })));
+  }
+
+  SECTION("void result with errors")
+  {
+    const auto constLValueSuccess = result<void, Error1, Error2>{};
+    CHECK(constLValueSuccess.visit(
+      kdl::overload([]() { return true; }, [](const auto&) { return false; })));
+
+    const auto constLValueError1 = result<void, Error1, Error2>{Error1{}};
+    CHECK(constLValueError1.visit(kdl::overload(
+      []() { return false; },
+      [](const Error1&) { return true; },
+      [](const Error2&) { return false; })));
+
+    const auto constLValueError2 = result<void, Error1, Error2>{Error2{}};
+    CHECK(constLValueError2.visit(kdl::overload(
+      []() { return false; },
+      [](const Error1&) { return false; },
+      [](const Error2&) { return true; })));
+
+    auto nonConstLValueSuccess = result<void, Error1, Error2>{};
+    CHECK(nonConstLValueSuccess.visit(
+      kdl::overload([]() { return true; }, [](const auto&) { return false; })));
+
+    auto nonConstLValueError1 = result<void, Error1, Error2>{Error1{}};
+    CHECK(nonConstLValueError1.visit(kdl::overload(
+      []() { return false; },
+      [](const Error1&) { return true; },
+      [](const Error2&) { return false; })));
+
+    auto nonConstLValueError2 = result<void, Error1, Error2>{Error2{}};
+    CHECK(nonConstLValueError2.visit(kdl::overload(
+      []() { return false; },
+      [](const Error1&) { return false; },
+      [](const Error2&) { return true; })));
+
+    CHECK(result<void, Error1, Error2>{}.visit(
+      kdl::overload([]() { return true; }, [](auto&&) { return false; })));
+
+    CHECK(result<void, Error1, Error2>{Error1{}}.visit(kdl::overload(
+      []() { return false; },
+      [](Error1&&) { return true; },
+      [](Error2&&) { return false; })));
+
+    CHECK(result<void, Error1, Error2>{Error2{}}.visit(kdl::overload(
+      []() { return false; },
+      [](Error1&&) { return false; },
+      [](Error2&&) { return true; })));
+  }
+
+  SECTION("void result without errors")
+  {
+    const auto constLValueSuccess = result<void>{};
+    CHECK(constLValueSuccess.visit([]() { return true; }));
+
+    auto nonConstLValueSuccess = result<void>{};
+    CHECK(nonConstLValueSuccess.visit([]() { return true; }));
+
+    CHECK(result<void>{}.visit([]() { return true; }));
+  }
 }
 
 TEST_CASE("result_test.and_then")
 {
-  test_and_then_const_lvalue_ref<const result<int, Error1, Error2>, float>(1);
-  test_and_then_const_lvalue_ref<result<int, Error1, Error2>, float>(1);
-  test_and_then_const_lvalue_ref<const result<const int, Error1, Error2>, float>(1);
-  test_and_then_const_lvalue_ref<result<const int, Error1, Error2>, float>(1);
-  test_and_then_rvalue_ref<result<Counter, Error1, Error2>, Counter>(Counter{});
+  SECTION("non-void result")
+  {
+    const auto constLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+    CHECK(constLValueSuccessToSuccess.and_then([](const int& x) {
+      CHECK(x == 1);
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
+
+    const auto constLValueSuccessToError = result<int, Error1, Error2>{1};
+    CHECK(constLValueSuccessToError.and_then([](const int& x) {
+      CHECK(x == 1);
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
+
+    const auto constLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(constLValueError.and_then([](const int&) {
+      FAIL();
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+
+    auto nonConstLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+    CHECK(nonConstLValueSuccessToSuccess.and_then([](const int& x) {
+      CHECK(x == 1);
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
+
+    auto nonConstLValueSuccessToError = result<int, Error1, Error2>{1};
+    CHECK(nonConstLValueSuccessToError.and_then([](const int& x) {
+      CHECK(x == 1);
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
+
+    auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(nonConstLValueError.and_then([](const int&) {
+      FAIL();
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+
+    CHECK(result<int, Error1, Error2>{1}.and_then([](int&& x) {
+      CHECK(x == 1);
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
+
+    CHECK(result<int, Error1, Error2>{1}.and_then([](int&& x) {
+      CHECK(x == 1);
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
+
+    CHECK(result<int, Error1, Error2>{Error1{}}.and_then([](int&&) {
+      FAIL();
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+  }
+
+  SECTION("void result with errors")
+  {
+    const auto constLValueSuccessToSuccess = result<void, Error1, Error2>{};
+    CHECK(constLValueSuccessToSuccess.and_then([]() {
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
+
+    const auto constLValueSuccessToError = result<void, Error1, Error2>{};
+    CHECK(constLValueSuccessToError.and_then([]() {
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
+
+    const auto constLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(constLValueError.and_then([]() {
+      FAIL();
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+
+    auto nonConstLValueSuccessToSuccess = result<void, Error1, Error2>{};
+    CHECK(nonConstLValueSuccessToSuccess.and_then([]() {
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
+
+    auto nonConstLValueSuccessToError = result<void, Error1, Error2>{};
+    CHECK(nonConstLValueSuccessToError.and_then([]() {
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
+
+    auto nonConstLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(nonConstLValueError.and_then([]() {
+      FAIL();
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+
+    CHECK(result<void, Error1, Error2>{}.and_then([]() {
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
+
+    CHECK(result<void, Error1, Error2>{}.and_then([]() {
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
+
+    CHECK(result<void, Error1, Error2>{Error1{}}.and_then([]() {
+      FAIL();
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+  }
+
+  SECTION("void result without errors")
+  {
+    const auto constLValueSuccessToSuccess = result<void>{};
+    CHECK(constLValueSuccessToSuccess.and_then([]() {
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error3>{2.0f});
+
+    const auto constLValueSuccessToError = result<void>{};
+    CHECK(constLValueSuccessToError.and_then([]() {
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error3>{Error3{}});
+
+    auto nonConstLValueSuccessToSuccess = result<void>{};
+    CHECK(nonConstLValueSuccessToSuccess.and_then([]() {
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error3>{2.0f});
+
+    auto nonConstLValueSuccessToError = result<void>{};
+    CHECK(nonConstLValueSuccessToError.and_then([]() {
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error3>{Error3{}});
+
+    CHECK(result<void>{}.and_then([]() {
+      return kdl::result<float, Error3>{2.0f};
+    }) == kdl::result<float, Error3>{2.0f});
+
+    CHECK(result<void>{}.and_then([]() {
+      return kdl::result<float, Error3>{Error3{}};
+    }) == kdl::result<float, Error3>{Error3{}});
+  }
+}
+
+TEST_CASE("result_test.transform")
+{
+  SECTION("non-void result")
+  {
+    const auto constLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+    CHECK(constLValueSuccessToSuccess.transform([](const int& x) {
+      CHECK(x == 1);
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{2.0f});
+
+    const auto constLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(constLValueError.transform([](const int&) {
+      FAIL();
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+    auto nonConstLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+    CHECK(nonConstLValueSuccessToSuccess.transform([](const int& x) {
+      CHECK(x == 1);
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{2.0f});
+
+    auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(nonConstLValueError.transform([](const int&) {
+      FAIL();
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+    CHECK(result<int, Error1, Error2>{1}.transform([](int&& x) {
+      CHECK(x == 1);
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{2.0f});
+
+    CHECK(result<int, Error1, Error2>{Error1{}}.transform([](int&&) {
+      FAIL();
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{Error1{}});
+  }
+
+  SECTION("void result with errors")
+  {
+    const auto constLValueSuccessToSuccess = result<void, Error1, Error2>{};
+    CHECK(constLValueSuccessToSuccess.transform([]() {
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{2.0f});
+
+    const auto constLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(constLValueError.transform([]() {
+      FAIL();
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+    auto nonConstLValueSuccessToSuccess = result<void, Error1, Error2>{};
+    CHECK(nonConstLValueSuccessToSuccess.transform([]() {
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{2.0f});
+
+    auto nonConstLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(nonConstLValueError.transform([]() {
+      FAIL();
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+    CHECK(result<void, Error1, Error2>{}.transform([]() {
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{2.0f});
+
+    CHECK(result<void, Error1, Error2>{Error1{}}.transform([]() {
+      FAIL();
+      return 2.0f;
+    }) == kdl::result<float, Error1, Error2>{Error1{}});
+  }
+
+  SECTION("void result without errors")
+  {
+    const auto constLValueSuccessToSuccess = result<void>{};
+    CHECK(constLValueSuccessToSuccess.transform([]() {
+      return 2.0f;
+    }) == kdl::result<float>{2.0f});
+
+    auto nonConstLValueSuccessToSuccess = result<void>{};
+    CHECK(nonConstLValueSuccessToSuccess.transform([]() {
+      return 2.0f;
+    }) == kdl::result<float>{2.0f});
+
+    CHECK(result<void>{}.transform([]() { return 2.0f; }) == kdl::result<float>{2.0f});
+  }
 }
 
 TEST_CASE("result_test.or_else")
@@ -551,126 +663,33 @@ TEST_CASE("result_test.if_error")
   }
 }
 
-TEST_CASE("void_result_test.constructor")
-{
-  CHECK((result<void, float, std::string>().is_success()));
-  CHECK((result<void, float, std::string>(1.0f).is_error()));
-  CHECK((result<void, float, std::string>("").is_error()));
-
-  test_construct_success<const result<void, Error1, Error2>>();
-  test_construct_success<result<void, Error1, Error2>>();
-
-  test_construct_error<const result<void, Error1, Error2>>(Error1{});
-  test_construct_error<result<void, Error1, Error2>>(Error1{});
-
-  test_construct_error<const result<void, Error1, Error2>>(Error2{});
-  test_construct_error<result<void, Error1, Error2>>(Error2{});
-}
-
-TEST_CASE("void_result_test.converting_constructor")
-{
-  CHECK(
-    result<void, std::string, float>{result<void, std::string, float>{}}.is_success());
-  CHECK(result<void, std::string, float>{result<void, std::string, float>{"asdf"}}
-          .is_error());
-
-  CHECK(
-    result<void, std::string, float>{result<void, float, std::string>{}}.is_success());
-  CHECK(result<void, std::string, float>{result<void, float, std::string>{"asdf"}}
-          .is_error());
-
-  CHECK(result<void, std::string, float>{result<void, std::string>{}}.is_success());
-  CHECK(result<void, std::string, float>{result<void, std::string>{"asdf"}}.is_error());
-
-  CHECK(result<void, std::string, float>{result<void, float>{}}.is_success());
-  CHECK(result<void, std::string, float>{result<void, float>{1.0f}}.is_error());
-
-  // must trigger static assert
-  // CHECK(result<void, std::string, float>{result<void, float,
-  // double>{1.0f}}.is_error());
-}
-
-TEST_CASE("void_result_test.visit")
-{
-  test_visit_success_with_opt_value<const result<void, Error1, Error2>>();
-  test_visit_success_with_opt_value<result<void, Error1, Error2>>();
-
-  test_visit_error_const_lvalue_ref_with_opt_value<const result<void, Error1, Error2>>(
-    Error1{});
-  test_visit_error_const_lvalue_ref_with_opt_value<result<void, Error1, Error2>>(
-    Error1{});
-  test_visit_error_rvalue_ref_with_opt_value<result<void, Counter, Error2>>(Counter{});
-}
-
-TEST_CASE("void_result_test.and_then")
-{
-  const auto r_success = result<void, Error1, Error2>();
-  const auto r_error = result<void, Error1, Error2>(Error2{});
-
-  SECTION("mapping function returns a result type")
-  {
-    const auto f_success = []() { return kdl::result<bool, Error3>(true); };
-    const auto f_error = []() { return kdl::result<bool, Error3>(Error3{}); };
-    const auto f_void = []() { return kdl::result<void, Error3>(); };
-
-    CHECK(r_success.and_then(f_success) == result<bool, Error1, Error2, Error3>(true));
-    CHECK(r_success.and_then(f_error) == result<bool, Error1, Error2, Error3>(Error3{}));
-    CHECK(r_error.and_then(f_success) == result<bool, Error1, Error2, Error3>(Error2{}));
-    CHECK(r_success.and_then(f_void) == result<void, Error1, Error2, Error3>());
-  }
-
-  SECTION("mapping function returns some other type")
-  {
-    const auto f_success = []() { return true; };
-    const auto f_void = []() {};
-
-    CHECK(r_success.transform(f_success) == result<bool, Error1, Error2>(true));
-    CHECK(r_error.transform(f_success) == result<bool, Error1, Error2>(Error2{}));
-    CHECK(r_success.transform(f_void) == result<void, Error1, Error2>());
-  }
-}
-
-TEST_CASE("combine_results", "result_test")
+TEST_CASE("combine_results")
 {
   using R1 = result<int, Error1, Error2>;
   using R2 = result<double, Error2, Error3>;
 
-  auto r1 = R1(1);
-  auto r2 = R2(2.0);
-  auto r3 = R2(Error2{});
+  auto r1 = R1{1};
+  auto r2 = R2{2.0};
+  auto r3 = R2{Error2{}};
 
-  CHECK(combine_results(r1, r2).is_success());
-  CHECK(combine_results(r1, r2).visit(kdl::overload(
-    [](const std::tuple<int, double>& t) {
-      CHECK(t == std::make_tuple(1, 2.0));
-      return true;
-    },
-    [](const auto&) { return false; })));
+  CHECK(
+    combine_results(r1, r2)
+    == result<std::tuple<int, double>, Error1, Error2, Error3>{std::tuple{1, 2.0}});
 
-  CHECK(combine_results(r1, r3).is_error());
-  CHECK(combine_results(r1, r3).visit(kdl::overload(
-    [](const std::tuple<int, double>&) { return false; },
-    [](const Error2&) { return true; },
-    [](const auto&) { return false; })));
+  CHECK(
+    combine_results(r1, r3)
+    == result<std::tuple<int, double>, Error1, Error2, Error3>{Error2{}});
 
-  CHECK(combine_results(r1, R2(2.0)).is_success());
-  CHECK(combine_results(r1, R2(2.0))
-          .visit(kdl::overload(
-            [](const std::tuple<int, double>& t) {
-              CHECK(t == std::make_tuple(1, 2.0));
-              return true;
-            },
-            [](const auto&) { return false; })));
+  CHECK(
+    combine_results(r1, R2{2.0})
+    == result<std::tuple<int, double>, Error1, Error2, Error3>{std::tuple{1, 2.0}});
 
-  CHECK(combine_results(r1, R2(Error2{})).is_error());
-  CHECK(combine_results(r1, R2(Error2{}))
-          .visit(kdl::overload(
-            [](const std::tuple<int, double>&) { return false; },
-            [](const Error2&) { return true; },
-            [](const auto&) { return false; })));
+  CHECK(
+    combine_results(r1, R2{Error2{}})
+    == result<std::tuple<int, double>, Error1, Error2, Error3>{Error2{}});
 }
 
-TEST_CASE("result.for_each_result", "result_test")
+TEST_CASE("result.for_each_result")
 {
   SECTION("with empty range")
   {
@@ -710,7 +729,7 @@ TEST_CASE("result.for_each_result", "result_test")
   }
 }
 
-TEST_CASE("void_result.for_each_result", "result_test")
+TEST_CASE("void_result.for_each_result")
 {
   SECTION("with empty range")
   {
@@ -751,7 +770,7 @@ TEST_CASE("void_result.for_each_result", "result_test")
   }
 }
 
-TEST_CASE("result.collect_values", "result_test")
+TEST_CASE("result.collect_values")
 {
   auto errors = std::vector<std::string>{};
   const auto errorHandler = [&](std::string&& error) {


### PR DESCRIPTION
This PR refactors the result types to give them a more functional API. We add a new function `result::or_else` to replace `result::map_errors` and `result::handle_errors`.