### PR TITLE
Fix fs refactor bugs

### DIFF
--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -46,6 +46,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace TrenchBroom
@@ -189,28 +190,27 @@ namespace
 {
 std::string readInfoComment(std::istream& stream, const std::string& name)
 {
-  constexpr auto MaxChars = 64u;
-  auto line = std::string{MaxChars};
-
   const auto expectedHeader = "// " + name + ": ";
 
-  stream.getline(line.data(), MaxChars);
+  auto lineBuffer = std::string{};
+  std::getline(stream, lineBuffer);
   if (stream.fail())
   {
     return "";
   }
 
-  if (line.substr(0, expectedHeader.size()) != expectedHeader)
+  const auto lineView = std::string_view{lineBuffer};
+  if (!kdl::cs::str_is_prefix(lineView, expectedHeader))
   {
     return "";
   }
 
-  auto result = line.substr(expectedHeader.size());
+  auto result = lineView.substr(expectedHeader.size());
   if (!result.empty() && result.back() == '\r')
   {
-    result.pop_back();
+    result = result.substr(0, result.length() - 1);
   }
-  return result;
+  return std::string{result};
 }
 } // namespace
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -915,18 +915,25 @@ void MapDocument::loadPointFile(const std::filesystem::path path)
     unloadPointFile();
   }
 
-  IO::Disk::withInputStream(path, [&](auto& file) {
-    if (auto trace = Model::loadPointFile(file))
-    {
-      m_pointFile = PointFile{*trace, path};
-      info() << "Loaded point file " << path;
-      pointFileWasLoadedNotifier();
-    }
-    else
-    {
-      warn() << "Failed to load point file " << path;
-    }
-  });
+  try
+  {
+    IO::Disk::withInputStream(path, [&](auto& file) {
+      if (auto trace = Model::loadPointFile(file))
+      {
+        m_pointFile = PointFile{*trace, path};
+        info() << "Loaded point file " << path;
+        pointFileWasLoadedNotifier();
+      }
+      else
+      {
+        warn() << "Failed to load point file " << path;
+      }
+    });
+  }
+  catch (const FileSystemException& e)
+  {
+    error() << "Could not load point file '" << path << "': " << e.what();
+  }
 }
 
 bool MapDocument::isPointFileLoaded() const

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -19,9 +19,12 @@
 
 #include "TestEnvironment.h"
 
+#include "IO/DiskIO.h"
 #include "IO/PathQt.h"
 #include "Macros.h"
 #include "Uuid.h"
+
+#include "kdl/invoke.h"
 
 #include <fstream>
 #include <string>
@@ -97,6 +100,20 @@ std::string TestEnvironment::loadFile(const std::filesystem::path& path) const
 {
   auto stream = std::ifstream{m_dir / path, std::ios::in};
   return std::string{std::istreambuf_iterator<char>{stream}, {}};
+}
+
+void TestEnvironment::withTempFile(
+  const std::string& contents, const std::function<void(const std::filesystem::path&)>& f)
+{
+  const auto path = m_dir / generateUuid();
+  auto removeFile = kdl::invoke_later{[&]() {
+    // ignore errors
+    auto error = std::error_code{};
+    std::filesystem::remove(path, error);
+  }};
+
+  Disk::withOutputStream(path, [&](auto& stream) { stream << contents; });
+  f(path);
 }
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -19,12 +19,8 @@
 
 #include "TestEnvironment.h"
 
-#include "IO/DiskIO.h"
 #include "IO/PathQt.h"
 #include "Macros.h"
-#include "Uuid.h"
-
-#include "kdl/invoke.h"
 
 #include <fstream>
 #include <string>
@@ -102,18 +98,5 @@ std::string TestEnvironment::loadFile(const std::filesystem::path& path) const
   return std::string{std::istreambuf_iterator<char>{stream}, {}};
 }
 
