### PR TITLE
Preview animation sequences for Assimp models

### DIFF
--- a/common/src/IO/AssimpParser.cpp
+++ b/common/src/IO/AssimpParser.cpp
@@ -160,8 +160,6 @@ public:
   }
 };
 
-} // namespace
-
 /**
  * Gets the channel index for a particular assimp node, matched by name.
  * Returns -1 if this node doesn't have a channel for this animation.
@@ -258,7 +256,7 @@ std::vector<AssimpBoneInformation> getAnimationInformation(
       const auto b = getChannelIndex(animation, *parentNode);
       if (b >= 0)
       {
-        nodeTransformation = indivTransforms[b];
+        nodeTransformation = indivTransforms[static_cast<size_t>(b)];
 
         // if this is the first parent of the bone, set the parent id
         if (parentNode == boneNode->mParent)
@@ -282,6 +280,8 @@ std::vector<AssimpBoneInformation> getAnimationInformation(
 
   return transforms;
 }
+
+} // namespace
 
 std::unique_ptr<Assets::EntityModel> AssimpParser::doInitializeModel(
   TrenchBroom::Logger& logger)
@@ -327,7 +327,7 @@ std::unique_ptr<Assets::EntityModel> AssimpParser::doInitializeModel(
 }
 
 void AssimpParser::doLoadFrame(
-  const size_t frameIndex, Assets::EntityModel& model, Logger& logger)
+  const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */)
 {
   // Import the file as an Assimp scene and populate our vectors
   auto importer = Assimp::Importer{};
@@ -544,10 +544,10 @@ struct vertexBoneWeight
   const float m_weight;
   const aiBone* m_bone;
 
-  vertexBoneWeight(size_t m_bone_index, float m_weight, const aiBone* m_bone)
-    : m_boneIndex(m_bone_index)
-    , m_weight(m_weight)
-    , m_bone(m_bone)
+  vertexBoneWeight(size_t boneIndex, float weight, const aiBone* bone)
+    : m_boneIndex(boneIndex)
+    , m_weight(weight)
+    , m_bone(bone)
   {
   }
 };

--- a/common/src/IO/AssimpParser.h
+++ b/common/src/IO/AssimpParser.h
@@ -78,16 +78,16 @@ struct AssimpBoneInformation
   AssimpBoneInformation() = default;
 
   AssimpBoneInformation(
-    size_t m_bone_index,
-    int32_t m_parent_index,
-    const aiString& m_name,
-    const aiMatrix4x4& m_local_transform,
-    const aiMatrix4x4& m_global_transform)
-    : m_boneIndex(m_bone_index)
-    , m_parentIndex(m_parent_index)
-    , m_name(m_name)
-    , m_localTransform(m_local_transform)
-    , m_globalTransform(m_global_transform)
+    size_t boneIndex,
+    int32_t parentIndex,
+    const aiString& name,
+    const aiMatrix4x4& localTransform,
+    const aiMatrix4x4& globalTransform)
+    : m_boneIndex(boneIndex)
+    , m_parentIndex(parentIndex)
+    , m_name(name)
+    , m_localTransform(localTransform)
+    , m_globalTransform(globalTransform)
   {
   }
 };

--- a/common/src/IO/AssimpParser.h
+++ b/common/src/IO/AssimpParser.h
@@ -25,7 +25,7 @@
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
 
-#include <assimp/matrix4x4.h>
+#include <assimp/types.h>
 
 #include <filesystem>
 #include <vector>
@@ -67,6 +67,31 @@ struct AssimpVertex
   }
 };
 
