### PR TITLE
Node Origin Added

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1052,6 +1052,7 @@ void MapViewBase::doRender()
   renderPortalFile(renderContext, renderBatch);
   renderCompass(renderBatch);
   renderFPS(renderContext, renderBatch);
+  renderSelectionOrigin(renderContext, renderBatch);
 
   renderBatch.render(renderContext);
 }
@@ -1168,6 +1169,24 @@ void MapViewBase::renderFPS(
   {
     auto renderService = Renderer::RenderService{renderContext, renderBatch};
     renderService.renderHeadsUp(m_currentFPS);
+  }
+}
+
+void MapViewBase::renderSelectionOrigin(
+  Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch)
+{
+  auto document = kdl::mem_lock(m_document);
+
+  if (document->hasSelectedNodes() && !m_toolBox.rotateObjectsToolActive()) {
+    const vm::bbox3& bounds = document->selectionBounds();
+
+    Renderer::RenderService renderService(renderContext, renderBatch);
+    renderService.setShowOccludedObjects();
+
+    renderService.setForegroundColor(pref(Preferences::SelectedHandleColor));
+    renderService.renderHandleHighlight(vm::vec3f(bounds.center()));
+    renderService.setForegroundColor(pref(Preferences::InfoOverlayTextColor));
+    renderService.setBackgroundColor(pref(Preferences::InfoOverlayBackgroundColor));
   }
 }
 

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -340,6 +340,8 @@ private: // implement RenderView interface
   void renderCompass(Renderer::RenderBatch& renderBatch);
   void renderFPS(
     Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
+  void renderSelectionOrigin(
+    Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
 
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;


### PR DESCRIPTION
Allows mappers to see the center of a brush or entity to help with keeping things symmetric.