### PR TITLE
4294: Ensure that VirtualFileSystem::makeAbsolute checks path info

### DIFF
--- a/common/src/IO/VirtualFileSystem.cpp
+++ b/common/src/IO/VirtualFileSystem.cpp
@@ -80,8 +80,10 @@ Result<std::filesystem::path> VirtualFileSystem::makeAbsolute(
     if (matches(mountPoint, path))
     {
       const auto pathSuffix = suffix(mountPoint, path);
-      if (const auto absPath = mountPoint.mountedFileSystem->makeAbsolute(pathSuffix);
-          absPath.is_success())
+      const auto absPath = mountPoint.mountedFileSystem->makeAbsolute(pathSuffix);
+      if (
+        absPath.is_success()
+        && mountPoint.mountedFileSystem->pathInfo(pathSuffix) != PathInfo::Unknown)
       {
         return absPath;
       }

--- a/common/test/src/IO/TestFileSystem.cpp
+++ b/common/test/src/IO/TestFileSystem.cpp
@@ -91,11 +91,7 @@ PathInfo TestFileSystem::pathInfo(const std::filesystem::path& path) const
 Result<std::filesystem::path> TestFileSystem::makeAbsolute(
   const std::filesystem::path& path) const
 {
-  if (findEntry(path))
-  {
-    return m_absolutePathPrefix / path;
-  }
-  return Error{};
+  return m_absolutePathPrefix / path;
 }
 
 namespace

--- a/common/test/src/IO/tst_FileSystem.cpp
+++ b/common/test/src/IO/tst_FileSystem.cpp
@@ -55,8 +55,8 @@ TEST_CASE("FileSystem")
 
   SECTION("makeAbsolute")
   {
-    CHECK(fs.makeAbsolute("/") == Result<std::filesystem::path>{Error{}});
-    CHECK(fs.makeAbsolute("/foo") == Result<std::filesystem::path>{Error{}});
+    CHECK(fs.makeAbsolute("/") == Result<std::filesystem::path>{"/"});
+    CHECK(fs.makeAbsolute("/foo") == Result<std::filesystem::path>{"/foo"});
   }
 
   SECTION("pathInfo")


### PR DESCRIPTION
Closes #4294.