-void TestEnvironment::withTempFile(
-  const std::string& contents, const std::function<void(const std::filesystem::path&)>& f)
-{
-  const auto path = m_dir / generateUuid();
-  auto removeFile = kdl::invoke_later{[&]() {
-    // ignore errors
-    auto error = std::error_code{};
-    std::filesystem::remove(path, error);
-  }};
-
-  Disk::withOutputStream(path, [&](auto& stream) { stream << contents; });
-  f(path);
-}
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/IO/TestEnvironment.h
+++ b/common/test/src/IO/TestEnvironment.h
@@ -53,6 +53,10 @@ public:
   bool fileExists(const std::filesystem::path& path) const;
 
   std::string loadFile(const std::filesystem::path& path) const;
+
+  void withTempFile(
+    const std::string& contents,
+    const std::function<void(const std::filesystem::path&)>& f);
 };
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/IO/TestEnvironment.h
+++ b/common/test/src/IO/TestEnvironment.h
@@ -19,6 +19,11 @@
 
 #pragma once
 
+#include "IO/DiskIO.h"
+#include "Uuid.h"
+
+#include "kdl/invoke.h"
+
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -54,9 +59,19 @@ public:
 
   std::string loadFile(const std::filesystem::path& path) const;
 
-  void withTempFile(
-    const std::string& contents,
-    const std::function<void(const std::filesystem::path&)>& f);
+  template <typename F>
+  auto withTempFile(const std::string& contents, const F& f)
+  {
+    const auto path = m_dir / generateUuid();
+    auto removeFile = kdl::invoke_later{[&]() {
+      // ignore errors
+      auto error = std::error_code{};
+      std::filesystem::remove(path, error);
+    }};
+
+    Disk::withOutputStream(path, [&](auto& stream) { stream << contents; });
+    return f(path);
+  }
 };
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/Model/tst_GameFactory.cpp
+++ b/common/test/src/Model/tst_GameFactory.cpp
@@ -110,5 +110,40 @@ TEST_CASE("GameFactory.initialize")
   CHECK(gameConfig.compilationConfig.profiles.size() == 1);
   CHECK(gameConfig.gameEngineConfig.profiles.size() == 1);
 }
+
+TEST_CASE("GameFactory.detectGame")
+{
+  using namespace std::string_literals;
+
+  auto env = IO::TestEnvironment{setupTestEnvironment};
+
+  auto& gameFactory = GameFactory::instance();
+  REQUIRE_NOTHROW(
+    gameFactory.initialize({{env.dir() / gamesPath}, env.dir() / userPath}));
+
+  const auto detectGame = [&](const auto& mapFile) {
+    return env.withTempFile(
+      mapFile, [&](const auto& path) { return gameFactory.detectGame(path); });
+  };
+
+  CHECK(detectGame(R"(// Game: Quake
+// Format: Quake2
+)") == std::pair{"Quake"s, MapFormat::Quake2});
+
+
+  CHECK(detectGame(R"(// Game: Quake
+// Format: Quake2
+{
+"classname" "worldspawn"
+{
+( -712 1280 -448 ) ( -904 1280 -448 ) ( -904 992 -448 ) attribsExplicit 56 -32 0 1 1 8 9 700
+( -904 992 -416 ) ( -904 1280 -416 ) ( -712 1280 -416 ) attribsOmitted 32 32 0 1 1
+( -832 968 -416 ) ( -832 1256 -416 ) ( -832 1256 -448 ) attribsExplicitlyZero 16 96 0 1 1 0 0 0
+( -920 1088 -448 ) ( -920 1088 -416 ) ( -680 1088 -416 ) rtz/c_mf_v3c 56 96 0 1 1 0 0 0
+( -968 1152 -448 ) ( -920 1152 -448 ) ( -944 1152 -416 ) rtz/c_mf_v3c 56 96 0 1 1 0 0 0
+( -896 1056 -416 ) ( -896 1056 -448 ) ( -896 1344 -448 ) rtz/c_mf_v3c 16 96 0 1 1 0 0 0
+}
+})") == std::pair{"Quake"s, MapFormat::Quake2});
+}
 } // namespace Model
 } // namespace TrenchBroom


### PR DESCRIPTION
This PR fixes two crashes:

- reading a game info comment can crash
- reloading a point file crashes when the point file no longer exists

These crashes were introduced during a large refactoring of the file IO code.