### PR TITLE
4270: Allow capital 'E' when parsing float number in scientific notation

### DIFF
--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -419,7 +419,7 @@ protected:
       readDigits();
     }
 
-    if (curChar() == 'e')
+    if (curChar() == 'e' || curChar() == 'E')
     {
       advance();
       if (curChar() == '+' || curChar() == '-' || isDigit(curChar()))

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -573,32 +573,27 @@ bool TrenchBroomApp::event(QEvent* event)
 }
 #endif
 
-bool TrenchBroomApp::openFilesOrWelcomeFrame(const QStringList& fileNames)
+void TrenchBroomApp::openFilesOrWelcomeFrame(const QStringList& fileNames)
 {
-  if (!fileNames.isEmpty())
+  auto anyDocumentOpened = false;
+  if (useSDI())
   {
-    if (useSDI())
-    {
-      const auto path = IO::pathFromQString(fileNames.at(0));
-      if (!path.empty())
-      {
-        openDocument(path);
-      }
-    }
-    else
-    {
-      for (const auto& fileName : fileNames)
-      {
-        const auto path = IO::pathFromQString(fileName);
-        openDocument(path);
-      }
-    }
+    const auto path = IO::pathFromQString(fileNames.at(0));
+    anyDocumentOpened = !path.empty() && openDocument(path);
   }
   else
   {
+    for (const auto& fileName : fileNames)
+    {
+      const auto path = IO::pathFromQString(fileName);
+      anyDocumentOpened = anyDocumentOpened | (!path.empty() && openDocument(path));
+    }
+  }
+
+  if (!anyDocumentOpened)
+  {
     showWelcomeWindow();
   }
-  return true;
 }
 
 void TrenchBroomApp::showWelcomeWindow()

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -89,7 +89,7 @@ public:
 #ifdef __APPLE__
   bool event(QEvent* event) override;
 #endif
-  bool openFilesOrWelcomeFrame(const QStringList& fileNames);
+  void openFilesOrWelcomeFrame(const QStringList& fileNames);
 
 public:
   void showWelcomeWindow();

--- a/common/test/src/IO/tst_NodeReader.cpp
+++ b/common/test/src/IO/tst_NodeReader.cpp
@@ -120,5 +120,32 @@ TEST_CASE("NodeReaderTest.convertValveToStandardMapFormatInGroups")
     dynamic_cast<const ParaxialTexCoordSystem*>(&brush.face(0).texCoordSystem())
     != nullptr);
 }
+
+TEST_CASE("NodeReaderTest.readScientificNotation")
+{
+  // https://github.com/TrenchBroom/TrenchBroom/issues/4270
+
+  const auto data = R"(
+{
+"classname" "worldspawn"
+"sounds" "1"
+"MaxRange" "4096"
+"mapversion" "220"
+{
+( 112 16 16 ) ( 112 16 17 ) ( 112 15 16 ) __TB_empty [ -1.8369701E-16 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1 
+( 128 0 32 ) ( 128 0 33 ) ( 129 0 32 ) __TB_empty [ 1 -1.8369701e-16 0 0 ] [ 0 0 -1 0 ] 0 1 1 
+( 112 16 16 ) ( 112 15 16 ) ( 113 16 16 ) __TB_empty [ 1.8369701e-16 1 0 0 ] [ -1 1.8369701E-16 0 0 ] 270 1 1 
+( 128 0 80 ) ( 129 0 80 ) ( 128 -1 80 ) __TB_empty [ -1.8369701e-16 -1 0 0 ] [ -1 1.8369701E-16 0 0 ] 90 1 1 
+( 112 16 16 ) ( 113 16 16 ) ( 112 16 17 ) __TB_empty [ -1 1.8369701E-16 0 0 ] [ 0 0 -1 0 ] 0 1 1 
+( 128 0 32 ) ( 128 -1 32 ) ( 128 0 33 ) __TB_empty [ 1.8369701e-16 1 0 0 ] [ 0 0 -1 0 ] 0 1 1 
+}
+)";
+
+  const auto worldBounds = vm::bbox3{4096.0};
+  auto status = IO::TestParserStatus{};
+
+  auto nodes = IO::NodeReader::read(data, MapFormat::Valve, worldBounds, {}, {}, status);
+  CHECK(nodes.size() == 1);
+}
 } // namespace Model
 } // namespace TrenchBroom


### PR DESCRIPTION
Closes #4270.