+struct AssimpBoneInformation
+{
+  size_t m_boneIndex{0};
+  int32_t m_parentIndex{-1};
+  aiString m_name;
+  aiMatrix4x4 m_localTransform;
+  aiMatrix4x4 m_globalTransform;
+
+  AssimpBoneInformation() = default;
+
+  AssimpBoneInformation(
+    size_t m_bone_index,
+    int32_t m_parent_index,
+    const aiString& m_name,
+    const aiMatrix4x4& m_local_transform,
+    const aiMatrix4x4& m_global_transform)
+    : m_boneIndex(m_bone_index)
+    , m_parentIndex(m_parent_index)
+    , m_name(m_name)
+    , m_localTransform(m_local_transform)
+    , m_globalTransform(m_global_transform)
+  {
+  }
+};
+
 class AssimpParser : public EntityModelParser
 {
 private:
@@ -85,13 +110,27 @@ public:
 
 private:
   std::unique_ptr<Assets::EntityModel> doInitializeModel(Logger& logger) override;
+  void doLoadFrame(
+    size_t frameIndex, Assets::EntityModel& model, Logger& logger) override;
+  void loadSceneFrame(
+    const aiScene* scene, const size_t frameIndex, Assets::EntityModel& model);
+  void processRootNode(
+    const aiNode& node,
+    const aiScene& scene,
+    const aiMatrix4x4& transform,
+    const aiMatrix4x4& axisTransform,
+    const std::vector<AssimpBoneInformation>& boneTransforms);
   void processNode(
     const aiNode& node,
     const aiScene& scene,
     const aiMatrix4x4& transform,
-    const aiMatrix4x4& axisTransform);
+    const aiMatrix4x4& axisTransform,
+    const std::vector<AssimpBoneInformation>& boneTransforms);
   void processMesh(
-    const aiMesh& mesh, const aiMatrix4x4& transform, const aiMatrix4x4& axisTransform);
+    const aiMesh& mesh,
+    const aiMatrix4x4& transform,
+    const aiMatrix4x4& axisTransform,
+    const std::vector<AssimpBoneInformation>& boneTransforms);
   void processMaterials(const aiScene& scene, Logger& logger);
   static aiMatrix4x4 get_axis_transform(const aiScene& scene);
 };


### PR DESCRIPTION
*Please note: this is for a static preview of each animation sequence only.* Real time animation playback is not the aim of this change.

TB supports the "frame" key for Quake 2 (and possibly other) models, as some games use different frames of an animation to pose a body in different positions (e.g. misc_deadsoldier). For HL1 and other skeletal animations supported by Assimp, it is normal to use sequences for this instead. The aim here is to provide functionality similar to the "frame" key in Quake 2 models, but for sequences in Assimp models.

I'm not experienced with C++, I've tried the best I could to follow standards, but I've likely done some things wrong, please let me know.

---

This change detects if an Assimp model has skeletal animation and creates a "frame" for each animation in the model. The user can then map their framekey to a property (such as "sequence") to preview the first frame of each sequence in the editor.

I addded this specifically for HL1 animation support, but this uses Assimp's generic animation mechanisms, mostly by looking at the assimp viewer code. I tested this on a few other static models and they worked fine, however it is quite difficult to find other animated models that Assimp would load, so it's not tested for any other animated model formats.

When animations are not present in the Assimp scene, it will default to using the same behaviour as it did before.

Contains a fix to detect when Assimp has loaded HL1 studio models and handle its issue of rendering all submodels for each body part, instead of just one submodel per body part. Supporting selectable body parts is quite possible, but will need changes to other parts of the application so extra keys can be passed through to the asset loader.

Related to #1140

---

To fully test this an FGD change is required. The easiest way to do this is to edit the Half-Life FGD like so:

```
@PointClass base(Monster, TalkMonster)
  size(-16 -16 0, 16 16 72)
  model({ "path": "models/scientist.mdl", "frame": sequence })
= monster_scientist : "Scared Scientist" 
[ ... ]
```
Note the addition of `"frame": sequence` in the model definition.
Then you can place a monster_scientist in the map and change the `sequence` value as you like.

Some interesting sequence numbers to try:
- 2 (run)
- 13 (idle)
- 37 (lying_on_back)
- 74 (sitting2) [NOTE that the sitting animations are positioned in a slightly strange way, this is the correct behaviour]
- 85 (ventpull1)

![TrenchBroom_deJYDhlZPv](https://github.com/TrenchBroom/TrenchBroom/assets/3071180/316e0977-64c5-437f-af2d-09a6f622940a)