### PR TITLE
4171: Destroy preference manager in application destructor

### DIFF
--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -67,6 +67,7 @@ int main(int argc, char* argv[])
   // actually work with TB.)
   qputenv("QT_OPENGL_BUGLIST", ":/opengl_buglist.json");
 
+  // PreferenceManager is destroyed by TrenchBroomApp::~TrenchBroomApp()
   TrenchBroom::PreferenceManager::createInstance<TrenchBroom::AppPreferenceManager>();
   TrenchBroom::View::TrenchBroomApp app(argc, argv);
 

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -69,6 +69,12 @@ public:
     m_initialized = false;
   }
 
+  static void destroyInstance()
+  {
+    m_instance.reset();
+    m_initialized = false;
+  }
+
   template <typename T>
   Preference<T>& dynamicPreference(const std::filesystem::path& path, T&& defaultValue)
   {

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -192,7 +192,10 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
 #endif
 }
 
-TrenchBroomApp::~TrenchBroomApp() = default;
+TrenchBroomApp::~TrenchBroomApp()
+{
+  PreferenceManager::destroyInstance();
+}
 
 void TrenchBroomApp::parseCommandLineAndShowFrame()
 {

--- a/common/test/src/RunAllTests.cpp
+++ b/common/test/src/RunAllTests.cpp
@@ -39,7 +39,5 @@ int main(int argc, char** argv)
   // set the locale to US so that we can parse floats attribute
   std::setlocale(LC_NUMERIC, "C");
 
-  const int result = Catch::Session().run(argc, argv);
-
-  return result;
+  return Catch::Session().run(argc, argv);
 }

--- a/dump-shortcuts/src/Main.cpp
+++ b/dump-shortcuts/src/Main.cpp
@@ -251,6 +251,8 @@ int main(int argc, char* argv[])
   TrenchBroom::View::printMenuShortcuts(out);
   TrenchBroom::View::printActionShortcuts(out);
 
+  TrenchBroom::PreferenceManager::destroyInstance();
+
   out.flush();
   if (out.status() == QTextStream::Ok)
   {


### PR DESCRIPTION
Closes #4171. This change ensures that the preference manager is destroyed before the application shuts down. This might eliminate a hang that occurs `QFileSystemWatcher` because the preference manager uses a `QFileSystemWatcher` to reload the preference file when it changes on disk. I don't know for sure, but it might be that the watcher must be destroyed before the app terminates.