### PR TITLE
4214: Only cancel mouse drags if window deactivates

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -902,6 +902,16 @@ void MapViewBase::hideAllEntityLinks()
   setPref(Preferences::FaceRenderMode, Preferences::entityLinkModeNone());
 }
 
+bool MapViewBase::event(QEvent* event)
+{
+  if (event->type() == QEvent::WindowDeactivate)
+  {
+    cancelMouseDrag();
+  }
+
+  return RenderView::event(event);
+}
+
 void MapViewBase::focusInEvent(QFocusEvent* event)
 {
   updateActionStates(); // enable/disable QShortcut's to reflect whether we have focus
@@ -914,7 +924,6 @@ void MapViewBase::focusInEvent(QFocusEvent* event)
 
 void MapViewBase::focusOutEvent(QFocusEvent* event)
 {
-  cancelMouseDrag();
   clearModifierKeys();
   update();
   RenderView::focusOutEvent(event);

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -302,7 +302,7 @@ public: // view filters
   void showDirectlySelectedEntityLinks();
   void hideAllEntityLinks();
 
-protected:
+  bool event(QEvent* event) override;
   void focusInEvent(QFocusEvent* event) override;
   void focusOutEvent(QFocusEvent* event) override;
 

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -78,10 +78,14 @@ void UVView::setSubDivisions(const vm::vec2i& subDivisions)
   update();
 }
 
-void UVView::focusOutEvent(QFocusEvent* event)
+bool UVView::event(QEvent* event)
 {
-  ToolBoxConnector::cancelDrag();
-  RenderView::focusOutEvent(event);
+  if (event->type() == QEvent::WindowDeactivate)
+  {
+    cancelDrag();
+  }
+
+  return RenderView::event(event);
 }
 
 void UVView::createTools()

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -91,8 +91,7 @@ public:
 
   void setSubDivisions(const vm::vec2i& subDivisions);
 
-protected:
-  void focusOutEvent(QFocusEvent* event) override;
+  bool event(QEvent* event) override;
 
 private:
   void createTools();


### PR DESCRIPTION
Closes #4214.

Some windows managers deactivate views when the mouse cursor leaves them regardless of whether a drag is in progress. This would lead to mouse drags being cancelled inadvertedly because we cancel mouse drags when a map view or the UV view lose focus.

In this commit, we change it so that we cancel mouse drags when the window is deactivated.