### PR TITLE
4152: Undo commands when cancelling a transaction

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -5183,6 +5183,11 @@ Transaction::~Transaction()
   assert(m_state != State::Running);
 }
 
+Transaction::State Transaction::state() const
+{
+  return m_state;
+}
+
 bool Transaction::commit()
 {
   assert(m_state == State::Running);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -5173,39 +5173,39 @@ Transaction::Transaction(std::shared_ptr<MapDocument> document, std::string name
 
 Transaction::Transaction(MapDocument& document, std::string name)
   : m_document{document}
-  , m_state{TransactionState::Running}
+  , m_state{State::Running}
 {
   begin(std::move(name));
 }
 
 Transaction::~Transaction()
 {
-  assert(m_state != TransactionState::Running);
+  assert(m_state != State::Running);
 }
 
 bool Transaction::commit()
 {
-  assert(m_state == TransactionState::Running);
+  assert(m_state == State::Running);
   if (m_document.commitTransaction())
   {
-    m_state = TransactionState::Committed;
+    m_state = State::Committed;
     return true;
   }
 
-  m_state = TransactionState::Cancelled;
+  m_state = State::Cancelled;
   return false;
 }
 
 void Transaction::rollback()
 {
-  assert(m_state == TransactionState::Running);
+  assert(m_state == State::Running);
   m_document.rollbackTransaction();
 }
 
 void Transaction::cancel()
 {
-  assert(m_state == TransactionState::Running);
-  m_state = TransactionState::Cancelled;
+  assert(m_state == State::Running);
+  m_state = State::Cancelled;
 }
 
 void Transaction::begin(std::string name)

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -5210,6 +5210,7 @@ void Transaction::rollback()
 void Transaction::cancel()
 {
   assert(m_state == State::Running);
+  m_document.cancelTransaction();
   m_state = State::Cancelled;
 }
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -806,7 +806,7 @@ private: // observers
 class Transaction
 {
 private:
-  enum class TransactionState
+  enum class State
   {
     Running,
     Committed,
@@ -814,7 +814,7 @@ private:
   };
 
   MapDocument& m_document;
-  TransactionState m_state;
+  State m_state;
 
 public:
   explicit Transaction(std::weak_ptr<MapDocument> document, std::string name = "");

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -805,7 +805,7 @@ private: // observers
 
 class Transaction
 {
-private:
+public:
   enum class State
   {
     Running,
@@ -813,6 +813,7 @@ private:
     Cancelled,
   };
 
+private:
   MapDocument& m_document;
   State m_state;
 
@@ -821,6 +822,8 @@ public:
   explicit Transaction(std::shared_ptr<MapDocument> document, std::string name = "");
   explicit Transaction(MapDocument& document, std::string name = "");
   ~Transaction();
+
+  State state() const;
 
   bool commit();
   void rollback();

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -131,6 +131,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/tst_SwapNodeContents.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_TagManagement.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_TextOutputAdapter.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/tst_Transaction.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_TransformNodes.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_Undo.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_UpdateLinkedGroupsCommand.cpp"

--- a/common/test/src/View/tst_Transaction.cpp
+++ b/common/test/src/View/tst_Transaction.cpp
@@ -83,10 +83,7 @@ TEST_CASE_METHOD(MapDocumentTest, "Transaction")
     CHECK(transaction.state() == Transaction::State::Cancelled);
 
     document->selectAllNodes();
-    /* EXPECTED:
     CHECK(document->selectedNodes().empty());
-    ACTUAL: */
-    CHECK_FALSE(document->selectedNodes().empty());
   }
 }
 

--- a/common/test/src/View/tst_Transaction.cpp
+++ b/common/test/src/View/tst_Transaction.cpp
@@ -1,0 +1,93 @@
+/*
+ Copyright (C) 2023 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MapDocumentTest.h"
+#include "TestUtils.h"
+
+#include "Model/Entity.h"
+#include "Model/EntityNode.h"
+
+#include <vecmath/mat_ext.h>
+
+#include "Catch2.h"
+
+namespace TrenchBroom::View
+{
+
+TEST_CASE_METHOD(MapDocumentTest, "Transaction")
+{
+  document->selectAllNodes();
+  document->deleteObjects();
+  document->selectAllNodes();
+
+  REQUIRE(document->selectedNodes().empty());
+
+  auto* entityNode = new Model::EntityNode{Model::Entity{}};
+
+  auto transaction = Transaction{document};
+  CHECK(transaction.state() == Transaction::State::Running);
+
+  document->addNodes({{document->parentForNodes(), {entityNode}}});
+  document->selectNodes({entityNode});
+  document->transformObjects("translate", vm::translation_matrix(vm::vec3{1, 0, 0}));
+
+  REQUIRE(transaction.state() == Transaction::State::Running);
+  REQUIRE(entityNode->entity().origin() == vm::vec3{1, 0, 0});
+
+  SECTION("commit")
+  {
+    CHECK(transaction.commit());
+
+    CHECK(transaction.state() == Transaction::State::Committed);
+    CHECK(entityNode->entity().origin() == vm::vec3{1, 0, 0});
+
+    document->undoCommand();
+    document->selectAllNodes();
+
+    CHECK(document->selectedNodes().empty());
+  }
+
+  SECTION("rollback")
+  {
+    transaction.rollback();
+
+    CHECK(transaction.state() == Transaction::State::Running);
+
+    document->selectAllNodes();
+    CHECK(document->selectedNodes().empty());
+
+    // must commit the transaction in order to destroy it
+    transaction.commit();
+  }
+
+  SECTION("cancel")
+  {
+    transaction.cancel();
+
+    CHECK(transaction.state() == Transaction::State::Cancelled);
+
+    document->selectAllNodes();
+    /* EXPECTED:
+    CHECK(document->selectedNodes().empty());
+    ACTUAL: */
+    CHECK_FALSE(document->selectedNodes().empty());
+  }
+}
+
+} // namespace TrenchBroom::View


### PR DESCRIPTION
Closes #4152.

This is most likely the cause of undo / redo menu items getting disabled. The transaction stack was not actually cleared by the command manager when a transaction is canceled via `Transaction::cancel()`, and undo / redo is disabled while a transaction is ongoing.