### PR TITLE
Sort includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,3 +71,41 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Cpp11
 UseTab: Never
+
+# We must include Qt headers first because of this issue:
+# https://bugreports.qt.io/browse/QTBUG-73263
+# The following configuration groups includes like so:
+# - main include file
+# - Qt includes
+# - TB includes
+# - kdl lib
+# - vecmath lib
+# - std lib
+# - anything else
+# - catch2
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^<GL/glew\.h>$'
+    Priority:        1
+    CaseSensitive:   true
+  - Regex:           '^<Q.*'
+    Priority:        2
+    CaseSensitive:   true
+  - Regex:           '^<kdl/.*'
+    Priority:        4
+  - Regex:           '^"kdl/.*'
+    Priority:        4
+  - Regex:           '^<vecmath/.*'
+    Priority:        5
+  - Regex:           '^"vecmath/.*'
+    Priority:        5
+  - Regex:           '^<catch2/.*'
+    Priority:        10
+  - Regex:           '^".*'
+    Priority:        3
+  - Regex:           '^<.+/.*'
+    Priority:        7
+  - Regex:           '^<.*'
+    Priority:        8
+  - Regex:           '^.*'
+    Priority:        9

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,6 +11,7 @@ jobs:
           - 'common'
           - 'dump-shortcuts'
           - 'lib/kdl'
+          - 'lib/vecmath'
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.

--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -17,17 +17,17 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QApplication>
+#include <QSettings>
+#include <QSurfaceFormat>
+#include <QtGlobal>
+
 #include "Model/GameFactory.h"
 #include "PreferenceManager.h"
 #include "TrenchBroomApp.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentCommandFacade.h"
 #include "View/MapFrame.h"
-
-#include <QApplication>
-#include <QSettings>
-#include <QSurfaceFormat>
-#include <QtGlobal>
 
 extern void qt_set_sequence_auto_mnemonic(bool b);
 

--- a/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
+++ b/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
@@ -17,7 +17,9 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "../../test/src/Catch2.h"
 #include "Assets/Texture.h"
+#include "BenchmarkUtils.h"
 #include "Exceptions.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
@@ -34,9 +36,6 @@
 #include <string>
 #include <tuple>
 #include <vector>
-
-#include "../../test/src/Catch2.h"
-#include "BenchmarkUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -26,11 +26,11 @@
 #include "Renderer/TexturedIndexRangeRenderer.h"
 #include "octree.h"
 
+#include <kdl/vector_utils.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/forward.h>
 #include <vecmath/intersection.h>
-
-#include <kdl/vector_utils.h>
 
 #include <string>
 

--- a/common/src/Assets/ModelDefinition.h
+++ b/common/src/Assets/ModelDefinition.h
@@ -24,6 +24,7 @@
 #include "IO/Path.h"
 
 #include <kdl/reflection_decl.h>
+
 #include <vecmath/vec.h>
 
 #include <iosfwd>

--- a/common/src/Assets/Palette.h
+++ b/common/src/Assets/Palette.h
@@ -24,9 +24,6 @@
 #include <kdl/reflection_decl.h>
 #include <kdl/result_forward.h>
 
-#include <kdl/reflection_decl.h>
-#include <kdl/result_forward.h>
-
 #include <cassert>
 #include <iosfwd>
 #include <memory>

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -18,15 +18,16 @@
  */
 
 #include "Texture.h"
+
 #include "Assets/TextureBuffer.h"
 #include "Assets/TextureCollection.h"
 #include "Macros.h"
 #include "Renderer/GL.h"
 
-#include <vecmath/vec_io.h>
-
 #include <kdl/overload.h>
 #include <kdl/reflection_impl.h>
+
+#include <vecmath/vec_io.h>
 
 #include <algorithm> // for std::max
 #include <cassert>

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -24,9 +24,9 @@
 #include "IO/Path.h"
 #include "Renderer/GL.h"
 
-#include <vecmath/forward.h>
-
 #include <kdl/reflection_decl.h>
+
+#include <vecmath/forward.h>
 
 #include <atomic>
 #include <set>

--- a/common/src/Assets/TextureBuffer.cpp
+++ b/common/src/Assets/TextureBuffer.cpp
@@ -24,7 +24,6 @@
 #include <vecmath/vec.h>
 
 #include <FreeImage.h>
-
 #include <algorithm> // for std::max
 
 namespace TrenchBroom

--- a/common/src/FileLogger.cpp
+++ b/common/src/FileLogger.cpp
@@ -19,6 +19,8 @@
 
 #include "FileLogger.h"
 
+#include <QString>
+
 #include "Ensure.h"
 #include "IO/DiskIO.h"
 #include "IO/IOUtils.h"
@@ -27,8 +29,6 @@
 
 #include <cassert>
 #include <string>
-
-#include <QString>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/Bsp29Parser.h
+++ b/common/src/IO/Bsp29Parser.h
@@ -22,12 +22,12 @@
 #include "Assets/TextureCollection.h"
 #include "IO/EntityModelParser.h"
 
+#include <vecmath/forward.h>
+#include <vecmath/vec.h>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <vecmath/forward.h>
-#include <vecmath/vec.h>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/DiskIO.cpp
+++ b/common/src/IO/DiskIO.cpp
@@ -19,6 +19,9 @@
 
 #include "DiskIO.h"
 
+#include <QDir>
+#include <QFileInfo>
+
 #include "Exceptions.h"
 #include "IO/File.h"
 #include "IO/FileSystemUtils.h"
@@ -30,9 +33,6 @@
 
 #include <fstream>
 #include <string>
