### PR TITLE
Filter recent documents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ find_package(tinyxml2 CONFIG REQUIRED)
 
 # Find Qt and OpenGL
 find_package(OpenGL REQUIRED)
-find_package(Qt5 COMPONENTS Core Widgets Svg REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Svg Test REQUIRED)
 
 # Qt will warn about API's that were deprecated after 5.9.5.
 # Since we're not raising our minimum Qt version, and can't use the replacement

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -179,7 +179,7 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
   const auto& actionManager = ActionManager::instance();
   actionManager.visitMainMenu(menuBuilder);
 
-  addRecentDocumentMenu(menuBuilder.recentDocumentsMenu);
+  addRecentDocumentMenu(*menuBuilder.recentDocumentsMenu);
 
   auto context = ActionExecutionContext{nullptr, nullptr};
   for (auto [tbAction, qtAction] : actionMap)
@@ -325,12 +325,12 @@ const std::vector<std::filesystem::path>& TrenchBroomApp::recentDocuments() cons
   return m_recentDocuments->recentDocuments();
 }
 
-void TrenchBroomApp::addRecentDocumentMenu(QMenu* menu)
+void TrenchBroomApp::addRecentDocumentMenu(QMenu& menu)
 {
   m_recentDocuments->addMenu(menu);
 }
 
-void TrenchBroomApp::removeRecentDocumentMenu(QMenu* menu)
+void TrenchBroomApp::removeRecentDocumentMenu(QMenu& menu)
 {
   m_recentDocuments->removeMenu(menu);
 }

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -163,6 +163,7 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
     &RecentDocuments::didChange,
     this,
     &TrenchBroomApp::recentDocumentsDidChange);
+  m_recentDocuments->reload();
 
 #ifdef __APPLE__
   setQuitOnLastWindowClosed(false);

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -61,6 +61,7 @@
 #include <QProxyStyle>
 #include <QStandardPaths>
 #include <QSysInfo>
+#include <QTimer>
 #include <QUrl>
 
 #include <kdl/path_utils.h>
@@ -69,6 +70,7 @@
 
 #include <fmt/format.h>
 
+#include <chrono>
 #include <clocale>
 #include <csignal>
 #include <cstdlib>
