### PR TITLE
Improve result type

### DIFF
--- a/common/src/IO/AssimpParser.cpp
+++ b/common/src/IO/AssimpParser.cpp
@@ -390,7 +390,7 @@ std::optional<Assets::Texture> loadFallbackTexture(const FileSystem& fs)
       auto result = readFreeImageTexture("", reader);
       if (result.is_success())
       {
-        return result.release();
+        return std::move(result).value();
       }
     }
     catch (const Exception& /*ex1*/)

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -39,7 +39,7 @@
 
 #include <kdl/parallel.h>
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/string_format.h>
 #include <kdl/string_utils.h>
 #include <kdl/vector_utils.h>
@@ -141,7 +141,7 @@ void MapReader::onStandardBrushFace(
       face.setFilePosition(line, 1u);
       onBrushFace(std::move(face), status);
     })
-    .or_else([&](const Model::BrushError e) {
+    .transform_error([&](const Model::BrushError e) {
       status.error(line, kdl::str_to_string("Skipping face: ", e));
     });
 }
@@ -163,7 +163,7 @@ void MapReader::onValveBrushFace(
       face.setFilePosition(line, 1u);
       onBrushFace(std::move(face), status);
     })
-    .or_else([&](const Model::BrushError e) {
+    .transform_error([&](const Model::BrushError e) {
       status.error(line, kdl::str_to_string("Skipping face: ", e));
     });
 }
@@ -651,7 +651,7 @@ static std::vector<std::optional<NodeInfo>> createNodesFromObjectInfos(
         .transform([&](NodeInfo&& nodeInfo) -> std::optional<NodeInfo> {
           return std::move(nodeInfo);
         })
-        .or_else([&](const NodeError& e) -> std::optional<NodeInfo> {
+        .transform_error([&](const NodeError& e) -> std::optional<NodeInfo> {
           status.error(e.line, e.msg);
           return std::nullopt;
         })

--- a/common/src/IO/ObjParser.cpp
+++ b/common/src/IO/ObjParser.cpp
@@ -341,7 +341,7 @@ std::optional<Assets::Texture> NvObjParser::loadMaterial(const std::string& name
       auto result = readFreeImageTexture("", reader);
       if (result.is_success())
       {
-        return result.release();
+        return std::move(result).value();
       }
     }
     catch (const Exception&)

--- a/common/src/IO/ResourceUtils.cpp
+++ b/common/src/IO/ResourceUtils.cpp
@@ -65,7 +65,7 @@ Assets::Texture loadDefaultTexture(
       auto reader = file->reader().buffer();
       return readFreeImageTexture(name, reader)
         .if_error([&](const ReadTextureError& e) { throw AssetException{e.msg.c_str()}; })
-        .release();
+        .value();
     }
     catch (const Exception& e)
     {

--- a/common/src/IO/SkinLoader.cpp
+++ b/common/src/IO/SkinLoader.cpp
@@ -88,7 +88,7 @@ Assets::Texture loadShader(const Path& path, const FileSystem& fs, Logger& logge
       const auto file = fs.openFile(actualPath);
       return readQuake3ShaderTexture(name, *file, fs)
         .if_error([](const auto& e) { throw AssetException{e.msg.c_str()}; })
-        .release();
+        .value();
     }
     catch (const Exception& e)
     {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -30,7 +30,7 @@
 #include "Polyhedron_Matcher.h"
 
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/string_utils.h>
 #include <kdl/vector_utils.h>
 
@@ -1096,7 +1096,7 @@ void Brush::applyUVLock(
       }
       rightFace.resetTexCoordSystemCache();
     })
-    .or_else([](const BrushError) {
+    .transform_error([](const BrushError) {
       // do nothing
     });
 }
@@ -1125,7 +1125,7 @@ kdl::result<void, BrushError> Brush::updateFacesFromGeometry(
             applyUVLock(matcher, leftFace, rightFace);
           }
         })
-        .or_else([&](const BrushError e) {
+        .transform_error([&](const BrushError e) {
           if (!error)
           {
             error = e;
@@ -1240,7 +1240,7 @@ kdl::result<Brush, BrushError> Brush::createBrush(
   const BrushGeometry& geometry,
   const std::vector<const Brush*>& subtrahends) const
 {
-  return kdl::for_each_result(
+  return kdl::fold_results(
            geometry.faces(),
            [&](const auto* face) {
              const auto* h1 = face->boundary().front();

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -27,7 +27,7 @@
 
 #include <kdl/overload.h>
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/string_utils.h>
 
 #include <cassert>
@@ -162,7 +162,7 @@ kdl::result<Brush, BrushError> BrushBuilder::createCuboid(
        BrushFaceAttributes(bottomTexture, m_defaultAttribs)}, // bottom
     });
 
-  return kdl::for_each_result(
+  return kdl::fold_results(
            specs,
            [&](const auto spec) {
              const auto& [p1, p2, p3, attrs] = spec;
@@ -183,7 +183,7 @@ kdl::result<Brush, BrushError> BrushBuilder::createBrush(
 {
   assert(polyhedron.closed());
 
-  return kdl::for_each_result(
+  return kdl::fold_results(
            polyhedron.faces(),
            [&](const auto* face) {
              const auto& boundary = face->boundary();

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -202,7 +202,7 @@ std::unique_ptr<WorldNode> GameImpl::doNewMap(
     .transform([&](Brush&& b) {
       worldNode->defaultLayer()->addChild(new BrushNode{std::move(b)});
     })
-    .or_else([&](const Model::BrushError e) {
+    .transform_error([&](const Model::BrushError e) {
       logger.error() << "Could not create default brush: " << e;
     });
 

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -345,7 +345,7 @@ void AppPreferenceManager::initialize()
           });
       }
     })
-    .or_else(kdl::overload(
+    .transform_error(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath
@@ -400,7 +400,7 @@ void AppPreferenceManager::discardChanges()
 void AppPreferenceManager::saveChangesImmediately()
 {
   writeV2SettingsToPath(m_preferencesFilePath, m_cache)
-    .or_else(kdl::overload(
+    .transform_error(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath
@@ -499,7 +499,7 @@ void AppPreferenceManager::loadCacheFromDisk()
   readV2SettingsFromPath(m_preferencesFilePath)
     .transform(
       [&](std::map<IO::Path, QJsonValue>&& prefs) { m_cache = std::move(prefs); })
-    .or_else(kdl::overload(
+    .transform_error(kdl::overload(
       [&](const PreferenceErrors::FileAccessError&) {
         // This happens e.g. if you don't have read permissions for
         // m_preferencesFilePath

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -997,7 +997,7 @@ void ClipTool::updateBrushes()
         .transform([&]() {
           brushMap[node->parent()].push_back(new Model::BrushNode(std::move(brush)));
         })
-        .or_else([&](const Model::BrushError e) {
+        .transform_error([&](const Model::BrushError e) {
           document->error() << "Could not clip brush: " << e;
         });
     };

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -62,7 +62,7 @@ void CreateComplexBrushTool::update(const Model::Polyhedron3& polyhedron)
     builder.createBrush(*m_polyhedron, document->currentTextureName())
       .transform(
         [&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
-      .or_else([&](const Model::BrushError e) {
+      .transform_error([&](const Model::BrushError e) {
         updateBrush(nullptr);
         document->error() << "Could not update brush: " << e;
       });

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -50,7 +50,7 @@ void CreateSimpleBrushTool::update(const vm::bbox3& bounds)
 
   builder.createCuboid(bounds, document->currentTextureName())
     .transform([&](Model::Brush&& b) { updateBrush(new Model::BrushNode(std::move(b))); })
-    .or_else([&](const Model::BrushError e) {
+    .transform_error([&](const Model::BrushError e) {
       updateBrush(nullptr);
       document->error() << "Could not update brush: " << e;
     });

--- a/common/src/View/ExtrudeTool.cpp
+++ b/common/src/View/ExtrudeTool.cpp
@@ -40,7 +40,7 @@
 #include <kdl/overload.h>
 #include <kdl/reflection_impl.h>
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/string_utils.h>
 #include <kdl/vector_utils.h>
 
@@ -411,7 +411,7 @@ bool splitBrushesOutward(
   auto newDragFaces = std::vector<Model::BrushFaceHandle>{};
   auto newNodes = std::map<Model::Node*, std::vector<Model::Node*>>{};
 
-  return kdl::for_each_result(
+  return kdl::fold_results(
            dragState.initialDragHandles,
            [&](const auto& dragHandle) {
              auto* brushNode = dragHandle.faceHandle.node();

--- a/common/src/View/UpdateLinkedGroupsCommandBase.cpp
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<CommandResult> UpdateLinkedGroupsCommandBase::performDo(
       setModificationCount(document);
       return std::move(commandResult);
     })
-    .or_else([&](const Model::UpdateLinkedGroupsError& e) {
+    .transform_error([&](const Model::UpdateLinkedGroupsError& e) {
       doPerformUndo(document);
       if (document)
       {

--- a/common/src/View/UpdateLinkedGroupsHelper.cpp
+++ b/common/src/View/UpdateLinkedGroupsHelper.cpp
@@ -28,7 +28,7 @@
 
 #include <kdl/overload.h>
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/vector_utils.h>
 
 #include <algorithm>
@@ -137,7 +137,7 @@ UpdateLinkedGroupsHelper::computeLinkedGroupUpdates(
   }
 
   const auto& worldBounds = document.worldBounds();
-  return kdl::for_each_result(
+  return kdl::fold_results(
            changedLinkedGroups,
            [&](const auto* groupNode) {
              const auto groupNodesToUpdate = kdl::vec_erase(

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -354,7 +354,7 @@ public: // csg convex merge
         }
         transaction.commit();
       })
-      .or_else([&](const Model::BrushError e) {
+      .transform_error([&](const Model::BrushError e) {
         document->error() << "Could not create brush: " << e;
       });
   }

--- a/common/test/src/IO/tst_LoadTextureCollection.cpp
+++ b/common/test/src/IO/tst_LoadTextureCollection.cpp
@@ -79,7 +79,7 @@ std::optional<TextureCollectionInfo> makeInfo(
           };
         })};
     })
-    .release_or(std::nullopt);
+    .value_or(std::nullopt);
 }
 
 } // namespace

--- a/common/test/src/IO/tst_Quake3ShaderFileSystem.cpp
+++ b/common/test/src/IO/tst_Quake3ShaderFileSystem.cpp
@@ -80,8 +80,6 @@ TEST_CASE("Quake3ShaderFileSystemTest.testSkipMalformedFiles")
 
   // We need to mount the fallback dir so that we can find "__TB_empty.png" which is
   // automatically linked when no editor image is available.
-  // We need to mount the fallback dir so that we can find "__TB_empty.png" which is
-  // automatically linked when no editor image is available.
   auto fs = VirtualFileSystem{};
   fs.mount(Path{}, std::make_unique<DiskFileSystem>(fallbackDir));
   fs.mount(Path{}, std::make_unique<DiskFileSystem>(testDir));

--- a/common/test/src/IO/tst_ReadFreeImageTexture.cpp
+++ b/common/test/src/IO/tst_ReadFreeImageTexture.cpp
@@ -115,18 +115,17 @@ static void testImageContents(const Assets::Texture& texture, const ColorMatch m
 
 TEST_CASE("ReadFreeImageTextureTest.testPNGContents")
 {
-  testImageContents(loadTexture("pngContentsTest.png").release(), ColorMatch::Exact);
+  testImageContents(loadTexture("pngContentsTest.png").value(), ColorMatch::Exact);
 }
 
 TEST_CASE("ReadFreeImageTextureTest.testJPGContents")
 {
-  testImageContents(
-    loadTexture("jpgContentsTest.jpg").release(), ColorMatch::Approximate);
+  testImageContents(loadTexture("jpgContentsTest.jpg").value(), ColorMatch::Approximate);
 }
 
 TEST_CASE("ReadFreeImageTextureTest.alphaMaskTest")
 {
-  const auto texture = loadTexture("alphaMaskTest.png").release();
+  const auto texture = loadTexture("alphaMaskTest.png").value();
   const std::size_t w = 25u;
   const std::size_t h = 10u;
 

--- a/common/test/src/IO/tst_ReadFreeImageTexture.cpp
+++ b/common/test/src/IO/tst_ReadFreeImageTexture.cpp
@@ -58,7 +58,7 @@ static void assertTexture(
       CHECK((GL_BGRA == texture.format() || GL_RGBA == texture.format()));
       CHECK(texture.type() == Assets::TextureType::Opaque);
     })
-    .or_else([](const auto&) { FAIL(); });
+    .transform_error([](const auto&) { FAIL(); });
 }
 
 TEST_CASE("ReadFreeImageTextureTest.testLoadPngs")

--- a/common/test/src/Model/tst_Brush.cpp
+++ b/common/test/src/Model/tst_Brush.cpp
@@ -35,7 +35,7 @@
 
 #include <kdl/intrusive_circular_list.h>
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/approx.h>
@@ -2270,16 +2270,17 @@ TEST_CASE("BrushTest.subtractCuboidFromCuboid")
         subtrahendTexture)
       .value();
 
-  const auto result = kdl::collect_values(
-    minuend.subtract(MapFormat::Standard, worldBounds, defaultTexture, subtrahend),
-    [](const auto&) {});
-  CHECK(result.size() == 3u);
+  const auto fragments =
+    kdl::fold_results(
+      minuend.subtract(MapFormat::Standard, worldBounds, defaultTexture, subtrahend))
+      .value();
+  CHECK(fragments.size() == 3u);
 
   const Brush* left = nullptr;
   const Brush* top = nullptr;
   const Brush* right = nullptr;
 
-  for (const Brush& brush : result)
+  for (const Brush& brush : fragments)
   {
     if (brush.findFace(vm::plane3(32.0, vm::vec3::neg_x())))
     {
@@ -2400,12 +2401,13 @@ TEST_CASE("BrushTest.subtractDisjoint")
   const Brush brush1 = builder.createCuboid(brush1Bounds, "texture").value();
   const Brush brush2 = builder.createCuboid(brush2Bounds, "texture").value();
 
-  const auto result = kdl::collect_values(
-    brush1.subtract(MapFormat::Standard, worldBounds, "texture", brush2),
-    [](const auto&) {});
-  CHECK(result.size() == 1u);
+  const auto fragments =
+    kdl::fold_results(
+      brush1.subtract(MapFormat::Standard, worldBounds, "texture", brush2))
+      .value();
+  CHECK(fragments.size() == 1u);
 
-  const Brush& subtraction = result.at(0);
+  const Brush& subtraction = fragments.at(0);
   CHECK_THAT(
     subtraction.vertexPositions(), Catch::UnorderedEquals(brush1.vertexPositions()));
 }
@@ -2422,10 +2424,11 @@ TEST_CASE("BrushTest.subtractEnclosed")
   const Brush brush1 = builder.createCuboid(brush1Bounds, "texture").value();
   const Brush brush2 = builder.createCuboid(brush2Bounds, "texture").value();
 
-  const auto result = kdl::collect_values(
-    brush1.subtract(MapFormat::Standard, worldBounds, "texture", brush2),
-    [](const auto&) {});
-  CHECK(result.size() == 0u);
+  const auto fragments =
+    kdl::fold_results(
+      brush1.subtract(MapFormat::Standard, worldBounds, "texture", brush2))
+      .value();
+  CHECK(fragments.empty());
 }
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/test/src/Model/tst_BrushRegression.cpp
+++ b/common/test/src/Model/tst_BrushRegression.cpp
@@ -35,7 +35,7 @@
 
 #include <kdl/intrusive_circular_list.h>
 #include <kdl/result.h>
-#include <kdl/result_for_each.h>
+#include <kdl/result_fold.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/approx.h>
@@ -1560,10 +1560,9 @@ TEST_CASE("BrushTest.subtractTruncatedCones")
   const Brush& minuend = static_cast<BrushNode*>(minuendNodes.front())->brush();
   const Brush& subtrahend = static_cast<BrushNode*>(subtrahendNodes.front())->brush();
 
-  const auto result = kdl::collect_values(
-    minuend.subtract(MapFormat::Valve, worldBounds, "some_texture", subtrahend),
-    [](const auto&) {});
-  CHECK_FALSE(result.empty());
+  const auto result = kdl::fold_results(
+    minuend.subtract(MapFormat::Valve, worldBounds, "some_texture", subtrahend));
+  CHECK_FALSE(result.is_error());
 
   kdl::col_delete_all(minuendNodes);
   kdl::col_delete_all(subtrahendNodes);
@@ -1699,10 +1698,11 @@ TEST_CASE("BrushTest.subtractPipeFromCubeWithMissingFragments")
   const Brush& minuend = static_cast<BrushNode*>(minuendNodes.front())->brush();
   const Brush& subtrahend = static_cast<BrushNode*>(subtrahendNodes.front())->brush();
 
-  const auto result = kdl::collect_values(
-    minuend.subtract(MapFormat::Standard, worldBounds, "some_texture", subtrahend),
-    [](const auto&) {});
-  CHECK(result.size() == 8u);
+  const auto fragments =
+    kdl::fold_results(
+      minuend.subtract(MapFormat::Standard, worldBounds, "some_texture", subtrahend))
+      .value();
+  CHECK(fragments.size() == 8u);
 
   kdl::col_delete_all(minuendNodes);
   kdl::col_delete_all(subtrahendNodes);

--- a/common/test/src/Model/tst_GroupNode.cpp
+++ b/common/test/src/Model/tst_GroupNode.cpp
@@ -190,14 +190,14 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
   {
     updateLinkedGroups(groupNode, {}, worldBounds)
       .transform([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
-      .or_else([](const auto&) { FAIL(); });
+      .transform_error([](const auto&) { FAIL(); });
   }
 
   SECTION("Target group list contains only source group")
   {
     updateLinkedGroups(groupNode, {&groupNode}, worldBounds)
       .transform([&](const UpdateLinkedGroupsResult& r) { CHECK(r.empty()); })
-      .or_else([](const auto&) { FAIL(); });
+      .transform_error([](const auto&) { FAIL(); });
   }
 
   SECTION("Update a single target group")
@@ -236,7 +236,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroups")
 
         CHECK(newEntityNode->entity().origin() == vm::vec3(1.0, 2.0, 3.0));
       })
-      .or_else([](const auto&) { FAIL(); });
+      .transform_error([](const auto&) { FAIL(); });
   }
 }
 
@@ -289,7 +289,7 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
 
         CHECK(newEntityNode->entity().origin() == vm::vec3(0.0, 2.0, 0.0));
       })
-      .or_else([](const auto&) { FAIL(); });
+      .transform_error([](const auto&) { FAIL(); });
   }
 
   SECTION("Transforming the inner group node's entity and updating the linked group")
@@ -320,7 +320,7 @@ TEST_CASE("GroupNodeTest.updateNestedLinkedGroups")
 
         CHECK(newEntityNode->entity().origin() == vm::vec3(1.0, 2.0, 0.0));
       })
-      .or_else([](const auto&) { FAIL(); });
+      .transform_error([](const auto&) { FAIL(); });
   }
 }
 
@@ -392,7 +392,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsRecursively")
       CHECK(newInnerGroupEntityNodeClone != nullptr);
       CHECK(newInnerGroupEntityNodeClone->entity() == innerGroupEntityNode->entity());
     })
-    .or_else([](const auto&) { FAIL(); });
+    .transform_error([](const auto&) { FAIL(); });
 }
 
 TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds")
@@ -420,7 +420,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsExceedsWorldBounds")
 
   updateLinkedGroups(groupNode, {groupNodeClone.get()}, worldBounds)
     .transform([&](const UpdateLinkedGroupsResult&) { FAIL(); })
-    .or_else(kdl::overload(
+    .transform_error(kdl::overload(
       [](const BrushError&) { FAIL(); },
       [](const UpdateLinkedGroupsError& e) {
         CHECK(e == UpdateLinkedGroupsError::UpdateExceedsWorldBounds);
@@ -476,7 +476,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveNestedGroupNames")
         const auto* innerReplacement = static_cast<GroupNode*>(newChildren.front().get());
         CHECK(innerReplacement->name() == innerGroupNodeNestedClone->name());
       })
-      .or_else([](const auto&) { FAIL(); });
+      .transform_error([](const auto&) { FAIL(); });
   }
 }
 
@@ -620,7 +620,7 @@ TEST_CASE("GroupNodeTest.updateLinkedGroupsAndPreserveEntityProperties")
         newEntityNode->entity().protectedProperties(),
         Catch::UnorderedEquals(targetEntityNode->entity().protectedProperties()));
     })
-    .or_else([](const auto&) { FAIL(); });
+    .transform_error([](const auto&) { FAIL(); });
 }
 } // namespace Model
 } // namespace TrenchBroom

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -402,7 +402,7 @@ TEST_CASE("PreferencesTest.readV2")
 
   readV2SettingsFromPath("fixture/test/preferences-v2.json")
     .transform([](const std::map<IO::Path, QJsonValue>& prefs) { testV2Prefs(prefs); })
-    .or_else([](const auto&) { FAIL_CHECK(); });
+    .transform_error([](const auto&) { FAIL_CHECK(); });
 }
 
 TEST_CASE("PreferencesTest.testWriteReadV2")
@@ -414,7 +414,7 @@ TEST_CASE("PreferencesTest.testWriteReadV2")
   const QByteArray v2Serialized = writeV2SettingsToJSON(v2);
   parseV2SettingsFromJSON(v2Serialized)
     .transform([&](const std::map<IO::Path, QJsonValue>& prefs) { CHECK(v2 == prefs); })
-    .or_else([](const auto&) { FAIL_CHECK(); });
+    .transform_error([](const auto&) { FAIL_CHECK(); });
 }
 
 /**

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -28,7 +28,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/enum_array.h"
     "${KDL_INCLUDE_DIR}/kdl/result.h"
     "${KDL_INCLUDE_DIR}/kdl/result_combine.h"
-    "${KDL_INCLUDE_DIR}/kdl/result_for_each.h"
+    "${KDL_INCLUDE_DIR}/kdl/result_fold.h"
     "${KDL_INCLUDE_DIR}/kdl/result_forward.h"
     "${KDL_INCLUDE_DIR}/kdl/result_io.h"
     "${KDL_INCLUDE_DIR}/kdl/functional.h"

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -559,18 +559,6 @@ public:
   }
 
   /**
-   * Returns the value contained in this result if it is successful. Otherwise, throws
-   * `bad_result_access`.
-   *
-   * @return the value in this result
-   *
-   * @throw bad_result_access if this result is an error
-   */
-  auto release() { return std::move(*this).value(); }
-
-  auto release_or(Value x) { return std::move(*this).value_or(std::move(x)); }
-
-  /**
    * Returns a the error contained in this result if it not successful. Otherwise, throws
    * `bad_result_access`.
    *

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -52,9 +52,9 @@ struct make_result_type
 };
 
 template <typename Value, typename... Errors>
-struct make_result_type<Value, kdl::meta_type_list<Errors...>>
+struct make_result_type<Value, meta_type_list<Errors...>>
 {
-  using type = kdl::result<Value, Errors...>;
+  using type = result<Value, Errors...>;
 };
 
 template <typename Result>
@@ -63,7 +63,7 @@ struct is_result : public std::false_type
 };
 
 template <typename Value, typename... Errors>
-struct is_result<kdl::result<Value, Errors...>> : public std::true_type
+struct is_result<result<Value, Errors...>> : public std::true_type
 {
 };
 
@@ -73,7 +73,7 @@ struct chain_results
 };
 
 template <typename Value1, typename... Errors1, typename Value2, typename... Errors2>
-struct chain_results<kdl::result<Value1, Errors1...>, kdl::result<Value2, Errors2...>>
+struct chain_results<result<Value1, Errors1...>, result<Value2, Errors2...>>
 {
   using result = typename make_result_type<
     Value2,
@@ -288,9 +288,9 @@ public:
 
     if constexpr (std::is_same_v<Fn_Value, void>)
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&](const value_type& v) {
-          return f(v).visit(kdl::overload(
+          return f(v).visit(overload(
             []() { return Cm_Result{}; },
             [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -298,9 +298,9 @@ public:
     }
     else
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&](const value_type& v) {
-          return f(v).visit(kdl::overload(
+          return f(v).visit(overload(
             [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
             [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -326,10 +326,10 @@ public:
 
     if constexpr (std::is_same_v<Fn_Value, void>)
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&](value_type&& v) {
           return f(std::move(v))
-            .visit(kdl::overload(
+            .visit(overload(
               []() { return Cm_Result{}; },
               [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -337,10 +337,10 @@ public:
     }
     else
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&](value_type&& v) {
           return f(std::move(v))
-            .visit(kdl::overload(
+            .visit(overload(
               [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
               [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -352,11 +352,11 @@ public:
   auto transform(F&& f) const&
   {
     using Fn_Result = std::invoke_result_t<F, Value>;
-    using Cm_Result = kdl::result<Fn_Result, Errors...>;
+    using Cm_Result = result<Fn_Result, Errors...>;
 
     if constexpr (std::is_same_v<Fn_Result, void>)
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&](const value_type& v) {
           f(v);
           return Cm_Result{};
@@ -365,7 +365,7 @@ public:
     }
     else
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&](const value_type& v) { return Cm_Result{f(v)}; },
         [](const auto& e) { return Cm_Result{e}; }));
     }
@@ -379,11 +379,11 @@ public:
   auto transform(F&& f) &&
   {
     using Fn_Result = std::invoke_result_t<F, Value>;
-    using Cm_Result = kdl::result<Fn_Result, Errors...>;
+    using Cm_Result = result<Fn_Result, Errors...>;
 
     if constexpr (std::is_same_v<Fn_Result, void>)
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&](value_type&& v) {
           f(std::move(v));
           return Cm_Result{};
@@ -392,7 +392,7 @@ public:
     }
     else
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&](value_type&& v) { return Cm_Result{f(std::move(v))}; },
         [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }));
     }
@@ -436,7 +436,7 @@ public:
         std::is_same_v<typename Cm_Result::value_type, Value>,
         "Function must return result with same value type");
 
-      return visit(kdl::overload(
+      return visit(overload(
         [](const value_type& v) { return Cm_Result{v}; },
         [&](const auto& e) { return f(e); }));
     }
@@ -444,9 +444,9 @@ public:
     {
       static_assert(std::is_same_v<Fn_Result, Value>, "Function must return value type");
 
-      using Cm_Result = kdl::result<Fn_Result>;
+      using Cm_Result = result<Fn_Result>;
 
-      return visit(kdl::overload(
+      return visit(overload(
         [](const value_type& v) { return Cm_Result{v}; },
         [&](const auto& e) { return Cm_Result{f(e)}; }));
     }
@@ -473,7 +473,7 @@ public:
         std::is_same_v<typename Cm_Result::value_type, Value>,
         "Function must return value type");
 
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [](value_type&& v) { return Cm_Result{std::move(v)}; },
         [&](auto&& e) { return f(std::forward<decltype(e)>(e)); }));
     }
@@ -481,9 +481,9 @@ public:
     {
       static_assert(std::is_same_v<Fn_Result, Value>, "Function must return value type");
 
-      using Cm_Result = kdl::result<Fn_Result>;
+      using Cm_Result = result<Fn_Result>;
 
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [](value_type&& v) { return Cm_Result{std::move(v)}; },
         [&](auto&& e) { return Cm_Result{f(std::forward<decltype(e)>(e))}; }));
     }
@@ -498,7 +498,7 @@ public:
   template <typename F>
   auto if_error(F&& f) const&
   {
-    visit(kdl::overload([](const Value&) {}, [&](const auto& e) { f(e); }));
+    visit(overload([](const Value&) {}, [&](const auto& e) { f(e); }));
     return *this;
   }
 
@@ -510,7 +510,7 @@ public:
   auto if_error(F&& f) &&
   {
     std::move(*this).visit(
-      kdl::overload([](Value&&) {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
+      overload([](Value&&) {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
     return std::move(*this);
   }
 
@@ -524,14 +524,14 @@ public:
    */
   auto value() const&
   {
-    return visit(kdl::overload(
+    return visit(overload(
       [](const value_type& v) -> value_type { return v; },
       [](const auto&) -> value_type { throw bad_result_access{}; }));
   }
 
   auto value_or(Value x) const&
   {
-    return visit(kdl::overload(
+    return visit(overload(
       [](const value_type& v) -> value_type { return v; },
       [&](const auto&) -> value_type { return std::move(x); }));
   }
@@ -546,14 +546,14 @@ public:
    */
   auto value() &&
   {
-    return std::move(*this).visit(kdl::overload(
+    return std::move(*this).visit(overload(
       [](value_type&& v) -> value_type { return std::move(v); },
       [](const auto&) -> value_type { throw bad_result_access{}; }));
   }
 
   auto value_or(Value x) &&
   {
-    return std::move(*this).visit(kdl::overload(
+    return std::move(*this).visit(overload(
       [](value_type&& v) -> value_type { return std::move(v); },
       [&](const auto&) -> value_type { return std::move(x); }));
   }
@@ -580,7 +580,7 @@ public:
    */
   auto error() const&
   {
-    return visit(kdl::overload(
+    return visit(overload(
       [](const value_type&) -> std::variant<Errors...> { throw bad_result_access{}; },
       [](const auto& e) -> std::variant<Errors...> { return e; }));
   }
@@ -595,7 +595,7 @@ public:
    */
   auto error() &&
   {
-    return visit(kdl::overload(
+    return visit(overload(
       [](const value_type&) -> std::variant<Errors...> { throw bad_result_access{}; },
       [](auto&& e) -> std::variant<Errors...> { return std::forward<decltype(e)>(e); }));
   }
@@ -745,7 +745,7 @@ public:
 };
 
 
-constexpr auto void_success = kdl::result<void>{};
+constexpr auto void_success = result<void>{};
 
 /**
  * Wrapper class that can contain either nothing or one of several errors.
@@ -845,7 +845,7 @@ public:
   auto visit(Visitor&& visitor) const&
   {
     return std::visit(
-      kdl::overload(
+      overload(
         [&](const detail::void_success_value_type&) { return visitor(); },
         [&](const auto& e) { return visitor(e); }),
       m_value);
@@ -867,7 +867,7 @@ public:
   auto visit(Visitor&& visitor) &&
   {
     return std::visit(
-      kdl::overload(
+      overload(
         [&](detail::void_success_value_type&&) { return visitor(); },
         [&](auto&& e) { return visitor(std::forward<decltype(e)>(e)); }),
       std::move(m_value));
@@ -890,9 +890,9 @@ public:
 
     if constexpr (std::is_same_v<Fn_Value, void>)
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&]() {
-          return f().visit(kdl::overload(
+          return f().visit(overload(
             []() { return Cm_Result{}; },
             [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -900,9 +900,9 @@ public:
     }
     else
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&]() {
-          return f().visit(kdl::overload(
+          return f().visit(overload(
             [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
             [](auto&& fn_e) { return Cm_Result(std::forward<decltype(fn_e)>(fn_e)); }));
         },
@@ -927,9 +927,9 @@ public:
 
     if constexpr (std::is_same_v<Fn_Value, void>)
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&]() {
-          return f().visit(kdl::overload(
+          return f().visit(overload(
             []() { return Cm_Result{}; },
             [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -937,9 +937,9 @@ public:
     }
     else
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&]() {
-          return f().visit(kdl::overload(
+          return f().visit(overload(
             [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
             [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
         },
@@ -954,11 +954,11 @@ public:
   auto transform(F&& f) const&
   {
     using Fn_Result = std::invoke_result_t<F>;
-    using Cm_Result = kdl::result<Fn_Result, Errors...>;
+    using Cm_Result = result<Fn_Result, Errors...>;
 
     if constexpr (std::is_same_v<Fn_Result, void>)
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&]() {
           f();
           return Cm_Result{};
@@ -967,7 +967,7 @@ public:
     }
     else
     {
-      return visit(kdl::overload(
+      return visit(overload(
         [&]() { return Cm_Result{f()}; }, [](const auto& e) { return Cm_Result{e}; }));
     }
   }
@@ -979,11 +979,11 @@ public:
   auto transform(F&& f) &&
   {
     using Fn_Result = std::invoke_result_t<F>;
-    using Cm_Result = kdl::result<Fn_Result, Errors...>;
+    using Cm_Result = result<Fn_Result, Errors...>;
 
     if constexpr (std::is_same_v<Fn_Result, void>)
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&]() {
           f();
           return Cm_Result{};
@@ -992,7 +992,7 @@ public:
     }
     else
     {
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         [&]() { return Cm_Result{f()}; },
         [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }));
     }
@@ -1019,13 +1019,13 @@ public:
         "Function must return void result");
 
       return visit(
-        kdl::overload([]() { return Cm_Result{}; }, [&](const auto& e) { return f(e); }));
+        overload([]() { return Cm_Result{}; }, [&](const auto& e) { return f(e); }));
     }
     else
     {
       static_assert(std::is_same_v<Fn_Result, void>, "Function must return void");
 
-      visit(kdl::overload([]() {}, [&](const auto& e) { f(e); }));
+      visit(overload([]() {}, [&](const auto& e) { f(e); }));
       return result<void>{};
     }
   }
@@ -1046,7 +1046,7 @@ public:
     {
       using Cm_Result = Fn_Result;
 
-      return std::move(*this).visit(kdl::overload(
+      return std::move(*this).visit(overload(
         []() { return Cm_Result{}; },
         [&](auto&& e) { return f(std::forward<decltype(e)>(e)); }));
     }
@@ -1055,7 +1055,7 @@ public:
       static_assert(std::is_same_v<Fn_Result, void>, "Function must return void");
 
       std::move(*this).visit(
-        kdl::overload([]() {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
+        overload([]() {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
       return result<void>{};
     }
   }
@@ -1066,7 +1066,7 @@ public:
   template <typename F>
   auto if_error(F&& f) const&
   {
-    visit(kdl::overload([]() {}, [&](const auto& e) { f(e); }));
+    visit(overload([]() {}, [&](const auto& e) { f(e); }));
     return *this;
   }
 
@@ -1076,7 +1076,7 @@ public:
   template <typename F>
   auto if_error(F&& f) &&
   {
-    std::move(*this).visit(kdl::overload([]() {}, [&](auto&& e) { f(e); }));
+    std::move(*this).visit(overload([]() {}, [&](auto&& e) { f(e); }));
     return std::move(*this);
   }
 
@@ -1090,7 +1090,7 @@ public:
    */
   auto error() const&
   {
-    return visit(kdl::overload(
+    return visit(overload(
       []() -> std::variant<Errors...> { throw bad_result_access{}; },
       [](const auto& e) -> std::variant<Errors...> { return e; }));
   }
@@ -1105,7 +1105,7 @@ public:
    */
   auto error() &&
   {
-    return visit(kdl::overload(
+    return visit(overload(
       []() -> std::variant<Errors...> { throw bad_result_access{}; },
       [](auto&& e) -> std::variant<Errors...> { return std::forward<decltype(e)>(e); }));
   }

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -146,13 +146,13 @@ public:
   template <typename... ErrorSubset>
   // NOLINTNEXTLINE
   result(result<Value, ErrorSubset...> other)
+    : m_value{std::move(other).visit(overload(
+      [](Value&& v) -> variant_type { return std::move(v); },
+      [](auto&& e) -> variant_type { return std::forward<decltype(e)>(e); }))}
   {
     static_assert(
       meta_is_subset<meta_type_list<ErrorSubset...>, meta_type_list<Errors...>>::value,
       "Error types of result type to convert must be a subset of target result type");
-    std::move(other).visit(overload(
-      [&](Value&& v) { m_value = std::move(v); },
-      [&](auto&& e) { m_value = std::forward<decltype(e)>(e); }));
   }
 
 public:
@@ -169,9 +169,27 @@ public:
    * return anything
    */
   template <typename Visitor>
-  auto visit(Visitor&& visitor) const&
+  auto visit(const Visitor& visitor) const&
   {
-    return std::visit(std::forward<Visitor>(visitor), m_value);
+    return std::visit(visitor, m_value);
+  }
+
+  /**
+   * Visits the value or error contained in this result.
+   *
+   * The given visitor must accept the value type and all error types of this result. The
+   * value or error contained in this result is passed to the visitor by non const lvalue
+   * reference.
+   *
+   * @tparam Visitor the type of the visitor
+   * @param visitor the visitor to apply
+   * @return the value returned by the given visitor or void if the given visitor does not
+   * return anything
+   */
+  template <typename Visitor>
+  auto visit(const Visitor& visitor) &
+  {
+    return std::visit(visitor, m_value);
   }
 
   /**
@@ -187,9 +205,9 @@ public:
    * return anything
    */
   template <typename Visitor>
-  auto visit(Visitor&& visitor) &&
+  auto visit(const Visitor& visitor) &&
   {
-    return std::visit(std::forward<Visitor>(visitor), std::move(m_value));
+    return std::visit(visitor, std::move(m_value));
   }
 
   /**
@@ -275,100 +293,43 @@ public:
    * @return a new combined result with the type and value as described above
    */
   template <typename F>
-  auto and_then(F&& f) const&
+  auto and_then(const F& f) const&
   {
     using My_Result = result<Value, Errors...>;
-    using Fn_Result = std::invoke_result_t<F, Value>;
+    using Fn_Result = decltype(f(std::declval<const Value&>()));
 
     static_assert(
       detail::is_result<Fn_Result>::value, "Function must return a result type");
 
     using Cm_Result = typename detail::chain_results<My_Result, Fn_Result>::result;
-    using Fn_Value = typename Fn_Result::value_type;
 
-    if constexpr (std::is_same_v<Fn_Value, void>)
-    {
-      return visit(overload(
-        [&](const value_type& v) {
-          return f(v).visit(overload(
-            []() { return Cm_Result{}; },
-            [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
-    else
-    {
-      return visit(overload(
-        [&](const value_type& v) {
-          return f(v).visit(overload(
-            [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
-            [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
-  }
-
-  /**
-   * See the previous function. The only difference is that the value contained in this
-   * result is passed to `f` by rvalue reference to allow moving.
-   */
-  template <typename F>
-  auto and_then(F&& f) &&
-  {
-    using My_Result = result<Value, Errors...>;
-    using Fn_Result = std::invoke_result_t<F, Value>;
-
-    static_assert(
-      detail::is_result<Fn_Result>::value, "Function must return a result type");
-
-    using Cm_Result = typename detail::chain_results<My_Result, Fn_Result>::result;
-    using Fn_Value = typename Fn_Result::value_type;
-
-    if constexpr (std::is_same_v<Fn_Value, void>)
-    {
-      return std::move(*this).visit(overload(
-        [&](value_type&& v) {
-          return f(std::move(v))
-            .visit(overload(
-              []() { return Cm_Result{}; },
-              [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](auto&& e) { return Cm_Result{e}; }));
-    }
-    else
-    {
-      return std::move(*this).visit(overload(
-        [&](value_type&& v) {
-          return f(std::move(v))
-            .visit(overload(
-              [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
-              [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](auto&& e) { return Cm_Result{e}; }));
-    }
-  }
-
-  template <typename F>
-  auto transform(F&& f) const&
-  {
-    using Fn_Result = std::invoke_result_t<F, Value>;
-    using Cm_Result = result<Fn_Result, Errors...>;
-
-    if constexpr (std::is_same_v<Fn_Result, void>)
-    {
-      return visit(overload(
-        [&](const value_type& v) {
-          f(v);
-          return Cm_Result{};
-        },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
-    else
-    {
-      return visit(overload(
+    return std::visit(
+      overload(
         [&](const value_type& v) { return Cm_Result{f(v)}; },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
+        [](const auto& e) { return Cm_Result{e}; }),
+      m_value);
+  }
+
+  /**
+   * See the previous function. The only difference is that the value contained in this
+   * result is passed to `f` by non const lvalue reference.
+   */
+  template <typename F>
+  auto and_then(const F& f) &
+  {
+    using My_Result = result<Value, Errors...>;
+    using Fn_Result = decltype(f(std::declval<Value&>()));
+
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+
+    using Cm_Result = typename detail::chain_results<My_Result, Fn_Result>::result;
+
+    return std::visit(
+      overload(
+        [&](value_type& v) { return Cm_Result{f(v)}; },
+        [](auto& e) { return Cm_Result{e}; }),
+      m_value);
   }
 
   /**
@@ -376,26 +337,21 @@ public:
    * result is passed to `f` by rvalue reference to allow moving.
    */
   template <typename F>
-  auto transform(F&& f) &&
+  auto and_then(const F& f) &&
   {
-    using Fn_Result = std::invoke_result_t<F, Value>;
-    using Cm_Result = result<Fn_Result, Errors...>;
+    using My_Result = result<Value, Errors...>;
+    using Fn_Result = decltype(f(std::declval<Value&&>()));
 
-    if constexpr (std::is_same_v<Fn_Result, void>)
-    {
-      return std::move(*this).visit(overload(
-        [&](value_type&& v) {
-          f(std::move(v));
-          return Cm_Result{};
-        },
-        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }));
-    }
-    else
-    {
-      return std::move(*this).visit(overload(
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+
+    using Cm_Result = typename detail::chain_results<My_Result, Fn_Result>::result;
+
+    return std::visit(
+      overload(
         [&](value_type&& v) { return Cm_Result{f(std::move(v))}; },
-        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }));
-    }
+        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }),
+      std::move(m_value));
   }
 
   /**
@@ -420,36 +376,25 @@ public:
    * reference.
    */
   template <typename F>
-  auto or_else(F&& f) const&
+  auto or_else(const F& f) const&
   {
     static_assert(
       std::tuple_size_v<std::tuple<Errors...>> > 0,
       "Cannot apply or_else to a result type with empty error type list");
 
-    using Fn_Result = std::invoke_result_t<F, meta_front_v<Errors...>>;
+    using Fn_Result = decltype(f(std::declval<const meta_front_v<Errors...>&>()));
 
-    if constexpr (detail::is_result<Fn_Result>::value)
-    {
-      using Cm_Result = Fn_Result;
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+    static_assert(
+      std::is_same_v<typename Fn_Result::value_type, Value>,
+      "Function must return result with same value type");
 
-      static_assert(
-        std::is_same_v<typename Cm_Result::value_type, Value>,
-        "Function must return result with same value type");
-
-      return visit(overload(
-        [](const value_type& v) { return Cm_Result{v}; },
-        [&](const auto& e) { return f(e); }));
-    }
-    else
-    {
-      static_assert(std::is_same_v<Fn_Result, Value>, "Function must return value type");
-
-      using Cm_Result = result<Fn_Result>;
-
-      return visit(overload(
-        [](const value_type& v) { return Cm_Result{v}; },
-        [&](const auto& e) { return Cm_Result{f(e)}; }));
-    }
+    return std::visit(
+      overload(
+        [](const value_type& v) { return Fn_Result{v}; },
+        [&](const auto& e) { return f(e); }),
+      m_value);
   }
 
   /**
@@ -457,36 +402,191 @@ public:
    * result is passed to `f` by rvalue reference to allow moving.
    */
   template <typename F>
-  auto or_else(F&& f) &&
+  auto or_else(const F& f) &
   {
     static_assert(
       std::tuple_size_v<std::tuple<Errors...>> > 0,
       "Cannot apply or_else to a result type with empty error type list");
 
-    using Fn_Result = std::invoke_result_t<F, meta_front_v<Errors...>>;
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&>()));
 
-    if constexpr (detail::is_result<Fn_Result>::value)
-    {
-      using Cm_Result = Fn_Result;
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+    static_assert(
+      std::is_same_v<typename Fn_Result::value_type, Value>,
+      "Function must return result with same value type");
 
-      static_assert(
-        std::is_same_v<typename Cm_Result::value_type, Value>,
-        "Function must return value type");
+    return std::visit(
+      overload([](value_type& v) { return Fn_Result{v}; }, [&](auto& e) { return f(e); }),
+      m_value);
+  }
 
-      return std::move(*this).visit(overload(
+  /**
+   * See the previous function. The only difference is that the value contained in this
+   * result is passed to `f` by rvalue reference to allow moving.
+   */
+  template <typename F>
+  auto or_else(const F& f) &&
+  {
+    static_assert(
+      std::tuple_size_v<std::tuple<Errors...>> > 0,
+      "Cannot apply or_else to a result type with empty error type list");
+
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&&>()));
+
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+    static_assert(
+      std::is_same_v<typename Fn_Result::value_type, Value>,
+      "Function must return result with same value type");
+
+    return std::visit(
+      overload(
+        [](value_type&& v) { return Fn_Result{std::move(v)}; },
+        [&](auto&& e) { return f(std::forward<decltype(e)>(e)); }),
+      std::move(m_value));
+  }
+
+  template <typename F>
+  auto transform(const F& f) const&
+  {
+    using Fn_Result = decltype(f(std::declval<const Value&>()));
+    using Cm_Result = result<Fn_Result, Errors...>;
+
+    return std::visit(
+      overload(
+        [&](const value_type& v) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(v);
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(v)};
+          }
+        },
+        [](const auto& e) { return Cm_Result{e}; }),
+      m_value);
+  }
+
+  template <typename F>
+  auto transform(const F& f) &
+  {
+    using Fn_Result = decltype(f(std::declval<Value&>()));
+    using Cm_Result = result<Fn_Result, Errors...>;
+
+    return std::visit(
+      overload(
+        [&](value_type& v) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(v);
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(v)};
+          }
+        },
+        [](auto& e) { return Cm_Result{e}; }),
+      m_value);
+  }
+
+  /**
+   * See the previous function. The only difference is that the value contained in this
+   * result is passed to `f` by rvalue reference to allow moving.
+   */
+  template <typename F>
+  auto transform(const F& f) &&
+  {
+    using Fn_Result = decltype(f(std::declval<Value&&>()));
+    using Cm_Result = result<Fn_Result, Errors...>;
+
+    return std::visit(
+      overload(
+        [&](value_type&& v) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(std::move(v));
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(std::move(v))};
+          }
+        },
+        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }),
+      std::move(m_value));
+  }
+
+  template <typename F>
+  auto transform_error(const F& f) const&
+  {
+    using Fn_Result = decltype(f(std::declval<const meta_front_v<Errors...>&>()));
+    using Cm_Result = result<Fn_Result>;
+
+    return std::visit(
+      overload(
+        [](const value_type& v) { return Cm_Result{v}; },
+        [&](const auto& e) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(e);
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(e)};
+          }
+        }),
+      m_value);
+  }
+
+  template <typename F>
+  auto transform_error(const F& f) &
+  {
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&>()));
+    using Cm_Result = result<Fn_Result>;
+
+    return std::visit(
+      overload(
+        [](value_type& v) { return Cm_Result{v}; },
+        [&](auto& e) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(e);
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(e)};
+          }
+        }),
+      m_value);
+  }
+
+  template <typename F>
+  auto transform_error(const F& f) &&
+  {
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&&>()));
+    using Cm_Result = result<Fn_Result>;
+
+    return std::visit(
+      overload(
         [](value_type&& v) { return Cm_Result{std::move(v)}; },
-        [&](auto&& e) { return f(std::forward<decltype(e)>(e)); }));
-    }
-    else
-    {
-      static_assert(std::is_same_v<Fn_Result, Value>, "Function must return value type");
-
-      using Cm_Result = result<Fn_Result>;
-
-      return std::move(*this).visit(overload(
-        [](value_type&& v) { return Cm_Result{std::move(v)}; },
-        [&](auto&& e) { return Cm_Result{f(std::forward<decltype(e)>(e))}; }));
-    }
+        [&](auto&& e) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(std::forward<decltype(e)>(e));
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(std::forward<decltype(e)>(e))};
+          }
+        }),
+      std::move(m_value));
   }
 
   /**
@@ -496,9 +596,9 @@ public:
    * Use this function for error logging and such, but not for fixing any errors.
    */
   template <typename F>
-  auto if_error(F&& f) const&
+  auto if_error(const F& f) const&
   {
-    visit(overload([](const Value&) {}, [&](const auto& e) { f(e); }));
+    std::visit(overload([](const Value&) {}, [&](const auto& e) { f(e); }), m_value);
     return *this;
   }
 
@@ -507,10 +607,22 @@ public:
    * result is passed to `f` by rvalue reference to allow moving.
    */
   template <typename F>
-  auto if_error(F&& f) &&
+  auto if_error(const F& f) &
   {
-    std::move(*this).visit(
-      overload([](Value&&) {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
+    std::visit(overload([](Value&) {}, [&](auto& e) { f(e); }), m_value);
+    return std::move(*this);
+  }
+
+  /**
+   * See the previous function. The only difference is that the value contained in this
+   * result is passed to `f` by rvalue reference to allow moving.
+   */
+  template <typename F>
+  auto if_error(const F& f) &&
+  {
+    std::visit(
+      overload([](Value&&) {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }),
+      std::move(m_value));
     return std::move(*this);
   }
 
@@ -522,18 +634,13 @@ public:
    *
    * @throw bad_result_access if this result is an error
    */
-  auto value() const&
+  const value_type& value() const&
   {
-    return visit(overload(
-      [](const value_type& v) -> value_type { return v; },
-      [](const auto&) -> value_type { throw bad_result_access{}; }));
-  }
-
-  auto value_or(Value x) const&
-  {
-    return visit(overload(
-      [](const value_type& v) -> value_type { return v; },
-      [&](const auto&) -> value_type { return std::move(x); }));
+    return std::visit(
+      overload(
+        [](const value_type& v) -> const value_type& { return v; },
+        [](const auto&) -> const value_type& { throw bad_result_access{}; }),
+      m_value);
   }
 
   /**
@@ -544,23 +651,45 @@ public:
    *
    * @throw bad_result_access if this result is an error
    */
-  auto value() &&
+  value_type&& value() &&
   {
-    return std::move(*this).visit(overload(
-      [](value_type&& v) -> value_type { return std::move(v); },
-      [](const auto&) -> value_type { throw bad_result_access{}; }));
+    return std::visit(
+      overload(
+        [](value_type&& v) -> value_type&& { return std::move(v); },
+        [](const auto&) -> value_type&& { throw bad_result_access{}; }),
+      std::move(m_value));
   }
 
-  auto value_or(Value x) &&
+  value_type value() const&&
   {
-    return std::move(*this).visit(overload(
-      [](value_type&& v) -> value_type { return std::move(v); },
-      [&](const auto&) -> value_type { return std::move(x); }));
+    return std::visit(
+      overload(
+        [](value_type& v) -> value_type&& { return std::move(v); },
+        [](const auto&) -> value_type&& { throw bad_result_access{}; }),
+      std::move(m_value));
+  }
+
+  value_type value_or(Value x) const&
+  {
+    return std::visit(
+      overload(
+        [](const value_type& v) -> value_type { return v; },
+        [&](const auto&) -> value_type { return std::move(x); }),
+      m_value);
+  }
+
+  value_type value_or(Value x) &&
+  {
+    return std::visit(
+      overload(
+        [](value_type&& v) -> value_type { return std::move(v); },
+        [&](const auto&) -> value_type { return std::move(x); }),
+      std::move(m_value));
   }
 
   /**
-   * Returns a the error contained in this result if it not successful. Otherwise, throws
-   * `bad_result_access`.
+   * Returns a the error contained in this result if it not successful. Otherwise,
+   * throws `bad_result_access`.
    *
    * @return a std::variant<Errors...> containing a copy of the error in this result
    *
@@ -568,14 +697,33 @@ public:
    */
   auto error() const&
   {
-    return visit(overload(
-      [](const value_type&) -> std::variant<Errors...> { throw bad_result_access{}; },
-      [](const auto& e) -> std::variant<Errors...> { return e; }));
+    return std::visit(
+      overload(
+        [](const value_type&) -> std::variant<Errors...> { throw bad_result_access{}; },
+        [](const auto& e) -> std::variant<Errors...> { return e; }),
+      m_value);
   }
 
   /**
-   * Returns a the error contained in this result if it not successful. Otherwise, throws
-   * `bad_result_access`.
+   * Returns a the error contained in this result if it not successful. Otherwise,
+   * throws `bad_result_access`.
+   *
+   * @return a std::variant<Errors...> containing a copy of the error in this result
+   *
+   * @throw bad_result_access if this result is an error
+   */
+  auto error() &
+  {
+    return std::visit(
+      overload(
+        [](value_type&) -> std::variant<Errors...> { throw bad_result_access{}; },
+        [](auto& e) -> std::variant<Errors...> { return e; }),
+      m_value);
+  }
+
+  /**
+   * Returns a the error contained in this result if it not successful. Otherwise,
+   * throws `bad_result_access`.
    *
    * @return a std::variant<Errors...> containing the error in this result
    *
@@ -583,9 +731,11 @@ public:
    */
   auto error() &&
   {
-    return visit(overload(
-      [](const value_type&) -> std::variant<Errors...> { throw bad_result_access{}; },
-      [](auto&& e) -> std::variant<Errors...> { return std::forward<decltype(e)>(e); }));
+    return std::visit(
+      overload(
+        [](value_type&&) -> std::variant<Errors...> { throw bad_result_access{}; },
+        [](auto&& e) -> std::variant<Errors...> { return std::forward<decltype(e)>(e); }),
+      std::move(m_value));
   }
 
   /**
@@ -657,22 +807,11 @@ public:
    *
    * @tparam Visitor the type of the visitor
    * @param visitor the visitor to apply
-   * @return the value returned by the given visitor or void if the given visitor does not
-   * return anything
+   * @return the value returned by the given visitor or void if the given visitor does
+   * not return anything
    */
   template <typename Visitor>
-  auto visit(Visitor&& visitor) const&
-  {
-    return visitor();
-  }
-
-  /**
-   * Applies the given visitor this result.
-   *
-   * See above.
-   */
-  template <typename Visitor>
-  auto visit(Visitor&& visitor) &&
+  auto visit(const Visitor& visitor) const
   {
     return visitor();
   }
@@ -681,23 +820,9 @@ public:
    * See result<Value, Errors...>::and_then.
    */
   template <typename F>
-  auto and_then(F&& f) const&
+  auto and_then(const F& f) const
   {
-    using Fn_Result = std::invoke_result_t<F>;
-
-    static_assert(
-      detail::is_result<Fn_Result>::value, "Function must return a result type");
-
-    return f();
-  }
-
-  /**
-   * See result<Value, Errors...>::and_then.
-   */
-  template <typename F>
-  auto and_then(F&& f) &&
-  {
-    using Fn_Result = std::invoke_result_t<F>;
+    using Fn_Result = decltype(f());
 
     static_assert(
       detail::is_result<Fn_Result>::value, "Function must return a result type");
@@ -709,12 +834,20 @@ public:
    * See result<Value, Errors...>::transform.
    */
   template <typename F>
-  auto transform(F&& f) const
+  auto transform(const F& f) const
   {
-    using Fn_Result = std::invoke_result_t<F>;
+    using Fn_Result = decltype(f());
     using Cm_Result = result<Fn_Result>;
 
-    return Cm_Result{f()};
+    if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+    {
+      f();
+      return Cm_Result{};
+    }
+    else
+    {
+      return Cm_Result{f()};
+    }
   }
 
   /**
@@ -776,12 +909,13 @@ public:
   /**
    * Creates a new result that wraps the given value.
    *
-   * v must be convertible to detail::void_success_value_type or one of the error types of
-   * this result. If the value is passed by (const) lvalue reference, it is copied into
-   * this result, if it s passed by rvalue reference, then it is moved into this result.
+   * v must be convertible to detail::void_success_value_type or one of the error types
+   * of this result. If the value is passed by (const) lvalue reference, it is copied
+   * into this result, if it s passed by rvalue reference, then it is moved into this
+   * result.
    *
-   * @tparam T the type of the value, must match detail::void_success_value_type or one of
-   * the error types of this result
+   * @tparam T the type of the value, must match detail::void_success_value_type or one
+   * of the error types of this result
    * @param v the value
    */
   template <
@@ -826,16 +960,38 @@ public:
    *
    * @tparam Visitor the type of the visitor
    * @param visitor the visitor to apply
-   * @return the value returned by the given visitor or void if the given visitor does not
-   * return anything
+   * @return the value returned by the given visitor or void if the given visitor does
+   * not return anything
    */
   template <typename Visitor>
-  auto visit(Visitor&& visitor) const&
+  auto visit(const Visitor& visitor) const&
   {
     return std::visit(
       overload(
         [&](const detail::void_success_value_type&) { return visitor(); },
         [&](const auto& e) { return visitor(e); }),
+      m_value);
+  }
+
+  /**
+   * Applies the given visitor this result.
+   *
+   * The given visitor must accept void and all error types of this result.
+   * The error contained in this result is passed to the visitor by non const lvalue
+   * reference.
+   *
+   * @tparam Visitor the type of the visitor
+   * @param visitor the visitor to apply
+   * @return the value returned by the given visitor or void if the given visitor does
+   * not return anything
+   */
+  template <typename Visitor>
+  auto visit(const Visitor& visitor) &
+  {
+    return std::visit(
+      overload(
+        [&](detail::void_success_value_type&) { return visitor(); },
+        [&](auto& e) { return visitor(e); }),
       m_value);
   }
 
@@ -848,11 +1004,11 @@ public:
    *
    * @tparam Visitor the type of the visitor
    * @param visitor the visitor to apply
-   * @return the value returned by the given visitor or void if the given visitor does not
-   * return anything
+   * @return the value returned by the given visitor or void if the given visitor does
+   * not return anything
    */
   template <typename Visitor>
-  auto visit(Visitor&& visitor) &&
+  auto visit(const Visitor& visitor) &&
   {
     return std::visit(
       overload(
@@ -865,196 +1021,250 @@ public:
    * See result<Value, Errors...>::and_then.
    */
   template <typename F>
-  auto and_then(F&& f) const&
+  auto and_then(const F& f) const&
   {
     using My_Result = result<void, Errors...>;
-    using Fn_Result = std::invoke_result_t<F>;
+    using Fn_Result = decltype(f());
 
     static_assert(
       detail::is_result<Fn_Result>::value, "Function must return a result type");
 
     using Cm_Result = typename detail::chain_results<My_Result, Fn_Result>::result;
-    using Fn_Value = typename Fn_Result::value_type;
 
-    if constexpr (std::is_same_v<Fn_Value, void>)
-    {
-      return visit(overload(
-        [&]() {
-          return f().visit(overload(
-            []() { return Cm_Result{}; },
-            [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
-    else
-    {
-      return visit(overload(
-        [&]() {
-          return f().visit(overload(
-            [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
-            [](auto&& fn_e) { return Cm_Result(std::forward<decltype(fn_e)>(fn_e)); }));
-        },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
+    return std::visit(
+      overload(
+        [&](const detail::void_success_value_type&) { return Cm_Result{f()}; },
+        [](const auto& e) { return Cm_Result{e}; }),
+      m_value);
   }
 
   /**
    * See result<Value, Errors...>::and_then.
    */
   template <typename F>
-  auto and_then(F&& f) &&
+  auto and_then(const F& f) &&
   {
     using My_Result = result<void, Errors...>;
-    using Fn_Result = std::invoke_result_t<F>;
+    using Fn_Result = decltype(f());
 
     static_assert(
       detail::is_result<Fn_Result>::value, "Function must return a result type");
 
     using Cm_Result = typename detail::chain_results<My_Result, Fn_Result>::result;
-    using Fn_Value = typename Fn_Result::value_type;
 
-    if constexpr (std::is_same_v<Fn_Value, void>)
-    {
-      return std::move(*this).visit(overload(
-        [&]() {
-          return f().visit(overload(
-            []() { return Cm_Result{}; },
-            [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](auto&& e) { return Cm_Result{e}; }));
-    }
-    else
-    {
-      return std::move(*this).visit(overload(
-        [&]() {
-          return f().visit(overload(
-            [](Fn_Value&& fn_v) { return Cm_Result{std::move(fn_v)}; },
-            [](auto&& fn_e) { return Cm_Result{std::forward<decltype(fn_e)>(fn_e)}; }));
-        },
-        [](auto&& e) { return Cm_Result{e}; }));
-    }
-  }
-
-  /**
-   * See result<Value, Errors...>::transform.
-   */
-  template <typename F>
-  auto transform(F&& f) const&
-  {
-    using Fn_Result = std::invoke_result_t<F>;
-    using Cm_Result = result<Fn_Result, Errors...>;
-
-    if constexpr (std::is_same_v<Fn_Result, void>)
-    {
-      return visit(overload(
-        [&]() {
-          f();
-          return Cm_Result{};
-        },
-        [](const auto& e) { return Cm_Result{e}; }));
-    }
-    else
-    {
-      return visit(overload(
-        [&]() { return Cm_Result{f()}; }, [](const auto& e) { return Cm_Result{e}; }));
-    }
-  }
-
-  /**
-   * See result<Value, Errors...>::transform.
-   */
-  template <typename F>
-  auto transform(F&& f) &&
-  {
-    using Fn_Result = std::invoke_result_t<F>;
-    using Cm_Result = result<Fn_Result, Errors...>;
-
-    if constexpr (std::is_same_v<Fn_Result, void>)
-    {
-      return std::move(*this).visit(overload(
-        [&]() {
-          f();
-          return Cm_Result{};
-        },
-        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }));
-    }
-    else
-    {
-      return std::move(*this).visit(overload(
-        [&]() { return Cm_Result{f()}; },
-        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }));
-    }
+    return std::visit(
+      overload(
+        [&](detail::void_success_value_type&&) { return Cm_Result{f()}; },
+        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }),
+      std::move(m_value));
   }
 
   /**
    * See result<Value, Errors...>::or_else.
    */
   template <typename F>
-  auto or_else(F&& f) const&
+  auto or_else(const F& f) const&
   {
     static_assert(
       std::tuple_size_v<std::tuple<Errors...>> > 0,
       "Cannot apply or_else to a result type with empty error type list");
 
-    using Fn_Result = std::invoke_result_t<F, meta_front_v<Errors...>>;
+    using Fn_Result = decltype(f(std::declval<const meta_front_v<Errors...>&>()));
 
-    if constexpr (detail::is_result<Fn_Result>::value)
-    {
-      using Cm_Result = Fn_Result;
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+    static_assert(
+      std::is_same_v<typename Fn_Result::value_type, void>,
+      "Function must return void result");
 
-      static_assert(
-        std::is_same_v<typename Cm_Result::value_type, void>,
-        "Function must return void result");
-
-      return visit(
-        overload([]() { return Cm_Result{}; }, [&](const auto& e) { return f(e); }));
-    }
-    else
-    {
-      static_assert(std::is_same_v<Fn_Result, void>, "Function must return void");
-
-      visit(overload([]() {}, [&](const auto& e) { f(e); }));
-      return result<void>{};
-    }
+    return std::visit(
+      overload(
+        [](const detail::void_success_value_type&) { return Fn_Result{}; },
+        [&](const auto& e) { return f(e); }),
+      m_value);
   }
 
   /**
    * See result<Value, Errors...>::or_else.
    */
   template <typename F>
-  auto or_else(F&& f) &&
+  auto or_else(const F& f) &
   {
     static_assert(
       std::tuple_size_v<std::tuple<Errors...>> > 0,
       "Cannot apply or_else to a result type with empty error type list");
 
-    using Fn_Result = std::invoke_result_t<F, meta_front_v<Errors...>>;
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&>()));
 
-    if constexpr (detail::is_result<Fn_Result>::value)
-    {
-      using Cm_Result = Fn_Result;
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+    static_assert(
+      std::is_same_v<typename Fn_Result::value_type, void>,
+      "Function must return void result");
 
-      return std::move(*this).visit(overload(
-        []() { return Cm_Result{}; },
-        [&](auto&& e) { return f(std::forward<decltype(e)>(e)); }));
-    }
-    else
-    {
-      static_assert(std::is_same_v<Fn_Result, void>, "Function must return void");
+    return std::visit(
+      overload(
+        [](detail::void_success_value_type&) { return Fn_Result{}; },
+        [&](auto& e) { return f(e); }),
+      m_value);
+  }
 
-      std::move(*this).visit(
-        overload([]() {}, [&](auto&& e) { f(std::forward<decltype(e)>(e)); }));
-      return result<void>{};
-    }
+  /**
+   * See result<Value, Errors...>::or_else.
+   */
+  template <typename F>
+  auto or_else(const F& f) &&
+  {
+    static_assert(
+      std::tuple_size_v<std::tuple<Errors...>> > 0,
+      "Cannot apply or_else to a result type with empty error type list");
+
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&&>()));
+
+    static_assert(
+      detail::is_result<Fn_Result>::value, "Function must return a result type");
+    static_assert(
+      std::is_same_v<typename Fn_Result::value_type, void>,
+      "Function must return void result");
+
+    return std::visit(
+      overload(
+        [](detail::void_success_value_type&&) { return Fn_Result{}; },
+        [&](auto&& e) { return f(std::forward<decltype(e)>(e)); }),
+      std::move(m_value));
+  }
+
+  /**
+   * See result<Value, Errors...>::transform.
+   */
+  template <typename F>
+  auto transform(const F& f) const&
+  {
+    using Fn_Result = decltype(f());
+    using Cm_Result = result<Fn_Result, Errors...>;
+
+    return std::visit(
+      overload(
+        [&](const detail::void_success_value_type&) {
+          if constexpr (std::is_same_v<Fn_Result, void>)
+          {
+            f();
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f()};
+          }
+        },
+        [](const auto& e) { return Cm_Result{e}; }),
+      m_value);
+  }
+
+  /**
+   * See result<Value, Errors...>::transform.
+   */
+  template <typename F>
+  auto transform(const F& f) &&
+  {
+    using Fn_Result = decltype(f());
+    using Cm_Result = result<Fn_Result, Errors...>;
+
+    return std::visit(
+      overload(
+        [&](detail::void_success_value_type&&) {
+          if constexpr (std::is_same_v<Fn_Result, void>)
+          {
+            f();
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f()};
+          }
+        },
+        [](auto&& e) { return Cm_Result{std::forward<decltype(e)>(e)}; }),
+      std::move(m_value));
+  }
+
+  template <typename F>
+  auto transform_error(const F& f) const&
+  {
+    using Fn_Result = decltype(f(std::declval<const meta_front_v<Errors...>&>()));
+    using Cm_Result = result<Fn_Result>;
+
+    return std::visit(
+      overload(
+        [](const detail::void_success_value_type&) { return Cm_Result{}; },
+        [&](const auto& e) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(e);
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(e)};
+          }
+        }),
+      m_value);
+  }
+
+  template <typename F>
+  auto transform_error(const F& f) &
+  {
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&>()));
+    using Cm_Result = result<Fn_Result>;
+
+    return std::visit(
+      overload(
+        [](detail::void_success_value_type&) { return Cm_Result{}; },
+        [&](auto& e) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(e);
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(e)};
+          }
+        }),
+      m_value);
+  }
+
+  template <typename F>
+  auto transform_error(const F& f) &&
+  {
+    using Fn_Result = decltype(f(std::declval<meta_front_v<Errors...>&&>()));
+    using Cm_Result = result<Fn_Result>;
+
+    return std::visit(
+      overload(
+        [](detail::void_success_value_type&&) { return Cm_Result{}; },
+        [&](auto&& e) {
+          if constexpr (std::is_same_v<typename Cm_Result::value_type, void>)
+          {
+            f(std::forward<decltype(e)>(e));
+            return Cm_Result{};
+          }
+          else
+          {
+            return Cm_Result{f(std::forward<decltype(e)>(e))};
+          }
+        }),
+      std::move(m_value));
   }
 
   /**
    * See result<Value, Errors...>::if_error.
    */
   template <typename F>
-  auto if_error(F&& f) const&
+  auto if_error(const F& f) const&
   {
-    visit(overload([]() {}, [&](const auto& e) { f(e); }));
+    std::visit(
+      overload(
+        [](const detail::void_success_value_type&) {}, [&](const auto& e) { f(e); }),
+      m_value);
     return *this;
   }
 
@@ -1062,15 +1272,17 @@ public:
    * See result<Value, Errors...>::if_error.
    */
   template <typename F>
-  auto if_error(F&& f) &&
+  auto if_error(const F& f) &&
   {
-    std::move(*this).visit(overload([]() {}, [&](auto&& e) { f(e); }));
+    std::visit(
+      overload([](detail::void_success_value_type&&) {}, [&](auto&& e) { f(e); }),
+      std::move(m_value));
     return std::move(*this);
   }
 
   /**
-   * Returns a the error contained in this result if it not successful. Otherwise, throws
-   * `bad_result_access`.
+   * Returns a the error contained in this result if it not successful. Otherwise,
+   * throws `bad_result_access`.
    *
    * @return a std::variant<Errors...> containing a copy of the error in this result
    *
@@ -1078,14 +1290,37 @@ public:
    */
   auto error() const&
   {
-    return visit(overload(
-      []() -> std::variant<Errors...> { throw bad_result_access{}; },
-      [](const auto& e) -> std::variant<Errors...> { return e; }));
+    return std::visit(
+      overload(
+        [](const detail::void_success_value_type&) -> std::variant<Errors...> {
+          throw bad_result_access{};
+        },
+        [](const auto& e) -> std::variant<Errors...> { return e; }),
+      m_value);
   }
 
   /**
-   * Returns a the error contained in this result if it not successful. Otherwise, throws
-   * `bad_result_access`.
+   * Returns a the error contained in this result if it not successful. Otherwise,
+   * throws `bad_result_access`.
+   *
+   * @return a std::variant<Errors...> containing a copy of the error in this result
+   *
+   * @throw bad_result_access if this result is an error
+   */
+  auto error() &
+  {
+    return std::visit(
+      overload(
+        [](detail::void_success_value_type&) -> std::variant<Errors...> {
+          throw bad_result_access{};
+        },
+        [](auto& e) -> std::variant<Errors...> { return e; }),
+      m_value);
+  }
+
+  /**
+   * Returns a the error contained in this result if it not successful. Otherwise,
+   * throws `bad_result_access`.
    *
    * @return a std::variant<Errors...> containing the error in this result
    *
@@ -1093,9 +1328,13 @@ public:
    */
   auto error() &&
   {
-    return visit(overload(
-      []() -> std::variant<Errors...> { throw bad_result_access{}; },
-      [](auto&& e) -> std::variant<Errors...> { return std::forward<decltype(e)>(e); }));
+    return std::visit(
+      overload(
+        [](detail::void_success_value_type&&) -> std::variant<Errors...> {
+          throw bad_result_access{};
+        },
+        [](auto&& e) -> std::variant<Errors...> { return std::forward<decltype(e)>(e); }),
+      std::move(m_value));
   }
 
   /**

--- a/lib/kdl/include/kdl/result_combine.h
+++ b/lib/kdl/include/kdl/result_combine.h
@@ -37,8 +37,8 @@ struct combine_tuple_results
 
 template <typename Value1, typename... Errors1, typename... Values2, typename... Errors2>
 struct combine_tuple_results<
-  kdl::result<Value1, Errors1...>,
-  kdl::result<std::tuple<Values2...>, Errors2...>>
+  result<Value1, Errors1...>,
+  result<std::tuple<Values2...>, Errors2...>>
 {
   using result = typename make_result_type<
     std::tuple<Value1, Values2...>,
@@ -51,7 +51,7 @@ struct tuple_wrap
 };
 
 template <typename Value, typename... Errors>
-struct tuple_wrap<kdl::result<Value, Errors...>>
+struct tuple_wrap<result<Value, Errors...>>
 {
   using result =
     typename make_result_type<std::tuple<Value>, meta_type_list<Errors...>>::type;
@@ -72,7 +72,7 @@ auto combine_results(Result&& result)
     typename detail::tuple_wrap<std::remove_reference_t<Result>>::result;
   using value_type = typename std::remove_reference_t<Result>::value_type;
 
-  return result.visit(kdl::overload(
+  return result.visit(overload(
     [](value_type&& v) { return result_type{std::make_tuple(std::move(v))}; },
     [](const value_type& v) { return result_type{std::make_tuple(v)}; },
     [](auto&& e) { return result_type{std::forward<decltype(e)>(e)}; }));
@@ -116,10 +116,10 @@ auto combine_results(FirstResult&& firstResult, MoreResults&&... moreResults)
     combined_more_result_type>::result;
 
   return std::forward<FirstResult>(firstResult)
-    .visit(kdl::overload(
+    .visit(overload(
       [&](first_value_type&& firstValue) {
         return combine_results(std::forward<MoreResults>(moreResults)...)
-          .visit(kdl::overload(
+          .visit(overload(
             [&](typename combined_more_result_type::value_type&& remainingValues) {
               return result_type{std::tuple_cat(
                 std::tuple{std::move(firstValue)}, std::move(remainingValues))};
@@ -134,7 +134,7 @@ auto combine_results(FirstResult&& firstResult, MoreResults&&... moreResults)
       },
       [&](const first_value_type& firstValue) {
         return combine_results(std::forward<MoreResults>(moreResults)...)
-          .visit(kdl::overload(
+          .visit(overload(
             [&](typename combined_more_result_type::value_type&& remainingValues) {
               return result_type{
                 std::tuple_cat(std::tuple{firstValue}, std::move(remainingValues))};

--- a/lib/kdl/test/src/tst_result.cpp
+++ b/lib/kdl/test/src/tst_result.cpp
@@ -23,13 +23,21 @@
 #include "kdl/reflection_impl.h"
 #include "kdl/result.h"
 #include "kdl/result_combine.h"
-#include "kdl/result_for_each.h"
+#include "kdl/result_fold.h"
 #include "kdl/result_io.h"
 
 #include <iostream>
 #include <string>
 
 #include <catch2/catch.hpp>
+
+/*
+missing tests:
+if_error
+value all value categories?
+value_or all value categories?
+error()
+ */
 
 namespace kdl
 {
@@ -42,9 +50,23 @@ struct Error2
 {
   kdl_reflect_inline_empty(Error2);
 };
+
 struct Error3
 {
   kdl_reflect_inline_empty(Error3);
+};
+
+struct MoveOnly
+{
+  MoveOnly(const MoveOnly&) = delete;
+  MoveOnly& operator=(const MoveOnly&) = delete;
+
+  MoveOnly(MoveOnly&&) noexcept = default;
+  MoveOnly& operator=(MoveOnly&&) noexcept = default;
+
+  MoveOnly() = default;
+
+  kdl_reflect_inline_empty(MoveOnly);
 };
 
 struct Counter
@@ -79,43 +101,42 @@ struct Counter
     this->moves = c.moves + 1u;
     return *this;
   }
-};
 
-inline std::ostream& operator<<(std::ostream& str, const Counter&)
-{
-  str << "Counter";
-  return str;
-}
+  kdl_reflect_inline(Counter, copies, moves);
+};
 
 TEST_CASE("result_test.void_success")
 {
   CHECK(void_success == result<void>{});
   CHECK(void_success.is_success());
   CHECK_FALSE(void_success.is_error());
+
+  const auto make_void_success = []() { return void_success; };
+  make_void_success(); // no warning because void_success is not marked as nodiscard
 }
 
 TEST_CASE("result_test.constructor")
 {
   SECTION("non-void result")
   {
-    CHECK((result<int, float, std::string>{1}.value() == 1));
+    CHECK((result<int, Error1, Error2>{1}.value() == 1));
     CHECK(
-      (result<int, float, std::string>{1.0f}.error()
-       == std::variant<float, std::string>{1.0f}));
+      (result<int, Error1, Error2>{Error1{}}.error()
+       == std::variant<Error1, Error2>{Error1{}}));
     CHECK(
-      (result<int, float, std::string>{""}.error()
-       == std::variant<float, std::string>{""}));
+      (result<int, Error1, Error2>{Error2{}}.error()
+       == std::variant<Error1, Error2>{Error2{}}));
   }
 
   SECTION("void result with errors")
   {
-    CHECK((result<void, float, std::string>{}.is_success()));
+    CHECK((result<void, Error1, Error2>{}.is_success()));
     CHECK(
-      (result<void, float, std::string>{1.0f}.error()
-       == std::variant<float, std::string>{1.0f}));
+      (result<void, Error1, Error2>{Error1{}}.error()
+       == std::variant<Error1, Error2>{Error1{}}));
     CHECK(
-      (result<void, float, std::string>{""}.error()
-       == std::variant<float, std::string>{""}));
+      (result<void, Error1, Error2>{Error2{}}.error()
+       == std::variant<Error1, Error2>{Error2{}}));
   }
 
   SECTION("void result without errors") { CHECK((result<void>{}.is_success())); }
@@ -126,63 +147,63 @@ TEST_CASE("result_test.converting_constructor")
   SECTION("non-void result")
   {
     CHECK(
-      result<int, std::string, float>{result<int, std::string, float>{1}}
-      == result<int, std::string, float>{1});
+      result<MoveOnly, Error1, Error2>{result<MoveOnly, Error1, Error2>{MoveOnly{}}}
+      == result<MoveOnly, Error1, Error2>{MoveOnly{}});
     CHECK(
-      result<int, std::string, float>{result<int, std::string, float>{"asdf"}}
-      == result<int, std::string, float>{"asdf"});
+      result<int, Error1, Error2>{result<int, Error1, Error2>{Error1{}}}
+      == result<int, Error1, Error2>{Error1{}});
 
     CHECK(
-      result<int, std::string, float>{result<int, float, std::string>{1}}
-      == result<int, std::string, float>{1});
+      result<MoveOnly, Error1, Error2>{result<MoveOnly, Error2, Error1>{MoveOnly{}}}
+      == result<MoveOnly, Error1, Error2>{MoveOnly{}});
     CHECK(
-      result<int, std::string, float>{result<int, float, std::string>{"asdf"}}
-      == result<int, std::string, float>{"asdf"});
+      result<int, Error1, Error2>{result<int, Error2, Error1>{Error1{}}}
+      == result<int, Error1, Error2>{Error1{}});
 
     CHECK(
-      result<int, std::string, float>{result<int, std::string>{1}}
-      == result<int, std::string, float>{1});
+      result<MoveOnly, Error1, Error2>{result<MoveOnly, Error1>{MoveOnly{}}}
+      == result<MoveOnly, Error1, Error2>{MoveOnly{}});
     CHECK(
-      result<int, std::string, float>{result<int, std::string>{"asdf"}}
-      == result<int, std::string, float>{"asdf"});
+      result<int, Error1, Error2>{result<int, Error1>{Error1{}}}
+      == result<int, Error1, Error2>{Error1{}});
 
     CHECK(
-      result<int, std::string, float>{result<int, float>{1}}
-      == result<int, std::string, float>{1});
+      result<MoveOnly, Error1, Error2>{result<MoveOnly, Error2>{MoveOnly{}}}
+      == result<MoveOnly, Error1, Error2>{MoveOnly{}});
     CHECK(
-      result<int, std::string, float>{result<int, float>{1.0f}}
-      == result<int, std::string, float>{1.0f});
+      result<int, Error1, Error2>{result<int, Error2>{Error2{}}}
+      == result<int, Error1, Error2>{Error2{}});
   }
 
   SECTION("void result with errors")
   {
     CHECK(
-      result<void, std::string, float>{result<void, std::string, float>{}}
-      == result<void, std::string, float>{});
+      result<void, Error1, Error2>{result<void, Error1, Error2>{}}
+      == result<void, Error1, Error2>{});
     CHECK(
-      result<void, std::string, float>{result<void, std::string, float>{"asdf"}}
-      == result<void, std::string, float>{"asdf"});
+      result<void, Error1, Error2>{result<void, Error1, Error2>{Error1{}}}
+      == result<void, Error1, Error2>{Error1{}});
 
     CHECK(
-      result<void, std::string, float>{result<void, float, std::string>{}}
-      == result<void, std::string, float>{});
+      result<void, Error1, Error2>{result<void, Error2, Error1>{}}
+      == result<void, Error1, Error2>{});
     CHECK(
-      result<void, std::string, float>{result<void, float, std::string>{"asdf"}}
-      == result<void, std::string, float>{"asdf"});
+      result<void, Error1, Error2>{result<void, Error2, Error1>{Error1{}}}
+      == result<void, Error1, Error2>{Error1{}});
 
     CHECK(
-      result<void, std::string, float>{result<void, std::string>{}}
-      == result<void, std::string, float>{});
+      result<void, Error1, Error2>{result<void, Error1>{}}
+      == result<void, Error1, Error2>{});
     CHECK(
-      result<void, std::string, float>{result<void, std::string>{"asdf"}}
-      == result<void, std::string, float>{"asdf"});
+      result<void, Error1, Error2>{result<void, Error1>{Error1{}}}
+      == result<void, Error1, Error2>{Error1{}});
 
     CHECK(
-      result<void, std::string, float>{result<void, float>{}}
-      == result<void, std::string, float>{});
+      result<void, Error1, Error2>{result<void, Error2>{}}
+      == result<void, Error1, Error2>{});
     CHECK(
-      result<void, std::string, float>{result<void, float>{1.0f}}
-      == result<void, std::string, float>{1.0f});
+      result<void, Error1, Error2>{result<void, Error2>{Error2{}}}
+      == result<void, Error1, Error2>{Error2{}});
   }
 
   SECTION("void result without errors")
@@ -212,20 +233,23 @@ TEST_CASE("result_test.visit")
       [](const Error2&) { return true; })));
 
     auto nonConstLValueSuccess = result<int, Error1, Error2>{1};
-    CHECK(nonConstLValueSuccess.visit(kdl::overload(
-      [](const int& x) { return x == 1; }, [](const auto&) { return false; })));
+    CHECK(nonConstLValueSuccess.visit(
+      kdl::overload([](int& x) { return x == 1; }, [](auto&) { return false; })));
 
     auto nonConstLValueError1 = result<int, Error1, Error2>{Error1{}};
     CHECK(nonConstLValueError1.visit(kdl::overload(
-      [](const int&) { return false; },
-      [](const Error1&) { return true; },
-      [](const Error2&) { return false; })));
+      [](int&) { return false; },
+      [](Error1&) { return true; },
+      [](Error2&) { return false; })));
 
     auto nonConstLValueError2 = result<int, Error1, Error2>{Error2{}};
     CHECK(nonConstLValueError2.visit(kdl::overload(
-      [](const int&) { return false; },
-      [](const Error1&) { return false; },
-      [](const Error2&) { return true; })));
+      [](int&) { return false; },
+      [](Error1&) { return false; },
+      [](Error2&) { return true; })));
+
+    CHECK(result<MoveOnly, Error1, Error2>{MoveOnly{}}.visit(
+      kdl::overload([](MoveOnly&&) { return true; }, [](auto&&) { return false; })));
 
     CHECK(result<int, Error1, Error2>{1}.visit(
       kdl::overload([](int&& x) { return x == 1; }, [](auto&&) { return false; })));
@@ -261,19 +285,19 @@ TEST_CASE("result_test.visit")
 
     auto nonConstLValueSuccess = result<void, Error1, Error2>{};
     CHECK(nonConstLValueSuccess.visit(
-      kdl::overload([]() { return true; }, [](const auto&) { return false; })));
+      kdl::overload([]() { return true; }, [](auto&) { return false; })));
 
     auto nonConstLValueError1 = result<void, Error1, Error2>{Error1{}};
     CHECK(nonConstLValueError1.visit(kdl::overload(
       []() { return false; },
-      [](const Error1&) { return true; },
-      [](const Error2&) { return false; })));
+      [](Error1&) { return true; },
+      [](Error2&) { return false; })));
 
     auto nonConstLValueError2 = result<void, Error1, Error2>{Error2{}};
     CHECK(nonConstLValueError2.visit(kdl::overload(
       []() { return false; },
-      [](const Error1&) { return false; },
-      [](const Error2&) { return true; })));
+      [](Error1&) { return false; },
+      [](Error2&) { return true; })));
 
     CHECK(result<void, Error1, Error2>{}.visit(
       kdl::overload([]() { return true; }, [](auto&&) { return false; })));