-
-#include <QDir>
-#include <QFileInfo>
 
 namespace TrenchBroom::IO
 {

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -34,12 +34,11 @@
 
 #include <vecmath/vec_io.h>
 
-#include <tinyxml2.h>
-
 #include <cstdlib>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <tinyxml2.h>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/EntityDefinitionClassInfo.h
+++ b/common/src/IO/EntityDefinitionClassInfo.h
@@ -23,9 +23,9 @@
 #include "Color.h"
 #include "FloatType.h"
 
-#include <vecmath/bbox.h>
-
 #include <kdl/reflection_decl.h>
+
+#include <vecmath/bbox.h>
 
 #include <iosfwd>
 #include <memory>

--- a/common/src/IO/ExportOptions.cpp
+++ b/common/src/IO/ExportOptions.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "IO/ExportOptions.h"
+
 #include "Macros.h"
 
 #include <kdl/overload.h>

--- a/common/src/IO/ImageLoaderImpl.h
+++ b/common/src/IO/ImageLoaderImpl.h
@@ -21,9 +21,8 @@
 
 #include "IO/ImageLoader.h"
 
-#include <vector>
-
 #include <FreeImage.h>
+#include <vector>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/ImageSpriteParser.cpp
+++ b/common/src/IO/ImageSpriteParser.cpp
@@ -27,11 +27,11 @@
 #include "Renderer/IndexRangeMapBuilder.h"
 #include "Renderer/PrimType.h"
 
-#include <vecmath/bbox.h>
-#include <vecmath/vec.h>
-
 #include <kdl/result.h>
 #include <kdl/string_format.h>
+
+#include <vecmath/bbox.h>
+#include <vecmath/vec.h>
 
 #include <vector>
 

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -34,15 +34,15 @@
 #include "Model/VisibilityState.h"
 #include "Model/WorldNode.h"
 
-#include <vecmath/mat.h>
-#include <vecmath/mat_io.h>
-
 #include <kdl/parallel.h>
 #include <kdl/result.h>
 #include <kdl/result_fold.h>
 #include <kdl/string_format.h>
 #include <kdl/string_utils.h>
 #include <kdl/vector_utils.h>
+
+#include <vecmath/mat.h>
+#include <vecmath/mat_io.h>
 
 #include <cassert>
 #include <optional>

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -28,11 +28,11 @@
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
 
-#include <vecmath/vec_io.h> // for Color stream output operator
-
 #include <kdl/overload.h>
 #include <kdl/string_format.h>
 #include <kdl/string_utils.h>
+
+#include <vecmath/vec_io.h> // for Color stream output operator
 
 #include <fmt/format.h>
 

--- a/common/src/IO/ObjParser.cpp
+++ b/common/src/IO/ObjParser.cpp
@@ -33,10 +33,10 @@
 #include "Renderer/TexturedIndexRangeMap.h"
 #include "Renderer/TexturedIndexRangeMapBuilder.h"
 
-#include <vecmath/forward.h>
-
 #include <kdl/result.h>
 #include <kdl/string_utils.h>
+
+#include <vecmath/forward.h>
 
 #include <functional>
 #include <string>

--- a/common/src/IO/ParserStatus.cpp
+++ b/common/src/IO/ParserStatus.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "ParserStatus.h"
+
 #include "Exceptions.h"
 #include "Logger.h"
 

--- a/common/src/IO/PathQt.h
+++ b/common/src/IO/PathQt.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QString>
+
 #include "IO/Path.h"
 
 #include <string_view>
-
-#include <QString>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/ResourceUtils.cpp
+++ b/common/src/IO/ResourceUtils.cpp
@@ -19,6 +19,17 @@
 
 #include "ResourceUtils.h"
 
+#include <QApplication>
+#include <QColor>
+#include <QDebug>
+#include <QIcon>
+#include <QImage>
+#include <QPainter>
+#include <QPalette>
+#include <QPixmap>
+#include <QSvgRenderer>
+#include <QThread>
+
 #include "Assets/Texture.h"
 #include "Ensure.h"
 #include "IO/File.h"
@@ -34,17 +45,6 @@
 
 #include <map>
 #include <string>
-
-#include <QApplication>
-#include <QColor>
-#include <QDebug>
-#include <QIcon>
-#include <QImage>
-#include <QPainter>
-#include <QPalette>
-#include <QPixmap>
-#include <QSvgRenderer>
-#include <QThread>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/SystemPaths.cpp
+++ b/common/src/IO/SystemPaths.cpp
@@ -19,14 +19,14 @@
 
 #include "SystemPaths.h"
 
-#include "IO/DiskIO.h"
-#include "IO/PathInfo.h"
-#include "IO/PathQt.h"
-
 #include <QCoreApplication>
 #include <QDir>
 #include <QStandardPaths>
 #include <QString>
+
+#include "IO/DiskIO.h"
+#include "IO/PathInfo.h"
+#include "IO/PathQt.h"
 
 #include <string>
 #include <vector>

--- a/common/src/IO/Token.h
+++ b/common/src/IO/Token.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <kdl/string_utils.h>
+
 #include <cassert>
 #include <string>
-
-#include <kdl/string_utils.h>
 
 namespace TrenchBroom
 {

--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -19,10 +19,9 @@
 
 #pragma once
 
-#include "Token.h"
-
 #include "Exceptions.h"
 #include "Macros.h"
+#include "Token.h"
 
 #include <kdl/string_format.h>
 

--- a/common/src/IO/ZipFileSystem.h
+++ b/common/src/IO/ZipFileSystem.h
@@ -21,9 +21,9 @@
 
 #include "IO/ImageFileSystem.h"
 
-#include <memory>
-
 #include <miniz/miniz.h>
+
+#include <memory>
 
 namespace TrenchBroom
 {

--- a/common/src/Logger.cpp
+++ b/common/src/Logger.cpp
@@ -19,9 +19,9 @@
 
 #include "Logger.h"
 
-#include <string>
-
 #include <QString>
+
+#include <string>
 
 namespace TrenchBroom
 {

--- a/common/src/Model/BezierPatch.cpp
+++ b/common/src/Model/BezierPatch.cpp
@@ -22,11 +22,11 @@
 #include "Assets/Texture.h"
 #include "Ensure.h"
 
+#include <kdl/reflection_impl.h>
+
 #include <vecmath/bbox_io.h>
 #include <vecmath/bezier_surface.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/reflection_impl.h>
 
 #include <cassert>
 

--- a/common/src/Model/BezierPatch.h
+++ b/common/src/Model/BezierPatch.h
@@ -22,11 +22,11 @@
 #include "Assets/AssetReference.h"
 #include "FloatType.h"
 
+#include <kdl/reflection_decl.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
-
-#include <kdl/reflection_decl.h>
 
 #include <string>
 #include <vector>

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -18,12 +18,13 @@
  */
 
 #include "BrushFaceAttributes.h"
+
 #include "Assets/Texture.h"
+
+#include <kdl/reflection_impl.h>
 
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/reflection_impl.h>
 
 #include <string>
 

--- a/common/src/Model/BrushFaceAttributes.h
+++ b/common/src/Model/BrushFaceAttributes.h
@@ -21,9 +21,9 @@
 
 #include "Color.h"
 
-#include <vecmath/forward.h>
-
 #include <kdl/reflection_decl.h>
+
+#include <vecmath/forward.h>
 
 #include <optional>
 #include <string>

--- a/common/src/Model/BrushGeometry.h
+++ b/common/src/Model/BrushGeometry.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "FloatType.h"
-
 #include "Model/Polyhedron_BrushGeometryPayload.h"
 #include "Model/Polyhedron_DefaultPayload.h"
 #include "Model/Polyhedron_Forward.h"

--- a/common/src/Model/EntityRotation.h
+++ b/common/src/Model/EntityRotation.h
@@ -21,9 +21,9 @@
 
 #include "FloatType.h"
 
-#include <vecmath/forward.h>
-
 #include <kdl/reflection_decl.h>
+
+#include <vecmath/forward.h>
 
 #include <iosfwd>
 #include <optional>

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -28,9 +28,9 @@
 #include "Model/GameEngineConfig.h"
 #include "Model/Tag.h"
 
-#include <vecmath/bbox.h>
-
 #include <kdl/reflection_decl.h>
+
+#include <vecmath/bbox.h>
 
 #include <optional>
 #include <set>

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -24,11 +24,11 @@
 #include "Model/NodeVisitor.h"
 #include "Model/Tag.h"
 
+#include <kdl/reflection_decl.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/forward.h>
 #include <vecmath/util.h>
-
-#include <kdl/reflection_decl.h>
 
 #include <memory>
 #include <string>

--- a/common/src/Model/PatchNode.h
+++ b/common/src/Model/PatchNode.h
@@ -24,10 +24,10 @@
 #include "Model/Node.h"
 #include "Model/Object.h"
 
+#include <kdl/reflection_decl.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/vec.h>
-
-#include <kdl/reflection_decl.h>
 
 #include <optional>
 

--- a/common/src/Model/PickResult.cpp
+++ b/common/src/Model/PickResult.cpp
@@ -23,11 +23,11 @@
 #include "Model/CompareHits.h"
 #include "Model/Hit.h"
 
+#include <kdl/vector_utils.h>
+
 #include <vecmath/scalar.h>
 #include <vecmath/util.h>
 #include <vecmath/vec.h>
-
-#include <kdl/vector_utils.h>
 
 #include <algorithm>
 #include <cassert>

--- a/common/src/Model/PointTrace.h
+++ b/common/src/Model/PointTrace.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <kdl/reflection_decl.h>
+
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
-
-#include <kdl/reflection_decl.h>
 
 #include <optional>
 #include <vector>

--- a/common/src/Model/Polyhedron_Clip.h
+++ b/common/src/Model/Polyhedron_Clip.h
@@ -22,7 +22,6 @@
 #include "Ensure.h"
 #include "Exceptions.h"
 #include "Macros.h"
-
 #include "Polyhedron.h"
 
 #include <vecmath/plane.h>

--- a/common/src/Model/Polyhedron_ConvexHull.h
+++ b/common/src/Model/Polyhedron_ConvexHull.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "Macros.h"
-
 #include "Polyhedron.h"
 
 #include <kdl/vector_utils.h>

--- a/common/src/Model/Polyhedron_Face.h
+++ b/common/src/Model/Polyhedron_Face.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "Macros.h"
-
 #include "Polyhedron.h"
 
 #include <vecmath/constants.h>

--- a/common/src/Model/Polyhedron_IO.h
+++ b/common/src/Model/Polyhedron_IO.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Polyhedron.h"
+
 #include <kdl/intrusive_circular_list.h>
 
 #include <ostream>

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -21,7 +21,6 @@
 
 #include "FloatType.h"
 #include "Macros.h"
-
 #include "Model/BrushFaceAttributes.h"
 
 #include <vecmath/vec.h>

--- a/common/src/NotifierConnection.cpp
+++ b/common/src/NotifierConnection.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "NotifierConnection.h"
+
 #include "Notifier.h"
 
 #include <kdl/memory_utils.h>

--- a/common/src/Preference.cpp
+++ b/common/src/Preference.cpp
@@ -19,12 +19,12 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 #include "Preference.h"
 
-#include "Color.h"
-#include "IO/PathQt.h"
-
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QKeySequence>
+
+#include "Color.h"
+#include "IO/PathQt.h"
 
 namespace TrenchBroom
 {

--- a/common/src/Preference.h
+++ b/common/src/Preference.h
@@ -19,15 +19,15 @@
 
 #pragma once
 
+#include <QJsonValue>
+#include <QString>
+#include <QTextStream>
+
 #include "IO/Path.h"
 #include "Macros.h"
 #include "View/KeyboardShortcut.h"
 
 #include <optional>
-
-#include <QJsonValue>
-#include <QString>
-#include <QTextStream>
 
 class QKeySequence;
 

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -19,11 +19,6 @@
 
 #include "PreferenceManager.h"
 
-#include "IO/PathQt.h"
-#include "IO/SystemPaths.h"
-#include "Preferences.h"
-#include "View/Actions.h"
-
 #include <QDebug>
 #include <QDir>
 #include <QFileSystemWatcher>
@@ -32,6 +27,11 @@
 #include <QLockFile>
 #include <QMessageBox>
 #include <QSaveFile>
+
+#include "IO/PathQt.h"
+#include "IO/SystemPaths.h"
+#include "Preferences.h"
+#include "View/Actions.h"
 #if defined(Q_OS_WIN)
 #include <QSettings>
 #endif

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -19,6 +19,13 @@
 
 #pragma once
 
+#include <QApplication>
+#include <QByteArray>
+#include <QJsonParseError>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+
 #include "Ensure.h"
 #include "Macros.h"
 #include "Notifier.h"
@@ -30,13 +37,6 @@
 #include <map>
 #include <memory>
 #include <vector>
-
-#include <QApplication>
-#include <QByteArray>
-#include <QJsonParseError>
-#include <QString>
-#include <QThread>
-#include <QTimer>
 
 class QTextStream;
 class QFileSystemWatcher;

--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -18,12 +18,13 @@
  */
 
 #include "Preferences.h"
+
+#include <QKeySequence>
+
 #include "IO/Path.h"
 #include "View/MapViewLayout.h"
 
 #include <vecmath/util.h>
-
-#include <QKeySequence>
 
 namespace TrenchBroom
 {

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -23,9 +23,9 @@
 #include "IO/Path.h"
 #include "Preference.h"
 
-#include <vector>
-
 #include <vecmath/util.h>
+
+#include <vector>
 
 namespace TrenchBroom
 {

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -26,6 +26,7 @@
 #include "Renderer/TriangleRenderer.h"
 
 #include <kdl/vector_set.h>
+
 #include <vecmath/forward.h>
 
 #include <vector>

--- a/common/src/Renderer/FontManager.cpp
+++ b/common/src/Renderer/FontManager.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "FontManager.h"
+
 #include "Renderer/FontDescriptor.h"
 #include "Renderer/FreeTypeFontFactory.h"
 #include "Renderer/TextureFont.h"

--- a/common/src/Renderer/GL.h
+++ b/common/src/Renderer/GL.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <GL/glew.h>
+
 #include <string>
 #include <vector>
-
-#include <GL/glew.h>
 
 namespace TrenchBroom
 {

--- a/common/src/Renderer/RenderContext.cpp
+++ b/common/src/Renderer/RenderContext.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "RenderContext.h"
+
 #include "Renderer/Camera.h"
 
 namespace TrenchBroom

--- a/common/src/Renderer/SpikeGuideRenderer.cpp
+++ b/common/src/Renderer/SpikeGuideRenderer.cpp
@@ -31,11 +31,11 @@
 #include "Renderer/VboManager.h"
 #include "View/MapDocument.h"
 
-#include <memory>
-
 #include <vecmath/forward.h>
 #include <vecmath/ray.h>
 #include <vecmath/vec.h>
+
+#include <memory>
 
 namespace TrenchBroom
 {

--- a/common/src/Thread.cpp
+++ b/common/src/Thread.cpp
@@ -19,10 +19,10 @@
 
 #include "Thread.h"
 
-#include "Ensure.h"
-
 #include <QApplication>
 #include <QThread>
+
+#include "Ensure.h"
 
 namespace TrenchBroom
 {

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -49,6 +49,20 @@
 #include "View/MainMenuBuilder.h"
 #endif
 
+#include <QColor>
+#include <QCommandLineParser>
+#include <QDebug>
+#include <QDesktopServices>
+#include <QFile>
+#include <QFileDialog>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QPalette>
+#include <QProxyStyle>
+#include <QStandardPaths>
+#include <QSysInfo>
+#include <QUrl>
+
 #include <kdl/set_temp.h>
 #include <kdl/string_utils.h>
 
@@ -63,20 +77,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include <QColor>
-#include <QCommandLineParser>
-#include <QDebug>
-#include <QDesktopServices>
-#include <QFile>
-#include <QFileDialog>
-#include <QMenuBar>
-#include <QMessageBox>
-#include <QPalette>
-#include <QProxyStyle>
-#include <QStandardPaths>
-#include <QSysInfo>
-#include <QUrl>
 
 namespace TrenchBroom
 {

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QApplication>
+
 #include "Notifier.h"
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QApplication>
 
 class QMenu;
 class QSettings;

--- a/common/src/TrenchBroomStackWalker.cpp
+++ b/common/src/TrenchBroomStackWalker.cpp
@@ -19,8 +19,9 @@
 
 #ifdef _WIN32
 #ifdef _MSC_VER
-#include "StackWalker.h"
 #include <QMutexLocker>
+
+#include "StackWalker.h"
 #endif
 #else
 #include <execinfo.h>

--- a/common/src/View/AboutDialog.cpp
+++ b/common/src/View/AboutDialog.cpp
@@ -19,11 +19,11 @@
 
 #include "AboutDialog.h"
 
-#include "View/AppInfoPanel.h"
-#include "View/QtUtils.h"
-
 #include <QHBoxLayout>
 #include <QLabel>
+
+#include "View/AppInfoPanel.h"
+#include "View/QtUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -19,6 +19,9 @@
 
 #include "Actions.h"
 
+#include <QKeySequence>
+#include <QString>
+
 #include "Assets/EntityDefinition.h"
 #include "Model/EntityProperties.h"
 #include "Model/Tag.h"
@@ -32,9 +35,6 @@
 #include "View/MapViewBase.h"
 
 #include "vecmath/util.h"
-
-#include <QKeySequence>
-#include <QString>
 
 #include <cassert>
 #include <set>

--- a/common/src/View/Actions.h
+++ b/common/src/View/Actions.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <QKeySequence>
+
 #include "Ensure.h"
 #include "IO/Path.h"
 #include "Macros.h"
@@ -29,8 +31,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QKeySequence>
 
 namespace TrenchBroom
 {

--- a/common/src/View/Animation.cpp
+++ b/common/src/View/Animation.cpp
@@ -19,12 +19,12 @@
 
 #include "Animation.h"
 
+#include <QTimer>
+
 #include "Ensure.h"
 
 #include <algorithm>
 #include <cassert>
-
-#include <QTimer>
 
 namespace TrenchBroom
 {

--- a/common/src/View/Animation.h
+++ b/common/src/View/Animation.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <QElapsedTimer>
+#include <QObject>
+
 #include <map>
 #include <memory>
 #include <vector>
-
-#include <QElapsedTimer>
-#include <QObject>
 
 class QTimer;
 

--- a/common/src/View/AppInfoPanel.cpp
+++ b/common/src/View/AppInfoPanel.cpp
@@ -19,18 +19,18 @@
 
 #include "AppInfoPanel.h"
 
-#include "IO/ResourceUtils.h"
-#include "View/BorderLine.h"
-#include "View/ClickableLabel.h"
-#include "View/GetVersion.h"
-#include "View/QtUtils.h"
-
 #include <QApplication>
 #include <QClipboard>
 #include <QLabel>
 #include <QString>
 #include <QStringBuilder>
 #include <QVBoxLayout>
+
+#include "IO/ResourceUtils.h"
+#include "View/BorderLine.h"
+#include "View/ClickableLabel.h"
+#include "View/GetVersion.h"
+#include "View/QtUtils.h"
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/BrushVertexCommands.cpp
+++ b/common/src/View/BrushVertexCommands.cpp
@@ -18,8 +18,8 @@
  */
 
 #include "BrushVertexCommands.h"
-#include "View/SwapNodeContentsCommand.h"
 
+#include "View/SwapNodeContentsCommand.h"
 #include "View/VertexTool.h"
 
 #include <kdl/vector_utils.h>

--- a/common/src/View/CachingLogger.h
+++ b/common/src/View/CachingLogger.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <QString>
+
 #include "Logger.h"
 
 #include <string>
 #include <vector>
-
-#include <QString>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -19,16 +19,16 @@
 
 #include "CellView.h"
 
-#include "PreferenceManager.h"
-#include "Preferences.h"
-#include "View/CellLayout.h"
-#include "View/RenderView.h"
-
 #include <QDrag>
 #include <QMimeData>
 #include <QPropertyAnimation>
 #include <QScrollBar>
 #include <QToolTip>
+
+#include "PreferenceManager.h"
+#include "Preferences.h"
+#include "View/CellLayout.h"
+#include "View/RenderView.h"
 
 #include <algorithm>
 

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <QPoint>
+
 #include "View/CellLayout.h"
 #include "View/RenderView.h"
-
-#include <QPoint>
 
 class QScrollBar;
 class QDrag;

--- a/common/src/View/ChoosePathTypeDialog.cpp
+++ b/common/src/View/ChoosePathTypeDialog.cpp
@@ -19,14 +19,14 @@
 
 #include "ChoosePathTypeDialog.h"
 
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QRadioButton>
+
 #include "IO/PathQt.h"
 #include "IO/SystemPaths.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QDialogButtonBox>
-#include <QLabel>
-#include <QRadioButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ChoosePathTypeDialog.h
+++ b/common/src/View/ChoosePathTypeDialog.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "IO/Path.h"
-
 #include <QDialog>
+
+#include "IO/Path.h"
 
 class QRadioButton;
 class QWidget;

--- a/common/src/View/CollapsibleTitledPanel.cpp
+++ b/common/src/View/CollapsibleTitledPanel.cpp
@@ -19,12 +19,12 @@
 
 #include "CollapsibleTitledPanel.h"
 
+#include <QLabel>
+#include <QLayout>
+
 #include "View/BorderLine.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QLabel>
-#include <QLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CollapsibleTitledPanel.h
+++ b/common/src/View/CollapsibleTitledPanel.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "View/TitleBar.h"
-
 #include <QWidget>
+
+#include "View/TitleBar.h"
 
 class QLabel;
 

--- a/common/src/View/ColorButton.cpp
+++ b/common/src/View/ColorButton.cpp
@@ -19,11 +19,11 @@
 
 #include "ColorButton.h"
 
-#include "View/ViewConstants.h"
-
 #include <QBoxLayout>
 #include <QColorDialog>
 #include <QPushButton>
+
+#include "View/ViewConstants.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/ColorModel.cpp
+++ b/common/src/View/ColorModel.cpp
@@ -19,11 +19,11 @@
 
 #include "ColorModel.h"
 
+#include <QColorDialog>
+
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "QtUtils.h"
-
-#include <QColorDialog>
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/ColorModel.h
+++ b/common/src/View/ColorModel.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QAbstractTableModel>
+
 #include "Color.h"
 #include "IO/Path.h"
 #include "Preference.h"
-
-#include <QAbstractTableModel>
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/ColorsPreferencePane.cpp
+++ b/common/src/View/ColorsPreferencePane.cpp
@@ -19,14 +19,14 @@
 
 #include "ColorsPreferencePane.h"
 
-#include "View/ColorModel.h"
-#include "View/QtUtils.h"
-
 #include <QHeaderView>
 #include <QLabel>
 #include <QLineEdit>
 #include <QSortFilterProxyModel>
 #include <QTableView>
+
+#include "View/ColorModel.h"
+#include "View/QtUtils.h"
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -19,6 +19,8 @@
 
 #include "CommandProcessor.h"
 
+#include <QDateTime>
+
 #include "Exceptions.h"
 #include "Notifier.h"
 #include "View/Command.h"
@@ -30,8 +32,6 @@
 #include <kdl/vector_utils.h>
 
 #include <algorithm>
-
-#include <QDateTime>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationDialog.cpp
+++ b/common/src/View/CompilationDialog.cpp
@@ -19,6 +19,15 @@
 
 #include "CompilationDialog.h"
 
+#include <QApplication>
+#include <QCloseEvent>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTextEdit>
+
+#include "Ensure.h"
 #include "Model/CompilationProfile.h"
 #include "Model/Game.h"
 #include "Model/GameFactory.h"
@@ -32,16 +41,6 @@
 #include "View/Splitter.h"
 #include "View/TitledPanel.h"
 #include "View/ViewConstants.h"
-
-#include <QApplication>
-#include <QCloseEvent>
-#include <QDialogButtonBox>
-#include <QLabel>
-#include <QMessageBox>
-#include <QPushButton>
-#include <QTextEdit>
-
-#include "Ensure.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationDialog.h
+++ b/common/src/View/CompilationDialog.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "View/CompilationRun.h"
-
 #include <QDialog>
+
+#include "View/CompilationRun.h"
 
 class QLabel;
 class QPushButton;

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -19,6 +19,13 @@
 
 #include "CompilationProfileEditor.h"
 
+#include <QCompleter>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QMenu>
+#include <QStackedWidget>
+#include <QToolButton>
+
 #include "Model/CompilationProfile.h"
 #include "Model/CompilationTask.h"
 #include "View/BorderLine.h"
@@ -31,13 +38,6 @@
 
 #include "kdl/vector_utils.h"
 #include <kdl/memory_utils.h>
-
-#include <QCompleter>
-#include <QFormLayout>
-#include <QLineEdit>
-#include <QMenu>
-#include <QStackedWidget>
-#include <QToolButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationProfileListBox.cpp
+++ b/common/src/View/CompilationProfileListBox.cpp
@@ -19,12 +19,12 @@
 
 #include "CompilationProfileListBox.h"
 
+#include <QBoxLayout>
+
 #include "Model/CompilationConfig.h"
 #include "Model/CompilationProfile.h"
 #include "View/ElidedLabel.h"
 #include "View/QtUtils.h"
-
-#include <QBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationProfileManager.cpp
+++ b/common/src/View/CompilationProfileManager.cpp
@@ -19,6 +19,9 @@
 
 #include "CompilationProfileManager.h"
 
+#include <QMenu>
+#include <QToolButton>
+
 #include "Model/CompilationConfig.h"
 #include "Model/CompilationProfile.h"
 #include "View/BorderLine.h"
@@ -28,9 +31,6 @@
 #include "View/TitledPanel.h"
 
 #include "kdl/vector_utils.h"
-
-#include <QMenu>
-#include <QToolButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationProfileManager.h
+++ b/common/src/View/CompilationProfileManager.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "Model/CompilationConfig.h"
 
 #include <memory>
-
-#include <QWidget>
 
 class QAbstractButton;
 class QPoint;

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -19,6 +19,11 @@
 
 #include "CompilationRunner.h"
 
+#include <QDir>
+#include <QMetaEnum>
+#include <QProcess>
+#include <QtGlobal>
+
 #include "Exceptions.h"
 #include "IO/DiskIO.h"
 #include "IO/ExportOptions.h"
@@ -36,11 +41,6 @@
 #include <kdl/vector_utils.h>
 
 #include <string>
-
-#include <QDir>
-#include <QMetaEnum>
-#include <QProcess>
-#include <QtGlobal>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationRunner.h
+++ b/common/src/View/CompilationRunner.h
@@ -19,15 +19,15 @@
 
 #pragma once
 
+#include <QObject>
+#include <QProcess> // for QProcess::ProcessError
+
 #include "Macros.h"
 #include "Model/CompilationTask.h"
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QObject>
-#include <QProcess> // for QProcess::ProcessError
 
 namespace TrenchBroom
 {

--- a/common/src/View/CompilationTaskListBox.cpp
+++ b/common/src/View/CompilationTaskListBox.cpp
@@ -19,6 +19,15 @@
 
 #include "CompilationTaskListBox.h"
 
+#include <QBoxLayout>
+#include <QCheckBox>
+#include <QCompleter>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+
 #include "EL/EvaluationContext.h"
 #include "EL/Interpolator.h"
 #include "Model/CompilationProfile.h"
@@ -34,15 +43,6 @@
 
 #include <kdl/memory_utils.h>
 #include <kdl/overload.h>
-
-#include <QBoxLayout>
-#include <QCheckBox>
-#include <QCompleter>
-#include <QFileDialog>
-#include <QFormLayout>
-#include <QHBoxLayout>
-#include <QLineEdit>
-#include <QPushButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/Console.cpp
+++ b/common/src/View/Console.cpp
@@ -19,15 +19,15 @@
 
 #include "Console.h"
 
-#include "FileLogger.h"
-#include "View/ViewConstants.h"
-
-#include <string>
-
 #include <QDebug>
 #include <QScrollBar>
 #include <QTextEdit>
 #include <QVBoxLayout>
+
+#include "FileLogger.h"
+#include "View/ViewConstants.h"
+
+#include <string>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ContainerBar.h
+++ b/common/src/View/ContainerBar.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "View/BorderPanel.h"
-
 #include <QObject>
+
+#include "View/BorderPanel.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -19,15 +19,15 @@
 
 #include "ControlListBox.h"
 
-#include "View/BorderLine.h"
-#include "View/QtUtils.h"
-#include "View/ViewConstants.h"
-
 #include <QLabel>
 #include <QListWidget>
 #include <QMouseEvent>
 #include <QSizePolicy>
 #include <QVBoxLayout>
+
+#include "View/BorderLine.h"
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
 
 #include <iostream>
 

--- a/common/src/View/CrashDialog.cpp
+++ b/common/src/View/CrashDialog.cpp
@@ -19,17 +19,17 @@
 
 #include "CrashDialog.h"
 
-#include "IO/PathQt.h"
-#include "View/DialogHeader.h"
-#include "View/FormWithSectionsLayout.h"
-#include "View/GetVersion.h"
-#include "View/QtUtils.h"
-
 #include <QDesktopServices>
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QPushButton>
 #include <QUrl>
+
+#include "IO/PathQt.h"
+#include "View/DialogHeader.h"
+#include "View/FormWithSectionsLayout.h"
+#include "View/GetVersion.h"
+#include "View/QtUtils.h"
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/CrashDialog.h
+++ b/common/src/View/CrashDialog.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <string>
-
 #include <QDialog>
+
+#include <string>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CreateEntityTool.cpp
+++ b/common/src/View/CreateEntityTool.cpp
@@ -38,6 +38,7 @@
 #include "View/TransactionScope.h"
 
 #include <kdl/memory_utils.h>
+
 #include <vecmath/bbox.h>
 
 #include <string>

--- a/common/src/View/CurrentGameIndicator.cpp
+++ b/common/src/View/CurrentGameIndicator.cpp
@@ -19,12 +19,12 @@
 
 #include "CurrentGameIndicator.h"
 
+#include <QPixmap>
+#include <QString>
+
 #include "IO/Path.h"
 #include "IO/ResourceUtils.h"
 #include "Model/GameFactory.h"
-
-#include <QPixmap>
-#include <QString>
 
 namespace TrenchBroom
 {

--- a/common/src/View/CyclingMapView.cpp
+++ b/common/src/View/CyclingMapView.cpp
@@ -19,6 +19,9 @@
 
 #include "CyclingMapView.h"
 
+#include <QShortcut>
+#include <QStackedLayout>
+
 #include "FloatType.h"
 #include "Model/BrushNode.h"
 #include "Renderer/Camera.h"
@@ -29,9 +32,6 @@
 #include "View/MapViewActivationTracker.h"
 
 #include <vecmath/scalar.h>
-
-#include <QShortcut>
-#include <QStackedLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/DialogHeader.cpp
+++ b/common/src/View/DialogHeader.cpp
@@ -19,10 +19,10 @@
 
 #include "DialogHeader.h"
 
-#include "QtUtils.h"
-
 #include <QBoxLayout>
 #include <QLabel>
+
+#include "QtUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/EnableDisableTagCallback.h
+++ b/common/src/View/EnableDisableTagCallback.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <QObject>
+
 #include "Model/Tag.h"
 
 #include <string>
 #include <vector>
-
-#include <QObject>
 
 namespace TrenchBroom
 {

--- a/common/src/View/EntityBrowser.cpp
+++ b/common/src/View/EntityBrowser.cpp
@@ -19,6 +19,13 @@
 
 #include "EntityBrowser.h"
 
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QtGlobal>
+
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionManager.h"
 #include "Model/WorldNode.h"
@@ -30,13 +37,6 @@
 #include "View/ViewConstants.h"
 
 #include <kdl/memory_utils.h>
-
-#include <QComboBox>
-#include <QHBoxLayout>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QScrollBar>
-#include <QtGlobal>
 
 // for use in QVariant
 Q_DECLARE_METATYPE(TrenchBroom::Assets::EntityDefinitionSortOrder)

--- a/common/src/View/EntityBrowser.h
+++ b/common/src/View/EntityBrowser.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
 #include <vector>
-
-#include <QWidget>
 
 class QPushButton;
 class QComboBox;

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -19,6 +19,13 @@
 
 #include "EntityDefinitionFileChooser.h"
 
+#include <QDebug>
+#include <QFileDialog>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QVBoxLayout>
+
 #include "Assets/EntityDefinitionFileSpec.h"
 #include "IO/PathQt.h"
 #include "Model/Game.h"
@@ -31,13 +38,6 @@
 
 #include <kdl/memory_utils.h>
 #include <kdl/vector_utils.h>
-
-#include <QDebug>
-#include <QFileDialog>
-#include <QLabel>
-#include <QListWidget>
-#include <QPushButton>
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/EntityDefinitionFileChooser.h
+++ b/common/src/View/EntityDefinitionFileChooser.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QListWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
-
-#include <QListWidget>
 
 class QPushButton;
 class QListWidget;

--- a/common/src/View/EntityInspector.cpp
+++ b/common/src/View/EntityInspector.cpp
@@ -19,6 +19,8 @@
 
 #include "EntityInspector.h"
 
+#include <QVBoxLayout>
+
 #include "View/BorderLine.h"
 #include "View/CollapsibleTitledPanel.h"
 #include "View/EntityBrowser.h"
@@ -28,8 +30,6 @@
 #include "View/QtUtils.h"
 #include "View/Splitter.h"
 #include "View/TitledPanel.h"
-
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/EntityPropertyEditor.cpp
+++ b/common/src/View/EntityPropertyEditor.cpp
@@ -19,6 +19,12 @@
 
 #include "EntityPropertyEditor.h"
 
+#include <QChar>
+#include <QStringBuilder>
+#include <QTextEdit>
+#include <QTextStream>
+#include <QVBoxLayout>
+
 #include "Assets/EntityDefinition.h"
 #include "Assets/PropertyDefinition.h"
 #include "Model/EntityNodeBase.h"
@@ -31,12 +37,6 @@
 #include <kdl/memory_utils.h>
 
 #include <algorithm>
-
-#include <QChar>
-#include <QStringBuilder>
-#include <QTextEdit>
-#include <QTextStream>
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/EntityPropertyEditor.h
+++ b/common/src/View/EntityPropertyEditor.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QWidget>
 
 class QTextEdit;
 class QSplitter;

--- a/common/src/View/EntityPropertyGrid.cpp
+++ b/common/src/View/EntityPropertyGrid.cpp
@@ -19,6 +19,19 @@
 
 #include "EntityPropertyGrid.h"
 
+#include <QCheckBox>
+#include <QDebug>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QKeyEvent>
+#include <QKeySequence>
+#include <QMenu>
+#include <QShortcut>
+#include <QSortFilterProxyModel>
+#include <QTableView>
+#include <QTimer>
+#include <QToolButton>
+
 #include "Macros.h"
 #include "Model/EntityProperties.h"
 #include "View/BorderLine.h"
@@ -35,19 +48,6 @@
 #include <kdl/vector_utils.h>
 
 #include <vector>
-
-#include <QCheckBox>
-#include <QDebug>
-#include <QHBoxLayout>
-#include <QHeaderView>
-#include <QKeyEvent>
-#include <QKeySequence>
-#include <QMenu>
-#include <QShortcut>
-#include <QSortFilterProxyModel>
-#include <QTableView>
-#include <QTimer>
-#include <QToolButton>
 
 #define GRID_LOG(x)
 

--- a/common/src/View/EntityPropertyGrid.h
+++ b/common/src/View/EntityPropertyGrid.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QWidget>
 
 class QTableView;
 class QCheckBox;

--- a/common/src/View/EntityPropertyItemDelegate.cpp
+++ b/common/src/View/EntityPropertyItemDelegate.cpp
@@ -19,18 +19,18 @@
 
 #include "EntityPropertyItemDelegate.h"
 
-#include "View/EntityPropertyModel.h"
-#include "View/EntityPropertyTable.h"
-
-#include <string>
-#include <vector>
-
 #include <QCompleter>
 #include <QDebug>
 #include <QEvent>
 #include <QLineEdit>
 #include <QSortFilterProxyModel>
 #include <QTimer>
+
+#include "View/EntityPropertyModel.h"
+#include "View/EntityPropertyTable.h"
+
+#include <string>
+#include <vector>
 
 namespace TrenchBroom
 {

--- a/common/src/View/EntityPropertyModel.cpp
+++ b/common/src/View/EntityPropertyModel.cpp
@@ -19,6 +19,14 @@
 
 #include "EntityPropertyModel.h"
 
+#include <QBrush>
+#include <QByteArray>
+#include <QDebug>
+#include <QIcon>
+#include <QMessageBox>
+#include <QString>
+#include <QTimer>
+
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionManager.h"
 #include "Assets/PropertyDefinition.h"
@@ -49,14 +57,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-#include <QBrush>
-#include <QByteArray>
-#include <QDebug>
-#include <QIcon>
-#include <QMessageBox>
-#include <QString>
-#include <QTimer>
 
 #define MODEL_LOG(x)
 

--- a/common/src/View/EntityPropertyModel.h
+++ b/common/src/View/EntityPropertyModel.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <kdl/reflection_decl.h>
-
 #include <QAbstractTableModel>
+
+#include <kdl/reflection_decl.h>
 
 #include <iosfwd>
 #include <map>

--- a/common/src/View/ExtrudeTool.h
+++ b/common/src/View/ExtrudeTool.h
@@ -26,12 +26,12 @@
 #include "NotifierConnection.h"
 #include "View/Tool.h"
 
+#include <kdl/reflection_decl.h>
+
 #include <vecmath/forward.h>
 #include <vecmath/line.h>
 #include <vecmath/plane.h>
 #include <vecmath/vec.h>
-
-#include <kdl/reflection_decl.h>
 
 #include <memory>
 #include <variant>

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -19,6 +19,12 @@
 
 #include "FaceAttribsEditor.h"
 
+#include <QLabel>
+#include <QLineEdit>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QtGlobal>
+
 #include "Assets/Texture.h"
 #include "Color.h"
 #include "Model/BrushFace.h"
@@ -48,12 +54,6 @@
 
 #include <memory>
 #include <string>
-
-#include <QLabel>
-#include <QLineEdit>
-#include <QToolButton>
-#include <QVBoxLayout>
-#include <QtGlobal>
 
 namespace TrenchBroom
 {

--- a/common/src/View/FaceAttribsEditor.h
+++ b/common/src/View/FaceAttribsEditor.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "NotifierConnection.h"
-
 #include <QWidget>
+
+#include "NotifierConnection.h"
 
 #include <memory>
 #include <vector>

--- a/common/src/View/FaceInspector.cpp
+++ b/common/src/View/FaceInspector.cpp
@@ -19,6 +19,8 @@
 
 #include "FaceInspector.h"
 
+#include <QVBoxLayout>
+
 #include "Assets/Texture.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceAttributes.h"
@@ -35,8 +37,6 @@
 #include "View/TitledPanel.h"
 
 #include <kdl/memory_utils.h>
-
-#include <QVBoxLayout>
 
 #include <vector>
 

--- a/common/src/View/FlagsEditor.cpp
+++ b/common/src/View/FlagsEditor.cpp
@@ -19,12 +19,12 @@
 
 #include "FlagsEditor.h"
 
+#include <QCheckBox>
+#include <QGridLayout>
+
 #include "Ensure.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QCheckBox>
-#include <QGridLayout>
 
 #include <cassert>
 

--- a/common/src/View/FlagsPopupEditor.cpp
+++ b/common/src/View/FlagsPopupEditor.cpp
@@ -18,14 +18,15 @@
  */
 
 #include "FlagsPopupEditor.h"
-#include "View/ElidedLabel.h"
-#include "View/FlagsEditor.h"
-#include "View/PopupButton.h"
-#include "View/ViewConstants.h"
 
 #include <QDebug>
 #include <QHBoxLayout>
 #include <QLabel>
+
+#include "View/ElidedLabel.h"
+#include "View/FlagsEditor.h"
+#include "View/PopupButton.h"
+#include "View/ViewConstants.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/FlashSelectionAnimation.cpp
+++ b/common/src/View/FlashSelectionAnimation.cpp
@@ -19,10 +19,10 @@
 
 #include "FlashSelectionAnimation.h"
 
+#include <QWidget>
+
 #include "Color.h"
 #include "Renderer/MapRenderer.h"
-
-#include <QWidget>
 
 namespace TrenchBroom
 {

--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -19,14 +19,14 @@
 
 #include "FlyModeHelper.h"
 
+#include <QElapsedTimer>
+#include <QMouseEvent>
+
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/Camera.h"
 
 #include <vecmath/vec.h>
-
-#include <QElapsedTimer>
-#include <QMouseEvent>
 
 namespace TrenchBroom
 {

--- a/common/src/View/FormWithSectionsLayout.cpp
+++ b/common/src/View/FormWithSectionsLayout.cpp
@@ -19,12 +19,12 @@
 
 #include "FormWithSectionsLayout.h"
 
+#include <QBoxLayout>
+#include <QLabel>
+
 #include "View/BorderLine.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QBoxLayout>
-#include <QLabel>
 
 namespace TrenchBroom
 {

--- a/common/src/View/FourPaneMapView.cpp
+++ b/common/src/View/FourPaneMapView.cpp
@@ -19,15 +19,15 @@
 
 #include "FourPaneMapView.h"
 
+#include <QHBoxLayout>
+#include <QSettings>
+
 #include "View/Grid.h"
 #include "View/MapDocument.h"
 #include "View/MapView2D.h"
 #include "View/MapView3D.h"
 #include "View/QtUtils.h"
 #include "View/Splitter.h"
-
-#include <QHBoxLayout>
-#include <QSettings>
 
 namespace TrenchBroom
 {

--- a/common/src/View/FrameManager.cpp
+++ b/common/src/View/FrameManager.cpp
@@ -19,6 +19,8 @@
 
 #include "FrameManager.h"
 
+#include <QApplication>
+
 #include "Exceptions.h"
 #include "TrenchBroomApp.h"
 #include "View/AboutDialog.h"
@@ -28,8 +30,6 @@
 
 #include <cassert>
 #include <memory>
-
-#include <QApplication>
 
 namespace TrenchBroom
 {

--- a/common/src/View/GameDialog.cpp
+++ b/common/src/View/GameDialog.cpp
@@ -19,6 +19,12 @@
 
 #include "GameDialog.h"
 
+#include <QBoxLayout>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QPushButton>
+
 #include "Model/GameConfig.h"
 #include "Model/GameFactory.h"
 #include "PreferenceManager.h"
@@ -27,12 +33,6 @@
 #include "View/GameListBox.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QBoxLayout>
-#include <QComboBox>
-#include <QDialogButtonBox>
-#include <QLabel>
-#include <QPushButton>
 
 #include <cassert>
 #include <string>

--- a/common/src/View/GameDialog.h
+++ b/common/src/View/GameDialog.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <QDialog>
+
 #include "Model/MapFormat.h"
 #include "NotifierConnection.h"
 
 #include <string>
-
-#include <QDialog>
 
 class QComboBox;
 class QPushButton;

--- a/common/src/View/GameEngineDialog.cpp
+++ b/common/src/View/GameEngineDialog.cpp
@@ -19,6 +19,10 @@
 
 #include "GameEngineDialog.h"
 
+#include <QBoxLayout>
+#include <QCloseEvent>
+#include <QDialogButtonBox>
+
 #include "Model/GameConfig.h"
 #include "Model/GameFactory.h"
 #include "View/BorderLine.h"
@@ -27,10 +31,6 @@
 #include "View/QtUtils.h"
 
 #include <string>
-
-#include <QBoxLayout>
-#include <QCloseEvent>
-#include <QDialogButtonBox>
 
 namespace TrenchBroom
 {

--- a/common/src/View/GameEngineDialog.h
+++ b/common/src/View/GameEngineDialog.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <string>
-
 #include <QDialog>
+
+#include <string>
 
 class QKeyEvent;
 class QCloseEvent;

--- a/common/src/View/GameEngineProfileEditor.cpp
+++ b/common/src/View/GameEngineProfileEditor.cpp
@@ -19,6 +19,13 @@
 
 #include "GameEngineProfileEditor.h"
 
+#include <QBoxLayout>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QStackedWidget>
+
 #include "IO/DiskIO.h"
 #include "IO/PathInfo.h"
 #include "IO/PathQt.h"
@@ -28,13 +35,6 @@
 
 #include <kdl/set_temp.h>
 #include <kdl/string_compare.h>
-
-#include <QBoxLayout>
-#include <QFileDialog>
-#include <QFormLayout>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QStackedWidget>
 
 namespace TrenchBroom
 {

--- a/common/src/View/GameEngineProfileListBox.cpp
+++ b/common/src/View/GameEngineProfileListBox.cpp
@@ -19,13 +19,13 @@
 
 #include "GameEngineProfileListBox.h"
 
+#include <QBoxLayout>
+
 #include "IO/PathQt.h"
 #include "Model/GameEngineConfig.h"
 #include "Model/GameEngineProfile.h"
 #include "View/ElidedLabel.h"
 #include "View/QtUtils.h"
-
-#include <QBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/GameEngineProfileManager.cpp
+++ b/common/src/View/GameEngineProfileManager.cpp
@@ -19,6 +19,9 @@
 
 #include "GameEngineProfileManager.h"
 
+#include <QBoxLayout>
+#include <QToolButton>
+
 #include "IO/Path.h"
 #include "Model/GameEngineConfig.h"
 #include "Model/GameEngineProfile.h"
@@ -29,9 +32,6 @@
 #include "View/TitledPanel.h"
 
 #include "kdl/vector_utils.h"
-
-#include <QBoxLayout>
-#include <QToolButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/GameEngineProfileManager.h
+++ b/common/src/View/GameEngineProfileManager.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "Model/GameEngineConfig.h"
-
 #include <QWidget>
+
+#include "Model/GameEngineConfig.h"
 
 class QAbstractButton;
 

--- a/common/src/View/GamesPreferencePane.cpp
+++ b/common/src/View/GamesPreferencePane.cpp
@@ -19,22 +19,6 @@
 
 #include "GamesPreferencePane.h"
 
-#include "Exceptions.h"
-#include "FileLogger.h"
-#include "IO/Path.h"
-#include "IO/PathQt.h"
-#include "Model/Game.h"
-#include "Model/GameConfig.h"
-#include "Model/GameFactory.h"
-#include "PreferenceManager.h"
-#include "View/BorderLine.h"
-#include "View/FormWithSectionsLayout.h"
-#include "View/GameEngineDialog.h"
-#include "View/GameListBox.h"
-#include "View/MapDocument.h"
-#include "View/QtUtils.h"
-#include "View/ViewConstants.h"
-
 #include <QAction>
 #include <QBoxLayout>
 #include <QDesktopServices>
@@ -47,8 +31,23 @@
 #include <QToolButton>
 #include <QWidget>
 
+#include "Exceptions.h"
+#include "FileLogger.h"
 #include "IO/DiskIO.h"
+#include "IO/Path.h"
+#include "IO/PathQt.h"
 #include "IO/ResourceUtils.h"
+#include "Model/Game.h"
+#include "Model/GameConfig.h"
+#include "Model/GameFactory.h"
+#include "PreferenceManager.h"
+#include "View/BorderLine.h"
+#include "View/FormWithSectionsLayout.h"
+#include "View/GameEngineDialog.h"
+#include "View/GameListBox.h"
+#include "View/MapDocument.h"
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/GetVersion.cpp
+++ b/common/src/View/GetVersion.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "View/GetVersion.h"
+
 #include "Version.h"
 
 namespace TrenchBroom

--- a/common/src/View/HandleDragTracker.cpp
+++ b/common/src/View/HandleDragTracker.cpp
@@ -27,14 +27,14 @@
 #include "Model/HitAdapter.h"
 #include "View/Grid.h"
 
+#include <kdl/reflection_impl.h>
+
 #include <vecmath/distance.h>
 #include <vecmath/intersection.h>
 #include <vecmath/line.h>
 #include <vecmath/plane.h>
 #include <vecmath/quat.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/reflection_impl.h>
 
 #include <ostream>
 

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -25,10 +25,10 @@
 #include "View/DragTracker.h"
 #include "View/InputState.h"
 
+#include <kdl/reflection_decl.h>
+
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
-
-#include <kdl/reflection_decl.h>
 
 #include <functional>
 #include <memory>

--- a/common/src/View/ImageListBox.cpp
+++ b/common/src/View/ImageListBox.cpp
@@ -19,12 +19,12 @@
 
 #include "ImageListBox.h"
 
+#include <QBoxLayout>
+#include <QLabel>
+
 #include "View/ElidedLabel.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QBoxLayout>
-#include <QLabel>
 
 #include <cassert>
 

--- a/common/src/View/InfoPanel.cpp
+++ b/common/src/View/InfoPanel.cpp
@@ -19,11 +19,11 @@
 
 #include "InfoPanel.h"
 
+#include <QVBoxLayout>
+
 #include "View/Console.h"
 #include "View/IssueBrowser.h"
 #include "View/TabBook.h"
-
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/InfoPanel.h
+++ b/common/src/View/InfoPanel.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include <QWidget>
+
+#include <memory>
 
 namespace TrenchBroom
 {

--- a/common/src/View/InputState.cpp
+++ b/common/src/View/InputState.cpp
@@ -19,14 +19,14 @@
 
 #include "InputState.h"
 
+#include <QCursor>
+
 #include "FloatType.h"
 #include "Macros.h"
 #include "Model/CompareHits.h"
 #include "Renderer/Camera.h"
 
 #include <vecmath/vec.h>
-
-#include <QCursor>
 
 namespace TrenchBroom
 {

--- a/common/src/View/Inspector.cpp
+++ b/common/src/View/Inspector.cpp
@@ -19,6 +19,8 @@
 
 #include "Inspector.h"
 
+#include <QVBoxLayout>
+
 #include "View/EntityInspector.h"
 #include "View/FaceInspector.h"
 #include "View/MapInspector.h"
@@ -26,8 +28,6 @@
 #include "View/QtUtils.h"
 #include "View/TabBar.h"
 #include "View/TabBook.h"
-
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/Inspector.h
+++ b/common/src/View/Inspector.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include <QWidget>
+
+#include <memory>
 
 namespace TrenchBroom
 {

--- a/common/src/View/IssueBrowser.cpp
+++ b/common/src/View/IssueBrowser.cpp
@@ -19,6 +19,11 @@
 
 #include "IssueBrowser.h"
 
+#include <QCheckBox>
+#include <QList>
+#include <QStringList>
+#include <QVBoxLayout>
+
 #include "Model/Issue.h"
 #include "Model/Validator.h"
 #include "Model/WorldNode.h"
@@ -27,11 +32,6 @@
 #include "View/MapDocument.h"
 
 #include <kdl/memory_utils.h>
-
-#include <QCheckBox>
-#include <QList>
-#include <QStringList>
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -19,6 +19,12 @@
 
 #include "IssueBrowserView.h"
 
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QItemSelectionModel>
+#include <QMenu>
+#include <QTableView>
+
 #include "Ensure.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
@@ -37,12 +43,6 @@
 #include <kdl/vector_utils.h>
 
 #include <vector>
-
-#include <QHBoxLayout>
-#include <QHeaderView>
-#include <QItemSelectionModel>
-#include <QMenu>
-#include <QTableView>
 
 namespace TrenchBroom
 {

--- a/common/src/View/IssueBrowserView.h
+++ b/common/src/View/IssueBrowserView.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QAbstractItemModel>
+#include <QWidget>
+
 #include "Model/IssueType.h"
 
 #include <memory>
 #include <vector>
-
-#include <QAbstractItemModel>
-#include <QWidget>
 
 class QWidget;
 class QTableView;

--- a/common/src/View/KeySequenceEdit.cpp
+++ b/common/src/View/KeySequenceEdit.cpp
@@ -19,13 +19,13 @@
 
 #include "KeySequenceEdit.h"
 
-#include "View/LimitedKeySequenceEdit.h"
-#include "View/QtUtils.h"
-#include "View/ViewConstants.h"
-
 #include <QBoxLayout>
 #include <QStyle>
 #include <QToolButton>
+
+#include "View/LimitedKeySequenceEdit.h"
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/KeyboardPreferencePane.cpp
+++ b/common/src/View/KeyboardPreferencePane.cpp
@@ -19,14 +19,6 @@
 
 #include "KeyboardPreferencePane.h"
 
-#include "Macros.h"
-#include "View/Actions.h"
-#include "View/KeyboardShortcutItemDelegate.h"
-#include "View/KeyboardShortcutModel.h"
-#include "View/MapDocument.h"
-#include "View/QtUtils.h"
-#include "View/ViewConstants.h"
-
 #include <QBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
@@ -35,6 +27,14 @@
 #include <QSortFilterProxyModel>
 #include <QTableView>
 #include <QTimer>
+
+#include "Macros.h"
+#include "View/Actions.h"
+#include "View/KeyboardShortcutItemDelegate.h"
+#include "View/KeyboardShortcutModel.h"
+#include "View/MapDocument.h"
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/KeyboardShortcutItemDelegate.cpp
+++ b/common/src/View/KeyboardShortcutItemDelegate.cpp
@@ -19,10 +19,10 @@
 
 #include "KeyboardShortcutItemDelegate.h"
 
+#include <QItemEditorFactory>
+
 #include "View/KeySequenceEdit.h"
 #include "View/KeyboardShortcutModel.h"
-
-#include <QItemEditorFactory>
 
 namespace TrenchBroom
 {

--- a/common/src/View/KeyboardShortcutModel.cpp
+++ b/common/src/View/KeyboardShortcutModel.cpp
@@ -19,6 +19,8 @@
 
 #include "KeyboardShortcutModel.h"
 
+#include <QBrush>
+
 #include "IO/PathQt.h"
 #include "Preference.h"
 #include "PreferenceManager.h"
@@ -30,8 +32,6 @@
 
 #include <functional>
 #include <set>
-
-#include <QBrush>
 
 namespace TrenchBroom
 {

--- a/common/src/View/KeyboardShortcutModel.h
+++ b/common/src/View/KeyboardShortcutModel.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "IO/Path.h"
-
 #include <QAbstractTableModel>
+
+#include "IO/Path.h"
 
 #include <vector>
 

--- a/common/src/View/LaunchGameEngineDialog.cpp
+++ b/common/src/View/LaunchGameEngineDialog.cpp
@@ -19,6 +19,14 @@
 
 #include "LaunchGameEngineDialog.h"
 
+#include <QCompleter>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QLabel>
+#include <QMessageBox>
+#include <QProcess>
+#include <QPushButton>
+
 #include "EL/EvaluationContext.h"
 #include "EL/Interpolator.h"
 #include "IO/PathQt.h"
@@ -41,14 +49,6 @@
 #include <kdl/string_utils.h>
 
 #include <string>
-
-#include <QCompleter>
-#include <QDialogButtonBox>
-#include <QDir>
-#include <QLabel>
-#include <QMessageBox>
-#include <QProcess>
-#include <QPushButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/LaunchGameEngineDialog.h
+++ b/common/src/View/LaunchGameEngineDialog.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <QDialog>
+
 #include "Model/GameEngineConfig.h"
 #include "View/CompilationVariables.h"
 
 #include <memory>
-
-#include <QDialog>
 
 class QPushButton;
 

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -19,6 +19,12 @@
 
 #include "LayerEditor.h"
 
+#include <QInputDialog>
+#include <QMenu>
+#include <QMessageBox>
+#include <QToolButton>
+#include <QVBoxLayout>
+
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
 #include "Model/GroupNode.h"
@@ -29,6 +35,7 @@
 #include "View/LayerListBox.h"
 #include "View/MapDocument.h"
 #include "View/QtUtils.h"
+#include "ViewUtils.h"
 
 #include <kdl/memory_utils.h>
 #include <kdl/string_compare.h>
@@ -39,14 +46,6 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#include <QInputDialog>
-#include <QMenu>
-#include <QMessageBox>
-#include <QToolButton>
-#include <QVBoxLayout>
-
-#include "ViewUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/LayerEditor.h
+++ b/common/src/View/LayerEditor.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include <memory>
 #include <string>
-
-#include <QWidget>
 
 class QAbstractButton;
 

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -19,14 +19,6 @@
 
 #include "LayerListBox.h"
 
-#include "Model/LayerNode.h"
-#include "Model/WorldNode.h"
-#include "View/MapDocument.h"
-#include "View/QtUtils.h"
-#include "View/ViewConstants.h"
-
-#include <kdl/memory_utils.h>
-
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidgetItem>
@@ -34,6 +26,14 @@
 #include <QRadioButton>
 #include <QToolButton>
 #include <QtGlobal>
+
+#include "Model/LayerNode.h"
+#include "Model/WorldNode.h"
+#include "View/MapDocument.h"
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
+
+#include <kdl/memory_utils.h>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MainMenuBuilder.cpp
+++ b/common/src/View/MainMenuBuilder.cpp
@@ -19,10 +19,10 @@
 
 #include "MainMenuBuilder.h"
 
+#include <QMenuBar>
+
 #include "IO/ResourceUtils.h"
 #include "View/MapFrame.h"
-
-#include <QMenuBar>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -46,6 +46,25 @@
 #if !defined __APPLE__
 #include "View/BorderLine.h"
 #endif
+#include <QApplication>
+#include <QChildEvent>
+#include <QClipboard>
+#include <QComboBox>
+#include <QFileDialog>
+#include <QInputDialog>
+#include <QLabel>
+#include <QMessageBox>
+#include <QMimeData>
+#include <QPushButton>
+#include <QStatusBar>
+#include <QString>
+#include <QStringList>
+#include <QTableWidget>
+#include <QTimer>
+#include <QToolBar>
+#include <QVBoxLayout>
+#include <QtGlobal>
+
 #include "View/ClipTool.h"
 #include "View/ColorButton.h"
 #include "View/CompilationDialog.h"
@@ -86,25 +105,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-
-#include <QApplication>
-#include <QChildEvent>
-#include <QClipboard>
-#include <QComboBox>
-#include <QFileDialog>
-#include <QInputDialog>
-#include <QLabel>
-#include <QMessageBox>
-#include <QMimeData>
-#include <QPushButton>
-#include <QStatusBar>
-#include <QString>
-#include <QStringList>
-#include <QTableWidget>
-#include <QTimer>
-#include <QToolBar>
-#include <QVBoxLayout>
-#include <QtGlobal>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -19,14 +19,14 @@
 
 #pragma once
 
+#include <QDialog>
+#include <QMainWindow>
+#include <QPointer>
+
 #include "IO/ExportOptions.h"
 #include "Model/MapFormat.h"
 #include "NotifierConnection.h"
 #include "View/Selection.h"
-
-#include <QDialog>
-#include <QMainWindow>
-#include <QPointer>
 
 #include <chrono>
 #include <map>

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -19,6 +19,12 @@
 
 #include "MapInspector.h"
 
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QRadioButton>
+
 #include "Model/EntityProperties.h"
 #include "Model/WorldNode.h"
 #include "View/BorderLine.h"
@@ -37,12 +43,6 @@
 
 #include <optional>
 #include <utility>
-
-#include <QGridLayout>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QLineEdit>
-#include <QRadioButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MapViewActivationTracker.cpp
+++ b/common/src/View/MapViewActivationTracker.cpp
@@ -19,14 +19,14 @@
 
 #include "MapViewActivationTracker.h"
 
+#include <QApplication>
+#include <QDateTime>
+#include <QMouseEvent>
+
 #include "Ensure.h"
 #include "View/MapViewBase.h"
 
 #include <kdl/vector_utils.h>
-
-#include <QApplication>
-#include <QDateTime>
-#include <QMouseEvent>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MapViewBar.cpp
+++ b/common/src/View/MapViewBar.cpp
@@ -19,16 +19,16 @@
 
 #include "MapViewBar.h"
 
+#include <QHBoxLayout>
+#include <QResizeEvent>
+#include <QStackedLayout>
+
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "View/MapDocument.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
 #include "View/ViewEditor.h"
-
-#include <QHBoxLayout>
-#include <QResizeEvent>
-#include <QStackedLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -19,6 +19,13 @@
 
 #include "MapViewBase.h"
 
+#include <QDebug>
+#include <QMenu>
+#include <QMimeData>
+#include <QShortcut>
+#include <QString>
+#include <QtGlobal>
+
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionGroup.h"
 #include "Assets/EntityDefinitionManager.h"
@@ -65,8 +72,8 @@
 #include "View/QtUtils.h"
 #include "View/SelectionTool.h"
 #include "View/SignalDelayer.h"
-#include "kdl/vector_utils.h"
 
+#include "kdl/vector_utils.h"
 #include <kdl/memory_utils.h>
 #include <kdl/string_compare.h>
 #include <kdl/string_format.h>
@@ -76,13 +83,6 @@
 
 #include <sstream>
 #include <vector>
-
-#include <QDebug>
-#include <QMenu>
-#include <QMimeData>
-#include <QShortcut>
-#include <QString>
-#include <QtGlobal>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MapViewToolBox.cpp
+++ b/common/src/View/MapViewToolBox.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "MapViewToolBox.h"
+
 #include "Model/EditorContext.h"
 #include "View/ClipTool.h"
 #include "View/CreateComplexBrushTool.h"

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -19,6 +19,12 @@
 
 #include "ModEditor.h"
 
+#include <QLineEdit>
+#include <QListWidget>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
 #include "Model/EntityNode.h"
 #include "Model/Game.h"
 #include "Notifier.h"
@@ -33,12 +39,6 @@
 #include <kdl/memory_utils.h>
 #include <kdl/string_compare.h>
 #include <kdl/vector_utils.h>
-
-#include <QLineEdit>
-#include <QListWidget>
-#include <QToolButton>
-#include <QVBoxLayout>
-#include <QWidget>
 
 #include <cassert>
 #include <string>

--- a/common/src/View/ModEditor.h
+++ b/common/src/View/ModEditor.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QWidget>
 
 class QLineEdit;
 class QListWidget;

--- a/common/src/View/MousePreferencePane.cpp
+++ b/common/src/View/MousePreferencePane.cpp
@@ -19,6 +19,9 @@
 
 #include "MousePreferencePane.h"
 
+#include <QCheckBox>
+#include <QLabel>
+
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "View/FormWithSectionsLayout.h"
@@ -26,9 +29,6 @@
 #include "View/QtUtils.h"
 #include "View/SliderWithLabel.h"
 #include "View/ViewConstants.h"
-
-#include <QCheckBox>
-#include <QLabel>
 
 #include <algorithm>
 

--- a/common/src/View/MoveObjectsToolPage.cpp
+++ b/common/src/View/MoveObjectsToolPage.cpp
@@ -19,17 +19,18 @@
 
 #include "MoveObjectsToolPage.h"
 
-#include "View/MapDocument.h"
-#include "View/ViewConstants.h"
-
-#include <kdl/memory_utils.h>
-#include <vecmath/vec.h>
-#include <vecmath/vec_io.h>
-
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+
+#include "View/MapDocument.h"
+#include "View/ViewConstants.h"
+
+#include <kdl/memory_utils.h>
+
+#include <vecmath/vec.h>
+#include <vecmath/vec_io.h>
 
 namespace TrenchBroom
 {

--- a/common/src/View/MoveObjectsToolPage.h
+++ b/common/src/View/MoveObjectsToolPage.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
-
-#include <QWidget>
 
 class QAbstractButton;
 class QLineEdit;

--- a/common/src/View/ObjExportDialog.cpp
+++ b/common/src/View/ObjExportDialog.cpp
@@ -20,6 +20,13 @@
 
 #include "ObjExportDialog.h"
 
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QRadioButton>
+
 #include "Ensure.h"
 #include "IO/ExportOptions.h"
 #include "IO/Path.h"
@@ -30,13 +37,6 @@
 #include "View/FormWithSectionsLayout.h"
 #include "View/MapDocument.h"
 #include "View/MapFrame.h"
-
-#include <QDialogButtonBox>
-#include <QFileDialog>
-#include <QLabel>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QRadioButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/OnePaneMapView.cpp
+++ b/common/src/View/OnePaneMapView.cpp
@@ -17,9 +17,9 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QGridLayout>
-
 #include "OnePaneMapView.h"
+
+#include <QGridLayout>
 
 #include "View/CyclingMapView.h"
 #include "View/Grid.h"

--- a/common/src/View/PopupButton.cpp
+++ b/common/src/View/PopupButton.cpp
@@ -18,12 +18,13 @@
  */
 
 #include "PopupButton.h"
-#include "View/PopupWindow.h"
-#include "View/QtUtils.h"
 
 #include <QHBoxLayout>
 #include <QToolButton>
 #include <QWindow>
+
+#include "View/PopupWindow.h"
+#include "View/QtUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/PreferenceDialog.cpp
+++ b/common/src/View/PreferenceDialog.cpp
@@ -19,6 +19,14 @@
 
 #include "PreferenceDialog.h"
 
+#include <QBoxLayout>
+#include <QCloseEvent>
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QStackedWidget>
+#include <QToolBar>
+#include <QToolButton>
+
 #include "IO/Path.h"
 #include "IO/ResourceUtils.h"
 #include "PreferenceManager.h"
@@ -31,14 +39,6 @@
 #include "View/PreferencePane.h"
 #include "View/QtUtils.h"
 #include "View/ViewPreferencePane.h"
-
-#include <QBoxLayout>
-#include <QCloseEvent>
-#include <QDialogButtonBox>
-#include <QPushButton>
-#include <QStackedWidget>
-#include <QToolBar>
-#include <QToolButton>
 
 namespace TrenchBroom
 {

--- a/common/src/View/PreferenceDialog.h
+++ b/common/src/View/PreferenceDialog.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include <QDialog>
+
+#include <memory>
 
 class QDialogButtonBox;
 class QStackedWidget;

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -19,17 +19,6 @@
 
 #include "QtUtils.h"
 
-#include "Color.h"
-
-#include "Ensure.h"
-#include "IO/Path.h"
-#include "IO/ResourceUtils.h"
-#include "Macros.h"
-#include "View/BorderLine.h"
-#include "View/MapFrame.h"
-#include "View/MapTextEncoding.h"
-#include "View/ViewConstants.h"
-
 #include <QApplication>
 #include <QBoxLayout>
 #include <QButtonGroup>
@@ -55,6 +44,16 @@
 #include <QVBoxLayout>
 #include <QWindow>
 #include <QtGlobal>
+
+#include "Color.h"
+#include "Ensure.h"
+#include "IO/Path.h"
+#include "IO/ResourceUtils.h"
+#include "Macros.h"
+#include "View/BorderLine.h"
+#include "View/MapFrame.h"
+#include "View/MapTextEncoding.h"
+#include "View/ViewConstants.h"
 
 // QDesktopWidget was deprecated in Qt 5.10 and we should use QGuiApplication::screenAt
 // in 5.10 and above Used in centerOnScreen

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -21,11 +21,6 @@
 
 #undef CursorShape
 
-#include "Ensure.h"
-#include "View/ViewConstants.h"
-
-#include <string>
-
 #include <QBoxLayout>
 #include <QObject>
 #include <QPointer>
@@ -33,6 +28,11 @@
 #include <QString>
 #include <QStringList>
 #include <QWidget>
+
+#include "Ensure.h"
+#include "View/ViewConstants.h"
+
+#include <string>
 
 class QButtonGroup;
 class QColor;

--- a/common/src/View/RecentDocumentListBox.h
+++ b/common/src/View/RecentDocumentListBox.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "View/ImageListBox.h"
-
 #include <QPixmap>
+
+#include "View/ImageListBox.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/RecentDocuments.cpp
+++ b/common/src/View/RecentDocuments.cpp
@@ -19,16 +19,16 @@
 
 #include "RecentDocuments.h"
 
+#include <QMenu>
+#include <QSettings>
+#include <QVariant>
+
 #include "IO/Path.h"
 #include "IO/PathQt.h"
 #include "Notifier.h"
 #include "View/QtUtils.h"
 
 #include <kdl/vector_utils.h>
-
-#include <QMenu>
-#include <QSettings>
-#include <QVariant>
 
 namespace TrenchBroom
 {

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QObject>
+
 #include "Notifier.h"
 
 #include <vector>
-
-#include <QObject>
 
 class QMenu;
 

--- a/common/src/View/RenderView.h
+++ b/common/src/View/RenderView.h
@@ -19,14 +19,16 @@
 
 #pragma once
 
-#include "Color.h"
-#include "Renderer/GL.h" // must be included here, before QOpenGLWidget, because it includes glew
-#include "View/InputEvent.h"
-
-#include <string>
+#include <GL/glew.h>
 
 #include <QElapsedTimer>
 #include <QOpenGLWidget>
+
+#include "Color.h"
+#include "Renderer/GL.h"
+#include "View/InputEvent.h"
+
+#include <string>
 
 #undef Bool
 #undef Status

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -19,6 +19,10 @@
 
 #include "ReplaceTextureDialog.h"
 
+#include <QDialogButtonBox>
+#include <QMessageBox>
+#include <QPushButton>
+
 #include "Assets/Texture.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceHandle.h"
@@ -33,10 +37,6 @@
 
 #include <kdl/memory_utils.h>
 #include <kdl/vector_utils.h>
-
-#include <QDialogButtonBox>
-#include <QMessageBox>
-#include <QPushButton>
 
 #include <sstream>
 #include <vector>

--- a/common/src/View/ReplaceTextureDialog.h
+++ b/common/src/View/ReplaceTextureDialog.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
+#include <QDialog>
+
 #include <memory>
 #include <vector>
-
-#include <QDialog>
 
 class QPushButton;
 

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -19,6 +19,14 @@
 
 #include "RotateObjectsToolPage.h"
 
+#include <QCheckBox>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QtGlobal>
+
 #include "FloatType.h"
 #include "Model/EntityProperties.h"
 #include "Model/WorldNode.h"
@@ -35,14 +43,6 @@
 #include <vecmath/util.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include <QCheckBox>
-#include <QComboBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QtGlobal>
 
 namespace TrenchBroom
 {

--- a/common/src/View/RotateObjectsToolPage.h
+++ b/common/src/View/RotateObjectsToolPage.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "FloatType.h"
 #include "NotifierConnection.h"
 
@@ -26,8 +28,6 @@
 #include <vecmath/util.h>
 
 #include <memory>
-
-#include <QWidget>
 
 class QCheckBox;
 class QComboBox;

--- a/common/src/View/ScaleObjectsToolPage.cpp
+++ b/common/src/View/ScaleObjectsToolPage.cpp
@@ -19,6 +19,14 @@
 
 #include "ScaleObjectsToolPage.h"
 
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QList>
+#include <QPushButton>
+#include <QStackedLayout>
+
 #include "FloatType.h"
 #include "View/Grid.h"
 #include "View/MapDocument.h"
@@ -30,14 +38,6 @@
 
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include <QComboBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QLineEdit>
-#include <QList>
-#include <QPushButton>
-#include <QStackedLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ScaleObjectsToolPage.h
+++ b/common/src/View/ScaleObjectsToolPage.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "FloatType.h"
 #include "NotifierConnection.h"
 
@@ -26,8 +28,6 @@
 
 #include <memory>
 #include <optional>
-
-#include <QWidget>
 
 class QComboBox;
 class QStackedLayout;

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -19,6 +19,7 @@
 
 #include "SetBrushFaceAttributesTool.h"
 
+#include "Ensure.h"
 #include "Model/Brush.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceHandle.h"
@@ -36,8 +37,6 @@
 #include <kdl/memory_utils.h>
 
 #include <vector>
-
-#include "Ensure.h"
 
 namespace TrenchBroom
 {

--- a/common/src/View/SetCurrentLayerCommand.cpp
+++ b/common/src/View/SetCurrentLayerCommand.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "SetCurrentLayerCommand.h"
+
 #include "View/MapDocumentCommandFacade.h"
 
 namespace TrenchBroom

--- a/common/src/View/SetLockStateCommand.cpp
+++ b/common/src/View/SetLockStateCommand.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "SetLockStateCommand.h"
+
 #include "Macros.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"

--- a/common/src/View/SetVisibilityCommand.cpp
+++ b/common/src/View/SetVisibilityCommand.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "SetVisibilityCommand.h"
+
 #include "Macros.h"
 #include "Model/VisibilityState.h"
 #include "View/MapDocumentCommandFacade.h"

--- a/common/src/View/SliderWithLabel.cpp
+++ b/common/src/View/SliderWithLabel.cpp
@@ -19,12 +19,12 @@
 
 #include "SliderWithLabel.h"
 
-#include "View/QtUtils.h"
-#include "View/ViewConstants.h"
-
 #include <QBoxLayout>
 #include <QLabel>
 #include <QSlider>
+
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
 
 #include <cmath> // for std::log10
 

--- a/common/src/View/SmartChoiceEditor.cpp
+++ b/common/src/View/SmartChoiceEditor.cpp
@@ -18,6 +18,13 @@
  */
 
 #include "SmartChoiceEditor.h"
+
+#include <QComboBox>
+#include <QDebug>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QtGlobal>
+
 #include "Assets/PropertyDefinition.h"
 #include "Model/EntityNodeBase.h"
 #include "View/MapDocument.h"
@@ -25,12 +32,6 @@
 #include "View/ViewConstants.h"
 
 #include <kdl/set_temp.h>
-
-#include <QComboBox>
-#include <QDebug>
-#include <QLabel>
-#include <QVBoxLayout>
-#include <QtGlobal>
 
 #include <cassert>
 

--- a/common/src/View/SmartColorEditor.cpp
+++ b/common/src/View/SmartColorEditor.cpp
@@ -19,6 +19,12 @@
 
 #include "SmartColorEditor.h"
 
+#include <QColor>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QRadioButton>
+#include <QScrollArea>
+
 #include "Assets/ColorRange.h"
 #include "Color.h"
 #include "Model/Entity.h"
@@ -37,12 +43,6 @@
 
 #include <kdl/overload.h>
 #include <kdl/vector_set.h>
-
-#include <QColor>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QRadioButton>
-#include <QScrollArea>
 
 namespace TrenchBroom
 {

--- a/common/src/View/SmartFlagsEditor.cpp
+++ b/common/src/View/SmartFlagsEditor.cpp
@@ -19,6 +19,9 @@
 
 #include "SmartFlagsEditor.h"
 
+#include <QScrollArea>
+#include <QVBoxLayout>
+
 #include "Assets/EntityDefinition.h"
 #include "Assets/PropertyDefinition.h"
 #include "Model/Entity.h"
@@ -33,9 +36,6 @@
 #include <cassert>
 #include <memory>
 #include <vector>
-
-#include <QScrollArea>
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/SmartPropertyEditor.h
+++ b/common/src/View/SmartPropertyEditor.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QWidget>
 
 namespace TrenchBroom
 {

--- a/common/src/View/SmartPropertyEditorManager.cpp
+++ b/common/src/View/SmartPropertyEditorManager.cpp
@@ -19,6 +19,9 @@
 
 #include "SmartPropertyEditorManager.h"
 
+#include <QStackedLayout>
+#include <QWidget>
+
 #include "Assets/PropertyDefinition.h"
 #include "Macros.h"
 #include "Model/Entity.h"
@@ -34,9 +37,6 @@
 #include <kdl/functional.h>
 #include <kdl/memory_utils.h>
 #include <kdl/string_compare.h>
-
-#include <QStackedLayout>
-#include <QWidget>
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/SmartPropertyEditorManager.h
+++ b/common/src/View/SmartPropertyEditorManager.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <functional>
 #include <string>
 #include <vector>
-
-#include <QWidget>
 
 class QStackedLayout;
 

--- a/common/src/View/SmartWadEditor.cpp
+++ b/common/src/View/SmartWadEditor.cpp
@@ -19,6 +19,10 @@
 
 #include "SmartWadEditor.h"
 
+#include <QFileDialog>
+#include <QListWidget>
+#include <QToolButton>
+
 #include "IO/Path.h"
 #include "IO/PathQt.h"
 #include "Model/EntityNodeBase.h"
@@ -30,10 +34,6 @@
 
 #include <kdl/string_utils.h>
 #include <kdl/vector_utils.h>
-
-#include <QFileDialog>
-#include <QListWidget>
-#include <QToolButton>
 
 namespace TrenchBroom::View
 {

--- a/common/src/View/SpinControl.cpp
+++ b/common/src/View/SpinControl.cpp
@@ -18,11 +18,12 @@
  */
 
 #include "SpinControl.h"
+
+#include <QGuiApplication>
+
 #include "View/QtUtils.h"
 
 #include <kdl/string_utils.h>
-
-#include <QGuiApplication>
 
 #include <cassert>
 

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -19,6 +19,8 @@
 
 #include "SwitchableMapViewContainer.h"
 
+#include <QGridLayout>
+
 #include "FloatType.h"
 #include "Model/PointTrace.h"
 #include "PreferenceManager.h"
@@ -39,8 +41,6 @@
 #include "View/TwoPaneMapView.h"
 
 #include <kdl/memory_utils.h>
-
-#include <QGridLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/SwitchableMapViewContainer.h
+++ b/common/src/View/SwitchableMapViewContainer.h
@@ -19,14 +19,14 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "FloatType.h"
 #include "Macros.h"
 #include "NotifierConnection.h"
 #include "View/MapView.h"
 
 #include <memory>
-
-#include <QWidget>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TabBar.cpp
+++ b/common/src/View/TabBar.cpp
@@ -19,14 +19,14 @@
 
 #include "TabBar.h"
 
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QStackedLayout>
+
 #include "Ensure.h"
 #include "View/QtUtils.h"
 #include "View/TabBook.h"
 #include "View/ViewConstants.h"
-
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QStackedLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TabBar.h
+++ b/common/src/View/TabBar.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "View/ContainerBar.h"
 
 #include <vector>
-
-#include <QWidget>
 
 class QHBoxLayout;
 class QLabel;

--- a/common/src/View/TabBook.cpp
+++ b/common/src/View/TabBook.cpp
@@ -19,12 +19,12 @@
 
 #include "TabBook.h"
 
+#include <QStackedLayout>
+#include <QVBoxLayout>
+
 #include "Ensure.h"
 #include "Macros.h"
 #include "View/TabBar.h"
-
-#include <QStackedLayout>
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TextOutputAdapter.cpp
+++ b/common/src/View/TextOutputAdapter.cpp
@@ -19,14 +19,14 @@
 
 #include "TextOutputAdapter.h"
 
-#include "Ensure.h"
-
-#include <string>
-
 #include <QByteArray>
 #include <QScrollBar>
 #include <QString>
 #include <QTextEdit>
+
+#include "Ensure.h"
+
+#include <string>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TextureBrowser.cpp
+++ b/common/src/View/TextureBrowser.cpp
@@ -19,6 +19,13 @@
 
 #include "TextureBrowser.h"
 
+#include <QComboBox>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QVBoxLayout>
+#include <QtGlobal>
+
 #include "Assets/Texture.h"
 #include "Assets/TextureManager.h"
 #include "PreferenceManager.h"
@@ -29,13 +36,6 @@
 #include "View/ViewConstants.h"
 
 #include <kdl/memory_utils.h>
-
-#include <QComboBox>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QScrollBar>
-#include <QVBoxLayout>
-#include <QtGlobal>
 
 // for use in QVariant
 Q_DECLARE_METATYPE(TrenchBroom::View::TextureSortOrder)

--- a/common/src/View/TextureBrowser.h
+++ b/common/src/View/TextureBrowser.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QWidget>
 
 class QPushButton;
 class QComboBox;

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -19,6 +19,9 @@
 
 #include "TextureBrowserView.h"
 
+#include <QMenu>
+#include <QTextStream>
+
 #include "Assets/Texture.h"
 #include "Assets/TextureCollection.h"
 #include "Assets/TextureManager.h"
@@ -46,9 +49,6 @@
 
 #include <string>
 #include <vector>
-
-#include <QMenu>
-#include <QTextStream>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ThreePaneMapView.cpp
+++ b/common/src/View/ThreePaneMapView.cpp
@@ -19,6 +19,8 @@
 
 #include "ThreePaneMapView.h"
 
+#include <QHBoxLayout>
+
 #include "View/CyclingMapView.h"
 #include "View/Grid.h"
 #include "View/MapDocument.h"
@@ -26,8 +28,6 @@
 #include "View/MapView3D.h"
 #include "View/QtUtils.h"
 #include "View/Splitter.h"
-
-#include <QHBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TitleBar.cpp
+++ b/common/src/View/TitleBar.cpp
@@ -19,12 +19,12 @@
 
 #include "TitleBar.h"
 
+#include <QHBoxLayout>
+#include <QLabel>
+
 #include "View/ControlListBox.h"
 #include "View/QtUtils.h"
 #include "View/ViewConstants.h"
-
-#include <QHBoxLayout>
-#include <QLabel>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TitledPanel.cpp
+++ b/common/src/View/TitledPanel.cpp
@@ -19,11 +19,11 @@
 
 #include "TitledPanel.h"
 
+#include <QVBoxLayout>
+
 #include "View/BorderLine.h"
 #include "View/TitleBar.h"
 #include "View/ViewConstants.h"
-
-#include <QVBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/Tool.cpp
+++ b/common/src/View/Tool.cpp
@@ -19,10 +19,10 @@
 
 #include "Tool.h"
 
-#include "IO/ResourceUtils.h"
-
 #include <QStackedLayout>
 #include <QWidget>
+
+#include "IO/ResourceUtils.h"
 
 #include <cassert>
 

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -19,6 +19,9 @@
 
 #include "ToolBox.h"
 
+#include <QDateTime>
+#include <QDebug>
+
 #include "Ensure.h"
 #include "View/DragTracker.h"
 #include "View/DropTracker.h"
@@ -30,9 +33,6 @@
 #include <cassert>
 #include <string>
 #include <utility>
-
-#include <QDateTime>
-#include <QDebug>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <QObject>
+
 #include "Notifier.h"
 #include "NotifierConnection.h"
 
@@ -26,8 +28,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QObject>
 
 class QWindow;
 class QFocusEvent;

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -19,6 +19,8 @@
 
 #include "ToolBoxConnector.h"
 
+#include <QGuiApplication>
+
 #include "Ensure.h"
 #include "Macros.h"
 #include "View/PickRequest.h"
@@ -27,8 +29,6 @@
 #include "View/ToolController.h"
 
 #include <string>
-
-#include <QGuiApplication>
 
 namespace TrenchBroom
 {

--- a/common/src/View/TwoPaneMapView.cpp
+++ b/common/src/View/TwoPaneMapView.cpp
@@ -19,14 +19,14 @@
 
 #include "TwoPaneMapView.h"
 
+#include <QHBoxLayout>
+
 #include "View/CyclingMapView.h"
 #include "View/Grid.h"
 #include "View/MapDocument.h"
 #include "View/MapView3D.h"
 #include "View/QtUtils.h"
 #include "View/Splitter.h"
-
-#include <QHBoxLayout>
 
 namespace TrenchBroom
 {

--- a/common/src/View/UVEditor.cpp
+++ b/common/src/View/UVEditor.cpp
@@ -19,6 +19,12 @@
 
 #include "UVEditor.h"
 
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QSpinBox>
+#include <QToolButton>
+#include <QtGlobal>
+
 #include "Model/BrushFaceHandle.h"
 #include "Model/ChangeBrushFaceAttributesRequest.h"
 #include "Model/Game.h"
@@ -28,12 +34,6 @@
 #include "View/ViewConstants.h"
 
 #include <kdl/memory_utils.h>
-
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QSpinBox>
-#include <QToolButton>
-#include <QtGlobal>
 
 namespace TrenchBroom
 {

--- a/common/src/View/UVEditor.h
+++ b/common/src/View/UVEditor.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "NotifierConnection.h"
 
 #include <memory>
-
-#include <QWidget>
 
 class QSpinBox;
 class QWidget;

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "UVOriginTool.h"
+
 #include "Assets/Texture.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushGeometry.h"

--- a/common/src/View/VariableStoreModel.h
+++ b/common/src/View/VariableStoreModel.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <QAbstractListModel>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <QAbstractListModel>
 
 class QModelIndex;
 class QVariant;

--- a/common/src/View/ViewConstants.cpp
+++ b/common/src/View/ViewConstants.cpp
@@ -20,11 +20,10 @@
 #include "ViewConstants.h"
 
 #include <QColor>
+#include <QDebug>
 #include <QFont>
 #include <QFontDatabase>
 #include <QWidget>
-
-#include <QDebug>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ViewEditor.cpp
+++ b/common/src/View/ViewEditor.cpp
@@ -19,6 +19,14 @@
 
 #include "ViewEditor.h"
 
+#include <QButtonGroup>
+#include <QCheckBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QScrollArea>
+
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionGroup.h"
 #include "Assets/EntityDefinitionManager.h"
@@ -38,14 +46,6 @@
 #include <kdl/memory_utils.h>
 
 #include <vector>
-
-#include <QButtonGroup>
-#include <QCheckBox>
-#include <QGridLayout>
-#include <QLabel>
-#include <QPushButton>
-#include <QRadioButton>
-#include <QScrollArea>
 
 namespace TrenchBroom
 {

--- a/common/src/View/ViewEditor.h
+++ b/common/src/View/ViewEditor.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <QWidget>
+
 #include "Model/TagType.h"
 #include "NotifierConnection.h"
 
 #include <memory>
 #include <vector>
-
-#include <QWidget>
 
 class QCheckBox;
 class QWidget;

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -19,23 +19,22 @@
 
 #include "ViewPreferencePane.h"
 
+#include <QBoxLayout>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QtGlobal>
+
 #include "PreferenceManager.h"
 #include "Preferences.h"
+#include "Renderer/GL.h"
 #include "View/ColorButton.h"
 #include "View/FormWithSectionsLayout.h"
 #include "View/QtUtils.h"
 #include "View/SliderWithLabel.h"
 #include "View/ViewConstants.h"
 
-#include "Renderer/GL.h"
-
 #include <vecmath/scalar.h>
-
-#include <QBoxLayout>
-#include <QCheckBox>
-#include <QComboBox>
-#include <QLabel>
-#include <QtGlobal>
 
 #include <array>
 #include <string>

--- a/common/src/View/ViewUtils.cpp
+++ b/common/src/View/ViewUtils.cpp
@@ -19,6 +19,11 @@
 
 #include "ViewUtils.h"
 
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QString>
+#include <QWidget>
+
 #include "Assets/EntityDefinitionFileSpec.h"
 #include "IO/PathQt.h"
 #include "Model/Game.h"
@@ -31,11 +36,6 @@
 #include <kdl/string_format.h>
 
 #include <memory>
-
-#include <QInputDialog>
-#include <QMessageBox>
-#include <QString>
-#include <QWidget>
 
 namespace TrenchBroom
 {

--- a/common/src/View/WelcomeWindow.cpp
+++ b/common/src/View/WelcomeWindow.cpp
@@ -19,6 +19,11 @@
 
 #include "WelcomeWindow.h"
 
+#include <QCloseEvent>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QPushButton>
+
 #include "IO/PathQt.h"
 #include "TrenchBroomApp.h"
 #include "View/AppInfoPanel.h"
@@ -26,11 +31,6 @@
 #include "View/QtUtils.h"
 #include "View/RecentDocumentListBox.h"
 #include "View/ViewConstants.h"
-
-#include <QCloseEvent>
-#include <QFileDialog>
-#include <QHBoxLayout>
-#include <QPushButton>
 
 namespace TrenchBroom::View
 {

--- a/common/src/octree.h
+++ b/common/src/octree.h
@@ -22,16 +22,16 @@
 #include "Ensure.h"
 #include "Exceptions.h"
 
+#include <kdl/overload.h>
+#include <kdl/reflection_decl.h>
+#include <kdl/reflection_impl.h>
+#include <kdl/vector_utils.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/bbox_io.h>
 #include <vecmath/intersection.h>
 #include <vecmath/ray.h>
 #include <vecmath/scalar.h>
-
-#include <kdl/overload.h>
-#include <kdl/reflection_decl.h>
-#include <kdl/reflection_impl.h>
-#include <kdl/vector_utils.h>
 
 #include <algorithm>
 #include <cassert>

--- a/common/test/src/Assets/EntityDefinitionTestUtils.cpp
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.cpp
@@ -20,6 +20,7 @@
 #include "EntityDefinitionTestUtils.h"
 
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "EL/EvaluationContext.h"
 #include "EL/Types.h"
 #include "EL/Value.h"
@@ -32,8 +33,6 @@
 
 #include <string>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Assets/tst_AssetUtils.cpp
+++ b/common/test/src/Assets/tst_AssetUtils.cpp
@@ -17,15 +17,13 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "TestLogger.h"
-
 #include "Assets/AssetUtils.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/Path.h"
+#include "TestLogger.h"
 
 #include <optional>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Assets/tst_ModelDefinition.cpp
+++ b/common/test/src/Assets/tst_ModelDefinition.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/ModelDefinition.h"
+#include "Catch2.h"
 #include "EL/Expression.h"
 #include "EL/VariableStore.h"
 #include "IO/ELParser.h"
@@ -25,8 +26,6 @@
 
 #include <map>
 #include <tuple>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Catch2.h
+++ b/common/test/src/Catch2.h
@@ -27,6 +27,8 @@
 // Include this header instead of <catch2/catch.hpp> to ensure that vecmath
 // stream operators work consistently.
 
+#include <kdl/result_io.h>
+
 #include <vecmath/bbox_io.h>
 #include <vecmath/forward.h>
 #include <vecmath/line_io.h>
@@ -34,8 +36,6 @@
 #include <vecmath/plane_io.h>
 #include <vecmath/ray_io.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/result_io.h>
 
 #define CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS 1
 #include <catch2/catch.hpp>

--- a/common/test/src/EL/tst_EL.cpp
+++ b/common/test/src/EL/tst_EL.cpp
@@ -17,15 +17,15 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "EL/ELExceptions.h"
 #include "EL/Types.h"
 #include "EL/Value.h"
+
 #include <vecmath/scalar.h>
 
 #include <limits>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/EL/tst_Expression.cpp
+++ b/common/test/src/EL/tst_Expression.cpp
@@ -17,8 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <cmath>
-
+#include "Catch2.h"
 #include "EL/ELExceptions.h"
 #include "EL/EvaluationContext.h"
 #include "EL/Expression.h"
@@ -29,12 +28,11 @@
 
 #include <kdl/overload.h>
 
+#include <cmath>
 #include <map>
 #include <string>
 #include <variant>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/EL/tst_Interpolator.cpp
+++ b/common/test/src/EL/tst_Interpolator.cpp
@@ -17,13 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "EL/EvaluationContext.h"
 #include "EL/Interpolator.h"
 #include "EL/Value.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -19,18 +19,17 @@
 
 #include "TestEnvironment.h"
 
-#include "IO/PathQt.h"
-#include "Macros.h"
-#include "Uuid.h"
-
-#include <string>
-
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QTextStream>
 
 #include "Catch2.h"
+#include "IO/PathQt.h"
+#include "Macros.h"
+#include "Uuid.h"
+
+#include <string>
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_AseParser.cpp
+++ b/common/test/src/IO/tst_AseParser.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/EntityModel.h"
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/AseParser.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
@@ -27,8 +28,6 @@
 #include "IO/Reader.h"
 #include "IO/VirtualFileSystem.h"
 #include "Logger.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_AseParserRegression.cpp
+++ b/common/test/src/IO/tst_AseParserRegression.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/EntityModel.h"
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/AseParser.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
@@ -27,8 +28,6 @@
 #include "IO/Reader.h"
 #include "IO/VirtualFileSystem.h"
 #include "Logger.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_AssimpParser.cpp
+++ b/common/test/src/IO/tst_AssimpParser.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/EntityModel.h"
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/AssimpParser.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
@@ -26,8 +27,6 @@
 #include "IO/Quake3ShaderFileSystem.h"
 #include "IO/Reader.h"
 #include "Logger.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_CompilationConfigParser.cpp
+++ b/common/test/src/IO/tst_CompilationConfigParser.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/CompilationConfigParser.h"
 #include "Model/CompilationConfig.h"
@@ -24,8 +25,6 @@
 #include "Model/CompilationTask.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_DefParser.cpp
+++ b/common/test/src/IO/tst_DefParser.cpp
@@ -20,6 +20,7 @@
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionTestUtils.h"
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
 #include "IO/DefParser.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -30,8 +31,6 @@
 
 #include <kdl/string_compare.h>
 #include <kdl/vector_utils.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_DiskFileSystem.cpp
+++ b/common/test/src/IO/tst_DiskFileSystem.cpp
@@ -17,6 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QFileInfo>
+#include <QString>
+
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
@@ -28,11 +32,6 @@
 #include "Macros.h"
 
 #include <algorithm>
-
-#include <QFileInfo>
-#include <QString>
-
-#include "Catch2.h"
 
 namespace TrenchBroom::IO
 {

--- a/common/test/src/IO/tst_DiskIO.cpp
+++ b/common/test/src/IO/tst_DiskIO.cpp
@@ -17,6 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QFileInfo>
+#include <QString>
+
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
@@ -28,11 +32,6 @@
 #include "Macros.h"
 
 #include <algorithm>
-
-#include <QFileInfo>
-#include <QString>
-
-#include "Catch2.h"
 
 namespace TrenchBroom::IO
 {

--- a/common/test/src/IO/tst_ELParser.cpp
+++ b/common/test/src/IO/tst_ELParser.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "EL/ELExceptions.h"
 #include "EL/EvaluationContext.h"
 #include "EL/Expression.h"
@@ -25,8 +26,6 @@
 
 #include <limits>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_EntParser.cpp
+++ b/common/test/src/IO/tst_EntParser.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/EntityDefinition.h"
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/DiskIO.h"
 #include "IO/EntParser.h"
@@ -30,8 +31,6 @@
 
 #include <algorithm>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_EntityDefinitionParser.cpp
+++ b/common/test/src/IO/tst_EntityDefinitionParser.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
 #include "EL/Expressions.h"
 #include "IO/EntityDefinitionClassInfo.h"
 #include "IO/EntityDefinitionParser.h"
@@ -25,8 +26,6 @@
 #include "Model/EntityProperties.h"
 
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_EntityModel.cpp
+++ b/common/test/src/IO/tst_EntityModel.cpp
@@ -17,27 +17,24 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "TestLogger.h"
-#include "TestUtils.h"
-
 #include "Assets/EntityModel.h"
+#include "Catch2.h"
 #include "Exceptions.h"
+#include "IO/DiskIO.h"
 #include "IO/EntityModelLoader.h"
+#include "IO/GameConfigParser.h"
 #include "IO/Path.h"
 #include "Model/Game.h"
-
-#include <optional>
-
-#include "IO/DiskIO.h"
-#include "IO/GameConfigParser.h"
 #include "Model/GameConfig.h"
 #include "Model/GameImpl.h"
+#include "TestLogger.h"
+#include "TestUtils.h"
 
 #include <vecmath/bbox.h>
 #include <vecmath/intersection.h>
 #include <vecmath/ray.h>
 
-#include "Catch2.h"
+#include <optional>
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_FgdParser.cpp
+++ b/common/test/src/IO/tst_FgdParser.cpp
@@ -20,6 +20,7 @@
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionTestUtils.h"
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
 #include "IO/DiskIO.h"
 #include "IO/FgdParser.h"
 #include "IO/File.h"
@@ -31,8 +32,6 @@
 
 #include <algorithm>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_FileSystem.cpp
+++ b/common/test/src/IO/tst_FileSystem.cpp
@@ -17,12 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/File.h"
 #include "IO/FileSystem.h"
-
 #include "TestFileSystem.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_GameConfigParser.cpp
+++ b/common/test/src/IO/tst_GameConfigParser.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "EL/Expression.h"
 #include "EL/Expressions.h"
 #include "IO/DiskIO.h"
@@ -28,8 +29,6 @@
 #include "Model/TagMatcher.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_GameEngineConfigParser.cpp
+++ b/common/test/src/IO/tst_GameEngineConfigParser.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/GameEngineConfigParser.h"
 #include "Model/GameEngineConfig.h"
@@ -25,8 +26,6 @@
 #include "kdl/vector_utils.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ImageFileSystem.cpp
+++ b/common/test/src/IO/tst_ImageFileSystem.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/DiskIO.h"
 #include "IO/DkPakFileSystem.h"
@@ -25,8 +26,6 @@
 #include "IO/PathInfo.h"
 #include "IO/WadFileSystem.h"
 #include "IO/ZipFileSystem.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_LoadTextureCollection.cpp
+++ b/common/test/src/IO/tst_LoadTextureCollection.cpp
@@ -20,6 +20,7 @@
 #include "Assets/Palette.h"
 #include "Assets/Texture.h"
 #include "Assets/TextureManager.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -36,8 +37,6 @@
 #include <kdl/result.h>
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Md3Parser.cpp
+++ b/common/test/src/IO/tst_Md3Parser.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/EntityModel.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -34,8 +35,6 @@
 
 #include <cstdio>
 #include <memory>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Md3ParserRegression.cpp
+++ b/common/test/src/IO/tst_Md3ParserRegression.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/EntityModel.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -34,8 +35,6 @@
 
 #include <cstdio>
 #include <memory>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_MdlParser.cpp
+++ b/common/test/src/IO/tst_MdlParser.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/EntityModel.h"
 #include "Assets/Palette.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -28,8 +29,6 @@
 #include "Model/EntityNode.h"
 
 #include <kdl/result.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_NodeReader.cpp
+++ b/common/test/src/IO/tst_NodeReader.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "Catch2.h"
-
 #include "FloatType.h"
 #include "IO/NodeReader.h"
 #include "IO/TestParserStatus.h"

--- a/common/test/src/IO/tst_NodeWriter.cpp
+++ b/common/test/src/IO/tst_NodeWriter.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/NodeWriter.h"
 #include "Model/BezierPatch.h"
@@ -33,6 +34,7 @@
 #include "Model/PatchNode.h"
 #include "Model/VisibilityState.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 
 #include <kdl/result.h>
 #include <kdl/string_compare.h>
@@ -48,9 +50,6 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ObjParser.cpp
+++ b/common/test/src/IO/tst_ObjParser.cpp
@@ -18,14 +18,13 @@
  */
 
 #include "Assets/EntityModel.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
 #include "IO/ObjParser.h"
 #include "IO/Reader.h"
 #include "Logger.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ObjSerializer.cpp
+++ b/common/test/src/IO/tst_ObjSerializer.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/ExportOptions.h"
 #include "IO/NodeWriter.h"
 #include "IO/ObjSerializer.h"
@@ -39,8 +40,6 @@
 #include <memory>
 #include <optional>
 #include <sstream>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Path.cpp
+++ b/common/test/src/IO/tst_Path.cpp
@@ -17,13 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/Path.h"
 #include "IO/PathQt.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Quake3ShaderFileSystem.cpp
+++ b/common/test/src/IO/tst_Quake3ShaderFileSystem.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Quake3Shader.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/Path.h"
@@ -26,8 +27,6 @@
 #include "Logger.h"
 
 #include <memory>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Quake3ShaderParser.cpp
+++ b/common/test/src/IO/tst_Quake3ShaderParser.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Quake3Shader.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -26,8 +27,6 @@
 #include "IO/TestParserStatus.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Quake3ShaderParserRegression.cpp
+++ b/common/test/src/IO/tst_Quake3ShaderParserRegression.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Quake3Shader.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -26,8 +27,6 @@
 #include "IO/TestParserStatus.h"
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ReadDdsTexture.cpp
+++ b/common/test/src/IO/tst_ReadDdsTexture.cpp
@@ -18,21 +18,19 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "IO/File.h"
-#include "TestUtils.h"
-
 #include "Assets/Palette.h"
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
+#include "IO/File.h"
 #include "IO/Path.h"
 #include "IO/ReadDdsTexture.h"
+#include "TestUtils.h"
 
 #include <kdl/result.h>
 
 #include <memory>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ReadFreeImageTexture.cpp
+++ b/common/test/src/IO/tst_ReadFreeImageTexture.cpp
@@ -17,22 +17,19 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "IO/File.h"
-#include "TestLogger.h"
-
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
+#include "IO/File.h"
 #include "IO/Path.h"
 #include "IO/ReadFreeImageTexture.h"
+#include "TestLogger.h"
+#include "TestUtils.h"
 
 #include <kdl/result.h>
 
 #include <string>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom::IO
 {

--- a/common/test/src/IO/tst_ReadM8Texture.cpp
+++ b/common/test/src/IO/tst_ReadM8Texture.cpp
@@ -17,22 +17,20 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "IO/File.h"
-#include "TestLogger.h"
-#include "TestUtils.h"
-
 #include "Assets/Palette.h"
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
+#include "IO/File.h"
 #include "IO/Path.h"
 #include "IO/ReadM8Texture.h"
+#include "TestLogger.h"
+#include "TestUtils.h"
 
 #include <kdl/result.h>
 
 #include <memory>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ReadMipTexture.cpp
+++ b/common/test/src/IO/tst_ReadMipTexture.cpp
@@ -17,25 +17,23 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "IO/File.h"
-#include "TestLogger.h"
-
 #include "Assets/Palette.h"
 #include "Assets/Texture.h"
 #include "Assets/TextureCollection.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
+#include "IO/File.h"
 #include "IO/Path.h"
 #include "IO/ReadMipTexture.h"
 #include "IO/TextureUtils.h"
 #include "IO/WadFileSystem.h"
 #include "Logger.h"
+#include "TestLogger.h"
 
 #include <kdl/result.h>
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom::IO
 {

--- a/common/test/src/IO/tst_ReadQuake3ShaderTexture.cpp
+++ b/common/test/src/IO/tst_ReadQuake3ShaderTexture.cpp
@@ -17,9 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "TestUtils.h"
-
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -27,14 +26,13 @@
 #include "IO/ReadQuake3ShaderTexture.h"
 #include "IO/VirtualFileSystem.h"
 #include "Logger.h"
+#include "TestUtils.h"
 
 #include <kdl/reflection_impl.h>
 #include <kdl/result.h>
 #include <kdl/result_io.h>
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom::IO
 {

--- a/common/test/src/IO/tst_ReadWalTexture.cpp
+++ b/common/test/src/IO/tst_ReadWalTexture.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/Palette.h"
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
@@ -26,10 +27,6 @@
 #include "IO/ReadWalTexture.h"
 
 #include <kdl/result.h>
-
-#include <kdl/result.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Reader.cpp
+++ b/common/test/src/IO/tst_Reader.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
 #include "IO/Reader.h"
@@ -24,8 +25,6 @@
 
 #include <memory>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_ResourceUtils.cpp
+++ b/common/test/src/IO/tst_ResourceUtils.cpp
@@ -18,14 +18,13 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/ResourceUtils.h"
+#include "TestLogger.h"
 
 #include <memory>
-
-#include "Catch2.h"
-#include "TestLogger.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_TestFileSystem.cpp
+++ b/common/test/src/IO/tst_TestFileSystem.cpp
@@ -17,12 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/File.h"
 #include "IO/FileSystem.h"
-
 #include "TestFileSystem.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_TextureUtils.cpp
+++ b/common/test/src/IO/tst_TextureUtils.cpp
@@ -18,17 +18,16 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
 #include "IO/Path.h"
 #include "IO/ReadFreeImageTexture.h"
 #include "IO/TextureUtils.h"
+#include "Logger.h"
 
 #include <kdl/result.h>
-
-#include "Catch2.h"
-#include "Logger.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_Tokenizer.cpp
+++ b/common/test/src/IO/tst_Tokenizer.cpp
@@ -17,14 +17,13 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/Token.h"
 #include "IO/Tokenizer.h"
 
-#include <string>
-
 #include <vecmath/approx.h>
 
-#include "Catch2.h"
+#include <string>
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_VirtualFileSystem.cpp
+++ b/common/test/src/IO/tst_VirtualFileSystem.cpp
@@ -17,14 +17,13 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/File.h"
 #include "IO/TestFileSystem.h"
 #include "IO/VirtualFileSystem.h"
 
 #include <kdl/overload.h>
 #include <kdl/reflection_impl.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_WorldReader.cpp
+++ b/common/test/src/IO/tst_WorldReader.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/DiskIO.h"
 #include "IO/File.h"
 #include "IO/TestParserStatus.h"
@@ -32,6 +33,7 @@
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 
 #include <vecmath/mat.h>
 #include <vecmath/mat_ext.h>
@@ -40,9 +42,6 @@
 #include <fmt/format.h>
 
 #include <string>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/IO/tst_WorldReaderRegression.cpp
+++ b/common/test/src/IO/tst_WorldReaderRegression.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/TestParserStatus.h"
 #include "IO/WorldReader.h"
 #include "Model/BezierPatch.h"
@@ -29,15 +30,13 @@
 #include "Model/LayerNode.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 
 #include <vecmath/mat.h>
 #include <vecmath/mat_ext.h>
 #include <vecmath/vec.h>
 
 #include <string>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -17,9 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "TestGame.h"
+
 #include "Assets/EntityDefinitionFileSpec.h"
 #include "Assets/EntityModel.h"
 #include "Assets/TextureManager.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/BrushFaceReader.h"
 #include "IO/DiskFileSystem.h"
@@ -42,10 +45,6 @@
 #include <fstream>
 #include <memory>
 #include <vector>
-
-#include "Catch2.h"
-
-#include "TestGame.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_BezierPatch.cpp
+++ b/common/test/src/Model/tst_BezierPatch.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 
 #include <vecmath/mat.h>
@@ -27,8 +28,6 @@
 
 #include <tuple>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Brush.cpp
+++ b/common/test/src/Model/tst_Brush.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "FloatType.h"
 #include "IO/DiskIO.h"
@@ -32,6 +33,7 @@
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
 #include "Model/Polyhedron.h"
+#include "TestUtils.h"
 
 #include <kdl/intrusive_circular_list.h>
 #include <kdl/result.h>
@@ -48,9 +50,6 @@
 #include <fstream>
 #include <string>
 #include <vector>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_BrushBuilder.cpp
+++ b/common/test/src/Model/tst_BrushBuilder.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -26,8 +27,6 @@
 #include <kdl/result.h>
 
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_BrushFace.cpp
+++ b/common/test/src/Model/tst_BrushFace.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "FloatType.h"
 #include "IO/NodeReader.h"
@@ -35,6 +36,7 @@
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/ParaxialTexCoordSystem.h"
 #include "Model/Polyhedron.h"
+#include "TestUtils.h"
 
 #include <kdl/result.h>
 #include <kdl/vector_utils.h>
@@ -47,9 +49,6 @@
 
 #include <memory>
 #include <vector>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_BrushNode.cpp
+++ b/common/test/src/Model/tst_BrushNode.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/NodeReader.h"
 #include "IO/TestParserStatus.h"
@@ -34,6 +35,7 @@
 #include "Model/MapFormat.h"
 #include "Model/PatchNode.h"
 #include "Model/PickResult.h"
+#include "TestUtils.h"
 
 #include <kdl/collection_utils.h>
 #include <kdl/result.h>
@@ -50,9 +52,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_BrushNodeRegression.cpp
+++ b/common/test/src/Model/tst_BrushNodeRegression.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/NodeReader.h"
 #include "IO/TestParserStatus.h"
@@ -33,6 +34,7 @@
 #include "Model/MapFormat.h"
 #include "Model/PatchNode.h"
 #include "Model/PickResult.h"
+#include "TestUtils.h"
 
 #include <kdl/collection_utils.h>
 #include <kdl/result.h>
@@ -49,9 +51,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_BrushRegression.cpp
+++ b/common/test/src/Model/tst_BrushRegression.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "FloatType.h"
 #include "IO/DiskIO.h"
@@ -32,6 +33,7 @@
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
 #include "Model/Polyhedron.h"
+#include "TestUtils.h"
 
 #include <kdl/intrusive_circular_list.h>
 #include <kdl/result.h>
@@ -48,9 +50,6 @@
 #include <fstream>
 #include <string>
 #include <vector>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_EditorContext.cpp
+++ b/common/test/src/Model/tst_EditorContext.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "Model/BezierPatch.h"
 #include "Model/BrushBuilder.h"
@@ -42,8 +43,6 @@
 
 #include <functional>
 #include <tuple>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Entity.cpp
+++ b/common/test/src/Model/tst_Entity.cpp
@@ -19,6 +19,7 @@
 
 #include "Assets/EntityDefinition.h"
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
 #include "EL/Expressions.h"
 #include "FloatType.h"
 #include "IO/ELParser.h"
@@ -33,8 +34,6 @@
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_EntityNode.cpp
+++ b/common/test/src/Model/tst_EntityNode.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -46,8 +47,6 @@
 
 #include <memory>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_EntityNodeIndex.cpp
+++ b/common/test/src/Model/tst_EntityNodeIndex.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/EntityNode.h"
 #include "Model/EntityNodeBase.h"
 #include "Model/EntityNodeIndex.h"
@@ -25,8 +26,6 @@
 
 #include <string>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_EntityNodeLink.cpp
+++ b/common/test/src/Model/tst_EntityNodeLink.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/Entity.h"
 #include "Model/EntityNode.h"
 #include "Model/EntityNodeBase.h"
@@ -27,8 +28,6 @@
 #include <kdl/vector_utils.h>
 
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_EntityRegression.cpp
+++ b/common/test/src/Model/tst_EntityRegression.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "Color.h"
 #include "EL/ELExceptions.h"
 #include "EL/Expression.h"
@@ -31,8 +32,6 @@
 #include <vecmath/bbox_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_EntityRotation.cpp
+++ b/common/test/src/Model/tst_EntityRotation.cpp
@@ -17,12 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "FloatType.h"
-#include "Macros.h"
-
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityModel.h"
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
+#include "FloatType.h"
+#include "Macros.h"
 #include "Model/Entity.h"
 #include "Model/EntityProperties.h"
 #include "Model/EntityRotation.h"
@@ -34,8 +34,6 @@
 #include <vecmath/scalar.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Game.cpp
+++ b/common/test/src/Model/tst_Game.cpp
@@ -20,6 +20,7 @@
 #include "Assets/Texture.h"
 #include "Assets/TextureCollection.h"
 #include "Assets/TextureManager.h"
+#include "Catch2.h"
 #include "IO/DiskIO.h"
 #include "IO/GameConfigParser.h"
 #include "IO/IOUtils.h"
@@ -30,8 +31,6 @@
 #include "Model/GameImpl.h"
 
 #include <kdl/vector_utils.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_GameFactory.cpp
+++ b/common/test/src/Model/tst_GameFactory.cpp
@@ -17,11 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/TestEnvironment.h"
 #include "Model/GameConfig.h"
 #include "Model/GameFactory.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Group.cpp
+++ b/common/test/src/Model/tst_Group.cpp
@@ -17,9 +17,11 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
+#include "Model/Group.h"
 #include "TestUtils.h"
 
-#include "Model/Group.h"
+#include <kdl/result.h>
 
 #include <vecmath/bbox.h>
 #include <vecmath/bbox_io.h>
@@ -27,12 +29,8 @@
 #include <vecmath/mat_ext.h>
 #include <vecmath/mat_io.h>
 
-#include <kdl/result.h>
-
 #include <memory>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_GroupNode.cpp
+++ b/common/test/src/Model/tst_GroupNode.cpp
@@ -17,8 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "TestUtils.h"
-
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -32,6 +31,9 @@
 #include "Model/PatchNode.h"
 #include "Model/UpdateLinkedGroupsError.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
+
+#include <kdl/result.h>
 
 #include <vecmath/bbox.h>
 #include <vecmath/bbox_io.h>
@@ -39,12 +41,8 @@
 #include <vecmath/mat_ext.h>
 #include <vecmath/mat_io.h>
 
-#include <kdl/result.h>
-
 #include <memory>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Issue.cpp
+++ b/common/test/src/Model/tst_Issue.cpp
@@ -17,8 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Model/Issue.h"
-
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -27,6 +26,7 @@
 #include "Model/EntityNode.h"
 #include "Model/Group.h"
 #include "Model/GroupNode.h"
+#include "Model/Issue.h"
 #include "Model/MapFormat.h"
 #include "Model/PatchNode.h"
 
@@ -37,8 +37,6 @@
 #include <vecmath/bbox_io.h>
 
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_LayerNode.cpp
+++ b/common/test/src/Model/tst_LayerNode.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
@@ -32,8 +33,6 @@
 
 #include <kdl/result.h>
 #include <kdl/result_io.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_ModelUtils.cpp
+++ b/common/test/src/Model/tst_ModelUtils.cpp
@@ -17,8 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Model/ModelUtils.h"
-
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -32,8 +31,10 @@
 #include "Model/LayerNode.h"
 #include "Model/LockState.h"
 #include "Model/MapFormat.h"
+#include "Model/ModelUtils.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 
 #include "kdl/vector_utils.h"
 #include <kdl/result.h>
@@ -46,9 +47,6 @@
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Node.cpp
+++ b/common/test/src/Model/tst_Node.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "EL/Expression.h"
 #include "EL/Expressions.h"
 #include "EL/Value.h"
@@ -52,8 +53,6 @@
 
 #include <variant>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_NodeCollection.cpp
+++ b/common/test/src/Model/tst_NodeCollection.cpp
@@ -17,8 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Model/NodeCollection.h"
-
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -30,6 +29,7 @@
 #include "Model/Layer.h"
 #include "Model/LayerNode.h"
 #include "Model/MapFormat.h"
+#include "Model/NodeCollection.h"
 #include "Model/PatchNode.h"
 
 #include <kdl/result.h>
@@ -39,8 +39,6 @@
 #include <vecmath/bbox_io.h>
 
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_PatchNode.cpp
+++ b/common/test/src/Model/tst_PatchNode.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "FloatType.h"
 #include "Model/BezierPatch.h"
 #include "Model/EditorContext.h"
@@ -30,8 +31,6 @@
 #include <vecmath/ray_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "Catch2.h"
 
 namespace vm
 {

--- a/common/test/src/Model/tst_PointTrace.cpp
+++ b/common/test/src/Model/tst_PointTrace.cpp
@@ -17,14 +17,13 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/PointTrace.h"
 
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
 #include <sstream>
-
-#include "Catch2.h"
 
 namespace TrenchBroom::Model
 {

--- a/common/test/src/Model/tst_Polyhedron.cpp
+++ b/common/test/src/Model/tst_Polyhedron.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "FloatType.h"
 #include "Model/Polyhedron.h"
 #include "Model/Polyhedron_BrushGeometryPayload.h"
@@ -31,8 +32,6 @@
 #include <iterator>
 #include <set>
 #include <tuple>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_PolyhedronRegression.cpp
+++ b/common/test/src/Model/tst_PolyhedronRegression.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "FloatType.h"
 #include "Model/Polyhedron.h"
 #include "Model/Polyhedron_BrushGeometryPayload.h"
@@ -31,8 +32,6 @@
 #include <iterator>
 #include <set>
 #include <tuple>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_PortalFile.cpp
+++ b/common/test/src/Model/tst_PortalFile.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "IO/DiskIO.h"
 #include "IO/Path.h"
 #include "Model/PortalFile.h"
@@ -24,8 +25,6 @@
 #include <vecmath/polygon.h>
 
 #include <memory>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_Tagging.cpp
+++ b/common/test/src/Model/tst_Tagging.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
@@ -27,8 +28,6 @@
 #include "Model/WorldNode.h"
 
 #include <kdl/result.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_TexCoordSystem.cpp
+++ b/common/test/src/Model/tst_TexCoordSystem.cpp
@@ -18,14 +18,13 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "FloatType.h"
 #include "Model/BrushFaceAttributes.h"
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/ParaxialTexCoordSystem.h"
 
 #include <vecmath/vec.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Model/tst_WorldNode.cpp
+++ b/common/test/src/Model/tst_WorldNode.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
@@ -29,6 +30,7 @@
 #include "Model/MapFormat.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "octree.h"
 
 #include <kdl/result.h>
@@ -38,9 +40,6 @@
 #include <vecmath/mat.h>
 #include <vecmath/mat_ext.h>
 #include <vecmath/mat_io.h>
-
-#include "Catch2.h"
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Renderer/tst_AllocationTracker.cpp
+++ b/common/test/src/Renderer/tst_AllocationTracker.cpp
@@ -17,13 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Renderer/AllocationTracker.h"
 
 #include <algorithm>
 #include <random>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Renderer/tst_Camera.cpp
+++ b/common/test/src/Renderer/tst_Camera.cpp
@@ -17,10 +17,9 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Renderer/Camera.h"
 #include "Renderer/PerspectiveCamera.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/Renderer/tst_Vertex.cpp
+++ b/common/test/src/Renderer/tst_Vertex.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Renderer/GLVertex.h"
 #include "Renderer/GLVertexType.h"
 
@@ -24,8 +25,6 @@
 #include <vecmath/vec.h>
 
 #include <cstring>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/RunAllTests.cpp
+++ b/common/test/src/RunAllTests.cpp
@@ -19,13 +19,12 @@
 
 #define CATCH_CONFIG_RUNNER
 
+#include "Catch2.h"
 #include "Ensure.h"
 #include "TestPreferenceManager.h"
 #include "TrenchBroomApp.h"
 
 #include <clocale>
-
-#include "Catch2.h"
 
 int main(int argc, char** argv)
 {

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "TestUtils.h"
-#include "TestLogger.h"
 
 #include "Assets/Texture.h"
 #include "Ensure.h"
@@ -33,6 +32,7 @@
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/ParaxialTexCoordSystem.h"
 #include "Model/PatchNode.h"
+#include "TestLogger.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentCommandFacade.h"
 

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
+#include "Catch2.h"
 #include "FloatType.h"
-
 #include "Model/MapFormat.h"
 
 #include <kdl/vector_set.h>
@@ -34,8 +34,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_ActionContext.cpp
+++ b/common/test/src/View/tst_ActionContext.cpp
@@ -17,9 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "View/ActionContext.h"
-
 #include "Catch2.h"
+#include "View/ActionContext.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_AddNodes.cpp
+++ b/common/test/src/View/tst_AddNodes.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
 #include "Model/EntityNode.h"
@@ -27,6 +28,8 @@
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
 
+#include <kdl/overload.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/bbox_io.h>
 #include <vecmath/mat.h>
@@ -34,10 +37,6 @@
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/overload.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_Autosaver.cpp
+++ b/common/test/src/View/tst_Autosaver.cpp
@@ -17,23 +17,21 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QString>
+
+#include "Catch2.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/Path.h"
 #include "IO/TestEnvironment.h"
 #include "Logger.h"
 #include "Model/BrushNode.h"
 #include "Model/LayerNode.h"
+#include "TestUtils.h"
 #include "View/Autosaver.h"
 #include "View/MapDocumentTest.h"
 
 #include <chrono>
 #include <thread>
-
-#include <QString>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_ChangeBrushFaceAttributes.cpp
+++ b/common/test/src/View/tst_ChangeBrushFaceAttributes.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceHandle.h"
 #include "Model/BrushNode.h"
@@ -27,12 +28,9 @@
 #include "Model/LayerNode.h"
 #include "Model/TestGame.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_ClipToolController.cpp
+++ b/common/test/src/View/tst_ClipToolController.cpp
@@ -17,6 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
+#include "MapDocumentTest.h"
 #include "Model/BrushNode.h"
 #include "Model/LayerNode.h"
 #include "Model/WorldNode.h"
@@ -26,10 +28,6 @@
 #include "View/Grid.h"
 #include "View/PasteType.h"
 #include "View/Tool.h"
-
-#include "Catch2.h"
-
-#include "MapDocumentTest.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_CommandProcessor.cpp
+++ b/common/test/src/View/tst_CommandProcessor.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Macros.h"
 #include "NotifierConnection.h"
 #include "View/CommandProcessor.h"
@@ -30,8 +31,6 @@
 #include <optional>
 #include <thread>
 #include <variant>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_CompilationRunner.cpp
+++ b/common/test/src/View/tst_CompilationRunner.cpp
@@ -17,26 +17,24 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "TestUtils.h"
+#include <QObject>
+#include <QTextEdit>
 
+#include "Catch2.h"
 #include "EL/VariableStore.h"
 #include "IO/TestEnvironment.h"
 #include "MapDocumentTest.h"
 #include "Model/CompilationTask.h"
+#include "TestUtils.h"
 #include "View/CompilationContext.h"
 #include "View/CompilationRunner.h"
 #include "View/CompilationVariables.h"
 #include "View/TextOutputAdapter.h"
 
-#include <QObject>
-#include <QTextEdit>
-
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_CopyPaste.cpp
+++ b/common/test/src/View/tst_CopyPaste.cpp
@@ -18,9 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
@@ -28,11 +27,10 @@
 #include "Model/LayerNode.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/PasteType.h"
 
 #include <kdl/result.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_Csg.cpp
+++ b/common/test/src/View/tst_Csg.cpp
@@ -18,9 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushNode.h"
@@ -28,10 +27,9 @@
 #include "Model/LayerNode.h"
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 
 #include <kdl/result.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_ExtrudeTool.cpp
+++ b/common/test/src/View/tst_ExtrudeTool.cpp
@@ -18,9 +18,9 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "View/ExtrudeTool.h"
-
+#include "Catch2.h"
 #include "IO/Path.h"
+#include "MapDocumentTest.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
@@ -34,6 +34,9 @@
 #include "Model/PickResult.h"
 #include "Model/WorldNode.h"
 #include "Renderer/PerspectiveCamera.h"
+#include "TestLogger.h"
+#include "TestUtils.h"
+#include "View/ExtrudeTool.h"
 
 #include <kdl/result.h>
 #include <kdl/string_utils.h>
@@ -46,12 +49,6 @@
 #include <vecmath/vec_io.h>
 
 #include <memory>
-
-#include "MapDocumentTest.h"
-#include "TestLogger.h"
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom::View
 {

--- a/common/test/src/View/tst_Grid.cpp
+++ b/common/test/src/View/tst_Grid.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/Texture.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
@@ -34,8 +35,6 @@
 #include <vecmath/segment.h>
 
 #include <cmath>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_GroupNodes.cpp
+++ b/common/test/src/View/tst_GroupNodes.cpp
@@ -17,10 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "TestUtils.h"
-#include "View/MapDocumentTest.h"
-
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceHandle.h"
@@ -33,6 +31,8 @@
 #include "Model/ModelUtils.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
+#include "View/MapDocumentTest.h"
 #include "View/PasteType.h"
 
 #include <kdl/result.h>
@@ -41,8 +41,6 @@
 
 #include <functional>
 #include <set>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_HandleDragTracker.cpp
+++ b/common/test/src/View/tst_HandleDragTracker.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/Hit.h"
 #include "Model/HitFilter.h"
 #include "Model/PickResult.h"
@@ -37,8 +38,6 @@
 
 #include <tuple>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_InputEvent.cpp
+++ b/common/test/src/View/tst_InputEvent.cpp
@@ -17,6 +17,10 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <QKeyEvent>
+#include <QtGlobal>
+
+#include "Catch2.h"
 #include "View/InputEvent.h"
 
 #include <kdl/overload.h>
@@ -26,11 +30,6 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include <list>
 #include <thread>
 #include <variant>
-
-#include <QKeyEvent>
-#include <QtGlobal>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_LayerNodes.cpp
+++ b/common/test/src/View/tst_LayerNodes.cpp
@@ -18,9 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
 #include "Model/GroupNode.h"
@@ -30,8 +29,7 @@
 #include "Model/PatchNode.h"
 #include "Model/VisibilityState.h"
 #include "Model/WorldNode.h"
-
-#include "Catch2.h"
+#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_MapDocument.cpp
+++ b/common/test/src/View/tst_MapDocument.cpp
@@ -17,13 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Assets/EntityDefinition.h"
 #include "Assets/PropertyDefinition.h"
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "IO/WorldReader.h"
+#include "MapDocumentTest.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
@@ -34,13 +33,12 @@
 #include "Model/PatchNode.h"
 #include "Model/TestGame.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocumentCommandFacade.h"
 
 #include "kdl/map_utils.h"
 #include <kdl/result.h>
 #include <kdl/vector_utils.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_MoveHandleDragTracker.cpp
+++ b/common/test/src/View/tst_MoveHandleDragTracker.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Renderer/OrthographicCamera.h"
 #include "Renderer/PerspectiveCamera.h"
 #include "View/MoveHandleDragTracker.h"
@@ -27,8 +28,6 @@
 #include <vecmath/ray_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "Catch2.h"
 
 namespace vm
 {

--- a/common/test/src/View/tst_Picking.cpp
+++ b/common/test/src/View/tst_Picking.cpp
@@ -18,9 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushNode.h"
@@ -31,17 +30,16 @@
 #include "Model/HitFilter.h"
 #include "Model/PickResult.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/SelectionTool.h"
+
+#include <kdl/result.h>
 
 #include <vecmath/approx.h>
 #include <vecmath/ray.h>
 #include <vecmath/ray_io.h>
 
-#include <kdl/result.h>
-
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_RemoveNodes.cpp
+++ b/common/test/src/View/tst_RemoveNodes.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
@@ -24,14 +25,11 @@
 #include "Model/LayerNode.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
 
 #include <cstdio>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_ReparentNodes.cpp
+++ b/common/test/src/View/tst_ReparentNodes.cpp
@@ -17,17 +17,15 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
 #include "Model/GroupNode.h"
 #include "Model/LayerNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_RepeatableActions.cpp
+++ b/common/test/src/View/tst_RepeatableActions.cpp
@@ -17,8 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
+#include "TestUtils.h"
 #include "View/Command.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
@@ -34,10 +36,6 @@
 #include <vecmath/scalar.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_ScaleObjectsTool.cpp
+++ b/common/test/src/View/tst_ScaleObjectsTool.cpp
@@ -18,9 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "View/ScaleObjectsTool.h"
-
 #include "Catch2.h"
+#include "View/ScaleObjectsTool.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_Selection.cpp
+++ b/common/test/src/View/tst_Selection.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Exceptions.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
@@ -26,20 +27,17 @@
 #include "Model/NodeCollection.h"
 #include "Model/PatchNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
+
+#include <kdl/result.h>
 
 #include <vecmath/mat.h>
 #include <vecmath/mat_ext.h>
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/result.h>
-
-#include "Catch2.h"
-
-#include "TestUtils.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_SelectionTool.cpp
+++ b/common/test/src/View/tst_SelectionTool.cpp
@@ -17,10 +17,10 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Model/BrushBuilder.h"
-
+#include "Catch2.h"
 #include "FloatType.h"
 #include "Model/Brush.h"
+#include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushNode.h"
 #include "Model/EditorContext.h"
@@ -36,12 +36,10 @@
 #include "View/PickRequest.h"
 #include "View/SelectionTool.h"
 
-#include <vecmath/ray.h>
-
 #include <kdl/result.h>
 #include <kdl/vector_utils.h>
 
-#include "Catch2.h"
+#include <vecmath/ray.h>
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_SetEntityProperties.cpp
+++ b/common/test/src/View/tst_SetEntityProperties.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "Color.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushNode.h"
@@ -25,18 +26,15 @@
 #include "Model/EntityNode.h"
 #include "Model/GroupNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
 
-#include <vecmath/bbox.h>
-
 #include <kdl/result.h>
 
+#include <vecmath/bbox.h>
+
 #include <vector>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_SetLockState.cpp
+++ b/common/test/src/View/tst_SetLockState.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "Model/BezierPatch.h"
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
@@ -33,8 +34,6 @@
 #include <vecmath/bbox.h>
 
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_SetVisibilityState.cpp
+++ b/common/test/src/View/tst_SetVisibilityState.cpp
@@ -18,14 +18,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-
 #include "Model/BrushNode.h"
 #include "Model/EntityNode.h"
 #include "Model/GroupNode.h"
 #include "Model/PatchNode.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_SnapBrushVertices.cpp
+++ b/common/test/src/View/tst_SnapBrushVertices.cpp
@@ -17,13 +17,12 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/BrushNode.h"
 #include "Model/NodeCollection.h"
 #include "View/Grid.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_SwapNodeContents.cpp
+++ b/common/test/src/View/tst_SwapNodeContents.cpp
@@ -20,6 +20,7 @@
 #include "Assets/EntityDefinition.h"
 #include "Assets/Texture.h"
 #include "Assets/TextureManager.h"
+#include "Catch2.h"
 #include "FloatType.h"
 #include "IO/Path.h"
 #include "Model/BezierPatch.h"
@@ -31,6 +32,7 @@
 #include "Model/GroupNode.h"
 #include "Model/NodeContents.h"
 #include "Model/PatchNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
 #include "View/SwapNodeContentsCommand.h"
@@ -47,10 +49,6 @@
 #include <vecmath/vec_io.h>
 
 #include <memory>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_TagManagement.cpp
+++ b/common/test/src/View/tst_TagManagement.cpp
@@ -20,6 +20,7 @@
 #include "Assets/Texture.h"
 #include "Assets/TextureCollection.h"
 #include "Assets/TextureManager.h"
+#include "Catch2.h"
 #include "IO/Path.h"
 #include "IO/TestEnvironment.h"
 #include "Logger.h"
@@ -31,13 +32,10 @@
 #include "Model/Tag.h"
 #include "Model/TagMatcher.h"
 #include "Model/TestGame.h"
+#include "TestUtils.h"
 #include "View/MapDocumentTest.h"
 
 #include <vector>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_TextOutputAdapter.cpp
+++ b/common/test/src/View/tst_TextOutputAdapter.cpp
@@ -17,11 +17,10 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "View/TextOutputAdapter.h"
-
 #include <QTextEdit>
 
 #include "Catch2.h"
+#include "View/TextOutputAdapter.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_Transaction.cpp
+++ b/common/test/src/View/tst_Transaction.cpp
@@ -17,15 +17,13 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Model/Entity.h"
 #include "Model/EntityNode.h"
+#include "TestUtils.h"
 
 #include <vecmath/mat_ext.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom::View
 {

--- a/common/test/src/View/tst_TransformNodes.cpp
+++ b/common/test/src/View/tst_TransformNodes.cpp
@@ -18,9 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-#include "TestUtils.h"
-
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
@@ -33,6 +32,11 @@
 #include "Model/WorldNode.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
+#include "TestUtils.h"
+
+#include <kdl/result.h>
+#include <kdl/vector_utils.h>
+#include <kdl/zip_iterator.h>
 
 #include <vecmath/approx.h>
 #include <vecmath/mat.h>
@@ -41,13 +45,7 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
-#include <kdl/result.h>
-#include <kdl/vector_utils.h>
-#include <kdl/zip_iterator.h>
-
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_Undo.cpp
+++ b/common/test/src/View/tst_Undo.cpp
@@ -20,6 +20,7 @@
 #include "Assets/Texture.h"
 #include "Assets/TextureCollection.h"
 #include "Assets/TextureManager.h"
+#include "Catch2.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushNode.h"
 #include "Model/ChangeBrushFaceAttributesRequest.h"
@@ -28,14 +29,11 @@
 #include "Model/GroupNode.h"
 #include "Model/LayerNode.h"
 #include "Model/WorldNode.h"
+#include "TestUtils.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentTest.h"
 
 #include <cassert>
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_UpdateLinkedGroupsCommand.cpp
+++ b/common/test/src/View/tst_UpdateLinkedGroupsCommand.cpp
@@ -17,19 +17,16 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "View/UpdateLinkedGroupsCommand.h"
-
+#include "Catch2.h"
 #include "Model/BrushNode.h"
 #include "Model/Group.h"
 #include "Model/GroupNode.h"
+#include "TestUtils.h"
 #include "View/CurrentGroupCommand.h"
 #include "View/MapDocument.h"
 #include "View/MapDocumentCommandFacade.h"
 #include "View/MapDocumentTest.h"
-
-#include "TestUtils.h"
-
-#include "Catch2.h"
+#include "View/UpdateLinkedGroupsCommand.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_UpdateLinkedGroupsHelper.cpp
+++ b/common/test/src/View/tst_UpdateLinkedGroupsHelper.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Model/Brush.h"
 #include "Model/BrushNode.h"
 #include "Model/Entity.h"
@@ -31,6 +32,9 @@
 #include "View/MapDocumentTest.h"
 #include "View/UpdateLinkedGroupsHelper.h"
 
+#include <kdl/overload.h>
+#include <kdl/result.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/bbox_io.h>
 #include <vecmath/mat.h>
@@ -38,11 +42,6 @@
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include <kdl/overload.h>
-#include <kdl/result.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/View/tst_Validator.cpp
+++ b/common/test/src/View/tst_Validator.cpp
@@ -18,8 +18,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "MapDocumentTest.h"
-
 #include "Model/BrushNode.h"
 #include "Model/EmptyPropertyKeyValidator.h"
 #include "Model/EmptyPropertyValueValidator.h"
@@ -33,8 +33,6 @@
 
 #include <kdl/overload.h>
 #include <kdl/vector_utils.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/tst_Ensure.cpp
+++ b/common/test/src/tst_Ensure.cpp
@@ -17,10 +17,9 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Ensure.h"
 #include "Macros.h"
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/tst_Notifier.cpp
+++ b/common/test/src/tst_Notifier.cpp
@@ -17,12 +17,11 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "Notifier.h"
 
 #include <tuple>
 #include <vector>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -17,7 +17,11 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QString>
+#include <QTextStream>
+
 #include "Assets/EntityDefinition.h"
+#include "Catch2.h"
 #include "Color.h"
 #include "Model/Tag.h"
 #include "Model/TagMatcher.h"
@@ -34,11 +38,6 @@
 #include <iostream>
 #include <optional>
 #include <string>
-
-#include <QString>
-#include <QTextStream>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/tst_StackWalker.cpp
+++ b/common/test/src/tst_StackWalker.cpp
@@ -17,9 +17,8 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "TrenchBroomStackWalker.h"
-
 #include "Catch2.h"
+#include "TrenchBroomStackWalker.h"
 
 namespace TrenchBroom
 {

--- a/common/test/src/tst_octree.cpp
+++ b/common/test/src/tst_octree.cpp
@@ -17,16 +17,15 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Catch2.h"
 #include "octree.h"
+
+#include <kdl/string_utils.h>
 
 #include <vecmath/bbox.h>
 #include <vecmath/forward.h>
 #include <vecmath/ray.h>
 #include <vecmath/vec.h>
-
-#include <kdl/string_utils.h>
-
-#include "Catch2.h"
 
 namespace TrenchBroom
 {

--- a/dump-shortcuts/src/Main.cpp
+++ b/dump-shortcuts/src/Main.cpp
@@ -17,17 +17,16 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "View/Actions.h"
+#include <QApplication>
+#include <QFileInfo>
+#include <QSettings>
+#include <QTextStream>
 
 #include "IO/Path.h"
 #include "KeyStrings.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
-
-#include <QApplication>
-#include <QFileInfo>
-#include <QSettings>
-#include <QTextStream>
+#include "View/Actions.h"
 
 #include <array>
 #include <iostream>

--- a/lib/kdl/include/kdl/string_compare_detail.h
+++ b/lib/kdl/include/kdl/string_compare_detail.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
+#include "collection_utils.h"
+
 #include <algorithm> // for std::mismatch, std::sort, std::search, std::equal
 #include <string_view>
 #include <vector> // used in str_matches_glob
-
-#include "collection_utils.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_collection_utils.cpp
+++ b/lib/kdl/test/src/tst_collection_utils.cpp
@@ -18,11 +18,11 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include "kdl/collection_utils.h"
 
 #include <vector>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 

--- a/lib/kdl/test/src/tst_map_utils.cpp
+++ b/lib/kdl/test/src/tst_map_utils.cpp
@@ -18,13 +18,13 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include "kdl/map_utils.h"
 
 #include <map>
 #include <string>
 #include <vector>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 

--- a/lib/kdl/test/src/tst_parallel.cpp
+++ b/lib/kdl/test/src/tst_parallel.cpp
@@ -18,6 +18,8 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include "kdl/parallel.h"
 
 #include <array>
@@ -26,8 +28,6 @@
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 

--- a/lib/kdl/test/src/tst_vector_utils.cpp
+++ b/lib/kdl/test/src/tst_vector_utils.cpp
@@ -18,13 +18,13 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include "kdl/vector_utils.h"
 
 #include <memory>
 #include <set>
 #include <vector>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 

--- a/lib/vecmath/include/vecmath/ray.h
+++ b/lib/vecmath/include/vecmath/ray.h
@@ -21,12 +21,11 @@
 
 #pragma once
 
-#include "mat.h"
-#include "vec.h"
-
 #include "abstract_line.h"
+#include "mat.h"
 #include "scalar.h"
 #include "util.h"
+#include "vec.h"
 
 namespace vm
 {

--- a/lib/vecmath/test/src/tst_bbox.cpp
+++ b/lib/vecmath/test/src/tst_bbox.cpp
@@ -19,13 +19,13 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/bbox.h>
 #include <vecmath/bbox_io.h>
 #include <vecmath/forward.h>
 #include <vecmath/mat_ext.h>
 #include <vecmath/vec.h>
-
-#include "test_utils.h"
 
 #include <sstream>
 #include <vector>

--- a/lib/vecmath/test/src/tst_mat.cpp
+++ b/lib/vecmath/test/src/tst_mat.cpp
@@ -19,14 +19,14 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/mat.h>
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <sstream>
 

--- a/lib/vecmath/test/src/tst_mat_ext.cpp
+++ b/lib/vecmath/test/src/tst_mat_ext.cpp
@@ -19,6 +19,8 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/mat.h>
@@ -26,8 +28,6 @@
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <cstdlib>
 #include <ctime>

--- a/lib/vecmath/test/src/tst_mat_io.cpp
+++ b/lib/vecmath/test/src/tst_mat_io.cpp
@@ -18,12 +18,12 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/forward.h>
 #include <vecmath/mat_io.h>
 
 #include <sstream>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 

--- a/lib/vecmath/test/src/tst_plane.cpp
+++ b/lib/vecmath/test/src/tst_plane.cpp
@@ -19,6 +19,8 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/constexpr_util.h>
 #include <vecmath/forward.h>
@@ -29,8 +31,6 @@
 #include <vecmath/scalar.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <array>
 #include <sstream>

--- a/lib/vecmath/test/src/tst_polygon.cpp
+++ b/lib/vecmath/test/src/tst_polygon.cpp
@@ -19,6 +19,8 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/mat.h>
@@ -28,8 +30,6 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_ext.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <iterator>
 #include <vector>

--- a/lib/vecmath/test/src/tst_quat.cpp
+++ b/lib/vecmath/test/src/tst_quat.cpp
@@ -19,14 +19,14 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/quat.h>
 #include <vecmath/scalar.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 

--- a/lib/vecmath/test/src/tst_ray.cpp
+++ b/lib/vecmath/test/src/tst_ray.cpp
@@ -19,6 +19,8 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/mat.h>
@@ -30,8 +32,6 @@
 #include <vecmath/util.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <sstream>
 

--- a/lib/vecmath/test/src/tst_segment.cpp
+++ b/lib/vecmath/test/src/tst_segment.cpp
@@ -19,6 +19,8 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/constants.h>
 #include <vecmath/forward.h>
@@ -29,8 +31,6 @@
 #include <vecmath/segment.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <iterator>
 #include <vector>

--- a/lib/vecmath/test/src/tst_vec.cpp
+++ b/lib/vecmath/test/src/tst_vec.cpp
@@ -19,14 +19,14 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/mat_ext.h> // used by rotate_pos_x_by_degrees
 #include <vecmath/mat_io.h>
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <array>
 #include <limits>

--- a/lib/vecmath/test/src/tst_vec_ext.cpp
+++ b/lib/vecmath/test/src/tst_vec_ext.cpp
@@ -19,12 +19,12 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/approx.h>
 #include <vecmath/forward.h>
 #include <vecmath/vec_ext.h>
 #include <vecmath/vec_io.h>
-
-#include "test_utils.h"
 
 #include <array>
 #include <vector>

--- a/lib/vecmath/test/src/tst_vec_io.cpp
+++ b/lib/vecmath/test/src/tst_vec_io.cpp
@@ -19,12 +19,12 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "test_utils.h"
+
 #include <vecmath/forward.h>
 #include <vecmath/vec_io.h>
 
 #include <sstream>
-
-#include "test_utils.h"
 
 #include <catch2/catch.hpp>
 


### PR DESCRIPTION
This is a preparation for https://github.com/TrenchBroom/TrenchBroom/pull/4240 where we replace `IO::Path` with `std::filesystem::path`. It turns out that there is an issue with Cmake not passing the required C++ standard version to the compiler via its automoc support. Including Qt headers before std headers fixes this, so we enforce a grouping and order of includes using clang-format.