@@ -114,6 +116,8 @@ LONG WINAPI TrenchBroomUnhandledExceptionFilter(PEXCEPTION_POINTERS pExceptionPt
 TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
   : QApplication{argc, argv}
 {
+  using namespace std::chrono_literals;
+
   // When this flag is enabled, font and palette changes propagate as though the user had
   // manually called the corresponding QWidget methods.
   setAttribute(Qt::AA_UseStyleSheetPropagationInWidgetStyles);
@@ -164,6 +168,13 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
     this,
     &TrenchBroomApp::recentDocumentsDidChange);
   m_recentDocuments->reload();
+  m_recentDocumentsReloadTimer = new QTimer{};
+  connect(
+    m_recentDocumentsReloadTimer,
+    &QTimer::timeout,
+    m_recentDocuments.get(),
+    &RecentDocuments::reload);
+  m_recentDocumentsReloadTimer->start(1s);
 
 #ifdef __APPLE__
   setQuitOnLastWindowClosed(false);

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -156,7 +156,8 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
   // these must be initialized here and not earlier
   m_frameManager = std::make_unique<FrameManager>(useSDI());
 
-  m_recentDocuments = std::make_unique<RecentDocuments>(10);
+  m_recentDocuments = std::make_unique<RecentDocuments>(
+    10, [](const auto& path) { return std::filesystem::exists(path); });
   connect(
     m_recentDocuments.get(),
     &RecentDocuments::loadDocument,

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -68,8 +68,8 @@ private:
 
 public:
   const std::vector<std::filesystem::path>& recentDocuments() const;
-  void addRecentDocumentMenu(QMenu* menu);
-  void removeRecentDocumentMenu(QMenu* menu);
+  void addRecentDocumentMenu(QMenu& menu);
+  void removeRecentDocumentMenu(QMenu& menu);
   void updateRecentDocument(const std::filesystem::path& path);
 
   bool openDocument(const std::filesystem::path& path);

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -30,6 +30,7 @@
 
 class QMenu;
 class QSettings;
+class QTimer;
 
 namespace TrenchBroom
 {
@@ -49,6 +50,7 @@ private:
   std::unique_ptr<FrameManager> m_frameManager;
   std::unique_ptr<RecentDocuments> m_recentDocuments;
   std::unique_ptr<WelcomeWindow> m_welcomeWindow;
+  QTimer* m_recentDocumentsReloadTimer;
 
 public:
   static TrenchBroomApp& instance();

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -339,14 +339,14 @@ void MapFrame::updateUndoRedoActions()
 
 void MapFrame::addRecentDocumentsMenu()
 {
-  TrenchBroomApp& app = TrenchBroomApp::instance();
-  app.addRecentDocumentMenu(m_recentDocumentsMenu);
+  auto& app = TrenchBroomApp::instance();
+  app.addRecentDocumentMenu(*m_recentDocumentsMenu);
 }
 
 void MapFrame::removeRecentDocumentsMenu()
 {
   auto& app = TrenchBroomApp::instance();
-  app.removeRecentDocumentMenu(m_recentDocumentsMenu);
+  app.removeRecentDocumentMenu(*m_recentDocumentsMenu);
 }
 
 void MapFrame::updateRecentDocumentsMenu()

--- a/common/src/View/RecentDocumentListBox.cpp
+++ b/common/src/View/RecentDocumentListBox.cpp
@@ -26,15 +26,13 @@
 
 #include <cassert>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 RecentDocumentListBox::RecentDocumentListBox(QWidget* parent)
-  : ImageListBox("No Recent Documents", true, parent)
-  , m_documentIcon(IO::loadPixmapResource("DocIcon.png"))
+  : ImageListBox{"No Recent Documents", true, parent}
+  , m_documentIcon{IO::loadPixmapResource("DocIcon.png")}
 {
-  TrenchBroomApp& app = View::TrenchBroomApp::instance();
+  auto& app = View::TrenchBroomApp::instance();
   connect(
     &app,
     &TrenchBroomApp::recentDocumentsDidChange,
@@ -50,9 +48,8 @@ void RecentDocumentListBox::recentDocumentsDidChange()
 
 size_t RecentDocumentListBox::itemCount() const
 {
-  const TrenchBroomApp& app = View::TrenchBroomApp::instance();
-  const auto& recentDocuments = app.recentDocuments();
-  return recentDocuments.size();
+  const auto& app = View::TrenchBroomApp::instance();
+  return app.recentDocuments().size();
 }
 
 QPixmap RecentDocumentListBox::image(const size_t /* index */) const
@@ -87,5 +84,4 @@ void RecentDocumentListBox::doubleClicked(const size_t index)
     emit loadRecentDocument(documentPath);
   }
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/RecentDocumentListBox.h
+++ b/common/src/View/RecentDocumentListBox.h
@@ -25,9 +25,7 @@
 
 #include <filesystem>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 class RecentDocumentListBox : public ImageListBox
 {
@@ -50,5 +48,4 @@ private:
 signals:
   void loadRecentDocument(const std::filesystem::path& path);
 };
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/RecentDocuments.cpp
+++ b/common/src/View/RecentDocuments.cpp
@@ -72,12 +72,21 @@ RecentDocuments::RecentDocuments(const size_t maxSize, QObject* parent)
   , m_maxSize{maxSize}
 {
   assert(m_maxSize > 0);
-  loadFromConfig();
 }
 
 const std::vector<std::filesystem::path>& RecentDocuments::recentDocuments() const
 {
   return m_recentDocuments;
+}
+
+void RecentDocuments::reload()
+{
+  const auto previousRecentDocuments = loadFromConfig();
+  if (previousRecentDocuments != m_recentDocuments)
+  {
+    updateMenus();
+    emit didChange();
+  }
 }
 
 void RecentDocuments::addMenu(QMenu& menu)
@@ -116,9 +125,9 @@ void RecentDocuments::removePath(const std::filesystem::path& path)
   }
 }
 
-void RecentDocuments::loadFromConfig()
+std::vector<std::filesystem::path> RecentDocuments::loadFromConfig()
 {
-  m_recentDocuments = loadRecentDocuments(m_maxSize);
+  return std::exchange(m_recentDocuments, loadRecentDocuments(m_maxSize));
 }
 
 void RecentDocuments::saveToConfig()

--- a/common/src/View/RecentDocuments.cpp
+++ b/common/src/View/RecentDocuments.cpp
@@ -29,13 +29,11 @@
 
 #include <kdl/vector_utils.h>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 RecentDocuments::RecentDocuments(const size_t maxSize, QObject* parent)
-  : QObject(parent)
-  , m_maxSize(maxSize)
+  : QObject{parent}
+  , m_maxSize{maxSize}
 {
   assert(m_maxSize > 0);
   loadFromConfig();
@@ -46,19 +44,17 @@ const std::vector<std::filesystem::path>& RecentDocuments::recentDocuments() con
   return m_recentDocuments;
 }
 
-void RecentDocuments::addMenu(QMenu* menu)
+void RecentDocuments::addMenu(QMenu& menu)
 {
-  ensure(menu != nullptr, "menu is null");
   clearMenu(menu);
   createMenuItems(menu);
-  m_menus.push_back(menu);
+  m_menus.push_back(&menu);
 }
 
-void RecentDocuments::removeMenu(QMenu* menu)
+void RecentDocuments::removeMenu(QMenu& menu)
 {
-  ensure(menu != nullptr, "menu is null");
   clearMenu(menu);
-  m_menus = kdl::vec_erase(std::move(m_menus), menu);
+  m_menus = kdl::vec_erase(std::move(m_menus), &menu);
 }
 
 void RecentDocuments::updatePath(const std::filesystem::path& path)
@@ -71,9 +67,9 @@ void RecentDocuments::updatePath(const std::filesystem::path& path)
 
 void RecentDocuments::removePath(const std::filesystem::path& path)
 {
-  const size_t oldSize = m_recentDocuments.size();
+  const auto oldSize = m_recentDocuments.size();
 
-  const std::filesystem::path canonPath = path.lexically_normal();
+  const auto canonPath = path.lexically_normal();
   m_recentDocuments = kdl::vec_erase(std::move(m_recentDocuments), canonPath);
 
   if (oldSize > m_recentDocuments.size())
@@ -87,12 +83,11 @@ void RecentDocuments::removePath(const std::filesystem::path& path)
 void RecentDocuments::loadFromConfig()
 {
   m_recentDocuments.clear();
-  const QSettings settings;
+  const auto settings = QSettings{};
   for (size_t i = 0; i < m_maxSize; ++i)
   {
-    const auto key =
-      QString::fromStdString(std::string("RecentDocuments/") + std::to_string(i));
-    const QVariant value = settings.value(key);
+    const auto key = QString::fromStdString("RecentDocuments/" + std::to_string(i));
+    const auto value = settings.value(key);
     if (value.isValid())
     {
       m_recentDocuments.push_back(IO::pathFromQString(value.toString()));
@@ -106,13 +101,12 @@ void RecentDocuments::loadFromConfig()
 
 void RecentDocuments::saveToConfig()
 {
-  QSettings settings;
+  auto settings = QSettings{};
   settings.remove("RecentDocuments");
   for (size_t i = 0; i < m_recentDocuments.size(); ++i)
   {
-    const QString key =
-      QString::fromStdString(std::string("RecentDocuments/") + std::to_string(i));
-    const QVariant value = QVariant(IO::pathAsQString(m_recentDocuments[i]));
+    const auto key = QString::fromStdString("RecentDocuments/" + std::to_string(i));
+    const auto value = QVariant{IO::pathAsQString(m_recentDocuments[i])};
     settings.setValue(key, value);
   }
 }
@@ -137,23 +131,22 @@ void RecentDocuments::updateMenus()
 {
   for (auto* menu : m_menus)
   {
-    clearMenu(menu);
-    createMenuItems(menu);
+    clearMenu(*menu);
+    createMenuItems(*menu);
   }
 }
 
-void RecentDocuments::clearMenu(QMenu* menu)
+void RecentDocuments::clearMenu(QMenu& menu)
 {
-  menu->clear();
+  menu.clear();
 }
 
-void RecentDocuments::createMenuItems(QMenu* menu)
+void RecentDocuments::createMenuItems(QMenu& menu)
 {
   for (const auto& path : m_recentDocuments)
   {
-    menu->addAction(
+    menu.addAction(
       IO::pathAsQString(path.filename()), [this, path]() { loadDocument(path); });
   }
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -28,9 +28,7 @@
 
 class QMenu;
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 class RecentDocuments : public QObject
 {
@@ -47,8 +45,8 @@ public:
 
   const std::vector<std::filesystem::path>& recentDocuments() const;
 
-  void addMenu(QMenu* menu);
-  void removeMenu(QMenu* menu);
+  void addMenu(QMenu& menu);
+  void removeMenu(QMenu& menu);
 
   void updatePath(const std::filesystem::path& path);
   void removePath(const std::filesystem::path& path);
@@ -60,11 +58,10 @@ private:
   void insertPath(const std::filesystem::path& path);
 
   void updateMenus();
-  void clearMenu(QMenu* menu);
-  void createMenuItems(QMenu* menu);
+  void clearMenu(QMenu& menu);
+  void createMenuItems(QMenu& menu);
 signals:
   void loadDocument(const std::filesystem::path& path) const;
   void didChange();
 };
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -48,6 +48,8 @@ public:
 
   const std::vector<std::filesystem::path>& recentDocuments() const;
 
+  void reload();
+
   void addMenu(QMenu& menu);
   void removeMenu(QMenu& menu);
 
@@ -55,7 +57,7 @@ public:
   void removePath(const std::filesystem::path& path);
 
 private:
-  void loadFromConfig();
+  std::vector<std::filesystem::path> loadFromConfig();
   void saveToConfig();
 
   void insertPath(const std::filesystem::path& path);

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -30,6 +30,9 @@ class QMenu;
 
 namespace TrenchBroom::View
 {
+std::vector<std::filesystem::path> loadRecentDocuments(size_t max);
+void saveRecentDocuments(const std::vector<std::filesystem::path>& paths);
+
 class RecentDocuments : public QObject
 {
   Q_OBJECT

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -24,6 +24,7 @@
 #include "Notifier.h"
 
 #include <filesystem>
+#include <functional>
 #include <vector>
 
 class QMenu;
@@ -41,10 +42,15 @@ private:
   MenuList m_menus;
 
   size_t m_maxSize;
+  std::function<bool(std::filesystem::path)> m_filterPredicate;
   std::vector<std::filesystem::path> m_recentDocuments;
+  std::vector<std::filesystem::path> m_filteredDocuments;
 
 public:
-  explicit RecentDocuments(size_t maxSize, QObject* parent = nullptr);
+  RecentDocuments(
+    size_t maxSize,
+    std::function<bool(std::filesystem::path)> filterPredicate,
+    QObject* parent = nullptr);
 
   const std::vector<std::filesystem::path>& recentDocuments() const;
 
@@ -57,8 +63,9 @@ public:
   void removePath(const std::filesystem::path& path);
 
 private:
-  std::vector<std::filesystem::path> loadFromConfig();
+  void loadFromConfig();
   void saveToConfig();
+  std::vector<std::filesystem::path> updateFilteredDocuments();
 
   void insertPath(const std::filesystem::path& path);
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -118,6 +118,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/tst_MapDocument.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_MoveHandleDragTracker.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_Picking.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/tst_RecentDocuments.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_RemoveNodes.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_ReparentNodes.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_RepeatableActions.cpp"
@@ -166,7 +167,7 @@ set(TEST_FIXTURE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/fixture")
 add_library(common-test-utils OBJECT ${COMMON_TEST_UTILS_SOURCE})
 set_compiler_config(common-test-utils)
 target_include_directories(common-test-utils PUBLIC ${COMMON_TEST_SOURCE_DIR})
-target_link_libraries(common-test-utils PRIVATE common Catch2::Catch2)
+target_link_libraries(common-test-utils PRIVATE common Catch2::Catch2 Qt5::Test)
 
 macro(configure_test_target TARGET)
     target_link_libraries(${TARGET} PRIVATE common common-test-utils Catch2::Catch2)

--- a/common/test/src/View/tst_RecentDocuments.cpp
+++ b/common/test/src/View/tst_RecentDocuments.cpp
@@ -1,0 +1,276 @@
+/*
+ Copyright (C) 2023 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QMenu>
+#include <QSettings>
+#include <QtTest/QSignalSpy>
+
+#include "View/RecentDocuments.h"
+
+#include "kdl/vector_utils.h"
+
+#include "Catch2.h"
+
+namespace TrenchBroom::View
+{
+
+namespace
+{
+std::vector<QString> getTexts(const QList<QAction*>& actions)
+{
+  auto result = std::vector<QString>{};
+  for (const auto* action : actions)
+  {
+    result.push_back(action->text());
+  }
+  return result;
+}
+} // namespace
+
+TEST_CASE("RecentDocuments")
+{
+  SECTION("load and save")
+  {
+    saveRecentDocuments({});
+    CHECK(loadRecentDocuments(5).empty());
+
+    saveRecentDocuments({"this/that.map", "that/this.map"});
+    CHECK(
+      loadRecentDocuments(5)
+      == std::vector<std::filesystem::path>{"this/that.map", "that/this.map"});
+
+    saveRecentDocuments({"some/other.map"});
+    CHECK(loadRecentDocuments(5) == std::vector<std::filesystem::path>{"some/other.map"});
+
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+    });
+    CHECK(loadRecentDocuments(1) == std::vector<std::filesystem::path>{"1.map"});
+  }
+
+  SECTION("constructor")
+  {
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+    });
+
+    auto recentDocuments = RecentDocuments{5};
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "1.map",
+        "2.map",
+      });
+  }
+
+  SECTION("updatePath")
+  {
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+    });
+    auto recentDocuments = RecentDocuments{5};
+
+    auto spy = QSignalSpy{&recentDocuments, SIGNAL(didChange())};
+
+    recentDocuments.updatePath("2.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "2.map",
+        "1.map",
+      });
+    CHECK(
+      loadRecentDocuments(5)
+      == std::vector<std::filesystem::path>{
+        "2.map",
+        "1.map",
+      });
+    CHECK(spy.count() == 1);
+
+    recentDocuments.updatePath("3.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "3.map",
+        "2.map",
+        "1.map",
+      });
+    CHECK(spy.count() == 2);
+
+    recentDocuments.updatePath("3.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "3.map",
+        "2.map",
+        "1.map",
+      });
+    CHECK(spy.count() == 3);
+
+    recentDocuments.updatePath("4.map");
+    recentDocuments.updatePath("5.map");
+    recentDocuments.updatePath("6.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "6.map",
+        "5.map",
+        "4.map",
+        "3.map",
+        "2.map",
+      });
+    CHECK(
+      loadRecentDocuments(5)
+      == std::vector<std::filesystem::path>{
+        "6.map",
+        "5.map",
+        "4.map",
+        "3.map",
+        "2.map",
+      });
+    CHECK(spy.count() == 6);
+  }
+
+  SECTION("removePath")
+  {
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+      "3.map",
+    });
+    auto recentDocuments = RecentDocuments{5};
+
+    auto spy = QSignalSpy{&recentDocuments, SIGNAL(didChange())};
+
+    recentDocuments.removePath("2.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "1.map",
+        "3.map",
+      });
+    CHECK(
+      loadRecentDocuments(5)
+      == std::vector<std::filesystem::path>{
+        "1.map",
+        "3.map",
+      });
+    CHECK(spy.count() == 1);
+
+    recentDocuments.removePath("1.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "3.map",
+      });
+    CHECK(spy.count() == 2);
+
+    recentDocuments.removePath("1.map");
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "3.map",
+      });
+    CHECK(spy.count() == 2);
+
+    recentDocuments.removePath("3.map");
+    CHECK(recentDocuments.recentDocuments().empty());
+    CHECK(loadRecentDocuments(5).empty());
+    CHECK(spy.count() == 3);
+  }
+
+  SECTION("menus")
+  {
+    auto menu1 = QMenu{};
+    auto menu2 = QMenu{};
+
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+      "3.map",
+    });
+    auto recentDocuments = RecentDocuments{5};
+
+    recentDocuments.addMenu(menu1);
+    CHECK(
+      getTexts(menu1.actions())
+      == std::vector<QString>{
+        "1.map",
+        "2.map",
+        "3.map",
+      });
+
+    recentDocuments.addMenu(menu2);
+    CHECK(
+      getTexts(menu2.actions())
+      == std::vector<QString>{
+        "1.map",
+        "2.map",
+        "3.map",
+      });
+
+    recentDocuments.updatePath("4.map");
+    CHECK(
+      getTexts(menu1.actions())
+      == std::vector<QString>{
+        "4.map",
+        "1.map",
+        "2.map",
+        "3.map",
+      });
+    CHECK(
+      getTexts(menu2.actions())
+      == std::vector<QString>{
+        "4.map",
+        "1.map",
+        "2.map",
+        "3.map",
+      });
+
+    recentDocuments.removePath("1.map");
+    CHECK(
+      getTexts(menu1.actions())
+      == std::vector<QString>{
+        "4.map",
+        "2.map",
+        "3.map",
+      });
+    CHECK(
+      getTexts(menu2.actions())
+      == std::vector<QString>{
+        "4.map",
+        "2.map",
+        "3.map",
+      });
+
+    recentDocuments.removeMenu(menu2);
+    CHECK(
+      getTexts(menu1.actions())
+      == std::vector<QString>{
+        "4.map",
+        "2.map",
+        "3.map",
+      });
+    CHECK(menu2.actions().empty());
+  }
+}
+} // namespace TrenchBroom::View

--- a/common/test/src/View/tst_RecentDocuments.cpp
+++ b/common/test/src/View/tst_RecentDocuments.cpp
@@ -73,12 +73,56 @@ TEST_CASE("RecentDocuments")
     });
 
     auto recentDocuments = RecentDocuments{5};
+    CHECK(recentDocuments.recentDocuments().empty());
+  }
+
+  SECTION("reload")
+  {
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+    });
+
+    auto recentDocuments = RecentDocuments{5};
+    REQUIRE(recentDocuments.recentDocuments().empty());
+
+    auto spy = QSignalSpy{&recentDocuments, SIGNAL(didChange())};
+
+    REQUIRE(spy.count() == 0);
+
+    recentDocuments.reload();
     CHECK(
       recentDocuments.recentDocuments()
       == std::vector<std::filesystem::path>{
         "1.map",
         "2.map",
       });
+    CHECK(spy.count() == 1);
+
+    recentDocuments.reload();
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "1.map",
+        "2.map",
+      });
+    CHECK(spy.count() == 1);
+
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+      "3.map",
+    });
+
+    recentDocuments.reload();
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "1.map",
+        "2.map",
+        "3.map",
+      });
+    CHECK(spy.count() == 2);
   }
 
   SECTION("updatePath")
@@ -88,6 +132,7 @@ TEST_CASE("RecentDocuments")
       "2.map",
     });
     auto recentDocuments = RecentDocuments{5};
+    recentDocuments.reload();
 
     auto spy = QSignalSpy{&recentDocuments, SIGNAL(didChange())};
 
@@ -158,6 +203,7 @@ TEST_CASE("RecentDocuments")
       "3.map",
     });
     auto recentDocuments = RecentDocuments{5};
+    recentDocuments.reload();
 
     auto spy = QSignalSpy{&recentDocuments, SIGNAL(didChange())};
 
@@ -209,6 +255,7 @@ TEST_CASE("RecentDocuments")
       "3.map",
     });
     auto recentDocuments = RecentDocuments{5};
+    recentDocuments.reload();
 
     recentDocuments.addMenu(menu1);
     CHECK(


### PR DESCRIPTION
Reimplementation of https://github.com/TrenchBroom/TrenchBroom/pull/4283

This PR filters the recent documents list dynamically. Entries are hidden from the list as soon as the corresponding file cannot be found.