### PR TITLE
Use the first skin if an unknown skin index is provided

### DIFF
--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -463,7 +463,13 @@ std::unique_ptr<Renderer::TexturedIndexRangeRenderer> EntityModelSurface::buildR
   const size_t skinIndex, const size_t frameIndex)
 {
   assert(frameIndex < frameCount());
-  assert(skinIndex < skinCount());
+
+  // If an out of range skin is requested, use the first skin as a fallback
+  auto actualSkinIndex = skinIndex;
+  if (actualSkinIndex >= skinCount())
+  {
+    actualSkinIndex = 0;
+  }
 
   if (m_meshes[frameIndex] == nullptr)
   {
@@ -471,7 +477,7 @@ std::unique_ptr<Renderer::TexturedIndexRangeRenderer> EntityModelSurface::buildR
   }
   else
   {
-    const auto* skin = this->skin(skinIndex);
+    const auto* skin = this->skin(actualSkinIndex);
     return m_meshes[frameIndex]->buildRenderer(skin);
   }
 }
@@ -500,12 +506,9 @@ std::unique_ptr<Renderer::TexturedRenderer> EntityModel::buildRenderer(
   const auto actualSkinIndex = skinIndex + frame->skinOffset();
   for (const auto& surface : m_surfaces)
   {
-    if (actualSkinIndex < surface->skinCount())
+    if (auto renderer = surface->buildRenderer(actualSkinIndex, frameIndex))
     {
-      if (auto renderer = surface->buildRenderer(actualSkinIndex, frameIndex))
-      {
-        renderers.push_back(std::move(renderer));
-      }
+      renderers.push_back(std::move(renderer));
     }
   }
   if (renderers.empty())

--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -463,13 +463,7 @@ std::unique_ptr<Renderer::TexturedIndexRangeRenderer> EntityModelSurface::buildR
   const size_t skinIndex, const size_t frameIndex)
 {
   assert(frameIndex < frameCount());
-
-  // If an out of range skin is requested, use the first skin as a fallback
-  auto actualSkinIndex = skinIndex;
-  if (actualSkinIndex >= skinCount())
-  {
-    actualSkinIndex = 0;
-  }
+  assert(skinIndex < skinCount());
 
   if (m_meshes[frameIndex] == nullptr)
   {
@@ -477,7 +471,7 @@ std::unique_ptr<Renderer::TexturedIndexRangeRenderer> EntityModelSurface::buildR
   }
   else
   {
-    const auto* skin = this->skin(actualSkinIndex);
+    const auto* skin = this->skin(skinIndex);
     return m_meshes[frameIndex]->buildRenderer(skin);
   }
 }
@@ -506,7 +500,10 @@ std::unique_ptr<Renderer::TexturedRenderer> EntityModel::buildRenderer(
   const auto actualSkinIndex = skinIndex + frame->skinOffset();
   for (const auto& surface : m_surfaces)
   {
-    if (auto renderer = surface->buildRenderer(actualSkinIndex, frameIndex))
+    // If an out of range skin is requested, use the first skin as a fallback
+    const auto correctedSkinIndex =
+      actualSkinIndex < surface->skinCount() ? actualSkinIndex : 0;
+    if (auto renderer = surface->buildRenderer(correctedSkinIndex, frameIndex))
     {
       renderers.push_back(std::move(renderer));
     }

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(COMMON_TEST_UTILS_SOURCE
 
 set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/Assets/tst_AssetUtils.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/Assets/tst_EntityModel.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Assets/tst_ModelDefinition.cpp"
         "${COMMON_TEST_SOURCE_DIR}/EL/tst_EL.cpp"
         "${COMMON_TEST_SOURCE_DIR}/EL/tst_Expression.cpp"
@@ -33,7 +34,6 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_DiskIO.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_ELParser.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_EntityDefinitionParser.cpp"
-        "${COMMON_TEST_SOURCE_DIR}/IO/tst_EntityModel.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_EntParser.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_FgdParser.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_FileSystem.cpp"

--- a/common/test/src/Assets/tst_EntityModel.cpp
+++ b/common/test/src/Assets/tst_EntityModel.cpp
@@ -43,7 +43,7 @@ namespace Assets
 {
 TEST_CASE("BSP model intersection test")
 {
-  auto logger = TestLogger();
+  auto logger = TestLogger{};
   auto [game, gameConfig] = Model::loadGame("Quake");
 
   const auto path = std::filesystem::path{"cube.bsp"};
@@ -110,7 +110,7 @@ TEST_CASE("EntityModelTest.buildRenderer.defaultSkinIndex")
   // default to a skin index of 0 if the provided index is not
   // present for the surface.
 
-  auto model = EntityModel("test", PitchType::Normal, Orientation::Oriented);
+  auto model = EntityModel{"test", PitchType::Normal, Orientation::Oriented};
   model.addFrame();
   auto& frame = model.loadFrame(0, "test", vm::bbox3f{0, 8});
 
@@ -141,9 +141,9 @@ TEST_CASE("EntityModelTest.buildRenderer.defaultSkinIndex")
   const auto renderer1 = model.buildRenderer(1, 0);
   const auto renderer2 = model.buildRenderer(2, 0);
 
-  REQUIRE(renderer0 != nullptr);
-  REQUIRE(renderer1 != nullptr);
-  REQUIRE(renderer2 != nullptr);
+  CHECK(renderer0 != nullptr);
+  CHECK(renderer1 != nullptr);
+  CHECK(renderer2 != nullptr);
 }
 } // namespace Assets
 } // namespace TrenchBroom


### PR DESCRIPTION
This change is again related to the Assimp model support. Assimp supports skins by offering "alternative textures" for each mesh in the model. The tricky part is (at least when loading HL1 models), each mesh will only have 1 texture if there are no alternatives for it, so if you set a skin index greater than 0, all the meshes disappear except for the ones with alternate skins. And if you specify a skin index that isn't valid, the model doesn't render at all.

![ShareX_9L64HgVhMp](https://github.com/TrenchBroom/TrenchBroom/assets/3071180/b5b3b90c-0326-4533-8f06-36bbf8226abb)

This change simply allows the user to specify "invalid" skin indices, but it will default to using the first skin in the collection when the index is invalid. This has two advantages:

- the model doesn't disappear when the wrong skin index is specified (even though this might be a good way to point out to the user that something is wrong, I don't think an invisible model is the right way to go about that)
- when loading assimp models, the texture data for meshes without alternative textures doesn't need to be duplicated in memory for each skin

This shouldn't impact any of the games that TB ships with, as the only FGD with a non-hard coded skin key in the model specification is `func_model` in `DigitalPaintball2\pball2.fgd`, which has its skin property commented out. However I don't know if there are any specific reasons for the current skin behaviour. From what I can see, the only other asset format that loads multiple surfaces for a model is MD3.

![ShareX_NtVtXitCKn](https://github.com/TrenchBroom/TrenchBroom/assets/3071180/16c84818-340a-497d-901f-2269f3e308bd)
