### PR TITLE
Remove ToolController::anyToolDragging and use InputState::anyToolDragging

### DIFF
--- a/common/src/View/ExtrudeToolController.cpp
+++ b/common/src/View/ExtrudeToolController.cpp
@@ -80,7 +80,7 @@ void ExtrudeToolController::pick(
 
 void ExtrudeToolController::modifierKeyChange(const InputState& inputState)
 {
-  if (!anyToolDragging(inputState))
+  if (!inputState.anyToolDragging())
   {
     m_tool.updateProposedDragHandles(inputState.pickResult());
   }
@@ -88,7 +88,7 @@ void ExtrudeToolController::modifierKeyChange(const InputState& inputState)
 
 void ExtrudeToolController::mouseMove(const InputState& inputState)
 {
-  if (handleInput(inputState) && !anyToolDragging(inputState))
+  if (handleInput(inputState) && !inputState.anyToolDragging())
   {
     m_tool.updateProposedDragHandles(inputState.pickResult());
   }

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -316,7 +316,7 @@ private:
   {
     using namespace Model::HitFilters;
 
-    if (!anyToolDragging(inputState))
+    if (!inputState.anyToolDragging())
     {
       const Model::Hit& hit =
         inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));
@@ -454,7 +454,7 @@ protected:
   {
     using namespace Model::HitFilters;
 
-    if (!anyToolDragging(inputState))
+    if (!inputState.anyToolDragging())
     {
       const Model::Hit& hit =
         inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -148,7 +148,7 @@ void ScaleObjectsToolController::modifierKeyChange(const InputState& inputState)
 
 void ScaleObjectsToolController::mouseMove(const InputState& inputState)
 {
-  if (m_tool.applies() && !anyToolDragging(inputState))
+  if (m_tool.applies() && !inputState.anyToolDragging())
   {
     m_tool.updatePickedHandle(inputState.pickResult());
   }

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -117,7 +117,7 @@ static HandlePositionProposer makeHandlePositionProposer(
 
 void ShearObjectsToolController::mouseMove(const InputState& inputState)
 {
-  if (m_tool.applies() && !anyToolDragging(inputState))
+  if (m_tool.applies() && !inputState.anyToolDragging())
   {
     m_tool.updatePickedSide(inputState.pickResult());
   }

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -64,10 +64,6 @@ std::unique_ptr<DragTracker> ToolController::acceptMouseDrag(const InputState&)
 {
   return nullptr;
 }
-bool ToolController::anyToolDragging(const InputState&) const
-{
-  return false;
-}
 
 void ToolController::setRenderOptions(const InputState&, Renderer::RenderContext&) const
 {

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -76,7 +76,6 @@ public:
   virtual void mouseScroll(const InputState& inputState);
 
   virtual std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState);
-  virtual bool anyToolDragging(const InputState& inputState) const;
 
   virtual std::unique_ptr<DropTracker> acceptDrop(
     const InputState& inputState, const std::string& payload);

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -409,7 +409,7 @@ void UVOriginTool::render(
   Renderer::RenderContext&,
   Renderer::RenderBatch& renderBatch)
 {
-  if (!m_helper.valid() || anyToolDragging(inputState))
+  if (!m_helper.valid() || inputState.anyToolDragging())
   {
     return;
   }

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -394,7 +394,7 @@ void UVRotateTool::render(
   using namespace Model::HitFilters;
 
   if (
-    anyToolDragging(inputState) || !m_helper.valid()
+    inputState.anyToolDragging() || !m_helper.valid()
     || !m_helper.face()->attributes().valid())
   {
     return;

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -321,7 +321,7 @@ void UVScaleTool::render(
   using namespace Model::HitFilters;
 
   if (
-    anyToolDragging(inputState) || !m_helper.valid()
+    inputState.anyToolDragging() || !m_helper.valid()
     || !m_helper.face()->attributes().valid())
   {
     return;

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -177,7 +177,7 @@ private:
   {
     MovePartBase::render(inputState, renderContext, renderBatch);
 
-    if (!anyToolDragging(inputState))
+    if (!inputState.anyToolDragging())
     {
       const Model::Hit hit = findDraggableHandle(inputState);
       if (hit.hasType(

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -257,7 +257,7 @@ protected:
       Renderer::RenderBatch& renderBatch) override
     {
       m_tool.renderHandles(renderContext, renderBatch);
-      if (!anyToolDragging(inputState))
+      if (!inputState.anyToolDragging())
       {
         const auto hit = findDraggableHandle(inputState);
         if (hit.hasType(m_hitType))


### PR DESCRIPTION
This seems to be an oversight from a previous refactoring where I introduced `DragTracker`. There weren't any bug reports, but I noticed that the extrude tool would print

```
updateProposedDragHandles called during a drag
```

in the console if shift was released during a drag.