### PR TITLE
Fix crash if there is no file specified in the command line.

### DIFF
--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -578,8 +578,11 @@ void TrenchBroomApp::openFilesOrWelcomeFrame(const QStringList& fileNames)
   auto anyDocumentOpened = false;
   if (useSDI())
   {
-    const auto path = IO::pathFromQString(fileNames.at(0));
-    anyDocumentOpened = !path.empty() && openDocument(path);
+    if (fileNames.length() > 0)
+    {
+      const auto path = IO::pathFromQString(fileNames.at(0));
+      anyDocumentOpened = !path.empty() && openDocument(path);
+    }
   }
   else
   {


### PR DESCRIPTION
Closes #4280

Hopefully the correct fix with nothing else this time.