### PR TITLE
Add setBounds method to EntityModelLoadedFrame

### DIFF
--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -124,6 +124,11 @@ float EntityModelLoadedFrame::intersect(const vm::ray3f& ray) const
   return closestDistance;
 }
 
+void EntityModelLoadedFrame::setBounds(const vm::bbox3f& bounds)
+{
+  m_bounds = bounds;
+}
+
 void EntityModelLoadedFrame::addToSpacialTree(
   const std::vector<EntityModelVertex>& vertices,
   const Renderer::PrimType primType,

--- a/common/src/Assets/EntityModel.h
+++ b/common/src/Assets/EntityModel.h
@@ -195,6 +195,11 @@ public:
   float intersect(const vm::ray3f& ray) const override;
 
   /**
+   * Sets this frame's bounding box.
+   */
+  void setBounds(const vm::bbox3f& bounds);
+
+  /**
    * Adds the given primitives to the spacial tree for this frame.
    *
    * @param vertices the vertices


### PR DESCRIPTION
I'm working on some changes to the way the Assimp models are parsed - in order to support skins ("alternative textures") in Assimp models I need to load the model into 1 surface per mesh, instead of putting all meshes into one surface. Unfortunately the bounds of the frame are not known until all meshes have been loaded, meaning we don't know the bounds when initially creating the frame. (This is due to each animation sequence changing the bounds for the frame.) Adding a setter would mean I could assemble the bounds while loading the meshes into model surfaces, which is more efficient.

(intentionally keeping this PR small in case this approach is wrong and alternatives need to be discussed, let me know if there's better ways to do this)

The process would look something like this:

```c++
  // use a placeholder for the bounds to start with
  auto& frame = model.loadFrame(frameIndex, m_path.string(), vm::bbox3f(8.0f));

  // all the model vertices are stored in here, to assemble the bbox later
  // this is how the assimp parser currently does it, I think this can be improved
  // but that's not important for this demonstration....
  m_positions.clear();

  // process the assimp scene (pseudocode)
  // in reality this is a recursive tree traversal of the assimp scene
  for (auto mesh : some_iterator)
  {
    auto& surface = model.addSurface(mesh.mName.data);
    auto builder = Renderer::IndexRangeMapBuilder<Assets::EntityModelVertex::Type>{...};
    // code here...
    m_positions.add_range(all_the_mesh_vertices);
    surface.addIndexedMesh(frame, builder.vertices(), builder.indices());
  }

  // Build bounds.
  auto bounds = vm::bbox3f::builder{};
  if (m_positions.empty())
  {
    // Passing empty bounds as bbox crashes the program, don't let it happen.
    throw ParserException{"Model has no vertices. (So no valid bounding box.)"};
  }
  else
  {
    bounds.add(std::begin(m_positions), std::end(m_positions));
  }

  const auto actualBounds = bounds.bounds();
  frame.setBounds(actualBounds); // <--- setBounds used here
```