### PR TITLE
Use MDI on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ find_package(tinyxml2 CONFIG REQUIRED)
 
 # Find Qt and OpenGL
 find_package(OpenGL REQUIRED)
-find_package(Qt5 COMPONENTS Core Widgets Svg REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Svg Network REQUIRED)
 
 # Qt will warn about API's that were deprecated after 5.9.5.
 # Since we're not raising our minimum Qt version, and can't use the replacement

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -154,24 +154,8 @@ macro(configure_app_target APP_TARGET_NAME SHOULD_BUILD_MANUAL)
                 COMMAND ${CMAKE_COMMAND} -E copy "${APP_RESOURCE_DIR}/win32/icons/DocIcon.ico"    "${CMAKE_CURRENT_BINARY_DIR}"
                 COMMAND ${CMAKE_COMMAND} -E copy "${APP_RESOURCE_DIR}/win32/icons/WindowIcon.ico" "${CMAKE_CURRENT_BINARY_DIR}")
 
-        # Copy DLLs to app directory
-        add_custom_command(TARGET ${APP_TARGET_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:assimp::assimp>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeimage::FreeImage>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freetype>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:tinyxml2::tinyxml2>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:fmt::fmt>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Widgets>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Gui>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Core>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Svg>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>"
-                COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>/platforms"
-                COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>/styles"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>/platforms"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsVistaStylePlugin>" "$<TARGET_FILE_DIR:${APP_TARGET_NAME}>/styles")
-    endif()
+        copy_windows_dlls(${APP_TARGET_NAME})
+   endif()
 
     # Generate a small stripped PDB for release builds so we get stack traces with symbols
     if(COMPILER_IS_MSVC)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -169,6 +169,7 @@ macro(COPY_WINDOWS_DLLS TARGET)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Gui>" "$<TARGET_FILE_DIR:${TARGET}>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Core>" "$<TARGET_FILE_DIR:${TARGET}>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Svg>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Network>" "$<TARGET_FILE_DIR:${TARGET}>"
         COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${TARGET}>/platforms"
         COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${TARGET}>/styles"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" "$<TARGET_FILE_DIR:${TARGET}>/platforms"

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -155,6 +155,26 @@ macro(set_compiler_config TARGET)
     SET_XCODE_ATTRIBUTES(${TARGET})
 endmacro(set_compiler_config)
 
+macro(COPY_WINDOWS_DLLS TARGET)
+    # Copy DLLs to app directory
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:assimp::assimp>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeimage::FreeImage>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freetype>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:tinyxml2::tinyxml2>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:fmt::fmt>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Widgets>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Gui>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Core>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Svg>" "$<TARGET_FILE_DIR:${TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${TARGET}>/platforms"
+        COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${TARGET}>/styles"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" "$<TARGET_FILE_DIR:${TARGET}>/platforms"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsVistaStylePlugin>" "$<TARGET_FILE_DIR:${TARGET}>/styles")
+endmacro(COPY_WINDOWS_DLLS)
+
 macro(FIX_WIN32_PATH VARNAME)
     if(WIN32)
         STRING(REPLACE "/" "\\" ${VARNAME} "${${VARNAME}}")

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -413,6 +413,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/RotateObjectsTool.cpp
         ${COMMON_SOURCE_DIR}/View/RotateObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/RotateObjectsToolPage.cpp
+        ${COMMON_SOURCE_DIR}/View/RunGuard.cpp
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsTool.cpp
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolPage.cpp
@@ -933,6 +934,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/RotateObjectsTool.h
         ${COMMON_SOURCE_DIR}/View/RotateObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/RotateObjectsToolPage.h
+        ${COMMON_SOURCE_DIR}/View/RunGuard.h
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsTool.h
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolPage.h
@@ -1003,7 +1005,7 @@ set(COMMON_HEADER
 add_library(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})
 set_target_properties(common PROPERTIES AUTOMOC TRUE)
 target_include_directories(common PUBLIC ${COMMON_SOURCE_DIR})
-target_link_libraries(common PUBLIC tinyxml2::tinyxml2 kdl vecmath GLEW::GLEW miniz::miniz freeimage::FreeImage freetype OpenGL::GL Qt5::Widgets Qt5::Svg fmt::fmt assimp::assimp)
+target_link_libraries(common PUBLIC tinyxml2::tinyxml2 kdl vecmath GLEW::GLEW miniz::miniz freeimage::FreeImage freetype OpenGL::GL Qt5::Widgets Qt5::Svg Qt5::Network fmt::fmt assimp::assimp)
 
 # use precompiled headers on CMake 3.16 or later
 if (NOT TB_SUPPRESS_PCH AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")

--- a/common/benchmark/CMakeLists.txt
+++ b/common/benchmark/CMakeLists.txt
@@ -26,23 +26,7 @@ set(BENCHMARK_RESOURCE_DEST_DIR "$<TARGET_FILE_DIR:common-benchmark>")
 set(BENCHMARK_FIXTURE_DEST_DIR "${BENCHMARK_RESOURCE_DEST_DIR}/fixture")
 
 if(WIN32)
-    # Copy DLLs to app directory
-    add_custom_command(TARGET common-benchmark POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:assimp::assimp>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeimage::FreeImage>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freetype>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:tinyxml2::tinyxml2>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:fmt::fmt>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Widgets>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Gui>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Core>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Svg>" "$<TARGET_FILE_DIR:common-benchmark>"
-        COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:common-benchmark>/platforms"
-        COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:common-benchmark>/styles"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" "$<TARGET_FILE_DIR:common-benchmark>/platforms"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsVistaStylePlugin>" "$<TARGET_FILE_DIR:common-benchmark>/styles")
+  copy_windows_dlls(common-benchmark)
 endif()
 
 # Copy test fixtures

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -42,13 +42,13 @@
 #include "View/PreferenceDialog.h"
 #include "View/QtUtils.h"
 #include "View/RecentDocuments.h"
+#include "View/RunGuard.h"
 #include "View/WelcomeWindow.h"
 #ifdef __APPLE__
 #include "View/MainMenuBuilder.h"
 #endif
 
 #include <QColor>
-#include <QCommandLineParser>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QFile>
@@ -194,11 +194,11 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
 
 TrenchBroomApp::~TrenchBroomApp() = default;
 
-void TrenchBroomApp::parseCommandLineAndShowFrame()
+void TrenchBroomApp::setRunGuard(RunGuard& runGuard)
 {
-  auto parser = QCommandLineParser{};
-  parser.process(*this);
-  openFilesOrWelcomeFrame(parser.positionalArguments());
+  connect(&runGuard, &RunGuard::commandReceived, [&](const auto& cmd) {
+    openFilesOrWelcomeFrame(cmd.split(";"));
+  });
 }
 
 FrameManager* TrenchBroomApp::frameManager()

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -618,11 +618,7 @@ void TrenchBroomApp::closeWelcomeWindow()
 
 bool TrenchBroomApp::useSDI()
 {
-#ifdef _WIN32
-  return true;
-#else
   return false;
-#endif
 }
 
 

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -40,6 +40,7 @@ namespace View
 class ExecutableEvent;
 class FrameManager;
 class RecentDocuments;
+class RunGuard;
 class WelcomeWindow;
 
 class TrenchBroomApp : public QApplication
@@ -56,8 +57,7 @@ public:
   TrenchBroomApp(int& argc, char** argv);
   ~TrenchBroomApp() override;
 
-public:
-  void parseCommandLineAndShowFrame();
+  void setRunGuard(RunGuard& runGuard);
 
   FrameManager* frameManager();
 

--- a/common/src/View/RunGuard.cpp
+++ b/common/src/View/RunGuard.cpp
@@ -1,0 +1,232 @@
+/*
+ Copyright (C) 2023 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "RunGuard.h"
+
+#include <QCryptographicHash>
+#include <QtNetwork/QLocalServer>
+#include <QtNetwork/QLocalSocket>
+
+#include <kdl/reflection_impl.h>
+
+namespace TrenchBroom::View
+{
+namespace
+{
+const auto SocketName = QString{"TrenchBroom RunGuard"};
+
+QString generateKeyHash(const QString& key, const QString& salt)
+{
+  auto data = QByteArray{};
+
+  data.append(key.toUtf8());
+  data.append(salt.toUtf8());
+  data = QCryptographicHash::hash(data, QCryptographicHash::Sha1).toHex();
+
+  return data;
+}
+} // namespace
+
+kdl_reflect_impl(CmdError);
+
+CmdServer::CmdServer(QString name, const CmdServerMode mode)
+  : m_name{std::move(name)}
+  , m_server{new QLocalServer{this}}
+{
+  if (mode == CmdServerMode::Async)
+  {
+    connect(m_server, &QLocalServer::newConnection, [&]() {
+      onNewConnection(CmdServerMode::Async);
+    });
+  }
+}
+
+bool CmdServer::start()
+{
+  if (m_server->isListening())
+  {
+    return true;
+  }
+
+  QLocalServer::removeServer(m_name);
+
+  if (!m_server->listen(m_name))
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void CmdServer::stop()
+{
+  if (m_server->isListening())
+  {
+    m_server->close();
+  }
+}
+
+bool CmdServer::processCommand()
+{
+  if (m_server->waitForNewConnection())
+  {
+    onNewConnection(CmdServerMode::Deferred);
+    return true;
+  }
+  return false;
+}
+
+QString CmdServer::serverName() const
+{
+  return m_server->fullServerName();
+}
+
+void CmdServer::onNewConnection(const CmdServerMode mode)
+{
+  auto* socket = m_server->nextPendingConnection();
+  connect(socket, &QLocalSocket::readyRead, [&]() {
+    const auto message = socket->readAll();
+    emit commandReceived(QString::fromUtf8(message));
+  });
+
+  if (mode == CmdServerMode::Deferred)
+  {
+    socket->waitForReadyRead();
+  }
+}
+
+
+kdl::result<void, CmdError> sendCommand(const QString& serverName, const QString& cmd)
+{
+  auto socket = QLocalSocket{};
+  socket.connectToServer(serverName);
+
+  if (!socket.waitForConnected())
+  {
+    return CmdError{("Could not connect to server at " + socket.fullServerName() + " ("
+                     + socket.errorString() + ")")
+                      .toStdString()};
+  }
+
+  socket.write(cmd.toUtf8());
+  if (!socket.waitForBytesWritten())
+  {
+    return CmdError{("Could not send to server at " + socket.fullServerName() + " ("
+                     + socket.errorString() + ")")
+                      .toStdString()};
+  }
+
+  socket.disconnectFromServer();
+  if (socket.state() != QLocalSocket::UnconnectedState && !socket.waitForDisconnected())
+  {
+    return CmdError{("Could not disconnect from server at " + socket.fullServerName()
+                     + " (" + socket.errorString() + ")")
+                      .toStdString()};
+  }
+
+  return kdl::void_success;
+}
+
+RunGuard::RunGuard(QString key)
+  : m_key{std::move(key)}
+  , m_memLockKey{generateKeyHash(m_key, "_memLockKey")}
+  , m_sharedMemKey{generateKeyHash(m_key, "_sharedMemKey")}
+  , m_memLock{m_memLockKey, 1}
+  , m_sharedMem{m_sharedMemKey}
+  , m_server{SocketName, CmdServerMode::Async}
+{
+  m_memLock.acquire();
+  {
+    auto fix = QSharedMemory{m_sharedMemKey};
+    fix.attach();
+  }
+  m_memLock.release();
+}
+
+RunGuard::~RunGuard()
+{
+  release();
+}
+
+bool RunGuard::isAnotherRunning()
+{
+  if (m_sharedMem.isAttached())
+  {
+    return false;
+  }
+
+  m_memLock.acquire();
+  const auto isRunning = m_sharedMem.attach();
+  if (isRunning)
+  {
+    m_sharedMem.detach();
+  }
+  m_memLock.release();
+
+  return isRunning;
+}
+
+bool RunGuard::tryToRun()
+{
+  if (isAnotherRunning())
+  { // Extra check
+    return false;
+  }
+
+  m_memLock.acquire();
+  const auto result = m_sharedMem.create(sizeof(quint64));
+  m_memLock.release();
+
+  if (!result || !m_server.start())
+  {
+    release();
+    return false;
+  }
+
+  qInfo() << "Listening for connections at " << m_server.serverName();
+
+  connect(&m_server, &CmdServer::commandReceived, [&](const auto& receivedCmd) {
+    emit commandReceived(receivedCmd);
+  });
+
+  return true;
+}
+
+void RunGuard::sendCommandToMainInstance(const QString& cmd)
+{
+  qInfo() << "Sending command " << cmd << " to main instance: " << m_server.serverName();
+
+  sendCommand(SocketName, cmd).or_else([](const auto& error) {
+    qWarning() << "Could not connect to main instance: "
+               << QString::fromStdString(error.msg);
+    return kdl::void_success;
+  });
+}
+
+void RunGuard::release()
+{
+  m_memLock.acquire();
+  if (m_sharedMem.isAttached())
+  {
+    m_sharedMem.detach();
+  }
+  m_memLock.release();
+}
+
+} // namespace TrenchBroom::View

--- a/common/src/View/RunGuard.h
+++ b/common/src/View/RunGuard.h
@@ -1,0 +1,105 @@
+/*
+ Copyright (C) 2023 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QSharedMemory>
+#include <QString>
+#include <QSystemSemaphore>
+
+#include <kdl/reflection_decl.h>
+#include <kdl/result.h>
+
+#include <string>
+
+class QSharedMemory;
+class QLocalServer;
+class QLocalSocket;
+
+// See https://stackoverflow.com/a/28172162
+
+namespace TrenchBroom::View
+{
+enum class CmdServerMode
+{
+  Async,
+  Deferred
+};
+
+struct CmdError
+{
+  std::string msg;
+
+  kdl_reflect_decl(CmdError, msg);
+};
+
+class CmdServer : public QObject
+{
+  Q_OBJECT
+private:
+  QString m_name;
+  QLocalServer* m_server;
+
+public:
+  explicit CmdServer(QString name, CmdServerMode mode);
+
+  bool start();
+  void stop();
+  bool processCommand();
+  QString serverName() const;
+
+signals:
+  void commandReceived(const QString& cmd);
+
+private:
+  void onNewConnection(CmdServerMode mode);
+};
+
+kdl::result<void, CmdError> sendCommand(const QString& serverName, const QString& cmd);
+
+class RunGuard : public QObject
+{
+  Q_OBJECT
+private:
+  const QString m_key;
+  const QString m_memLockKey;
+  const QString m_sharedMemKey;
+  QSystemSemaphore m_memLock;
+  QSharedMemory m_sharedMem;
+
+  CmdServer m_server;
+
+public:
+  explicit RunGuard(QString key);
+  ~RunGuard() override;
+
+  bool isAnotherRunning();
+  bool tryToRun();
+  void sendCommandToMainInstance(const QString& cmd);
+
+signals:
+  void commandReceived(const QString& cmd);
+
+private:
+  void release();
+
+  Q_DISABLE_COPY(RunGuard)
+};
+} // namespace TrenchBroom::View

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -121,6 +121,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/tst_RemoveNodes.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_ReparentNodes.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_RepeatableActions.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/tst_RunGuard.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_ScaleObjectsTool.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_Selection.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_SelectionTool.cpp"

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -182,23 +182,7 @@ macro(configure_test_target TARGET)
     set(TEST_FIXTURE_DEST_DIR "${TEST_RESOURCE_DEST_DIR}/fixture")
 
     if(WIN32)
-        # Copy DLLs to app directory
-        add_custom_command(TARGET ${TARGET} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:assimp::assimp>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeimage::FreeImage>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freetype>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:tinyxml2::tinyxml2>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:fmt::fmt>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Widgets>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Gui>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Core>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Svg>" "$<TARGET_FILE_DIR:${TARGET}>"
-            COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${TARGET}>/platforms"
-            COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:${TARGET}>/styles"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" "$<TARGET_FILE_DIR:${TARGET}>/platforms"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsVistaStylePlugin>" "$<TARGET_FILE_DIR:${TARGET}>/styles")
+      copy_windows_dlls(common-test)
     endif()
 
     # Copy some resource files required when initializing TrenchBroomApp

--- a/common/test/src/View/tst_RunGuard.cpp
+++ b/common/test/src/View/tst_RunGuard.cpp
@@ -1,0 +1,86 @@
+/*
+ Copyright (C) 2023 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QCoreApplication>
+#include <QtNetwork/QLocalServer>
+#include <QtNetwork/QLocalSocket>
+
+#include "View/RunGuard.h"
+
+#include "Catch2.h"
+
+namespace TrenchBroom::View
+{
+
+namespace
+{
+bool isSocketInUse(const QString& serverName)
+{
+  auto server = QLocalServer{};
+  return !server.listen(serverName);
+}
+} // namespace
+
+TEST_CASE("CmdServer")
+{
+  static const auto ServerName = "TestServer";
+  SECTION("start")
+  {
+    auto server = CmdServer{ServerName, CmdServerMode::Deferred};
+    CHECK(server.start());
+    CHECK(server.start());
+
+    SECTION("second instance always works")
+    {
+      auto other = CmdServer{ServerName, CmdServerMode::Deferred};
+      CHECK(other.start());
+    }
+  }
+
+#ifndef _WIN32
+  SECTION("stop")
+  {
+    auto server = CmdServer{ServerName, CmdServerMode::Deferred};
+    REQUIRE(server.start());
+    REQUIRE(isSocketInUse(ServerName));
+
+    server.stop();
+    CHECK(!isSocketInUse(ServerName));
+  }
+#endif
+
+  SECTION("sendCommand")
+  {
+    auto server = CmdServer{ServerName, CmdServerMode::Deferred};
+
+    auto lastCommand = QString{};
+    QObject::connect(&server, &CmdServer::commandReceived, [&](const auto& command) {
+      lastCommand = command;
+    });
+
+    REQUIRE(server.start());
+    CAPTURE(server.serverName());
+
+    REQUIRE(sendCommand(ServerName, "test command") == kdl::result<void, CmdError>{});
+    REQUIRE(server.processCommand());
+
+    CHECK(lastCommand == "test command");
+  }
+}
+} // namespace TrenchBroom::View

--- a/dump-shortcuts/CMakeLists.txt
+++ b/dump-shortcuts/CMakeLists.txt
@@ -17,21 +17,5 @@ set_compiler_config(dump-shortcuts)
 source_group(TREE "${COMMON_TEST_SOURCE_DIR}" FILES ${COMMON_TEST_SOURCE})
 
 if(WIN32)
-    # Copy DLLs to app directory
-    add_custom_command(TARGET dump-shortcuts POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:assimp::assimp>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeimage::FreeImage>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freetype>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:tinyxml2::tinyxml2>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:fmt::fmt>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Widgets>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Gui>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Core>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::Svg>" "$<TARGET_FILE_DIR:dump-shortcuts>"
-        COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:dump-shortcuts>/platforms"
-        COMMAND ${CMAKE_COMMAND} -E make_directory    "$<TARGET_FILE_DIR:dump-shortcuts>/styles"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsIntegrationPlugin>" "$<TARGET_FILE_DIR:dump-shortcuts>/platforms"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:Qt5::QWindowsVistaStylePlugin>" "$<TARGET_FILE_DIR:dump-shortcuts>/styles")
+  copy_windows_dlls(dump-shortcuts)
 endif()


### PR DESCRIPTION
Closes #4171.

This change just avoids multiple instances of TB on Windows like on the other platforms. With it, there no longer is a need to actively watch the preference file for changes and reload the preferences, so we remove that ability also.

- [x] enable MDI on Windows
- [ ] ensure that only one instance runs at a time
- [ ] remove MDI support
- [ ] remove support for hot reloading of preferences (incl. watching the file for changes)