@@ -324,22 +348,26 @@ TEST_CASE("result_test.and_then")
     }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
 
     auto nonConstLValueSuccessToSuccess = result<int, Error1, Error2>{1};
-    CHECK(nonConstLValueSuccessToSuccess.and_then([](const int& x) {
+    CHECK(nonConstLValueSuccessToSuccess.and_then([](int& x) {
       CHECK(x == 1);
       return kdl::result<float, Error3>{2.0f};
     }) == kdl::result<float, Error1, Error2, Error3>{2.0f});
 
     auto nonConstLValueSuccessToError = result<int, Error1, Error2>{1};
-    CHECK(nonConstLValueSuccessToError.and_then([](const int& x) {
+    CHECK(nonConstLValueSuccessToError.and_then([](int& x) {
       CHECK(x == 1);
       return kdl::result<float, Error3>{Error3{}};
     }) == kdl::result<float, Error1, Error2, Error3>{Error3{}});
 
     auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueError.and_then([](const int&) {
+    CHECK(nonConstLValueError.and_then([](int&) {
       FAIL();
       return kdl::result<float, Error3>{2.0f};
     }) == kdl::result<float, Error1, Error2, Error3>{Error1{}});
+
+    CHECK(result<MoveOnly, Error1, Error2>{MoveOnly{}}.and_then([](MoveOnly&& x) {
+      return kdl::result<MoveOnly, Error3>{std::move(x)};
+    }) == kdl::result<MoveOnly, Error1, Error2, Error3>{MoveOnly{}});
 
     CHECK(result<int, Error1, Error2>{1}.and_then([](int&& x) {
       CHECK(x == 1);
@@ -437,95 +465,6 @@ TEST_CASE("result_test.and_then")
   }
 }
 
-TEST_CASE("result_test.transform")
-{
-  SECTION("non-void result")
-  {
-    const auto constLValueSuccessToSuccess = result<int, Error1, Error2>{1};
-    CHECK(constLValueSuccessToSuccess.transform([](const int& x) {
-      CHECK(x == 1);
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{2.0f});
-
-    const auto constLValueError = result<int, Error1, Error2>{Error1{}};
-    CHECK(constLValueError.transform([](const int&) {
-      FAIL();
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{Error1{}});
-
-    auto nonConstLValueSuccessToSuccess = result<int, Error1, Error2>{1};
-    CHECK(nonConstLValueSuccessToSuccess.transform([](const int& x) {
-      CHECK(x == 1);
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{2.0f});
-
-    auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueError.transform([](const int&) {
-      FAIL();
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{Error1{}});
-
-    CHECK(result<int, Error1, Error2>{1}.transform([](int&& x) {
-      CHECK(x == 1);
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{2.0f});
-
-    CHECK(result<int, Error1, Error2>{Error1{}}.transform([](int&&) {
-      FAIL();
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{Error1{}});
-  }
-
-  SECTION("void result with errors")
-  {
-    const auto constLValueSuccessToSuccess = result<void, Error1, Error2>{};
-    CHECK(constLValueSuccessToSuccess.transform([]() {
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{2.0f});
-
-    const auto constLValueError = result<void, Error1, Error2>{Error1{}};
-    CHECK(constLValueError.transform([]() {
-      FAIL();
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{Error1{}});
-
-    auto nonConstLValueSuccessToSuccess = result<void, Error1, Error2>{};
-    CHECK(nonConstLValueSuccessToSuccess.transform([]() {
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{2.0f});
-
-    auto nonConstLValueError = result<void, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueError.transform([]() {
-      FAIL();
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{Error1{}});
-
-    CHECK(result<void, Error1, Error2>{}.transform([]() {
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{2.0f});
-
-    CHECK(result<void, Error1, Error2>{Error1{}}.transform([]() {
-      FAIL();
-      return 2.0f;
-    }) == kdl::result<float, Error1, Error2>{Error1{}});
-  }
-
-  SECTION("void result without errors")
-  {
-    const auto constLValueSuccessToSuccess = result<void>{};
-    CHECK(constLValueSuccessToSuccess.transform([]() {
-      return 2.0f;
-    }) == kdl::result<float>{2.0f});
-
-    auto nonConstLValueSuccessToSuccess = result<void>{};
-    CHECK(nonConstLValueSuccessToSuccess.transform([]() {
-      return 2.0f;
-    }) == kdl::result<float>{2.0f});
-
-    CHECK(result<void>{}.transform([]() { return 2.0f; }) == kdl::result<float>{2.0f});
-  }
-}
-
 TEST_CASE("result_test.or_else")
 {
   SECTION("non-void result")
@@ -537,43 +476,73 @@ TEST_CASE("result_test.or_else")
     }) == result<int, Error3>{1});
 
     const auto constLValueErrorToSuccess = result<int, Error1, Error2>{Error1{}};
-    CHECK(constLValueErrorToSuccess.or_else([](const auto&) {
-      return result<int, Error3>{2};
-    }) == result<int, Error3>{2});
+    CHECK(
+      constLValueErrorToSuccess.or_else(overload(
+        [](const Error1&) { return result<int, Error3>{2}; },
+        [](const Error2&) {
+          FAIL();
+          return result<int, Error3>{3};
+        }))
+      == result<int, Error3>{2});
 
     const auto constLValueErrorToError = result<int, Error1, Error2>{Error1{}};
-    CHECK(constLValueErrorToError.or_else([](const auto&) {
-      return result<int, Error3>{Error3{}};
-    }) == result<int, Error3>{Error3{}});
+    CHECK(
+      constLValueErrorToError.or_else(overload(
+        [](const Error1&) { return result<int, Error3>{Error3{}}; },
+        [](const Error2&) {
+          FAIL();
+          return result<int, Error3>{2};
+        }))
+      == result<int, Error3>{Error3{}});
 
     auto nonConstLValueSuccess = result<int, Error1, Error2>{1};
-    CHECK(nonConstLValueSuccess.or_else([](const auto&) {
+    CHECK(nonConstLValueSuccess.or_else([](auto&) {
       FAIL();
       return result<int, Error3>{2};
     }) == result<int, Error3>{1});
 
     auto nonConstLValueErrorToSuccess = result<int, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueErrorToSuccess.or_else([](const auto&) {
-      return result<int, Error3>{2};
-    }) == result<int, Error3>{2});
+    CHECK(
+      nonConstLValueErrorToSuccess.or_else(overload(
+        [](Error1&) { return result<int, Error3>{2}; },
+        [](Error2&) {
+          FAIL();
+          return result<int, Error3>{3};
+        }))
+      == result<int, Error3>{2});
 
     auto nonConstLValueErrorToError = result<int, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueErrorToError.or_else([](const auto&) {
-      return result<int, Error3>{Error3{}};
-    }) == result<int, Error3>{Error3{}});
+    CHECK(
+      nonConstLValueErrorToError.or_else(overload(
+        [](Error1&) { return result<int, Error3>{Error3{}}; },
+        [](Error2&) {
+          FAIL();
+          return result<int, Error3>{2};
+        }))
+      == result<int, Error3>{Error3{}});
 
-    CHECK(result<int, Error1, Error2>{1}.or_else([](auto&&) {
+    CHECK(result<MoveOnly, Error1, Error2>{MoveOnly{}}.or_else([](auto&&) {
       FAIL();
-      return result<int, Error3>{2};
-    }) == result<int, Error3>{1});
+      return result<MoveOnly, Error3>{Error3{}};
+    }) == result<MoveOnly, Error3>{MoveOnly{}});
 
-    CHECK(result<int, Error1, Error2>{Error1{}}.or_else([](auto&&) {
-      return result<int, Error3>{2};
-    }) == result<int, Error3>{2});
+    CHECK(
+      result<int, Error1, Error2>{Error1{}}.or_else(overload(
+        [](Error1&&) { return result<int, Error3>{2}; },
+        [](Error2&&) {
+          FAIL();
+          return result<int, Error3>{3};
+        }))
+      == result<int, Error3>{2});
 
-    CHECK(result<int, Error1, Error2>{Error1{}}.or_else([](auto&&) {
-      return result<int, Error3>{Error3{}};
-    }) == result<int, Error3>{Error3{}});
+    CHECK(
+      result<int, Error1, Error2>{Error1{}}.or_else(overload(
+        [](Error1&&) { return result<int, Error3>{Error3{}}; },
+        [](Error2&&) {
+          FAIL();
+          return result<int, Error3>{2};
+        }))
+      == result<int, Error3>{Error3{}});
   }
 
   SECTION("void result")
@@ -585,43 +554,318 @@ TEST_CASE("result_test.or_else")
     }) == result<void, Error3>{});
 
     const auto constLValueErrorToSuccess = result<void, Error1, Error2>{Error1{}};
-    CHECK(constLValueErrorToSuccess.or_else([](const auto&) {
-      return result<void, Error3>{};
-    }) == result<void, Error3>{});
+    CHECK(
+      constLValueErrorToSuccess.or_else(overload(
+        [](const Error1&) { return result<void, Error3>{}; },
+        [](const Error2&) {
+          FAIL();
+          return result<void, Error3>{Error3{}};
+        }))
+      == result<void, Error3>{});
 
     const auto constLValueErrorToError = result<void, Error1, Error2>{Error1{}};
-    CHECK(constLValueErrorToError.or_else([](const auto&) {
-      return result<void, Error3>{Error3{}};
-    }) == result<void, Error3>{Error3{}});
+    CHECK(
+      constLValueErrorToError.or_else(overload(
+        [](const Error1&) { return result<void, Error3>{Error3{}}; },
+        [](const Error2&) {
+          FAIL();
+          return result<void, Error3>{};
+        }))
+      == result<void, Error3>{Error3{}});
 
     auto nonConstLValueSuccess = result<void, Error1, Error2>{};
-    CHECK(nonConstLValueSuccess.or_else([](const auto&) {
+    CHECK(nonConstLValueSuccess.or_else([](auto&) {
       FAIL();
       return result<void, Error3>{};
     }) == result<void, Error3>{});
 
     auto nonConstLValueErrorToSuccess = result<void, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueErrorToSuccess.or_else([](const auto&) {
-      return result<void, Error3>{};
-    }) == result<void, Error3>{});
+    CHECK(
+      nonConstLValueErrorToSuccess.or_else(overload(
+        [](Error1&) { return result<void, Error3>{}; },
+        [](Error2&) {
+          FAIL();
+          return result<void, Error3>{Error3{}};
+        }))
+      == result<void, Error3>{});
 
     auto nonConstLValueErrorToError = result<void, Error1, Error2>{Error1{}};
-    CHECK(nonConstLValueErrorToError.or_else([](const auto&) {
-      return result<void, Error3>{Error3{}};
-    }) == result<void, Error3>{Error3{}});
+    CHECK(
+      nonConstLValueErrorToError.or_else(overload(
+        [](Error1&) { return result<void, Error3>{Error3{}}; },
+        [](Error2&) {
+          FAIL();
+          return result<void, Error3>{};
+        }))
+      == result<void, Error3>{Error3{}});
 
     CHECK(result<void, Error1, Error2>{}.or_else([](auto&&) {
       FAIL();
       return result<void, Error3>{};
     }) == result<void, Error3>{});
 
-    CHECK(result<void, Error1, Error2>{Error1{}}.or_else([](auto&&) {
-      return result<void, Error3>{};
-    }) == result<void, Error3>{});
+    CHECK(
+      result<void, Error1, Error2>{Error1{}}.or_else(overload(
+        [](Error1&&) { return result<void, Error3>{}; },
+        [](Error2&&) {
+          FAIL();
+          return result<void, Error3>{Error3{}};
+        }))
+      == result<void, Error3>{});
 
-    CHECK(result<void, Error1, Error2>{Error1{}}.or_else([](auto&&) {
-      return result<void, Error3>{Error3{}};
-    }) == result<void, Error3>{Error3{}});
+    CHECK(
+      result<void, Error1, Error2>{Error1{}}.or_else(overload(
+        [](Error1&&) { return result<void, Error3>{Error3{}}; },
+        [](Error2&&) {
+          FAIL();
+          return result<void, Error3>{};
+        }))
+      == result<void, Error3>{Error3{}});
+  }
+}
+
+TEST_CASE("result_test.transform")
+{
+  SECTION("non-void result")
+  {
+    SECTION("transform to value")
+    {
+      const auto constLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+      CHECK(constLValueSuccessToSuccess.transform([](const int& x) {
+        CHECK(x == 1);
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{2.0f});
+
+      const auto constLValueError = result<int, Error1, Error2>{Error1{}};
+      CHECK(constLValueError.transform([](const int&) {
+        FAIL();
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+      auto nonConstLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+      CHECK(nonConstLValueSuccessToSuccess.transform([](int& x) {
+        CHECK(x == 1);
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{2.0f});
+
+      auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
+      CHECK(nonConstLValueError.transform([](int&) {
+        FAIL();
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+      CHECK(result<int, Error1, Error2>{1}.transform([](int&& x) {
+        CHECK(x == 1);
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{2.0f});
+
+      CHECK(result<int, Error1, Error2>{Error1{}}.transform([](int&&) {
+        FAIL();
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{Error1{}});
+    }
+
+    SECTION("transform to void")
+    {
+      const auto constLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+      CHECK(constLValueSuccessToSuccess.transform([](const int& x) {
+        CHECK(x == 1);
+      }) == kdl::result<void, Error1, Error2>{});
+
+      const auto constLValueError = result<int, Error1, Error2>{Error1{}};
+      CHECK(constLValueError.transform([](const int&) {
+        FAIL();
+      }) == kdl::result<void, Error1, Error2>{Error1{}});
+
+      auto nonConstLValueSuccessToSuccess = result<int, Error1, Error2>{1};
+      CHECK(nonConstLValueSuccessToSuccess.transform([](int& x) {
+        CHECK(x == 1);
+      }) == kdl::result<void, Error1, Error2>{});
+
+      auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
+      CHECK(nonConstLValueError.transform([](int&) {
+        FAIL();
+      }) == kdl::result<void, Error1, Error2>{Error1{}});
+
+      CHECK(result<int, Error1, Error2>{1}.transform([](int&& x) {
+        CHECK(x == 1);
+      }) == kdl::result<void, Error1, Error2>{});
+
+      CHECK(result<int, Error1, Error2>{Error1{}}.transform([](int&&) {
+        FAIL();
+      }) == kdl::result<void, Error1, Error2>{Error1{}});
+    }
+  }
+
+  SECTION("void result with errors")
+  {
+    SECTION("transform to value")
+    {
+      const auto constLValueSuccessToSuccess = result<void, Error1, Error2>{};
+      CHECK(constLValueSuccessToSuccess.transform([]() {
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{2.0f});
+
+      const auto constLValueError = result<void, Error1, Error2>{Error1{}};
+      CHECK(constLValueError.transform([]() {
+        FAIL();
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+      auto nonConstLValueSuccessToSuccess = result<void, Error1, Error2>{};
+      CHECK(nonConstLValueSuccessToSuccess.transform([]() {
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{2.0f});
+
+      auto nonConstLValueError = result<void, Error1, Error2>{Error1{}};
+      CHECK(nonConstLValueError.transform([]() {
+        FAIL();
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{Error1{}});
+
+      CHECK(result<void, Error1, Error2>{}.transform([]() {
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{2.0f});
+
+      CHECK(result<void, Error1, Error2>{Error1{}}.transform([]() {
+        FAIL();
+        return 2.0f;
+      }) == kdl::result<float, Error1, Error2>{Error1{}});
+    }
+
+    SECTION("transform to void")
+    {
+      const auto constLValueSuccessToSuccess = result<void, Error1, Error2>{};
+      CHECK(constLValueSuccessToSuccess.transform([]() {
+      }) == kdl::result<void, Error1, Error2>{});
+
+      const auto constLValueError = result<void, Error1, Error2>{Error1{}};
+      CHECK(constLValueError.transform([]() {
+        FAIL();
+      }) == kdl::result<void, Error1, Error2>{Error1{}});
+
+      auto nonConstLValueSuccessToSuccess = result<void, Error1, Error2>{};
+      CHECK(nonConstLValueSuccessToSuccess.transform([]() {
+      }) == kdl::result<void, Error1, Error2>{});
+
+      auto nonConstLValueError = result<void, Error1, Error2>{Error1{}};
+      CHECK(nonConstLValueError.transform([]() {
+        FAIL();
+      }) == kdl::result<void, Error1, Error2>{Error1{}});
+
+      CHECK(result<void, Error1, Error2>{}.transform([]() {
+      }) == kdl::result<void, Error1, Error2>{});
+
+      CHECK(result<void, Error1, Error2>{Error1{}}.transform([]() {
+        FAIL();
+      }) == kdl::result<void, Error1, Error2>{Error1{}});
+    }
+  }
+
+  SECTION("void result without errors")
+  {
+    SECTION("transform to value")
+    {
+      const auto constLValueSuccessToSuccess = result<void>{};
+      CHECK(constLValueSuccessToSuccess.transform([]() {
+        return 2.0f;
+      }) == kdl::result<float>{2.0f});
+
+      auto nonConstLValueSuccessToSuccess = result<void>{};
+      CHECK(nonConstLValueSuccessToSuccess.transform([]() {
+        return 2.0f;
+      }) == kdl::result<float>{2.0f});
+
+      CHECK(result<void>{}.transform([]() { return 2.0f; }) == kdl::result<float>{2.0f});
+    }
+
+    SECTION("transform to void")
+    {
+      const auto constLValueSuccessToSuccess = result<void>{};
+      CHECK(constLValueSuccessToSuccess.transform([]() {}) == kdl::result<void>{});
+
+      auto nonConstLValueSuccessToSuccess = result<void>{};
+      CHECK(nonConstLValueSuccessToSuccess.transform([]() {}) == kdl::result<void>{});
+
+      CHECK(result<void>{}.transform([]() {}) == kdl::result<void>{});
+    }
+  }
+}
+
+
+TEST_CASE("result_test.transform_error")
+{
+  SECTION("result can be discarded")
+  {
+    result<void, Error1>{}.transform_error([](const auto&) {}); // must not warn
+  }
+
+  SECTION("non-void result")
+  {
+    const auto constLValueSuccess = result<int, Error1, Error2>{1};
+    CHECK(constLValueSuccess.transform_error([](const auto&) {
+      FAIL();
+      return 2;
+    }) == result<int>{1});
+
+    const auto constLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(
+      constLValueError.transform_error(
+        overload([](const Error1&) { return 2; }, [](const Error2&) { return 3; }))
+      == result<int>{2});
+
+    auto nonConstLValueSuccess = result<int, Error1, Error2>{1};
+    CHECK(nonConstLValueSuccess.transform_error([](auto&) {
+      FAIL();
+      return 2;
+    }) == result<int>{1});
+
+    auto nonConstLValueError = result<int, Error1, Error2>{Error1{}};
+    CHECK(
+      nonConstLValueError.transform_error(
+        overload([](Error1&) { return 2; }, [](Error2&) { return 3; }))
+      == result<int>{2});
+
+    CHECK(result<MoveOnly, Error1, Error2>{MoveOnly{}}.transform_error([](auto&&) {
+      FAIL();
+      return MoveOnly{};
+    }) == result<MoveOnly>{MoveOnly{}});
+
+    CHECK(
+      result<int, Error1, Error2>{Error1{}}.transform_error(
+        overload([](Error1&&) { return 2; }, [](Error2&&) { return 3; }))
+      == result<int>{2});
+  }
+
+  SECTION("void result")
+  {
+    const auto constLValueSuccess = result<void, Error1, Error2>{};
+    CHECK(
+      constLValueSuccess.transform_error([](const auto&) { FAIL(); }) == result<void>{});
+
+    const auto constLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(
+      constLValueError.transform_error(
+        overload([](const Error1&) { SUCCEED(); }, [](const Error2&) { FAIL(); }))
+      == result<void>{});
+
+    auto nonConstLValueSuccess = result<void, Error1, Error2>{};
+    CHECK(nonConstLValueSuccess.transform_error([](auto&) { FAIL(); }) == result<void>{});
+
+    auto nonConstLValueError = result<void, Error1, Error2>{Error1{}};
+    CHECK(
+      nonConstLValueError.transform_error(
+        overload([](Error1&) { SUCCEED(); }, [](Error2&) { FAIL(); }))
+      == result<void>{});
+
+    CHECK(result<void, Error1, Error2>{}.transform_error([](auto&&) {
+      FAIL();
+    }) == result<void>{});
+
+    CHECK(
+      result<void, Error1, Error2>{Error1{}}.transform_error(
+        overload([](Error1&&) { SUCCEED(); }, [](Error2&&) { FAIL(); }))
+      == result<void>{});
   }
 }
 
@@ -668,9 +912,9 @@ TEST_CASE("combine_results")
   using R1 = result<int, Error1, Error2>;
   using R2 = result<double, Error2, Error3>;
 
-  auto r1 = R1{1};
-  auto r2 = R2{2.0};
-  auto r3 = R2{Error2{}};
+  const auto r1 = R1{1};
+  const auto r2 = R2{2.0};
+  const auto r3 = R2{Error2{}};
 
   CHECK(
     combine_results(r1, r2)
@@ -689,12 +933,12 @@ TEST_CASE("combine_results")
     == result<std::tuple<int, double>, Error1, Error2, Error3>{Error2{}});
 }
 
-TEST_CASE("result.for_each_result")
+TEST_CASE("result.fold_results")
 {
   SECTION("with empty range")
   {
     const auto vec = std::vector<int>{};
-    auto r = for_each_result(std::begin(vec), std::end(vec), [](const auto i) {
+    auto r = fold_results(std::begin(vec), std::end(vec), [](const auto i) {
       return result<int, std::string>{i * 2};
     });
     CHECK(r.is_success());
@@ -704,7 +948,7 @@ TEST_CASE("result.for_each_result")
   SECTION("success case")
   {
     const auto vec = std::vector<int>{1, 2, 3};
-    auto r = for_each_result(std::begin(vec), std::end(vec), [](const auto i) {
+    auto r = fold_results(std::begin(vec), std::end(vec), [](const auto i) {
       return result<int, std::string>{i * 2};
     });
     CHECK(r.is_success());
@@ -714,7 +958,7 @@ TEST_CASE("result.for_each_result")
   SECTION("error case")
   {
     const auto vec = std::vector<int>{1, 2, 3};
-    auto r = for_each_result(std::begin(vec), std::end(vec), [](const auto i) {
+    auto r = fold_results(std::begin(vec), std::end(vec), [](const auto i) {
       if (i % 2 != 0)
       {
         return result<int, std::string>{i * 2};
@@ -729,12 +973,12 @@ TEST_CASE("result.for_each_result")
   }
 }
 
-TEST_CASE("void_result.for_each_result")
+TEST_CASE("void_result.fold_results")
 {
   SECTION("with empty range")
   {
     const auto vec = std::vector<int>{};
-    auto r = for_each_result(
+    auto r = fold_results(
       std::begin(vec), std::end(vec), [](const auto) { return void_success; });
     CHECK(r.is_success());
   }
@@ -743,7 +987,7 @@ TEST_CASE("void_result.for_each_result")
   {
     const auto vec = std::vector<int>{1, 2, 3};
     auto vec_transformed = std::vector<int>{};
-    auto r = for_each_result(std::begin(vec), std::end(vec), [&](const auto i) {
+    auto r = fold_results(std::begin(vec), std::end(vec), [&](const auto i) {
       vec_transformed.push_back(i * 2);
       return void_success;
     });
@@ -754,7 +998,7 @@ TEST_CASE("void_result.for_each_result")
   SECTION("error case")
   {
     const auto vec = std::vector<int>{1, 2, 3};
-    auto r = for_each_result(
+    auto r = fold_results(
       std::begin(vec), std::end(vec), [](const auto i) -> result<void, std::string> {
         if (i % 2 != 0)
         {
@@ -767,35 +1011,6 @@ TEST_CASE("void_result.for_each_result")
       });
     CHECK(r.is_error());
     CHECK(std::visit([](const auto& e) { return e; }, r.error()) == "error");
-  }
-}
-
-TEST_CASE("result.collect_values")
-{
-  auto errors = std::vector<std::string>{};
-  const auto errorHandler = [&](std::string&& error) {
-    errors.push_back(std::move(error));
-  };
-
-  SECTION("with empty range")
-  {
-    const auto vec = std::vector<kdl::result<int, std::string>>{};
-    auto r = collect_values(std::begin(vec), std::end(vec), errorHandler);
-    CHECK_THAT(r, Catch::Equals(std::vector<int>{}));
-    CHECK_THAT(errors, Catch::Equals(std::vector<std::string>{}));
-  }
-
-  SECTION("nonempty range")
-  {
-    const auto vec = std::vector<kdl::result<int, std::string>>{
-      kdl::result<int, std::string>{1},
-      kdl::result<int, std::string>{"error 1"},
-      kdl::result<int, std::string>{2},
-      kdl::result<int, std::string>{"error 2"},
-    };
-    auto r = collect_values(std::begin(vec), std::end(vec), errorHandler);
-    CHECK_THAT(r, Catch::Equals(std::vector<int>{1, 2}));
-    CHECK_THAT(errors, Catch::Equals(std::vector<std::string>{"error 1", "error 2"}));
   }
 }
 } // namespace kdl


### PR DESCRIPTION
This PR generally improves and simplifies the `kdl::result` type. It also moves its API closer to that of `std::expected` by supplying only the same monadic functions, specifically `and_then`, `or_else`, `transform` and `transform_error`. Furthermore, we also simplify handling of ranges of results by means of `kdl::fold_results`.