### PR TITLE
Add copy texture name and copy texture context menu items

### DIFF
--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -372,9 +372,8 @@ bool Texture::isPrepared() const
 void Texture::prepare(const GLuint textureId, const int minFilter, const int magFilter)
 {
   assert(textureId > 0);
-  assert(m_textureId == 0);
 
-  if (!m_buffers.empty())
+  if (not isPrepared())
   {
     const auto compressed = isCompressedFormat(m_format);
 
@@ -447,7 +446,6 @@ void Texture::prepare(const GLuint textureId, const int minFilter, const int mag
       }
     }
 
-    m_buffers.clear();
     m_textureId = textureId;
   }
 }
@@ -539,7 +537,7 @@ void Texture::deactivate() const
   }
 }
 
-const Texture::BufferList& Texture::buffersIfUnprepared() const
+const Texture::BufferList& Texture::buffers() const
 {
   return m_buffers;
 }

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -238,9 +238,8 @@ public:
 public: // exposed for tests only
   /**
    * Returns the texture data in the format returned by format().
-   * Once prepare() is called, this will be an empty vector.
    */
-  const BufferList& buffersIfUnprepared() const;
+  const BufferList& buffers() const;
   /**
    * Will be one of GL_RGB, GL_BGR, GL_RGBA, GL_BGRA.
    */

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -19,6 +19,7 @@
 
 #include "MapViewBase.h"
 
+#include <QClipboard>
 #include <QDebug>
 #include <QMenu>
 #include <QMimeData>
@@ -1348,6 +1349,26 @@ void MapViewBase::showPopupMenuLater()
         .arg(QString::fromStdString(faceHandle->face().attributes().textureName())),
       mapFrame,
       [=] { mapFrame->revealTexture(texture); });
+
+    menu.addSeparator();
+
+    const auto clipboard = QApplication::clipboard();
+
+    menu.addAction(
+      tr("Copy texture name %1 to clipboard")
+        .arg(QString::fromStdString(faceHandle->face().attributes().textureName())),
+      mapFrame,
+      [=] {
+        const auto text =
+          QString::fromStdString(faceHandle->face().attributes().textureName());
+
+        clipboard->setText(text, QClipboard::Clipboard);
+
+        if (clipboard->supportsSelection())
+        {
+          clipboard->setText(text, QClipboard::Selection);
+        }
+      });
 
     menu.addSeparator();
   }

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -19,6 +19,7 @@
 
 #include "TextureBrowserView.h"
 
+#include <QClipboard>
 #include <QMenu>
 #include <QTextStream>
 
@@ -662,6 +663,20 @@ void TextureBrowserView::doContextMenu(
         auto doc = kdl::mem_lock(m_document);
         doc->selectFacesWithTexture(texture);
       });
+
+      const auto clipboard = QApplication::clipboard();
+
+      menu.addAction(tr("Copy name to clipboard"), this, [=] {
+        const auto textureName = QString::fromStdString(texture->name());
+
+        clipboard->setText(textureName, QClipboard::Clipboard);
+
+        if (clipboard->supportsSelection())
+        {
+          clipboard->setText(textureName, QClipboard::Selection);
+        }
+      });
+
       menu.exec(event->globalPos());
     }
   }

--- a/common/test/src/IO/tst_ReadFreeImageTexture.cpp
+++ b/common/test/src/IO/tst_ReadFreeImageTexture.cpp
@@ -84,7 +84,7 @@ static void testImageContents(const Assets::Texture& texture, const ColorMatch m
 
   CHECK(texture.width() == w);
   CHECK(texture.height() == h);
-  CHECK(texture.buffersIfUnprepared().size() == 1u);
+  CHECK(texture.buffers().size() == 1u);
   CHECK((GL_BGRA == texture.format() || GL_RGBA == texture.format()));
   CHECK(texture.type() == Assets::TextureType::Opaque);
 
@@ -129,11 +129,11 @@ TEST_CASE("ReadFreeImageTextureTest.alphaMaskTest")
 
   CHECK(texture.width() == w);
   CHECK(texture.height() == h);
-  CHECK(texture.buffersIfUnprepared().size() == 1u);
+  CHECK(texture.buffers().size() == 1u);
   CHECK((GL_BGRA == texture.format() || GL_RGBA == texture.format()));
   CHECK(texture.type() == Assets::TextureType::Masked);
 
-  auto& mip0Data = texture.buffersIfUnprepared().at(0);
+  auto& mip0Data = texture.buffers().at(0);
   CHECK(mip0Data.size() == w * h * 4);
 
   for (std::size_t y = 0; y < h; ++y)

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -460,7 +460,7 @@ int getComponentOfPixel(
     }
   }
 
-  const auto& mip0DataBuffer = texture.buffersIfUnprepared().at(0);
+  const auto& mip0DataBuffer = texture.buffers().at(0);
   assert(texture.width() * texture.height() * 4 == mip0DataBuffer.size());
   assert(x < texture.width());
   assert(y < texture.height());


### PR DESCRIPTION
This PR adds a new section in the context menu when right clicking on a texture:
- in 3D View:
![image](https://github.com/TrenchBroom/TrenchBroom/assets/2356631/f5fb2b76-52cf-42c7-903b-eed88c4576dd)

- and in Texture Browser:
![image](https://github.com/TrenchBroom/TrenchBroom/assets/2356631/b08d8db8-9432-47d9-9481-309e0a488a9d)

Two options are available at the moment:
- one to copy texture name (very useful when working with light_surface/info_texlights type of entities)
- and one to copy the actual texture image (makes editing textures much faster since you don't have to open Wally/etc to export them)

Memory is slightly higher since Texture::m_buffers isn't cleared anymore after preparation (I couldn't find another way to access texture buffer data, perhaps this can be improved)

Before:
![image](https://github.com/TrenchBroom/TrenchBroom/assets/2356631/7b4fb09e-b6c5-4f06-8313-c31a9561af8d)

After:
![image](https://github.com/TrenchBroom/TrenchBroom/assets/2356631/05aea861-737d-4907-bcca-fcb70591ce95)
