### PR TITLE
4303: Render Goldsource infodecals

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -2,6 +2,7 @@ set(COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Assets/ColorRange.cpp
+        ${COMMON_SOURCE_DIR}/Assets/DecalDefinition.cpp
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinition.cpp
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionFileSpec.cpp
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionGroup.cpp
@@ -479,6 +480,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Assets/AssetReference.h
         ${COMMON_SOURCE_DIR}/Assets/AssetUtils.h
         ${COMMON_SOURCE_DIR}/Assets/ColorRange.h
+        ${COMMON_SOURCE_DIR}/Assets/DecalDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionFileSpec.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionGroup.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -204,6 +204,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Renderer/Compass3D.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EdgeRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EntityLinkRenderer.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/EntityDecalRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EntityModelRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EntityRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FaceRenderer.cpp
@@ -715,6 +716,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Renderer/Compass3D.h
         ${COMMON_SOURCE_DIR}/Renderer/EdgeRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/EntityLinkRenderer.h
+        ${COMMON_SOURCE_DIR}/Renderer/EntityDecalRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/EntityModelRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/EntityRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/FaceRenderer.h

--- a/common/src/Assets/DecalDefinition.cpp
+++ b/common/src/Assets/DecalDefinition.cpp
@@ -1,0 +1,108 @@
+/*
+ Copyright (C) 2023 Daniel Walder
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DecalDefinition.h"
+
+#include "EL/EvaluationContext.h"
+#include "EL/Expressions.h"
+#include "EL/Types.h"
+#include "EL/Value.h"
+#include "EL/VariableStore.h"
+
+#include <kdl/reflection_impl.h>
+#include <kdl/string_compare.h>
+
+#include <vecmath/scalar.h>
+#include <vecmath/vec_io.h>
+
+namespace TrenchBroom
+{
+namespace Assets
+{
+
+namespace
+{
+std::string textureName(const EL::Value& value)
+{
+  using namespace std::string_literals;
+  return value.type() == EL::ValueType::String ? value.stringValue() : ""s;
+}
+
+DecalSpecification convertToDecal(const EL::Value& value)
+{
+  switch (value.type())
+  {
+  case EL::ValueType::Map:
+    return {textureName(value[DecalSpecificationKeys::Texture])};
+  case EL::ValueType::String:
+    return {textureName(value)};
+  case EL::ValueType::Boolean:
+  case EL::ValueType::Number:
+  case EL::ValueType::Array:
+  case EL::ValueType::Range:
+  case EL::ValueType::Null:
+  case EL::ValueType::Undefined:
+    break;
+  }
+
+  return {};
+}
+} // namespace
+
+kdl_reflect_impl(DecalSpecification);
+
+DecalDefinition::DecalDefinition()
+  : m_expression{EL::LiteralExpression{EL::Value::Undefined}, 0, 0}
+{
+}
+
+DecalDefinition::DecalDefinition(const size_t line, const size_t column)
+  : m_expression{EL::LiteralExpression{EL::Value::Undefined}, line, column}
+{
+}
+
+DecalDefinition::DecalDefinition(EL::Expression expression)
+  : m_expression{std::move(expression)}
+{
+}
+
+void DecalDefinition::append(const DecalDefinition& other)
+{
+  const auto line = m_expression.line();
+  const auto column = m_expression.column();
+
+  auto cases = std::vector<EL::Expression>{std::move(m_expression), other.m_expression};
+  m_expression = EL::Expression{EL::SwitchExpression{std::move(cases)}, line, column};
+}
+
+DecalSpecification DecalDefinition::decalSpecification(
+  const EL::VariableStore& variableStore) const
+{
+  return convertToDecal(m_expression.evaluate(EL::EvaluationContext{variableStore}));
+}
+
+DecalSpecification DecalDefinition::defaultDecalSpecification() const
+{
+  return decalSpecification(EL::NullVariableStore{});
+}
+
+kdl_reflect_impl(DecalDefinition);
+
+} // namespace Assets
+} // namespace TrenchBroom

--- a/common/src/Assets/DecalDefinition.h
+++ b/common/src/Assets/DecalDefinition.h
@@ -1,0 +1,80 @@
+/*
+ Copyright (C) 2023 Daniel Walder
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "EL/Expression.h"
+
+#include <kdl/reflection_decl.h>
+
+#include <vecmath/vec.h>
+
+#include <iosfwd>
+
+namespace TrenchBroom::Assets
+{
+
+namespace DecalSpecificationKeys
+{
+constexpr auto Texture = "texture";
+} // namespace DecalSpecificationKeys
+
+struct DecalSpecification
+{
+  std::string textureName;
+
+  kdl_reflect_decl(DecalSpecification, textureName);
+};
+
+class DecalDefinition
+{
+private:
+  EL::Expression m_expression;
+
+public:
+  DecalDefinition();
+  DecalDefinition(size_t line, size_t column);
+  explicit DecalDefinition(EL::Expression expression);
+
+  void append(const DecalDefinition& other);
+
+  /**
+   * Evaluates the decal expresion, using the given variable store to interpolate
+   * variables.
+   *
+   * @param variableStore the variable store to use when interpolating variables
+   * @return the decal specification
+   *
+   * @throws EL::Exception if the expression could not be evaluated
+   */
+  DecalSpecification decalSpecification(const EL::VariableStore& variableStore) const;
+
+  /**
+   * Evaluates the decal expresion.
+   *
+   * @return the decal specification
+   *
+   * @throws EL::Exception if the expression could not be evaluated
+   */
+  DecalSpecification defaultDecalSpecification() const;
+
+  kdl_reflect_decl(DecalDefinition, m_expression);
+};
+
+} // namespace TrenchBroom::Assets

--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -191,10 +191,12 @@ PointEntityDefinition::PointEntityDefinition(
   const vm::bbox3& bounds,
   std::string description,
   std::vector<std::shared_ptr<PropertyDefinition>> propertyDefinitions,
-  ModelDefinition modelDefinition)
+  ModelDefinition modelDefinition,
+  DecalDefinition decalDefinition)
   : EntityDefinition{std::move(name), color, std::move(description), std::move(propertyDefinitions)}
   , m_bounds{bounds}
   , m_modelDefinition{std::move(modelDefinition)}
+  , m_decalDefinition{std::move(decalDefinition)}
 {
 }
 
@@ -211,6 +213,11 @@ const vm::bbox3& PointEntityDefinition::bounds() const
 const ModelDefinition& PointEntityDefinition::modelDefinition() const
 {
   return m_modelDefinition;
+}
+
+const DecalDefinition& PointEntityDefinition::decalDefinition() const
+{
+  return m_decalDefinition;
 }
 
 BrushEntityDefinition::BrushEntityDefinition(

--- a/common/src/Assets/EntityDefinition.h
+++ b/common/src/Assets/EntityDefinition.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "Assets/DecalDefinition.h"
 #include "Assets/ModelDefinition.h"
 #include "Color.h"
 #include "FloatType.h"
@@ -103,6 +104,7 @@ class PointEntityDefinition : public EntityDefinition
 private:
   vm::bbox3 m_bounds;
   ModelDefinition m_modelDefinition;
+  DecalDefinition m_decalDefinition;
 
 public:
   PointEntityDefinition(
@@ -111,11 +113,13 @@ public:
     const vm::bbox3& bounds,
     std::string description,
     std::vector<std::shared_ptr<PropertyDefinition>> propertyDefinitions,
-    ModelDefinition modelDefinition);
+    ModelDefinition modelDefinition,
+    DecalDefinition decalDefinition);
 
   EntityDefinitionType type() const override;
   const vm::bbox3& bounds() const;
   const ModelDefinition& modelDefinition() const;
+  const DecalDefinition& decalDefinition() const;
 };
 
 class BrushEntityDefinition : public EntityDefinition

--- a/common/src/IO/EntityDefinitionClassInfo.h
+++ b/common/src/IO/EntityDefinitionClassInfo.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "Assets/DecalDefinition.h"
 #include "Assets/ModelDefinition.h"
 #include "Color.h"
 #include "FloatType.h"
@@ -62,6 +63,7 @@ struct EntityDefinitionClassInfo
   std::optional<Color> color;
   std::optional<vm::bbox3> size;
   std::optional<Assets::ModelDefinition> modelDefinition;
+  std::optional<Assets::DecalDefinition> decalDefinition;
 
   std::vector<std::shared_ptr<Assets::PropertyDefinition>> propertyDefinitions;
   std::vector<std::string> superClasses;
@@ -76,6 +78,7 @@ struct EntityDefinitionClassInfo
     color,
     size,
     modelDefinition,
+    decalDefinition,
     propertyDefinitions,
     superClasses);
 };

--- a/common/src/IO/EntityDefinitionParser.cpp
+++ b/common/src/IO/EntityDefinitionParser.cpp
@@ -148,6 +148,15 @@ static void inheritAttributes(
   {
     inheritingClass.modelDefinition->append(*superClass.modelDefinition);
   }
+
+  if (!inheritingClass.decalDefinition)
+  {
+    inheritingClass.decalDefinition = superClass.decalDefinition;
+  }
+  else if (superClass.decalDefinition)
+  {
+    inheritingClass.decalDefinition->append(*superClass.decalDefinition);
+  }
 }
 
 /**
@@ -419,7 +428,8 @@ std::unique_ptr<Assets::EntityDefinition> EntityDefinitionParser::createDefiniti
   const auto size = classInfo.size.value_or(DefaultSize);
   auto description = classInfo.description.value_or("");
   auto& attributes = classInfo.propertyDefinitions;
-  auto modelDefinition = classInfo.modelDefinition.value_or(Assets::ModelDefinition());
+  auto modelDefinition = classInfo.modelDefinition.value_or(Assets::ModelDefinition{});
+  auto decalDefinition = classInfo.decalDefinition.value_or(Assets::DecalDefinition{});
 
   switch (classInfo.type)
   {
@@ -430,7 +440,8 @@ std::unique_ptr<Assets::EntityDefinition> EntityDefinitionParser::createDefiniti
       size,
       std::move(description),
       std::move(attributes),
-      std::move(modelDefinition));
+      std::move(modelDefinition),
+      std::move(decalDefinition));
   case EntityDefinitionClassType::BrushClass:
     return std::make_unique<Assets::BrushEntityDefinition>(
       name, color, std::move(description), std::move(attributes));

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -37,17 +37,18 @@
 #include <kdl/string_utils.h>
 #include <kdl/vector_utils.h>
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
-{
-FgdTokenizer::FgdTokenizer(std::string_view str)
-  : Tokenizer(std::move(str), "", 0)
+
+FgdTokenizer::FgdTokenizer(const std::string_view str)
+  : Tokenizer{str, "", 0}
 {
 }
 
@@ -137,8 +138,8 @@ FgdTokenizer::Token FgdTokenizer::emitToken()
       e = readUntil(WordDelims);
       if (e == nullptr)
       {
-        throw ParserException(
-          startLine, startColumn, "Unexpected character: '" + std::string(c, 1) + "'");
+        throw ParserException{
+          startLine, startColumn, fmt::format("Unexpected character: '{}'", c)};
       }
       else
       {
@@ -151,11 +152,11 @@ FgdTokenizer::Token FgdTokenizer::emitToken()
 }
 
 FgdParser::FgdParser(
-  std::string_view str,
+  const std::string_view str,
   const Color& defaultEntityColor,
   const std::filesystem::path& path)
   : EntityDefinitionParser{defaultEntityColor}
-  , m_tokenizer{FgdTokenizer{std::move(str)}}
+  , m_tokenizer{FgdTokenizer{str}}
 {
   if (!path.empty() && path.is_absolute())
   {
@@ -195,22 +196,22 @@ FgdParser::TokenNameMap FgdParser::tokenNames() const
 class FgdParser::PushIncludePath
 {
 private:
-  FgdParser* m_parser;
+  FgdParser& m_parser;
 
 public:
-  PushIncludePath(FgdParser* parser, const std::filesystem::path& path)
+  PushIncludePath(FgdParser& parser, const std::filesystem::path& path)
     : m_parser{parser}
   {
-    m_parser->pushIncludePath(path);
+    m_parser.pushIncludePath(path);
   }
 
-  ~PushIncludePath() { m_parser->popIncludePath(); }
+  ~PushIncludePath() { m_parser.popIncludePath(); }
 };
 
-void FgdParser::pushIncludePath(const std::filesystem::path& path)
+void FgdParser::pushIncludePath(std::filesystem::path path)
 {
   assert(!isRecursiveInclude(path));
-  m_paths.push_back(path);
+  m_paths.push_back(std::move(path));
 }
 
 void FgdParser::popIncludePath()
@@ -221,15 +222,8 @@ void FgdParser::popIncludePath()
 
 std::filesystem::path FgdParser::currentRoot() const
 {
-  if (!m_paths.empty())
-  {
-    assert(!m_paths.back().empty());
-    return m_paths.back().parent_path();
-  }
-  else
-  {
-    return {};
-  }
+  assert(m_paths.empty() || !m_paths.back().empty());
+  return !m_paths.empty() ? m_paths.back().parent_path() : std::filesystem::path{};
 }
 
 bool FgdParser::isRecursiveInclude(const std::filesystem::path& path) const
@@ -300,7 +294,7 @@ std::optional<EntityDefinitionClassInfo> FgdParser::parseClassInfo(ParserStatus&
   }
   else
   {
-    const auto msg = "Unknown entity definition class '" + classname + "'";
+    const auto msg = fmt::format("Unknown entity definition class '{}'", classname);
     status.error(token.line(), token.column(), msg);
     throw ParserException{token.line(), token.column(), msg};
   }
@@ -405,7 +399,7 @@ EntityDefinitionClassInfo FgdParser::parseClassInfo(
       status.warn(
         token.line(),
         token.column(),
-        "Unknown entity definition header properties '" + typeName + "'");
+        fmt::format("Unknown entity definition header properties '{}'", typeName));
       skipClassProperty(status);
     }
     token = expect(status, FgdToken::Equality | FgdToken::Word, m_tokenizer.nextToken());
@@ -418,8 +412,7 @@ EntityDefinitionClassInfo FgdParser::parseClassInfo(
   if (token.type() == FgdToken::Colon)
   {
     m_tokenizer.nextToken();
-    const auto description = parseString(status);
-    classInfo.description = kdl::str_trim(description);
+    classInfo.description = kdl::str_trim(parseString(status));
   }
 
   classInfo.propertyDefinitions = parsePropertyDefinitions(status);
@@ -502,8 +495,9 @@ Assets::ModelDefinition FgdParser::parseModel(ParserStatus& status)
       status.warn(
         line,
         column,
-        "Legacy model expressions are deprecated, replace with '" + expression.asString()
-          + "'");
+        fmt::format(
+          "Legacy model expressions are deprecated, replace with '{}'",
+          expression.asString()));
       return Assets::ModelDefinition{expression};
     }
     catch (const ParserException&)
@@ -616,7 +610,9 @@ FgdParser::PropertyDefinitionList FgdParser::parsePropertyDefinitions(
     if (!addPropertyDefinition(propertyDefinitions, std::move(propertyDefinition)))
     {
       status.warn(
-        line, column, "Skipping duplicate property definition: '" + propertyKey + "'");
+        line,
+        column,
+        fmt::format("Skipping duplicate property definition: '{}'", propertyKey));
     }
 
     token = expect(status, FgdToken::Word | FgdToken::CBracket, m_tokenizer.nextToken());
@@ -664,12 +660,8 @@ FgdParser::PropertyDefinitionPtr FgdParser::parsePropertyDefinition(
   status.debug(
     line,
     column,
-    kdl::str_to_string(
-      "Unknown property definition type '",
-      typeName,
-      "' for property '",
-      propertyKey,
-      "'"));
+    fmt::format(
+      "Unknown property definition type '{}' for property '{}'", typeName, propertyKey));
   return parseUnknownPropertyDefinition(status, propertyKey);
 }
 
@@ -926,7 +918,9 @@ std::optional<float> FgdParser::parseDefaultFloatValue(ParserStatus& status)
       if (token.type() != FgdToken::String)
       {
         status.warn(
-          token.line(), token.column(), "Unquoted float default value " + token.data());
+          token.line(),
+          token.column(),
+          fmt::format("Unquoted float default value {}", token.data()));
       }
       return token.toFloat<float>();
     }
@@ -1033,8 +1027,7 @@ std::vector<EntityDefinitionClassInfo> FgdParser::parseInclude(ParserStatus& sta
   assert(kdl::ci::str_is_equal(token.data(), "@include"));
 
   expect(status, FgdToken::String, token = m_tokenizer.nextToken());
-  const auto path = std::filesystem::path(token.data());
-  return handleInclude(status, path);
+  return handleInclude(status, token.data());
 }
 
 std::vector<EntityDefinitionClassInfo> FgdParser::handleInclude(
@@ -1053,34 +1046,38 @@ std::vector<EntityDefinitionClassInfo> FgdParser::handleInclude(
       m_tokenizer.restoreStateAndSource(snapshot);
     }};
 
-  status.debug(m_tokenizer.line(), "Parsing included file '" + path.string() + "'");
+  status.debug(
+    m_tokenizer.line(), fmt::format("Parsing included file '{}'", path.string()));
 
   const auto filePath = currentRoot() / path;
   return m_fs->openFile(filePath)
     .transform([&](auto file) {
       status.debug(
         m_tokenizer.line(),
-        "Resolved '" + path.string() + "' to '" + filePath.string() + "'");
+        fmt::format("Resolved '{}' to '{}'", path.string(), filePath.string()));
 
       if (isRecursiveInclude(filePath))
       {
         status.error(
           m_tokenizer.line(),
-          "Skipping recursively included file: " + path.string() + " ("
-            + filePath.string() + ")");
+          fmt::format(
+            "Skipping recursively included file: {} ({})",
+            path.string(),
+            filePath.string()));
         return std::vector<EntityDefinitionClassInfo>{};
       }
 
-      const auto pushIncludePath = PushIncludePath{this, filePath};
+      const auto pushIncludePath = PushIncludePath{*this, filePath};
       auto reader = file->reader().buffer();
       m_tokenizer.replaceState(reader.stringView());
       return parseClassInfos(status);
     })
     .transform_error([&](auto e) {
-      status.error(m_tokenizer.line(), "Failed to parse included file: " + e.msg);
+      status.error(
+        m_tokenizer.line(), fmt::format("Failed to parse included file: {}", e.msg));
       return std::vector<EntityDefinitionClassInfo>{};
     })
     .value();
 }
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/FgdParser.h
+++ b/common/src/IO/FgdParser.h
@@ -31,16 +31,15 @@
 #include <string>
 #include <vector>
 
-namespace TrenchBroom
-{
-namespace Assets
+namespace TrenchBroom::Assets
 {
 class DecalDefinition;
 class ModelDefinition;
-} // namespace Assets
+} // namespace TrenchBroom::Assets
 
-namespace IO
+namespace TrenchBroom::IO
 {
+
 struct EntityDefinitionClassInfo;
 enum class EntityDefinitionClassType;
 class FileSystem;
@@ -95,7 +94,7 @@ public:
 
 private:
   class PushIncludePath;
-  void pushIncludePath(const std::filesystem::path& path);
+  void pushIncludePath(std::filesystem::path path);
   void popIncludePath();
 
   std::filesystem::path currentRoot() const;
@@ -163,5 +162,5 @@ private:
   std::vector<EntityDefinitionClassInfo> handleInclude(
     ParserStatus& status, const std::filesystem::path& path);
 };
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/FgdParser.h
+++ b/common/src/IO/FgdParser.h
@@ -35,8 +35,9 @@ namespace TrenchBroom
 {
 namespace Assets
 {
+class DecalDefinition;
 class ModelDefinition;
-}
+} // namespace Assets
 
 namespace IO
 {
@@ -118,6 +119,7 @@ private:
 
   std::vector<std::string> parseSuperClasses(ParserStatus& status);
   Assets::ModelDefinition parseModel(ParserStatus& status);
+  Assets::DecalDefinition parseDecal(ParserStatus& status);
   std::string parseNamedValue(ParserStatus& status, const std::string& name);
   void skipClassProperty(ParserStatus& status);
 

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -210,6 +210,21 @@ const vm::mat4x4& Entity::modelTransformation() const
   return m_cachedProperties.modelTransformation;
 }
 
+Assets::DecalSpecification Entity::decalSpecification() const
+{
+  if (
+    const auto* pointDefinition =
+      dynamic_cast<const Assets::PointEntityDefinition*>(m_definition.get()))
+  {
+    const auto variableStore = EntityPropertiesVariableStore{*this};
+    return pointDefinition->decalDefinition().decalSpecification(variableStore);
+  }
+  else
+  {
+    return Assets::DecalSpecification{};
+  }
+}
+
 void Entity::unsetEntityDefinitionAndModel()
 {
   if (m_definition.get() == nullptr && m_model == nullptr)

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -35,6 +35,7 @@ namespace TrenchBroom
 {
 namespace Assets
 {
+struct DecalSpecification;
 class EntityDefinition;
 class EntityModelFrame;
 struct ModelSpecification;
@@ -160,6 +161,8 @@ public:
 
   Assets::ModelSpecification modelSpecification() const;
   const vm::mat4x4& modelTransformation() const;
+
+  Assets::DecalSpecification decalSpecification() const;
 
   void unsetEntityDefinitionAndModel();
 

--- a/common/src/Renderer/EntityDecalRenderer.cpp
+++ b/common/src/Renderer/EntityDecalRenderer.cpp
@@ -1,0 +1,420 @@
+/*
+ Copyright (C) 2023 Daniel Walder
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "EntityDecalRenderer.h"
+
+#include "Assets/DecalDefinition.h"
+#include "Assets/Texture.h"
+#include "Assets/TextureManager.h"
+#include "BrushRendererArrays.h"
+#include "Model/BrushFace.h"
+#include "Model/BrushNode.h"
+#include "Model/EditorContext.h"
+#include "Model/EntityNode.h"
+#include "Model/ModelUtils.h"
+#include "Model/Polyhedron_Face.h"
+#include "Model/TexCoordSystem.h"
+#include "Model/WorldNode.h"
+#include "View/MapDocument.h"
+#include "octree.h"
+
+#include <kdl/memory_utils.h>
+#include <kdl/overload.h>
+
+#include <vecmath/intersection.h>
+
+#include <cstring>
+
+namespace TrenchBroom::Renderer
+{
+
+namespace
+{
+
+std::optional<Assets::DecalSpecification> getDecalSpecification(
+  const Model::EntityNode* entityNode)
+{
+  const auto decalSpec = entityNode->entity().decalSpecification();
+  return decalSpec.textureName.empty() ? std::nullopt : std::make_optional(decalSpec);
+}
+
+using Vertex = Renderer::GLVertexTypes::P3NT2::Vertex;
+std::vector<Vertex> createDecalBrushFace(
+  const Model::EntityNode* entityNode,
+  const Model::BrushNode* brush,
+  const Model::BrushFace& face,
+  const Assets::Texture* texture)
+{
+  assert(texture != nullptr);
+
+  const auto textureSize = vm::vec2f{float(texture->width()), float(texture->height())};
+  const auto textureName = texture->name();
+
+  // copy the face properties, used to calculate the decal size and texture coords
+  auto attrs = Model::BrushFaceAttributes{textureName, face.attributes()};
+  auto texCoords = face.texCoordSystem().clone();
+  const auto tex = texCoords.get();
+
+  // create the geometry for the decal
+  const auto plane = face.boundary();
+  const auto origin = entityNode->physicalBounds().center();
+  const auto center = plane.project_point(origin);
+
+  // re-project the vertices in case the texture axes are not on the face plane
+  const auto xShift = tex->xAxis() * double(attrs.xScale() * textureSize.x() / 2.0f);
+  const auto yShift = tex->yAxis() * double(attrs.yScale() * textureSize.y() / 2.0f);
+
+  // we want to shift every vertex by just a little bit to avoid z-fighting
+  const auto offset = plane.normal * 0.1;
+
+  // start with a rectangle
+  auto verts = std::vector{
+    plane.project_point(center + xShift - yShift) + offset, // Bottom Right
+    plane.project_point(center + xShift + yShift) + offset, // Top Right
+    plane.project_point(center - xShift + yShift) + offset, // Top Left
+    plane.project_point(center - xShift - yShift) + offset  // Bottom Left
+  };
+
+  // because the texture axes don't have to align to the face, we might have a reversed
+  // face here. if so, reverse the points to get a valid face for the plane
+  const auto [_, vertPlane] = vm::from_points(verts[0], verts[1], verts[2]);
+  if (!vm::is_equal(plane.normal, vertPlane.normal, vm::C::almost_zero()))
+  {
+    std::reverse(std::begin(verts), std::end(verts));
+  }
+
+  // calculate the texture offset based on the first vertex location
+  const auto vtx = verts[0];
+  const auto xOffs = -vm::dot(vtx, tex->xAxis()) / attrs.xScale();
+  const auto yOffs = -vm::dot(vtx, tex->yAxis()) / attrs.yScale();
+  attrs.setXOffset(float(xOffs));
+  attrs.setYOffset(float(yOffs));
+
+  // clip the decal geometry against every other plane in the brush
+  for (const auto& f : brush->brush().faces())
+  {
+    if (&f == &face)
+    {
+      // skip the face that the decal is to be applied to, it's coplanar
+      continue;
+    }
+
+    verts = vm::polygon_clip_by_plane(f.boundary(), std::begin(verts), std::end(verts));
+    if (verts.empty())
+    {
+      // the polygon is completely outside the brush bounds, no decal will be placed
+      return {};
+    }
+  }
+
+  // convert the geometry into a list of vertices
+  const auto norm = vm::vec3f{plane.normal};
+  return kdl::vec_transform(verts, [&](const auto& v) {
+    return Vertex{vm::vec3f{v}, norm, tex->getTexCoords(v, attrs, textureSize)};
+  });
+}
+
+} // namespace
+
+EntityDecalRenderer::EntityDecalRenderer(std::weak_ptr<View::MapDocument> document)
+  : m_document{std::move(document)}
+{
+  clear();
+}
+
+void EntityDecalRenderer::invalidate()
+{
+  for (auto& [ent, data] : m_entities)
+  {
+    invalidateDecalData(data);
+  }
+}
+
+void EntityDecalRenderer::clear()
+{
+  m_entities.clear();
+  m_vertexArray = std::make_shared<BrushVertexArray>();
+  m_faces = std::make_shared<TextureToBrushIndicesMap>();
+  m_faceRenderer = FaceRenderer{m_vertexArray, m_faces, m_faceColor};
+}
+
+void EntityDecalRenderer::updateNode(Model::Node* node)
+{
+  node->accept(kdl::overload(
+    [](Model::WorldNode*) {},
+    [](Model::LayerNode*) {},
+    [](Model::GroupNode*) {},
+    [&](const Model::EntityNode* entity) { updateEntity(entity); },
+    [&](const Model::BrushNode* brush) { updateBrush(brush); },
+    [](Model::PatchNode*) {}));
+}
+
+void EntityDecalRenderer::removeNode(Model::Node* node)
+{
+  node->accept(kdl::overload(
+    [](Model::WorldNode*) {},
+    [](Model::LayerNode*) {},
+    [](Model::GroupNode*) {},
+    [&](const Model::EntityNode* entity) { removeEntity(entity); },
+    [&](const Model::BrushNode* brush) { removeBrush(brush); },
+    [](Model::PatchNode*) {}));
+}
+
+void EntityDecalRenderer::updateEntity(const Model::EntityNode* entityNode)
+{
+  // if the entity isn't visible, don't create decal geometry for it
+  const auto& editorContext = kdl::mem_lock(m_document)->editorContext();
+
+  // check if the entity has a decal specification
+  const auto spec =
+    editorContext.visible(entityNode) ? getDecalSpecification(entityNode) : std::nullopt;
+
+  // see if we are tracking this entity
+  const auto entity = m_entities.find(entityNode);
+  const auto isTracking = entity != std::end(m_entities);
+  if (isTracking && spec)
+  {
+    // entity is being tracked and has a decal specification, invalidate it
+    invalidateDecalData(entity->second);
+  }
+  else if (isTracking)
+  {
+    // entity is being tracked but no longer has a decal specification
+    removeEntity(entityNode);
+  }
+  else if (spec.has_value())
+  {
+    // entity is not being tracked and has a decal specification, start tracking it
+    m_entities.insert({entityNode, EntityDecalData{}});
+  }
+}
+
+void EntityDecalRenderer::removeEntity(const Model::EntityNode* entityNode)
+{
+  if (const auto it = m_entities.find(entityNode); it != std::end(m_entities))
+  {
+    // make sure the entity data is cleaned up
+    invalidateDecalData(it->second);
+    m_entities.erase(it);
+  }
+}
+
+void EntityDecalRenderer::updateBrush(const Model::BrushNode* brushNode)
+{
+  // invalidate any entities that intersect this brush or are tracking this brush
+  for (auto& [ent, data] : m_entities)
+  {
+    // skip entities that are going to be recomputed anyway
+    if (!data.validated)
+    {
+      continue;
+    }
+
+    // if the brush is not visible, then it doesn't (currently) intersect
+    const auto& editorContext = kdl::mem_lock(m_document)->editorContext();
+    const auto intersects =
+      editorContext.visible(brushNode) && brushNode->intersects(ent);
+    const auto tracked = std::find(data.brushes.begin(), data.brushes.end(), brushNode)
+                         != data.brushes.end();
+
+    // if this brush is tracked by this entity or intersects, we'll need to
+    // recalculate the geometry
+    if (intersects || tracked)
+    {
+      invalidateDecalData(data);
+    }
+  }
+}
+
+void EntityDecalRenderer::removeBrush(const Model::BrushNode* brushNode)
+{
+  // invalidate any entities that are tracking this brush
+  for (auto& [ent, data] : m_entities)
+  {
+    // skip entities that are going to be recomputed anyway
+    if (!data.validated)
+    {
+      continue;
+    }
+
+    // if this brush is tracked by this entity, remove it and recalculate
+    const auto tracked = std::find(data.brushes.begin(), data.brushes.end(), brushNode)
+                         != data.brushes.end();
+    if (tracked)
+    {
+      invalidateDecalData(data);
+    }
+  }
+}
+
+void EntityDecalRenderer::invalidateDecalData(EntityDecalData& data) const
+{
+  // do nothing if the brush data is already marked as invalidated
+  if (!data.validated)
+  {
+    return;
+  }
+
+  data.validated = false;
+
+  // if the texture doesn't exist, do nothing
+  // also do nothing if the VBO storage fields are null, but it shouldn't happen
+  if (!data.texture || !data.vertexHolderKey || !data.faceIndicesKey)
+  {
+    return;
+  }
+
+  // update the VBO
+  m_vertexArray->deleteVerticesWithKey(data.vertexHolderKey);
+
+  const auto faceIndexHolder = m_faces->at(data.texture);
+  faceIndexHolder->zeroElementsWithKey(data.faceIndicesKey);
+
+  if (!faceIndexHolder->hasValidIndices())
+  {
+    // there are no indices left to render for this texture
+    m_faces->erase(data.texture);
+  }
+
+  data.vertexHolderKey = nullptr;
+  data.faceIndicesKey = nullptr;
+}
+
+void EntityDecalRenderer::validateDecalData(
+  const Model::EntityNode* entityNode, EntityDecalData& data) const
+{
+  if (data.validated)
+  {
+    // already validated, no need to check again
+    return;
+  }
+
+  const auto spec = getDecalSpecification(entityNode);
+  ensure(spec, "entity has a decal specification");
+
+  const auto& document = kdl::mem_lock(m_document);
+  const auto& editorContext = document->editorContext();
+  const auto* world = document->world();
+
+  // collect all the brush nodes that touch the entity's bbox
+  const auto entityBounds = entityNode->physicalBounds();
+  const auto intersectors = world->nodeTree().find_intersectors(entityBounds);
+
+  // track them in the entity
+  data.brushes.clear();
+  for (const auto* node : intersectors)
+  {
+    const auto* brushNode = dynamic_cast<const Model::BrushNode*>(node);
+    if (brushNode && editorContext.visible(brushNode))
+    {
+      data.brushes.push_back(brushNode);
+    }
+  }
+
+  data.texture = document->textureManager().texture(spec->textureName);
+  if (!data.texture)
+  {
+    // no decal texture was found, don't generate any geometry
+    data.validated = true;
+    return;
+  }
+
+  // `bbox` and methods in the veclib library perform inclusive intersection tests - that
+  // is, if two polygons share an edge, plane, or vertex, then they are considered to be
+  // intersecting. We need the opposite behaviour when placing decals: when the entity's
+  // bounding box 'touches' but doesn't actually intersect through a face, we do not want
+  // to place a decal on it. To achieve this logic, we shrink the bounds just a tiny bit
+  // so adjacent faces that don't actually breach the entity's bounding box are excluded.
+  const auto shrunkBounds = entityBounds.expand(-vm::C::almost_zero());
+
+  // create geometry for the decal
+  auto vertices = std::vector<Vertex>{};
+  auto indices = std::vector<size_t>{};
+
+  for (const auto& brush : data.brushes)
+  {
+    for (const auto& face : brush->brush().faces())
+    {
+      // see if this decal can be projected onto this face
+      const auto facePolygon = face.geometry()->vertexPositions();
+      if (vm::intersect_bbox_polygon(
+            shrunkBounds, facePolygon.begin(), facePolygon.end()))
+      {
+        const auto decalPolygon =
+          createDecalBrushFace(entityNode, brush, face, data.texture);
+        if (!decalPolygon.empty())
+        {
+          // add the geometry to be uploaded into the VBO
+          const auto vertexOffset = vertices.size();
+
+          vertices.insert(vertices.end(), decalPolygon.begin(), decalPolygon.end());
+          for (size_t i = 0; i < decalPolygon.size() - 2; ++i)
+          {
+            indices.push_back(vertexOffset);
+            indices.push_back(vertexOffset + i + 1);
+            indices.push_back(vertexOffset + i + 2);
+          }
+        }
+      }
+    }
+  }
+
+  if (!vertices.empty() && !indices.empty())
+  {
+    // upload the geometry into the VBO
+    assert(m_vertexArray != nullptr);
+    auto [vertBlock, vertDest] =
+      m_vertexArray->getPointerToInsertVerticesAt(vertices.size());
+    std::memcpy(vertDest, vertices.data(), vertices.size() * sizeof(*vertDest));
+    data.vertexHolderKey = vertBlock;
+
+    const auto brushVerticesStartIndex = GLuint(vertBlock->pos);
+
+    auto& faceVboMap = *m_faces;
+    auto& holderPtr = faceVboMap[data.texture];
+    if (!holderPtr)
+    {
+      // inserts into map!
+      holderPtr = std::make_shared<BrushIndexArray>();
+    }
+    auto [indexBlock, indexDest] =
+      holderPtr->getPointerToInsertElementsAt(indices.size());
+    auto* currentDest = indexDest;
+    for (const auto& i : indices)
+    {
+      *(currentDest++) = GLuint(brushVerticesStartIndex + i);
+    }
+    data.faceIndicesKey = indexBlock;
+  }
+
+  data.validated = true;
+}
+
+void EntityDecalRenderer::render(RenderContext&, RenderBatch& renderBatch)
+{
+  // update any invalidated entities if required
+  for (auto& [ent, data] : m_entities)
+  {
+    validateDecalData(ent, data);
+  }
+
+  m_faceRenderer.render(renderBatch);
+}
+
+} // namespace TrenchBroom::Renderer

--- a/common/src/Renderer/EntityDecalRenderer.h
+++ b/common/src/Renderer/EntityDecalRenderer.h
@@ -1,0 +1,126 @@
+/*
+ Copyright (C) 2023 Daniel Walder
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "Renderer/AllocationTracker.h"
+#include "Renderer/EdgeRenderer.h"
+#include "Renderer/FaceRenderer.h"
+#include "Renderer/Renderable.h"
+
+#include <kdl/vector_set.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace TrenchBroom::Assets
+{
+class Texture;
+struct DecalSpecification;
+} // namespace TrenchBroom::Assets
+
+namespace TrenchBroom::Model
+{
+class BrushFace;
+class BrushNode;
+class EntityNode;
+class Node;
+} // namespace TrenchBroom::Model
+
+namespace TrenchBroom::View
+{
+class MapDocument; // FIXME: Renderer should not depend on View
+} // namespace TrenchBroom::View
+
+namespace TrenchBroom::Renderer
+{
+class EntityDecalRenderer
+{
+private:
+  struct EntityDecalData
+  {
+    std::vector<const Model::BrushNode*> brushes;
+
+    /* will only be true if the brushes array has been calculated since the last change
+     * and the decal geometry is stored in the VBO */
+    bool validated = false;
+
+    Assets::Texture* texture = nullptr;
+
+    AllocationTracker::Block* vertexHolderKey = nullptr;
+    AllocationTracker::Block* faceIndicesKey = nullptr;
+  };
+
+  using EntityWithDependenciesMap =
+    std::unordered_map<const Model::EntityNode*, EntityDecalData>;
+
+  std::weak_ptr<View::MapDocument> m_document;
+  EntityWithDependenciesMap m_entities;
+
+  using Vertex = Renderer::GLVertexTypes::P3NT2::Vertex;
+  using TextureToBrushIndicesMap =
+    std::unordered_map<const Assets::Texture*, std::shared_ptr<BrushIndexArray>>;
+
+  std::shared_ptr<TextureToBrushIndicesMap> m_faces;
+  std::shared_ptr<BrushVertexArray> m_vertexArray;
+  FaceRenderer m_faceRenderer;
+  Color m_faceColor;
+
+public:
+  explicit EntityDecalRenderer(std::weak_ptr<View::MapDocument> document);
+
+  /**
+   * Equivalent to updateNode() on all added nodes.
+   */
+  void invalidate();
+
+  /**
+   * Equivalent to removeNode() on all added nodes.
+   */
+  void clear();
+
+  /**
+   * Adds a node if its not already present and invalidates it.
+   */
+  void updateNode(Model::Node* node);
+
+  /**
+   * Removes a node. Calling with an unknown node is allowed, but ignored.
+   */
+  void removeNode(Model::Node* node);
+
+private:
+  void updateEntity(const Model::EntityNode* entityNode);
+  void removeEntity(const Model::EntityNode* entityNode);
+  void updateBrush(const Model::BrushNode* brushNode);
+  void removeBrush(const Model::BrushNode* brushNode);
+
+  void invalidateDecalData(EntityDecalData& data) const;
+
+  void validateDecalData(
+    const Model::EntityNode* entityNode, EntityDecalData& data) const;
+
+public: // rendering
+  void render(RenderContext& renderContext, RenderBatch& renderBatch);
+
+  deleteCopy(EntityDecalRenderer);
+};
+} // namespace TrenchBroom::Renderer

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -49,6 +49,7 @@ class Node;
 
 namespace Renderer
 {
+class EntityDecalRenderer;
 class EntityLinkRenderer;
 class GroupLinkRenderer;
 class ObjectRenderer;
@@ -63,6 +64,7 @@ private:
   std::unique_ptr<ObjectRenderer> m_defaultRenderer;
   std::unique_ptr<ObjectRenderer> m_selectionRenderer;
   std::unique_ptr<ObjectRenderer> m_lockedRenderer;
+  std::unique_ptr<EntityDecalRenderer> m_entityDecalRenderer;
   std::unique_ptr<EntityLinkRenderer> m_entityLinkRenderer;
   std::unique_ptr<GroupLinkRenderer> m_groupLinkRenderer;
 
@@ -91,6 +93,8 @@ private:
     std::weak_ptr<View::MapDocument> document);
   static std::unique_ptr<ObjectRenderer> createLockRenderer(
     std::weak_ptr<View::MapDocument> document);
+  static std::unique_ptr<EntityDecalRenderer> createEntityDecalRenderer(
+    std::weak_ptr<View::MapDocument> document);
   void clear();
 
 public: // color config
@@ -109,6 +113,7 @@ private:
   void renderSelectionTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
   void renderLockedOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
   void renderLockedTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
+  void renderEntityDecals(RenderContext& renderContext, RenderBatch& renderBatch);
   void renderEntityLinks(RenderContext& renderContext, RenderBatch& renderBatch);
   void renderGroupLinks(RenderContext& renderContext, RenderBatch& renderBatch);
 
@@ -125,6 +130,7 @@ private:
   void updateAllNodes();
 
   void invalidateRenderers(Renderer renderers);
+  void invalidateEntityDecalRenderer();
   void invalidateEntityLinkRenderer();
   void invalidateGroupLinkRenderer();
   void reloadEntityModels();

--- a/common/src/octree.h
+++ b/common/src/octree.h
@@ -509,7 +509,7 @@ public:
 
   /**
    * Finds every data item in this tree whose bounding box intersects with the given ray
-   * and retuns a list of those items.
+   * and returns a list of those items.
    *
    * @param ray the ray to test
    * @return a list containing all found data items

--- a/common/src/octree.h
+++ b/common/src/octree.h
@@ -549,6 +549,46 @@ public:
   }
 
   /**
+   * Finds every data item in this tree whose bounding box intersects with the given bbox
+   * and returns a list of those items.
+   *
+   * @param bbox the bbox to test
+   * @return a list containing all found data items
+   */
+  std::vector<U> find_intersectors(const vm::bbox<T, 3>& bbox) const
+  {
+    auto result = std::vector<U>{};
+    find_intersectors(bbox, std::back_inserter(result));
+    return result;
+  }
+
+  /**
+   * Finds every data item in this tree whose bounding box intersects with the given bbox
+   * and appends it to the given output iterator.
+   *
+   * @tparam O the output iterator type
+   * @param bbox the bbox to test
+   * @param out the output iterator to append to
+   */
+  template <typename O>
+  void find_intersectors(const vm::bbox<T, 3>& bbox, O out) const
+  {
+    if (m_root)
+    {
+      visit_node_if(
+        *m_root,
+        [&](const auto& node) {
+          const auto& data = get_data(node);
+          std::copy(data.begin(), data.end(), out);
+        },
+        [&](const auto& node) {
+          const auto bounds = get_address(node).to_bounds(m_min_size);
+          return bbox.intersects(bounds);
+        });
+    }
+  }
+
+  /**
    * Finds every data item in this tree whose bounding box contains the given point and
    * returns a list of those items.
    *

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(COMMON_TEST_UTILS_SOURCE
 
 set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/Assets/tst_AssetUtils.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/Assets/tst_DecalDefinition.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Assets/tst_EntityModel.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Assets/tst_ModelDefinition.cpp"
         "${COMMON_TEST_SOURCE_DIR}/EL/tst_EL.cpp"

--- a/common/test/src/Assets/EntityDefinitionTestUtils.cpp
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.cpp
@@ -48,7 +48,7 @@ void assertModelDefinition(
   std::vector<EntityDefinition*> definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  EntityDefinition* definition = definitions[0];
+  const auto* definition = definitions[0];
   CHECK(definition->type() == EntityDefinitionType::PointEntity);
 
   assertModelDefinition(expected, definition, entityPropertiesStr);
@@ -63,8 +63,7 @@ void assertModelDefinition(
 {
   assert(definition->type() == EntityDefinitionType::PointEntity);
 
-  const PointEntityDefinition* pointDefinition =
-    static_cast<const PointEntityDefinition*>(definition);
+  const auto* pointDefinition = dynamic_cast<const PointEntityDefinition*>(definition);
   const ModelDefinition& modelDefinition = pointDefinition->modelDefinition();
   assertModelDefinition(expected, modelDefinition, entityPropertiesStr);
 }
@@ -79,6 +78,47 @@ void assertModelDefinition(
                                      .mapValue();
   const auto variableStore = EL::VariableTable(entityPropertiesMap);
   CHECK(actual.modelSpecification(variableStore) == expected);
+}
+
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  IO::EntityDefinitionParser& parser,
+  const std::string& entityPropertiesStr)
+{
+  IO::TestParserStatus status;
+  std::vector<EntityDefinition*> definitions = parser.parseDefinitions(status);
+  CHECK(definitions.size() == 1u);
+
+  const auto* definition = definitions[0];
+  CHECK(definition->type() == EntityDefinitionType::PointEntity);
+
+  assertDecalDefinition(expected, definition, entityPropertiesStr);
+
+  kdl::vec_clear_and_delete(definitions);
+}
+
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  const EntityDefinition* definition,
+  const std::string& entityPropertiesStr)
+{
+  assert(definition->type() == EntityDefinitionType::PointEntity);
+
+  const auto* pointDefinition = dynamic_cast<const PointEntityDefinition*>(definition);
+  const DecalDefinition& modelDefinition = pointDefinition->decalDefinition();
+  assertDecalDefinition(expected, modelDefinition, entityPropertiesStr);
+}
+
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  const DecalDefinition& actual,
+  const std::string& entityPropertiesStr)
+{
+  const auto entityPropertiesMap = IO::ELParser::parseStrict(entityPropertiesStr)
+                                     .evaluate(EL::EvaluationContext())
+                                     .mapValue();
+  const auto variableStore = EL::VariableTable(entityPropertiesMap);
+  CHECK(actual.decalSpecification(variableStore) == expected);
 }
 } // namespace Assets
 } // namespace TrenchBroom

--- a/common/test/src/Assets/EntityDefinitionTestUtils.cpp
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.cpp
@@ -35,17 +35,15 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
-{
-namespace Assets
+namespace TrenchBroom::Assets
 {
 void assertModelDefinition(
   const ModelSpecification& expected,
   IO::EntityDefinitionParser& parser,
   const std::string& entityPropertiesStr)
 {
-  IO::TestParserStatus status;
-  std::vector<EntityDefinition*> definitions = parser.parseDefinitions(status);
+  auto status = IO::TestParserStatus{};
+  auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
   const auto* definition = definitions[0];
@@ -64,7 +62,7 @@ void assertModelDefinition(
   assert(definition->type() == EntityDefinitionType::PointEntity);
 
   const auto* pointDefinition = dynamic_cast<const PointEntityDefinition*>(definition);
-  const ModelDefinition& modelDefinition = pointDefinition->modelDefinition();
+  const auto& modelDefinition = pointDefinition->modelDefinition();
   assertModelDefinition(expected, modelDefinition, entityPropertiesStr);
 }
 
@@ -74,9 +72,9 @@ void assertModelDefinition(
   const std::string& entityPropertiesStr)
 {
   const auto entityPropertiesMap = IO::ELParser::parseStrict(entityPropertiesStr)
-                                     .evaluate(EL::EvaluationContext())
+                                     .evaluate(EL::EvaluationContext{})
                                      .mapValue();
-  const auto variableStore = EL::VariableTable(entityPropertiesMap);
+  const auto variableStore = EL::VariableTable{entityPropertiesMap};
   CHECK(actual.modelSpecification(variableStore) == expected);
 }
 
@@ -85,8 +83,8 @@ void assertDecalDefinition(
   IO::EntityDefinitionParser& parser,
   const std::string& entityPropertiesStr)
 {
-  IO::TestParserStatus status;
-  std::vector<EntityDefinition*> definitions = parser.parseDefinitions(status);
+  auto status = IO::TestParserStatus{};
+  auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
   const auto* definition = definitions[0];
@@ -105,7 +103,7 @@ void assertDecalDefinition(
   assert(definition->type() == EntityDefinitionType::PointEntity);
 
   const auto* pointDefinition = dynamic_cast<const PointEntityDefinition*>(definition);
-  const DecalDefinition& modelDefinition = pointDefinition->decalDefinition();
+  const auto& modelDefinition = pointDefinition->decalDefinition();
   assertDecalDefinition(expected, modelDefinition, entityPropertiesStr);
 }
 
@@ -115,10 +113,9 @@ void assertDecalDefinition(
   const std::string& entityPropertiesStr)
 {
   const auto entityPropertiesMap = IO::ELParser::parseStrict(entityPropertiesStr)
-                                     .evaluate(EL::EvaluationContext())
+                                     .evaluate(EL::EvaluationContext{})
                                      .mapValue();
-  const auto variableStore = EL::VariableTable(entityPropertiesMap);
+  const auto variableStore = EL::VariableTable{entityPropertiesMap};
   CHECK(actual.decalSpecification(variableStore) == expected);
 }
-} // namespace Assets
-} // namespace TrenchBroom
+} // namespace TrenchBroom::Assets

--- a/common/test/src/Assets/EntityDefinitionTestUtils.h
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.h
@@ -37,6 +37,8 @@ namespace Assets
 class EntityDefinition;
 class ModelDefinition;
 struct ModelSpecification;
+class DecalDefinition;
+struct DecalSpecification;
 
 void assertModelDefinition(
   const ModelSpecification& expected,
@@ -61,6 +63,31 @@ void assertModelDefinition(
   const std::string defStr = kdl::str_replace_every(templateStr, "${MODEL}", modelStr);
   Parser parser(defStr, Color(1.0f, 1.0f, 1.0f, 1.0f));
   assertModelDefinition(expected, parser, entityPropertiesStr);
+}
+
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  IO::EntityDefinitionParser& parser,
+  const std::string& entityPropertiesStr = "{}");
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  const EntityDefinition* definition,
+  const std::string& entityPropertiesStr = "{}");
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  const DecalDefinition& actual,
+  const std::string& entityPropertiesStr = "{}");
+
+template <typename Parser>
+void assertDecalDefinition(
+  const DecalSpecification& expected,
+  const std::string& decalStr,
+  const std::string& templateStr,
+  const std::string& entityPropertiesStr = "{}")
+{
+  const std::string defStr = kdl::str_replace_every(templateStr, "${DECAL}", decalStr);
+  Parser parser(defStr, Color(1.0f, 1.0f, 1.0f, 1.0f));
+  assertDecalDefinition(expected, parser, entityPropertiesStr);
 }
 } // namespace Assets
 } // namespace TrenchBroom

--- a/common/test/src/Assets/EntityDefinitionTestUtils.h
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.h
@@ -25,14 +25,12 @@
 
 #include <string>
 
-namespace TrenchBroom
-{
-namespace IO
+namespace TrenchBroom::IO
 {
 class EntityDefinitionParser;
 }
 
-namespace Assets
+namespace TrenchBroom::Assets
 {
 class EntityDefinition;
 class ModelDefinition;
@@ -60,8 +58,8 @@ void assertModelDefinition(
   const std::string& templateStr,
   const std::string& entityPropertiesStr = "{}")
 {
-  const std::string defStr = kdl::str_replace_every(templateStr, "${MODEL}", modelStr);
-  Parser parser(defStr, Color(1.0f, 1.0f, 1.0f, 1.0f));
+  const auto defStr = kdl::str_replace_every(templateStr, "${MODEL}", modelStr);
+  auto parser = Parser{defStr, Color{1, 1, 1, 1}};
   assertModelDefinition(expected, parser, entityPropertiesStr);
 }
 
@@ -85,9 +83,8 @@ void assertDecalDefinition(
   const std::string& templateStr,
   const std::string& entityPropertiesStr = "{}")
 {
-  const std::string defStr = kdl::str_replace_every(templateStr, "${DECAL}", decalStr);
-  Parser parser(defStr, Color(1.0f, 1.0f, 1.0f, 1.0f));
+  const auto defStr = kdl::str_replace_every(templateStr, "${DECAL}", decalStr);
+  auto parser = Parser{defStr, Color{1, 1, 1, 1}};
   assertDecalDefinition(expected, parser, entityPropertiesStr);
 }
-} // namespace Assets
-} // namespace TrenchBroom
+} // namespace TrenchBroom::Assets

--- a/common/test/src/Assets/tst_DecalDefinition.cpp
+++ b/common/test/src/Assets/tst_DecalDefinition.cpp
@@ -1,0 +1,98 @@
+/*
+ Copyright (C) 2023 Daniel Walder
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Assets/DecalDefinition.h"
+#include "EL/VariableStore.h"
+#include "IO/ELParser.h"
+
+#include <map>
+#include <tuple>
+
+#include "Catch2.h"
+
+namespace TrenchBroom
+{
+namespace Assets
+{
+
+namespace
+{
+DecalDefinition makeDecalDefinition(const std::string& expression)
+{
+  auto parser = IO::ELParser{IO::ELParser::Mode::Strict, expression};
+  return DecalDefinition{parser.parse()};
+}
+} // namespace
+
+TEST_CASE("DecalDefinitionTest.append")
+{
+  auto d1 = makeDecalDefinition(R"("decal1")");
+  REQUIRE(d1.decalSpecification(EL::NullVariableStore{}) == DecalSpecification{"decal1"});
+
+  d1.append(makeDecalDefinition(R"("decal2")"));
+  CHECK(d1.decalSpecification(EL::NullVariableStore{}) == DecalSpecification{"decal1"});
+}
+
+TEST_CASE("DecalDefinitionTest.decalSpecification")
+{
+  using T = std::tuple<std::string, std::map<std::string, EL::Value>, DecalSpecification>;
+
+  // clang-format off
+  const auto 
+  [expression,                                 variables, expectedDecalSpecification] = GENERATE(values<T>({
+  {R"("decal1")",                              {},        {"decal1"}},
+  {R"({ texture: "decal2" })",                 {},        {"decal2"}},
+
+  {R"({ texture: texture })",                  {{"texture", EL::Value{"decal3"}}},
+                                                          {"decal3"}},
+  
+  }));
+  // clang-format on
+
+  CAPTURE(expression, variables);
+
+  const auto decalDefinition = makeDecalDefinition(expression);
+  CHECK(
+    decalDefinition.decalSpecification(EL::VariableTable{variables})
+    == expectedDecalSpecification);
+}
+
+TEST_CASE("DecalDefinitionTest.defaultDecalSpecification")
+{
+  using T = std::tuple<std::string, DecalSpecification>;
+
+  // clang-format off
+  const auto 
+  [expression,                 expectedDecalSpecification] = GENERATE(values<T>({
+  {R"("decal1")",              {"decal1"}},
+  {R"({ texture: "decal2" })", {"decal2"}},
+
+  {R"({ texture: texture })",  {}},
+  
+  }));
+  // clang-format on
+
+  CAPTURE(expression);
+
+  const auto decalDefinition = makeDecalDefinition(expression);
+  CHECK(decalDefinition.defaultDecalSpecification() == expectedDecalSpecification);
+}
+
+} // namespace Assets
+} // namespace TrenchBroom

--- a/common/test/src/IO/tst_EntityDefinitionParser.cpp
+++ b/common/test/src/IO/tst_EntityDefinitionParser.cpp
@@ -28,1109 +28,1094 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
-{
-TEST_CASE("resolveInheritance.filterBaseClasses")
-{
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef      properties superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-  });
 
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
+TEST_CASE("resolveInheritance")
+{
+  SECTION("filterBaseClasses")
+  {
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("filterRedundantClasses")
+  {
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "a",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       1,
+       "a",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       1,
+       "b",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "b",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       1,
+       "c",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       2,
+       "c",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "c",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "d",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       1,
+       "d",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "e",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       1,
+       "e",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "f",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       1,
+       "f",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       1,
+       "b",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       1,
+       "c",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       2,
+       "c",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "d",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "e",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 6u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("overrideMembersIfNotPresent")
+  {
+    const auto baseModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"abc"}}, 0, 0}};
+    const auto baseDecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"def"}}, 1, 0}};
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       "description",
+       Color{1, 2, 3},
+       vm::bbox3{-1, 1},
+       baseModelDef,
+       baseDecalDef,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "description",
+       Color{1, 2, 3},
+       vm::bbox3{-1, 1},
+       baseModelDef,
+       baseDecalDef,
+       {},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("skipMembersIfPresent")
+  {
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       "description",
+       Color{1, 2, 3},
+       vm::bbox3{-1, 1},
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "blah blah",
+       Color{2, 3, 4},
+       vm::bbox3{-2, 2},
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "blah blah",
+       Color{2, 3, 4},
+       vm::bbox3{-2, 2},
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("mergeModelDefinitions")
+  {
+    const auto baseModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"abc"}}, 0, 0}};
+    const auto pointModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"xyz"}}, 0, 0}};
+    auto mergedModelDef = pointModelDef;
+    mergedModelDef.append(baseModelDef);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       baseModelDef,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       pointModelDef,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       mergedModelDef,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+
+  SECTION("mergeDecalDefinitions")
+  {
+    const auto baseDecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"decal1"}}, 0, 0}};
+    const auto pointDecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"decal2"}}, 0, 0}};
+    auto mergedDecalDef = pointDecalDef;
+    mergedDecalDef.append(baseDecalDef);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       baseDecalDef,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       pointDecalDef,
+       {},
+       {"base"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       mergedDecalDef,
+       {},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("inheritPropertyDefinitions")
+  {
+    const auto a1_1 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a1_2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a2", "", "", false);
+    const auto a3 =
+      std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a1_1, a2},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a1_2, a3},
+       {"base"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a1_2, a3, a2},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("mergeSpawnflagsSimpleInheritance")
+  {
+    auto a1 = std::make_shared<Assets::FlagsPropertyDefinition>(
+      Model::EntityPropertyKeys::Spawnflags);
+    a1->addOption(1 << 1, "a1_1", "", true);
+    a1->addOption(1 << 2, "a1_2", "", false);
+
+    auto a2 = std::make_shared<Assets::FlagsPropertyDefinition>(
+      Model::EntityPropertyKeys::Spawnflags);
+    a2->addOption(1 << 2, "a2_2", "", true);
+    a2->addOption(1 << 4, "a2_4", "", false);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a1},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a2},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    const auto output = resolveInheritance(status, input);
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+    CHECK(output.size() == 1u);
+
+    const auto& classInfo = output.front();
+    CHECK(classInfo.propertyDefinitions.size() == 1u);
+
+    const auto propertyDefinition = classInfo.propertyDefinitions.front();
+    CHECK(propertyDefinition->type() == Assets::PropertyDefinitionType::FlagsProperty);
+
+    const auto& flagsPropertyDefinition =
+      static_cast<const Assets::FlagsPropertyDefinition&>(*propertyDefinition.get());
+    CHECK(flagsPropertyDefinition.key() == Model::EntityPropertyKeys::Spawnflags);
+
+    const auto& options = flagsPropertyDefinition.options();
+    CHECK_THAT(
+      options,
+      Catch::Equals(std::vector<Assets::FlagsPropertyOption>{
+        {1 << 1, "a1_1", "", true},
+        {1 << 2, "a2_2", "", true},
+        {1 << 4, "a2_4", "", false},
+      }));
+  }
+
+  SECTION("chainOfBaseClasses")
+  {
+    const auto a1_1 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a1_2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a2", "", "", false);
+    const auto a3 =
+      std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
+
+    const auto base1ModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"abc"}}, 0, 0}};
+    const auto base2ModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"def"}}, 0, 0}};
+    const auto pointModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"xyz"}}, 0, 0}};
+    auto mergedModelDef = pointModelDef;
+    mergedModelDef.append(base2ModelDef);
+    mergedModelDef.append(base1ModelDef);
+
+    const auto base1DecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"dec1"}}, 0, 0}};
+    const auto base2DecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"dec2"}}, 0, 0}};
+    const auto pointDecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"dec3"}}, 0, 0}};
+    auto mergedDecalDef = pointDecalDef;
+    mergedDecalDef.append(base2DecalDef);
+    mergedDecalDef.append(base1DecalDef);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base1",
+       "base1",
+       std::nullopt,
+       vm::bbox3{-2, 2},
+       base1ModelDef,
+       base1DecalDef,
+       {a1_1, a2},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base2",
+       "base2",
+       Color{1, 2, 3},
+       std::nullopt,
+       base2ModelDef,
+       base2DecalDef,
+       {a1_2, a3},
+       {"base1"}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       pointModelDef,
+       pointDecalDef,
+       {},
+       {"base2"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "base2",
+       Color{1, 2, 3},
+       vm::bbox3{-2, 2},
+       mergedModelDef,
+       mergedDecalDef,
+       {a1_2, a3, a2},
+       {"base2"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("multipleBaseClasses")
+  {
+    const auto a1_1 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a1_2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a2", "", "", false);
+    const auto a3 =
+      std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
+
+    const auto base1ModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"abc"}}, 0, 0}};
+    const auto base2ModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"def"}}, 0, 0}};
+    const auto pointModelDef = Assets::ModelDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"xyz"}}, 0, 0}};
+    auto mergedModelDef = pointModelDef;
+    mergedModelDef.append(base1ModelDef);
+    mergedModelDef.append(base2ModelDef);
+
+    const auto base1DecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"dec1"}}, 0, 0}};
+    const auto base2DecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"dec2"}}, 0, 0}};
+    const auto pointDecalDef = Assets::DecalDefinition{
+      EL::Expression{EL::LiteralExpression{EL::Value{"dec3"}}, 0, 0}};
+    auto mergedDecalDef = pointDecalDef;
+    mergedDecalDef.append(base1DecalDef);
+    mergedDecalDef.append(base2DecalDef);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base1",
+       "base1",
+       std::nullopt,
+       vm::bbox3{-2, 2},
+       base1ModelDef,
+       base1DecalDef,
+       {a1_1, a2},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base2",
+       "base2",
+       Color{1, 2, 3},
+       std::nullopt,
+       base2ModelDef,
+       base2DecalDef,
+       {a1_2, a3},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       pointModelDef,
+       pointDecalDef,
+       {},
+       {"base1", "base2"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "base1",
+       Color{1, 2, 3},
+       vm::bbox3{-2, 2},
+       mergedModelDef,
+       mergedDecalDef,
+       {a1_1, a2, a3},
+       {"base1", "base2"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("diamondInheritance")
+  {
+    const auto a1 =
+      std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
+    const auto a2_1 =
+      std::make_shared<Assets::StringPropertyDefinition>("a2_1", "", "", false);
+    const auto a2_2 =
+      std::make_shared<Assets::StringPropertyDefinition>("a2_2", "", "", false);
+    const auto a3 =
+      std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
+
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base1",
+       "base1",
+       std::nullopt,
+       vm::bbox3{-2, 2},
+       std::nullopt,
+       std::nullopt,
+       {a1},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base2_1",
+       "base2_1",
+       Color{1, 2, 3},
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a2_1},
+       {"base1"}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "base2_2",
+       "base2_2",
+       std::nullopt,
+       vm::bbox3{-1, 1},
+       std::nullopt,
+       std::nullopt,
+       {a2_2},
+       {"base1"}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point1",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a3},
+       {"base2_1", "base2_2"}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point2",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {a3},
+       {"base2_2", "base2_1"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point1",
+       "base2_1",
+       Color{1, 2, 3},
+       vm::bbox3{-2, 2},
+       std::nullopt,
+       std::nullopt,
+       {a3, a2_1, a1, a2_2},
+       {"base2_1", "base2_2"}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point2",
+       "base2_2",
+       Color{1, 2, 3},
+       vm::bbox3{-1, 1},
+       std::nullopt,
+       std::nullopt,
+       {a3, a2_2, a1, a2_1},
+       {"base2_2", "base2_1"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("overloadedSuperClass")
+  {
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "base",
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "base",
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "base",
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "base",
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "brush",
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
+
+  SECTION("indirectOverloadedSuperClass")
+  {
+    const auto input = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "base",
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "base",
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BaseClass,
+       0,
+       0,
+       "mid",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"base"}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"mid"}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"mid"}},
+    };
+    const auto expected = std::vector<EntityDefinitionClassInfo>{
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "base",
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "base",
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {}},
+      {EntityDefinitionClassType::PointClass,
+       0,
+       0,
+       "point",
+       "point",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"mid"}},
+      {EntityDefinitionClassType::BrushClass,
+       0,
+       0,
+       "brush",
+       "brush",
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       {},
+       {"mid"}},
+    };
+
+    auto status = TestParserStatus{};
+    CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+    CHECK(status.countStatus(LogLevel::Warn) == 0u);
+    CHECK(status.countStatus(LogLevel::Error) == 0u);
+  }
 }
-
-TEST_CASE("resolveInheritance.filterRedundantClasses")
-{
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef      properties superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "a",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     1,
-     "a",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     1,
-     "b",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "b",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     1,
-     "c",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     2,
-     "c",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "c",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "d",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     1,
-     "d",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "e",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     1,
-     "e",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "f",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     1,
-     "f",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     1,
-     "b",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     1,
-     "c",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     2,
-     "c",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "d",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "e",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 6u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.overrideMembersIfNotPresent")
-{
-  const auto baseModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
-  const auto baseDecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("def")), 1, 0));
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description    color size
-    // modelDef      properties superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     "description",
-     Color(1, 2, 3),
-     vm::bbox3(-1, 1),
-     baseModelDef,
-     baseDecalDef,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "description",
-     Color(1, 2, 3),
-     vm::bbox3(-1, 1),
-     baseModelDef,
-     baseDecalDef,
-     {},
-     {"base"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.skipMembersIfPresent")
-{
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description    color size
-    // modelDef      proeprties superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     "description",
-     Color(1, 2, 3),
-     vm::bbox3(-1, 1),
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "blah blah",
-     Color(2, 3, 4),
-     vm::bbox3(-2, 2),
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "blah blah",
-     Color(2, 3, 4),
-     vm::bbox3(-2, 2),
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.mergeModelDefinitions")
-{
-  const auto baseModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
-  const auto pointModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("xyz")), 0, 0));
-  auto mergedModelDef = pointModelDef;
-  mergedModelDef.append(baseModelDef);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef        properties superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     baseModelDef,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     pointModelDef,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     mergedModelDef,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-
-TEST_CASE("resolveInheritance.mergeDecalDefinitions")
-{
-  const auto baseDecalDef = Assets::DecalDefinition{
-    EL::Expression{EL::LiteralExpression{EL::Value{"decal1"}}, 0, 0}};
-  const auto pointDecalDef = Assets::DecalDefinition{
-    EL::Expression{EL::LiteralExpression{EL::Value{"decal2"}}, 0, 0}};
-  auto mergedDecalDef = pointDecalDef;
-  mergedDecalDef.append(baseDecalDef);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>{
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     baseDecalDef,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     pointDecalDef,
-     {},
-     {"base"}},
-  };
-  const auto expected = std::vector<EntityDefinitionClassInfo>{
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     mergedDecalDef,
-     {},
-     {"base"}},
-  };
-
-  auto status = TestParserStatus{};
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.inheritPropertyDefinitions")
-{
-  const auto a1_1 =
-    std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a1_2 =
-    std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a2 = std::make_shared<Assets::StringPropertyDefinition>("a2", "", "", false);
-  const auto a3 = std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef      properties      superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a1_1, a2},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a1_2, a3},
-     {"base"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a1_2, a3, a2},
-     {"base"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.mergeSpawnflagsSimpleInheritance")
-{
-  auto a1 = std::make_shared<Assets::FlagsPropertyDefinition>(
-    Model::EntityPropertyKeys::Spawnflags);
-  a1->addOption(1 << 1, "a1_1", "", true);
-  a1->addOption(1 << 2, "a1_2", "", false);
-
-  auto a2 = std::make_shared<Assets::FlagsPropertyDefinition>(
-    Model::EntityPropertyKeys::Spawnflags);
-  a2->addOption(1 << 2, "a2_2", "", true);
-  a2->addOption(1 << 4, "a2_4", "", false);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef      properties  superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a1},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a2},
-     {"base"}},
-  });
-
-  TestParserStatus status;
-  const auto output = resolveInheritance(status, input);
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-  CHECK(output.size() == 1u);
-
-  const auto& classInfo = output.front();
-  CHECK(classInfo.propertyDefinitions.size() == 1u);
-
-  const auto propertyDefinition = classInfo.propertyDefinitions.front();
-  CHECK(propertyDefinition->type() == Assets::PropertyDefinitionType::FlagsProperty);
-
-  const auto& flagsPropertyDefinition =
-    static_cast<const Assets::FlagsPropertyDefinition&>(*propertyDefinition.get());
-  CHECK(flagsPropertyDefinition.key() == Model::EntityPropertyKeys::Spawnflags);
-
-  const auto& options = flagsPropertyDefinition.options();
-  CHECK_THAT(
-    options,
-    Catch::Equals(std::vector<Assets::FlagsPropertyOption>({
-      {1 << 1, "a1_1", "", true},
-      {1 << 2, "a2_2", "", true},
-      {1 << 4, "a2_4", "", false},
-    })));
-}
-
-TEST_CASE("resolveInheritance.chainOfBaseClasses")
-{
-  const auto a1_1 =
-    std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a1_2 =
-    std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a2 = std::make_shared<Assets::StringPropertyDefinition>("a2", "", "", false);
-  const auto a3 = std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
-
-  const auto base1ModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
-  const auto base2ModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("def")), 0, 0));
-  const auto pointModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("xyz")), 0, 0));
-  auto mergedModelDef = pointModelDef;
-  mergedModelDef.append(base2ModelDef);
-  mergedModelDef.append(base1ModelDef);
-
-  const auto base1DecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("dec1")), 0, 0));
-  const auto base2DecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("dec2")), 0, 0));
-  const auto pointDecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("dec3")), 0, 0));
-  auto mergedDecalDef = pointDecalDef;
-  mergedDecalDef.append(base2DecalDef);
-  mergedDecalDef.append(base1DecalDef);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type  l  c  name description  color size
-    // modelDef  decalDef  properties  superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base1",
-     "base1",
-     std::nullopt,
-     vm::bbox3(-2, 2),
-     base1ModelDef,
-     base1DecalDef,
-     {a1_1, a2},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base2",
-     "base2",
-     Color(1, 2, 3),
-     std::nullopt,
-     base2ModelDef,
-     base2DecalDef,
-     {a1_2, a3},
-     {"base1"}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     pointModelDef,
-     pointDecalDef,
-     {},
-     {"base2"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "base2",
-     Color(1, 2, 3),
-     vm::bbox3(-2, 2),
-     mergedModelDef,
-     mergedDecalDef,
-     {a1_2, a3, a2},
-     {"base2"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.multipleBaseClasses")
-{
-  const auto a1_1 =
-    std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a1_2 =
-    std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a2 = std::make_shared<Assets::StringPropertyDefinition>("a2", "", "", false);
-  const auto a3 = std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
-
-  const auto base1ModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
-  const auto base2ModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("def")), 0, 0));
-  const auto pointModelDef = Assets::ModelDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("xyz")), 0, 0));
-  auto mergedModelDef = pointModelDef;
-  mergedModelDef.append(base1ModelDef);
-  mergedModelDef.append(base2ModelDef);
-
-  const auto base1DecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("dec1")), 0, 0));
-  const auto base2DecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("dec2")), 0, 0));
-  const auto pointDecalDef = Assets::DecalDefinition(
-    EL::Expression(EL::LiteralExpression(EL::Value("dec3")), 0, 0));
-  auto mergedDecalDef = pointDecalDef;
-  mergedDecalDef.append(base1DecalDef);
-  mergedDecalDef.append(base2DecalDef);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type  l  c  name description  color size
-    // modelDef  decalDef  properties  superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base1",
-     "base1",
-     std::nullopt,
-     vm::bbox3(-2, 2),
-     base1ModelDef,
-     base1DecalDef,
-     {a1_1, a2},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base2",
-     "base2",
-     Color(1, 2, 3),
-     std::nullopt,
-     base2ModelDef,
-     base2DecalDef,
-     {a1_2, a3},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     pointModelDef,
-     pointDecalDef,
-     {},
-     {"base1", "base2"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "base1",
-     Color(1, 2, 3),
-     vm::bbox3(-2, 2),
-     mergedModelDef,
-     mergedDecalDef,
-     {a1_1, a2, a3},
-     {"base1", "base2"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.diamondInheritance")
-{
-  const auto a1 = std::make_shared<Assets::StringPropertyDefinition>("a1", "", "", false);
-  const auto a2_1 =
-    std::make_shared<Assets::StringPropertyDefinition>("a2_1", "", "", false);
-  const auto a2_2 =
-    std::make_shared<Assets::StringPropertyDefinition>("a2_2", "", "", false);
-  const auto a3 = std::make_shared<Assets::StringPropertyDefinition>("a3", "", "", false);
-
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name       description    color size
-    // modelDef      properties      superclasses
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base1",
-     "base1",
-     std::nullopt,
-     vm::bbox3(-2, 2),
-     std::nullopt,
-     std::nullopt,
-     {a1},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base2_1",
-     "base2_1",
-     Color(1, 2, 3),
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a2_1},
-     {"base1"}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "base2_2",
-     "base2_2",
-     std::nullopt,
-     vm::bbox3(-1, 1),
-     std::nullopt,
-     std::nullopt,
-     {a2_2},
-     {"base1"}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point1",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a3},
-     {"base2_1", "base2_2"}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point2",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {a3},
-     {"base2_2", "base2_1"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point1",
-     "base2_1",
-     Color(1, 2, 3),
-     vm::bbox3(-2, 2),
-     std::nullopt,
-     std::nullopt,
-     {a3, a2_1, a1, a2_2},
-     {"base2_1", "base2_2"}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point2",
-     "base2_2",
-     Color(1, 2, 3),
-     vm::bbox3(-1, 1),
-     std::nullopt,
-     std::nullopt,
-     {a3, a2_2, a1, a2_1},
-     {"base2_2", "base2_1"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.overloadedSuperClass")
-{
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name      description   color size
-    // modelDef      properties      superclasses
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "base",
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "base",
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "base",
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "base",
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "brush",
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-
-TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
-{
-  const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name      description   color size
-    // modelDef      properties      superclasses
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "base",
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "base",
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BaseClass,
-     0,
-     0,
-     "mid",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"base"}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"mid"}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"mid"}},
-  });
-  const auto expected = std::vector<EntityDefinitionClassInfo>({
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "base",
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "base",
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {}},
-    {EntityDefinitionClassType::PointClass,
-     0,
-     0,
-     "point",
-     "point",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"mid"}},
-    {EntityDefinitionClassType::BrushClass,
-     0,
-     0,
-     "brush",
-     "brush",
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     std::nullopt,
-     {},
-     {"mid"}},
-  });
-
-  TestParserStatus status;
-  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
-  CHECK(status.countStatus(LogLevel::Warn) == 0u);
-  CHECK(status.countStatus(LogLevel::Error) == 0u);
-}
-} // namespace IO
-} // namespace TrenchBroom
+} // namespace TrenchBroom::IO

--- a/common/test/src/IO/tst_EntityDefinitionParser.cpp
+++ b/common/test/src/IO/tst_EntityDefinitionParser.cpp
@@ -45,6 +45,7 @@ TEST_CASE("resolveInheritance.filterBaseClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
@@ -55,12 +56,14 @@ TEST_CASE("resolveInheritance.filterBaseClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
      0,
      0,
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -77,12 +80,14 @@ TEST_CASE("resolveInheritance.filterBaseClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
      0,
      0,
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -110,12 +115,14 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      1,
      "a",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -130,6 +137,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BaseClass,
@@ -140,12 +148,14 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      1,
      "c",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -160,6 +170,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BaseClass,
@@ -170,12 +181,14 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      0,
      "d",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -186,6 +199,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      0,
      1,
      "d",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -200,6 +214,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
@@ -210,12 +225,14 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BaseClass,
      0,
      0,
      "f",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -226,6 +243,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      0,
      1,
      "f",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -242,12 +260,14 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      1,
      "c",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -262,6 +282,7 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
@@ -272,12 +293,14 @@ TEST_CASE("resolveInheritance.filterRedundantClasses")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
      0,
      0,
      "e",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -296,6 +319,8 @@ TEST_CASE("resolveInheritance.overrideMembersIfNotPresent")
 {
   const auto baseModelDef = Assets::ModelDefinition(
     EL::Expression(EL::LiteralExpression(EL::Value("abc")), 0, 0));
+  const auto baseDecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("def")), 1, 0));
 
   const auto input = std::vector<EntityDefinitionClassInfo>({
     // type                                   l  c  name     description    color size
@@ -308,12 +333,14 @@ TEST_CASE("resolveInheritance.overrideMembersIfNotPresent")
      Color(1, 2, 3),
      vm::bbox3(-1, 1),
      baseModelDef,
+     baseDecalDef,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      0,
      "point",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -330,6 +357,7 @@ TEST_CASE("resolveInheritance.overrideMembersIfNotPresent")
      Color(1, 2, 3),
      vm::bbox3(-1, 1),
      baseModelDef,
+     baseDecalDef,
      {},
      {"base"}},
   });
@@ -353,6 +381,7 @@ TEST_CASE("resolveInheritance.skipMembersIfPresent")
      Color(1, 2, 3),
      vm::bbox3(-1, 1),
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
@@ -362,6 +391,7 @@ TEST_CASE("resolveInheritance.skipMembersIfPresent")
      "blah blah",
      Color(2, 3, 4),
      vm::bbox3(-2, 2),
+     std::nullopt,
      std::nullopt,
      {},
      {"base"}},
@@ -374,6 +404,7 @@ TEST_CASE("resolveInheritance.skipMembersIfPresent")
      "blah blah",
      Color(2, 3, 4),
      vm::bbox3(-2, 2),
+     std::nullopt,
      std::nullopt,
      {},
      {"base"}},
@@ -405,6 +436,7 @@ TEST_CASE("resolveInheritance.mergeModelDefinitions")
      std::nullopt,
      std::nullopt,
      baseModelDef,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::PointClass,
@@ -415,6 +447,7 @@ TEST_CASE("resolveInheritance.mergeModelDefinitions")
      std::nullopt,
      std::nullopt,
      pointModelDef,
+     std::nullopt,
      {},
      {"base"}},
   });
@@ -427,11 +460,66 @@ TEST_CASE("resolveInheritance.mergeModelDefinitions")
      std::nullopt,
      std::nullopt,
      mergedModelDef,
+     std::nullopt,
      {},
      {"base"}},
   });
 
   TestParserStatus status;
+  CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
+  CHECK(status.countStatus(LogLevel::Warn) == 0u);
+  CHECK(status.countStatus(LogLevel::Error) == 0u);
+}
+
+
+TEST_CASE("resolveInheritance.mergeDecalDefinitions")
+{
+  const auto baseDecalDef = Assets::DecalDefinition{
+    EL::Expression{EL::LiteralExpression{EL::Value{"decal1"}}, 0, 0}};
+  const auto pointDecalDef = Assets::DecalDefinition{
+    EL::Expression{EL::LiteralExpression{EL::Value{"decal2"}}, 0, 0}};
+  auto mergedDecalDef = pointDecalDef;
+  mergedDecalDef.append(baseDecalDef);
+
+  const auto input = std::vector<EntityDefinitionClassInfo>{
+    {EntityDefinitionClassType::BaseClass,
+     0,
+     0,
+     "base",
+     std::nullopt,
+     std::nullopt,
+     std::nullopt,
+     std::nullopt,
+     baseDecalDef,
+     {},
+     {}},
+    {EntityDefinitionClassType::PointClass,
+     0,
+     0,
+     "point",
+     std::nullopt,
+     std::nullopt,
+     std::nullopt,
+     std::nullopt,
+     pointDecalDef,
+     {},
+     {"base"}},
+  };
+  const auto expected = std::vector<EntityDefinitionClassInfo>{
+    {EntityDefinitionClassType::PointClass,
+     0,
+     0,
+     "point",
+     std::nullopt,
+     std::nullopt,
+     std::nullopt,
+     std::nullopt,
+     mergedDecalDef,
+     {},
+     {"base"}},
+  };
+
+  auto status = TestParserStatus{};
   CHECK_THAT(resolveInheritance(status, input), Catch::UnorderedEquals(expected));
   CHECK(status.countStatus(LogLevel::Warn) == 0u);
   CHECK(status.countStatus(LogLevel::Error) == 0u);
@@ -457,12 +545,14 @@ TEST_CASE("resolveInheritance.inheritPropertyDefinitions")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {a1_1, a2},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      0,
      "point",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -475,6 +565,7 @@ TEST_CASE("resolveInheritance.inheritPropertyDefinitions")
      0,
      0,
      "point",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -512,12 +603,14 @@ TEST_CASE("resolveInheritance.mergeSpawnflagsSimpleInheritance")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {a1},
      {}},
     {EntityDefinitionClassType::PointClass,
      0,
      0,
      "point",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -571,9 +664,19 @@ TEST_CASE("resolveInheritance.chainOfBaseClasses")
   mergedModelDef.append(base2ModelDef);
   mergedModelDef.append(base1ModelDef);
 
+  const auto base1DecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("dec1")), 0, 0));
+  const auto base2DecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("dec2")), 0, 0));
+  const auto pointDecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("dec3")), 0, 0));
+  auto mergedDecalDef = pointDecalDef;
+  mergedDecalDef.append(base2DecalDef);
+  mergedDecalDef.append(base1DecalDef);
+
   const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef        properties      superclasses
+    // type  l  c  name description  color size
+    // modelDef  decalDef  properties  superclasses
     {EntityDefinitionClassType::BaseClass,
      0,
      0,
@@ -582,6 +685,7 @@ TEST_CASE("resolveInheritance.chainOfBaseClasses")
      std::nullopt,
      vm::bbox3(-2, 2),
      base1ModelDef,
+     base1DecalDef,
      {a1_1, a2},
      {}},
     {EntityDefinitionClassType::BaseClass,
@@ -592,6 +696,7 @@ TEST_CASE("resolveInheritance.chainOfBaseClasses")
      Color(1, 2, 3),
      std::nullopt,
      base2ModelDef,
+     base2DecalDef,
      {a1_2, a3},
      {"base1"}},
     {EntityDefinitionClassType::PointClass,
@@ -602,6 +707,7 @@ TEST_CASE("resolveInheritance.chainOfBaseClasses")
      std::nullopt,
      std::nullopt,
      pointModelDef,
+     pointDecalDef,
      {},
      {"base2"}},
   });
@@ -614,6 +720,7 @@ TEST_CASE("resolveInheritance.chainOfBaseClasses")
      Color(1, 2, 3),
      vm::bbox3(-2, 2),
      mergedModelDef,
+     mergedDecalDef,
      {a1_2, a3, a2},
      {"base2"}},
   });
@@ -643,9 +750,19 @@ TEST_CASE("resolveInheritance.multipleBaseClasses")
   mergedModelDef.append(base1ModelDef);
   mergedModelDef.append(base2ModelDef);
 
+  const auto base1DecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("dec1")), 0, 0));
+  const auto base2DecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("dec2")), 0, 0));
+  const auto pointDecalDef = Assets::DecalDefinition(
+    EL::Expression(EL::LiteralExpression(EL::Value("dec3")), 0, 0));
+  auto mergedDecalDef = pointDecalDef;
+  mergedDecalDef.append(base1DecalDef);
+  mergedDecalDef.append(base2DecalDef);
+
   const auto input = std::vector<EntityDefinitionClassInfo>({
-    // type                                   l  c  name     description   color size
-    // modelDef        properties      superclasses
+    // type  l  c  name description  color size
+    // modelDef  decalDef  properties  superclasses
     {EntityDefinitionClassType::BaseClass,
      0,
      0,
@@ -654,6 +771,7 @@ TEST_CASE("resolveInheritance.multipleBaseClasses")
      std::nullopt,
      vm::bbox3(-2, 2),
      base1ModelDef,
+     base1DecalDef,
      {a1_1, a2},
      {}},
     {EntityDefinitionClassType::BaseClass,
@@ -664,6 +782,7 @@ TEST_CASE("resolveInheritance.multipleBaseClasses")
      Color(1, 2, 3),
      std::nullopt,
      base2ModelDef,
+     base2DecalDef,
      {a1_2, a3},
      {}},
     {EntityDefinitionClassType::PointClass,
@@ -674,6 +793,7 @@ TEST_CASE("resolveInheritance.multipleBaseClasses")
      std::nullopt,
      std::nullopt,
      pointModelDef,
+     pointDecalDef,
      {},
      {"base1", "base2"}},
   });
@@ -686,6 +806,7 @@ TEST_CASE("resolveInheritance.multipleBaseClasses")
      Color(1, 2, 3),
      vm::bbox3(-2, 2),
      mergedModelDef,
+     mergedDecalDef,
      {a1_1, a2, a3},
      {"base1", "base2"}},
   });
@@ -716,6 +837,7 @@ TEST_CASE("resolveInheritance.diamondInheritance")
      std::nullopt,
      vm::bbox3(-2, 2),
      std::nullopt,
+     std::nullopt,
      {a1},
      {}},
     {EntityDefinitionClassType::BaseClass,
@@ -724,6 +846,7 @@ TEST_CASE("resolveInheritance.diamondInheritance")
      "base2_1",
      "base2_1",
      Color(1, 2, 3),
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      {a2_1},
@@ -736,6 +859,7 @@ TEST_CASE("resolveInheritance.diamondInheritance")
      std::nullopt,
      vm::bbox3(-1, 1),
      std::nullopt,
+     std::nullopt,
      {a2_2},
      {"base1"}},
     {EntityDefinitionClassType::PointClass,
@@ -746,12 +870,14 @@ TEST_CASE("resolveInheritance.diamondInheritance")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {a3},
      {"base2_1", "base2_2"}},
     {EntityDefinitionClassType::PointClass,
      0,
      0,
      "point2",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -768,6 +894,7 @@ TEST_CASE("resolveInheritance.diamondInheritance")
      Color(1, 2, 3),
      vm::bbox3(-2, 2),
      std::nullopt,
+     std::nullopt,
      {a3, a2_1, a1, a2_2},
      {"base2_1", "base2_2"}},
     {EntityDefinitionClassType::PointClass,
@@ -777,6 +904,7 @@ TEST_CASE("resolveInheritance.diamondInheritance")
      "base2_2",
      Color(1, 2, 3),
      vm::bbox3(-1, 1),
+     std::nullopt,
      std::nullopt,
      {a3, a2_2, a1, a2_1},
      {"base2_2", "base2_1"}},
@@ -801,6 +929,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
@@ -808,6 +937,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      0,
      "base",
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -821,12 +951,14 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {"base"}},
     {EntityDefinitionClassType::BrushClass,
      0,
      0,
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -843,6 +975,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
@@ -850,6 +983,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      0,
      "base",
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -863,6 +997,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {"base"}},
     {EntityDefinitionClassType::BrushClass,
@@ -870,6 +1005,7 @@ TEST_CASE("resolveInheritance.overloadedSuperClass")
      0,
      "brush",
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -896,6 +1032,7 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
@@ -906,12 +1043,14 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BaseClass,
      0,
      0,
      "mid",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -926,12 +1065,14 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {"mid"}},
     {EntityDefinitionClassType::BrushClass,
      0,
      0,
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -948,6 +1089,7 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {}},
     {EntityDefinitionClassType::BrushClass,
@@ -955,6 +1097,7 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      0,
      "base",
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,
@@ -968,6 +1111,7 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      std::nullopt,
      std::nullopt,
      std::nullopt,
+     std::nullopt,
      {},
      {"mid"}},
     {EntityDefinitionClassType::BrushClass,
@@ -975,6 +1119,7 @@ TEST_CASE("resolveInheritance.indirectOverloadedSuperClass")
      0,
      "brush",
      "brush",
+     std::nullopt,
      std::nullopt,
      std::nullopt,
      std::nullopt,

--- a/common/test/src/IO/tst_FgdParser.cpp
+++ b/common/test/src/IO/tst_FgdParser.cpp
@@ -867,6 +867,19 @@ TEST_CASE("FgdParserTest.parseLegacyModelWithParseError")
   kdl::vec_clear_and_delete(definitions);
 }
 
+static const auto FgdDecalDefinitionTemplate =
+  R"(@PointClass decal(${DECAL}) = infodecal : "Decal" [])";
+
+using Assets::assertDecalDefinition;
+
+TEST_CASE("FgdParserTest.parseELDecalDefinition")
+{
+  static const auto DecalDefinition = R"({ texture: "decal1" })";
+
+  assertDecalDefinition<FgdParser>(
+    Assets::DecalSpecification{"decal1"}, DecalDefinition, FgdDecalDefinitionTemplate);
+}
+
 TEST_CASE("FgdParserTest.parseMissingBounds")
 {
   const auto file = R"(

--- a/common/test/src/Model/tst_Entity.cpp
+++ b/common/test/src/Model/tst_Entity.cpp
@@ -38,25 +38,245 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::Model
 {
-namespace Model
+TEST_CASE("EntityTest")
 {
-TEST_CASE("EntityTest.defaults")
-{
-  auto entity = Entity{};
+  SECTION("defaults")
+  {
+    auto entity = Entity{};
 
-  CHECK(entity.classname() == EntityPropertyValues::NoClassname);
-  CHECK(entity.pointEntity());
-  CHECK(entity.origin() == vm::vec3::zero());
-  CHECK(entity.rotation() == vm::mat4x4::identity());
-}
+    CHECK(entity.classname() == EntityPropertyValues::NoClassname);
+    CHECK(entity.pointEntity());
+    CHECK(entity.origin() == vm::vec3::zero());
+    CHECK(entity.rotation() == vm::mat4x4::identity());
+  }
 
-TEST_CASE("EntityTest.setProperties")
-{
-  SECTION("Updates cached model transformation")
+  SECTION("setProperties")
+  {
+    SECTION("Updates cached model transformation")
+    {
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+      auto definition = Assets::PointEntityDefinition{
+        "some_name",
+        Color{},
+        vm::bbox3{32.0},
+        "",
+        {},
+        Assets::ModelDefinition{
+          {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
+           0,
+           0}},
+        {}};
+
+      auto entity = Entity{};
+      entity.setDefinition(config, &definition);
+      REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+
+      entity.setProperties(config, {{"modelscale", "1 2 3"}});
+
+      CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 2, 3}));
+    }
+  }
+
+  SECTION("setDefaultProperties")
+  {
+    const auto propertyConfig = EntityPropertyConfig{};
+
+    auto definition = Assets::PointEntityDefinition{
+      "some_name",
+      Color{},
+      vm::bbox3{32.0},
+      "",
+      {
+        std::make_shared<Assets::StringPropertyDefinition>(
+          "some_prop", "", "", !true(readOnly)),
+        std::make_shared<Assets::StringPropertyDefinition>(
+          "some_default_prop", "", "", !true(readOnly), "value"),
+      },
+      {},
+      {}};
+
+    using T = std::tuple<
+      std::vector<EntityProperty>,
+      SetDefaultPropertyMode,
+      std::vector<EntityProperty>>;
+
+    const auto [initialProperties, mode, expectedProperties] = GENERATE(values<T>({
+      {{}, SetDefaultPropertyMode::SetExisting, std::vector<EntityProperty>{}},
+      {{}, SetDefaultPropertyMode::SetMissing, {{"some_default_prop", "value"}}},
+      {{}, SetDefaultPropertyMode::SetAll, {{"some_default_prop", "value"}}},
+      {{{"some_default_prop", "other_value"}},
+       SetDefaultPropertyMode::SetExisting,
+       {{"some_default_prop", "value"}}},
+      {{{"some_default_prop", "other_value"}},
+       SetDefaultPropertyMode::SetMissing,
+       {{"some_default_prop", "other_value"}}},
+      {{{"some_default_prop", "other_value"}},
+       SetDefaultPropertyMode::SetAll,
+       {{"some_default_prop", "value"}}},
+    }));
+
+    auto entity = Entity{propertyConfig, initialProperties};
+    setDefaultProperties(propertyConfig, definition, entity, mode);
+
+    CHECK_THAT(entity.properties(), Catch::Matchers::UnorderedEquals(expectedProperties));
+  }
+
+  SECTION("definitionBounds")
+  {
+    auto pointEntityDefinition = Assets::PointEntityDefinition(
+      "some_name", Color{}, vm::bbox3{32.0}, "", {}, {}, {});
+    auto entity = Entity{};
+
+    SECTION("Returns default bounds if no definition is set")
+    {
+      CHECK(entity.definitionBounds() == vm::bbox3{8.0});
+    }
+
+    SECTION("Returns definition bounds if definition is set")
+    {
+      entity.setDefinition({}, &pointEntityDefinition);
+      CHECK(entity.definitionBounds() == vm::bbox3{32.0});
+    }
+  }
+
+  SECTION("setDefinition")
+  {
+    SECTION("Updates cached model transformation")
+    {
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+      auto definition = Assets::PointEntityDefinition{
+        "some_name",
+        Color{},
+        vm::bbox3{32.0},
+        "",
+        {},
+        Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}},
+        {}};
+
+      auto entity = Entity{};
+      REQUIRE(entity.modelTransformation() == vm::mat4x4::identity());
+
+      entity.setDefinition(config, &definition);
+      CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    }
+  }
+
+  SECTION("modelSpecification")
+  {
+    auto modelExpression = IO::ELParser::parseStrict(R"({{ 
+      spawnflags == 0 -> "maps/b_shell0.bsp",
+      spawnflags == 1 -> "maps/b_shell1.bsp",
+                         "maps/b_shell2.bsp"
+  }})");
+
+    auto definition = Assets::PointEntityDefinition{
+      "some_name",
+      Color{},
+      vm::bbox3{32.0},
+      "",
+      {},
+      Assets::ModelDefinition{modelExpression},
+      {}};
+
+    auto entity = Entity{};
+    entity.setDefinition({}, &definition);
+    CHECK(
+      entity.modelSpecification()
+      == Assets::ModelSpecification{"maps/b_shell0.bsp", 0, 0});
+
+    entity.addOrUpdateProperty({}, EntityPropertyKeys::Spawnflags, "1");
+    CHECK(
+      entity.modelSpecification()
+      == Assets::ModelSpecification{"maps/b_shell1.bsp", 0, 0});
+  }
+
+  SECTION("decalSpecification")
+  {
+    auto decalExpression = IO::ELParser::parseStrict(R"({ texture: texture })");
+
+    auto definition = Assets::PointEntityDefinition{
+      "some_name",
+      Color{},
+      vm::bbox3{32.0},
+      "",
+      {},
+      {},
+      Assets::DecalDefinition{decalExpression}};
+
+    auto entity = Entity{};
+    entity.setDefinition({}, &definition);
+    CHECK(entity.decalSpecification() == Assets::DecalSpecification{""});
+
+    entity.addOrUpdateProperty({}, "texture", "decal1");
+    CHECK(entity.decalSpecification() == Assets::DecalSpecification{"decal1"});
+  }
+
+  SECTION("unsetEntityDefinitionAndModel")
   {
     auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+    auto definition = Assets::PointEntityDefinition{
+      "some_name",
+      Color{},
+      vm::bbox3{32.0},
+      "",
+      {},
+      Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}},
+      {}};
+
+    auto entity = Entity{};
+    entity.setDefinition(config, &definition);
+    REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+
+    entity.unsetEntityDefinitionAndModel();
+    CHECK(entity.definition() == nullptr);
+    CHECK(entity.modelTransformation() == vm::mat4x4::identity());
+  }
+
+  SECTION("addOrUpdateProperty")
+  {
+    // needs to be created here so that it is destroyed last
+    auto definition = Assets::PointEntityDefinition{
+      "some_name", Color{}, vm::bbox3{32.0}, "", {}, {}, {}};
+
+    auto entity = Entity{};
+    REQUIRE(entity.property("test") == nullptr);
+
+    entity.addOrUpdateProperty({}, "test", "value");
+    CHECK(*entity.property("test") == "value");
+
+    entity.addOrUpdateProperty({}, "test", "newValue");
+    CHECK(*entity.property("test") == "newValue");
+
+    SECTION("Setting a new property to protected by default")
+    {
+      entity.addOrUpdateProperty({}, "newKey", "newValue", true);
+      CHECK_THAT(
+        entity.protectedProperties(),
+        Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+
+      entity.addOrUpdateProperty({}, "test", "anotherValue", true);
+      CHECK_THAT(
+        entity.protectedProperties(),
+        Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+    }
+
+    SECTION("Updates cached model transformation")
+    {
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+
+      entity.setDefinition({}, &definition);
+      REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 1, 1}));
+
+      entity.addOrUpdateProperty(config, "something", "else");
+      CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    }
+  }
+
+  SECTION("renameProperty")
+  {
+    // needs to be created here so that it is destroyed last
     auto definition = Assets::PointEntityDefinition{
       "some_name",
       Color{},
@@ -70,637 +290,425 @@ TEST_CASE("EntityTest.setProperties")
       {}};
 
     auto entity = Entity{};
-    entity.setDefinition(config, &definition);
-    REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
 
-    entity.setProperties(config, {{"modelscale", "1 2 3"}});
-
-    CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 2, 3}));
-  }
-}
-
-TEST_CASE("EntityTest.setDefaultProperties")
-{
-  const auto propertyConfig = EntityPropertyConfig{};
-
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color{},
-    vm::bbox3{32.0},
-    "",
+    SECTION("Rename non existing property")
     {
-      std::make_shared<Assets::StringPropertyDefinition>(
-        "some_prop", "", "", !true(readOnly)),
-      std::make_shared<Assets::StringPropertyDefinition>(
-        "some_default_prop", "", "", !true(readOnly), "value"),
-    },
-    {},
-    {}};
+      REQUIRE(!entity.hasProperty("originalKey"));
+      entity.renameProperty({}, "originalKey", "newKey");
+      CHECK(!entity.hasProperty("originalKey"));
+      CHECK(!entity.hasProperty("newKey"));
+    }
 
-  using T = std::tuple<
-    std::vector<EntityProperty>,
-    SetDefaultPropertyMode,
-    std::vector<EntityProperty>>;
+    entity.addOrUpdateProperty({}, "originalKey", "originalValue");
+    REQUIRE(*entity.property("originalKey") == "originalValue");
 
-  const auto [initialProperties, mode, expectedProperties] = GENERATE(values<T>({
-    {{}, SetDefaultPropertyMode::SetExisting, std::vector<EntityProperty>{}},
-    {{}, SetDefaultPropertyMode::SetMissing, {{"some_default_prop", "value"}}},
-    {{}, SetDefaultPropertyMode::SetAll, {{"some_default_prop", "value"}}},
-    {{{"some_default_prop", "other_value"}},
-     SetDefaultPropertyMode::SetExisting,
-     {{"some_default_prop", "value"}}},
-    {{{"some_default_prop", "other_value"}},
-     SetDefaultPropertyMode::SetMissing,
-     {{"some_default_prop", "other_value"}}},
-    {{{"some_default_prop", "other_value"}},
-     SetDefaultPropertyMode::SetAll,
-     {{"some_default_prop", "value"}}},
-  }));
+    SECTION("Rename existing property")
+    {
+      entity.renameProperty({}, "originalKey", "newKey");
+      CHECK(!entity.hasProperty("originalKey"));
+      CHECK(*entity.property("newKey") == "originalValue");
+    }
 
-  auto entity = Entity{propertyConfig, initialProperties};
-  setDefaultProperties(propertyConfig, definition, entity, mode);
+    SECTION("Rename existing property - name conflict")
+    {
+      entity.addOrUpdateProperty({}, "newKey", "newValue");
 
-  CHECK_THAT(entity.properties(), Catch::Matchers::UnorderedEquals(expectedProperties));
-}
+      entity.renameProperty({}, "originalKey", "newKey");
+      CHECK(!entity.hasProperty("originalKey"));
+      CHECK(*entity.property("newKey") == "originalValue");
+    }
 
-TEST_CASE("EntityTest.definitionBounds")
-{
-  auto pointEntityDefinition =
-    Assets::PointEntityDefinition("some_name", Color(), vm::bbox3(32.0), "", {}, {}, {});
-  Entity entity;
+    SECTION("Rename existing protected property")
+    {
+      entity.setProtectedProperties({"originalKey"});
+      entity.renameProperty({}, "originalKey", "newKey");
+      CHECK_THAT(
+        entity.protectedProperties(),
+        Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+    }
 
-  SECTION("Returns default bounds if no definition is set")
-  {
-    CHECK(entity.definitionBounds() == vm::bbox3(8.0));
+    SECTION("Updates cached model transformation")
+    {
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+
+      entity.setDefinition(config, &definition);
+      entity.addOrUpdateProperty(config, "something", "1 2 3");
+      REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+
+      entity.renameProperty(config, "something", "modelscale");
+      CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 2, 3}));
+
+      entity.renameProperty(config, "modelscale", "not modelscale");
+      CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    }
   }
 
-  SECTION("Returns definition bounds if definition is set")
+  SECTION("removeProperty")
   {
-    entity.setDefinition({}, &pointEntityDefinition);
-    CHECK(entity.definitionBounds() == vm::bbox3(32.0));
-  }
-}
-
-TEST_CASE("EntityTest.setDefinition")
-{
-  SECTION("Updates cached model transformation")
-  {
-    auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+    // needs to be created here so that it is destroyed last
     auto definition = Assets::PointEntityDefinition{
       "some_name",
-      Color(),
-      vm::bbox3(32.0),
+      Color{},
+      vm::bbox3{32.0},
       "",
       {},
-      Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}},
+      Assets::ModelDefinition{
+        {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
+         0,
+         0}},
       {}};
 
     auto entity = Entity{};
-    REQUIRE(entity.modelTransformation() == vm::mat4x4::identity());
 
-    entity.setDefinition(config, &definition);
-    CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
-  }
-}
+    SECTION("Remove non existing property")
+    {
+      REQUIRE(!entity.hasProperty("key"));
+      entity.removeProperty({}, "key");
+      CHECK(!entity.hasProperty("key"));
+    }
 
-TEST_CASE("EntityTest.modelSpecification")
-{
-  auto modelExpression = IO::ELParser::parseStrict(R"({{ 
-      spawnflags == 0 -> "maps/b_shell0.bsp",
-      spawnflags == 1 -> "maps/b_shell1.bsp",
-                         "maps/b_shell2.bsp"
-  }})");
+    SECTION("Remove existing property")
+    {
+      entity.addOrUpdateProperty({}, "key", "value");
+      entity.removeProperty({}, "key");
+      CHECK(!entity.hasProperty("key"));
+    }
 
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color(),
-    vm::bbox3(32.0),
-    "",
-    {},
-    Assets::ModelDefinition{modelExpression},
-    {}};
+    SECTION("Remove protected property")
+    {
+      entity.addOrUpdateProperty({}, "newKey", "value", true);
+      REQUIRE_THAT(
+        entity.protectedProperties(),
+        Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
 
-  auto entity = Entity{};
-  entity.setDefinition({}, &definition);
-  CHECK(
-    entity.modelSpecification() == Assets::ModelSpecification{"maps/b_shell0.bsp", 0, 0});
+      entity.removeProperty({}, "newKey");
+      REQUIRE(!entity.hasProperty("newKey"));
+      CHECK_THAT(
+        entity.protectedProperties(),
+        Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+    }
 
-  entity.addOrUpdateProperty({}, EntityPropertyKeys::Spawnflags, "1");
-  CHECK(
-    entity.modelSpecification() == Assets::ModelSpecification{"maps/b_shell1.bsp", 0, 0});
-}
+    SECTION("Updates cached model transformation")
+    {
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
 
-TEST_CASE("EntityTest.decalSpecification")
-{
-  auto decalExpression = IO::ELParser::parseStrict(R"({ texture: texture })");
+      entity.setDefinition(config, &definition);
+      entity.addOrUpdateProperty(config, "modelscale", "1 2 3");
+      REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 2, 3}));
 
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color(),
-    vm::bbox3(32.0),
-    "",
-    {},
-    {},
-    Assets::DecalDefinition{decalExpression}};
-
-  auto entity = Entity{};
-  entity.setDefinition({}, &definition);
-  CHECK(entity.decalSpecification() == Assets::DecalSpecification{""});
-
-  entity.addOrUpdateProperty({}, "texture", "decal1");
-  CHECK(entity.decalSpecification() == Assets::DecalSpecification{"decal1"});
-}
-
-TEST_CASE("EntityTest.unsetEntityDefinitionAndModel")
-{
-  auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color(),
-    vm::bbox3(32.0),
-    "",
-    {},
-    Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}},
-    {}};
-
-  auto entity = Entity{};
-  entity.setDefinition(config, &definition);
-  REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
-
-  entity.unsetEntityDefinitionAndModel();
-  CHECK(entity.definition() == nullptr);
-  CHECK(entity.modelTransformation() == vm::mat4x4::identity());
-}
-
-TEST_CASE("EntityTest.addOrUpdateProperty")
-{
-  // needs to be created here so that it is destroyed last
-  auto definition =
-    Assets::PointEntityDefinition{"some_name", Color{}, vm::bbox3{32.0}, "", {}, {}, {}};
-
-  Entity entity;
-  REQUIRE(entity.property("test") == nullptr);
-
-  entity.addOrUpdateProperty({}, "test", "value");
-  CHECK(*entity.property("test") == "value");
-
-  entity.addOrUpdateProperty({}, "test", "newValue");
-  CHECK(*entity.property("test") == "newValue");
-
-  SECTION("Setting a new property to protected by default")
-  {
-    entity.addOrUpdateProperty({}, "newKey", "newValue", true);
-    CHECK_THAT(
-      entity.protectedProperties(),
-      Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
-
-    entity.addOrUpdateProperty({}, "test", "anotherValue", true);
-    CHECK_THAT(
-      entity.protectedProperties(),
-      Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+      entity.removeProperty(config, "modelscale");
+      CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    }
   }
 
-  SECTION("Updates cached model transformation")
+  SECTION("hasProperty")
   {
-    auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+    auto entity = Entity{};
+    CHECK(!entity.hasProperty("value"));
 
-    entity.setDefinition({}, &definition);
-    REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 1, 1}));
-
-    entity.addOrUpdateProperty(config, "something", "else");
-    CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
-  }
-}
-
-TEST_CASE("EntityTest.renameProperty")
-{
-  // needs to be created here so that it is destroyed last
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color{},
-    vm::bbox3{32.0},
-    "",
-    {},
-    Assets::ModelDefinition{
-      {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
-       0,
-       0}},
-    {}};
-
-  Entity entity;
-
-  SECTION("Rename non existing property")
-  {
-    REQUIRE(!entity.hasProperty("originalKey"));
-    entity.renameProperty({}, "originalKey", "newKey");
-    CHECK(!entity.hasProperty("originalKey"));
-    CHECK(!entity.hasProperty("newKey"));
+    entity.setProperties({}, {{"key", "value"}});
+    CHECK(entity.hasProperty("key"));
   }
 
-  entity.addOrUpdateProperty({}, "originalKey", "originalValue");
-  REQUIRE(*entity.property("originalKey") == "originalValue");
-
-  SECTION("Rename existing property")
+  SECTION("originUpdateWithSetProperties")
   {
-    entity.renameProperty({}, "originalKey", "newKey");
-    CHECK(!entity.hasProperty("originalKey"));
-    CHECK(*entity.property("newKey") == "originalValue");
+    auto entity = Entity{};
+    entity.setProperties({}, {{"origin", "10 20 30"}});
+
+    CHECK(entity.origin() == vm::vec3{10, 20, 30});
   }
 
-  SECTION("Rename existing property - name conflict")
+  SECTION("hasPropertyWithPrefix")
   {
-    entity.addOrUpdateProperty({}, "newKey", "newValue");
+    auto entity = Entity{};
+    entity.setProperties(
+      {},
+      {
+        {"somename", "somevalue"},
+        {"someothername", "someothervalue"},
+      });
 
-    entity.renameProperty({}, "originalKey", "newKey");
-    CHECK(!entity.hasProperty("originalKey"));
-    CHECK(*entity.property("newKey") == "originalValue");
+    CHECK(entity.hasPropertyWithPrefix("somename", "somevalue"));
+    CHECK(entity.hasPropertyWithPrefix("some", "somevalue"));
+    CHECK(entity.hasPropertyWithPrefix("some", "someothervalue"));
+    CHECK(entity.hasPropertyWithPrefix("someother", "someothervalue"));
+    CHECK(!entity.hasPropertyWithPrefix("someother", "somevalue"));
+    CHECK(!entity.hasPropertyWithPrefix("sime", ""));
   }
 
-  SECTION("Rename existing protected property")
+  SECTION("hasNumberedProperty")
   {
-    entity.setProtectedProperties({"originalKey"});
-    entity.renameProperty({}, "originalKey", "newKey");
-    CHECK_THAT(
-      entity.protectedProperties(),
-      Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+    auto entity = Entity{};
+    entity.setProperties(
+      {},
+      {
+        {"target", "value"},
+        {"target1", "value1"},
+        {"target2", "value2"},
+      });
+
+    CHECK(entity.hasNumberedProperty("target", "value"));
+    CHECK(entity.hasNumberedProperty("target", "value1"));
+    CHECK(entity.hasNumberedProperty("target", "value2"));
+    CHECK(!entity.hasNumberedProperty("targe", "value"));
+    CHECK(!entity.hasNumberedProperty("somename", ""));
   }
 
-  SECTION("Updates cached model transformation")
+  SECTION("property")
   {
-    auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+    auto entity = Entity{};
 
-    entity.setDefinition(config, &definition);
-    entity.addOrUpdateProperty(config, "something", "1 2 3");
-    REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    CHECK(entity.property("key") == nullptr);
 
-    entity.renameProperty(config, "something", "modelscale");
-    CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 2, 3}));
-
-    entity.renameProperty(config, "modelscale", "not modelscale");
-    CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
-  }
-}
-
-TEST_CASE("EntityTest.removeProperty")
-{
-  // needs to be created here so that it is destroyed last
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color{},
-    vm::bbox3{32.0},
-    "",
-    {},
-    Assets::ModelDefinition{
-      {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
-       0,
-       0}},
-    {}};
-
-  Entity entity;
-
-  SECTION("Remove non existing property")
-  {
-    REQUIRE(!entity.hasProperty("key"));
-    entity.removeProperty({}, "key");
-    CHECK(!entity.hasProperty("key"));
-  }
-
-  SECTION("Remove existing property")
-  {
     entity.addOrUpdateProperty({}, "key", "value");
-    entity.removeProperty({}, "key");
-    CHECK(!entity.hasProperty("key"));
+    CHECK(entity.property("key") != nullptr);
+    CHECK(*entity.property("key") == "value");
   }
 
-  SECTION("Remove protected property")
+  SECTION("classname")
   {
-    entity.addOrUpdateProperty({}, "newKey", "value", true);
-    REQUIRE_THAT(
-      entity.protectedProperties(),
-      Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
+    auto entity = Entity{};
+    REQUIRE(!entity.hasProperty(EntityPropertyKeys::Classname));
 
-    entity.removeProperty({}, "newKey");
-    REQUIRE(!entity.hasProperty("newKey"));
-    CHECK_THAT(
-      entity.protectedProperties(),
-      Catch::UnorderedEquals(std::vector<std::string>{"newKey"}));
-  }
-
-  SECTION("Updates cached model transformation")
-  {
-    auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
-
-    entity.setDefinition(config, &definition);
-    entity.addOrUpdateProperty(config, "modelscale", "1 2 3");
-    REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{1, 2, 3}));
-
-    entity.removeProperty(config, "modelscale");
-    CHECK(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
-  }
-}
-
-TEST_CASE("EntityTest.hasProperty")
-{
-  Entity entity;
-  CHECK(!entity.hasProperty("value"));
-
-  entity.setProperties({}, {{"key", "value"}});
-  CHECK(entity.hasProperty("key"));
-}
-
-TEST_CASE("EntityTest.originUpdateWithSetProperties")
-{
-  Entity entity;
-  entity.setProperties({}, {{"origin", "10 20 30"}});
-
-  CHECK(entity.origin() == vm::vec3(10, 20, 30));
-}
-
-TEST_CASE("EntityTest.hasPropertyWithPrefix")
-{
-  Entity entity;
-  entity.setProperties(
-    {},
+    SECTION("Entities without a classname property return a default name")
     {
-      {"somename", "somevalue"},
-      {"someothername", "someothervalue"},
-    });
+      CHECK(entity.classname() == EntityPropertyValues::NoClassname);
+    }
 
-  CHECK(entity.hasPropertyWithPrefix("somename", "somevalue"));
-  CHECK(entity.hasPropertyWithPrefix("some", "somevalue"));
-  CHECK(entity.hasPropertyWithPrefix("some", "someothervalue"));
-  CHECK(entity.hasPropertyWithPrefix("someother", "someothervalue"));
-  CHECK(!entity.hasPropertyWithPrefix("someother", "somevalue"));
-  CHECK(!entity.hasPropertyWithPrefix("sime", ""));
-}
-
-TEST_CASE("EntityTest.hasNumberedProperty")
-{
-  Entity entity;
-  entity.setProperties(
-    {},
+    entity.addOrUpdateProperty({}, EntityPropertyKeys::Classname, "testclass");
+    SECTION("Entities with a classname property return the value")
     {
-      {"target", "value"},
-      {"target1", "value1"},
-      {"target2", "value2"},
-    });
+      CHECK(*entity.property(EntityPropertyKeys::Classname) == "testclass");
+      CHECK(entity.classname() == "testclass");
+    }
 
-  CHECK(entity.hasNumberedProperty("target", "value"));
-  CHECK(entity.hasNumberedProperty("target", "value1"));
-  CHECK(entity.hasNumberedProperty("target", "value2"));
-  CHECK(!entity.hasNumberedProperty("targe", "value"));
-  CHECK(!entity.hasNumberedProperty("somename", ""));
-}
+    SECTION("addOrUpdateProperty updates cached classname property")
+    {
+      entity.addOrUpdateProperty({}, EntityPropertyKeys::Classname, "newclass");
+      CHECK(*entity.property(EntityPropertyKeys::Classname) == "newclass");
+      CHECK(entity.classname() == "newclass");
+    }
 
-TEST_CASE("EntityTest.property")
-{
-  Entity entity;
-
-  CHECK(entity.property("key") == nullptr);
-
-  entity.addOrUpdateProperty({}, "key", "value");
-  CHECK(entity.property("key") != nullptr);
-  CHECK(*entity.property("key") == "value");
-}
-
-TEST_CASE("EntityTest.classname")
-{
-  Entity entity;
-  REQUIRE(!entity.hasProperty(EntityPropertyKeys::Classname));
-
-  SECTION("Entities without a classname property return a default name")
-  {
-    CHECK(entity.classname() == EntityPropertyValues::NoClassname);
+    SECTION("setProperties updates cached classname property")
+    {
+      entity.setProperties({}, {{EntityPropertyKeys::Classname, "newclass"}});
+      CHECK(*entity.property(EntityPropertyKeys::Classname) == "newclass");
+      CHECK(entity.classname() == "newclass");
+    }
   }
 
-  entity.addOrUpdateProperty({}, EntityPropertyKeys::Classname, "testclass");
-  SECTION("Entities with a classname property return the value")
+  SECTION("setClassname")
   {
+    auto entity = Entity{};
+    REQUIRE(entity.classname() == EntityPropertyValues::NoClassname);
+
+    entity.setClassname({}, "testclass");
     CHECK(*entity.property(EntityPropertyKeys::Classname) == "testclass");
     CHECK(entity.classname() == "testclass");
+
+    SECTION("Updates cached classname property")
+    {
+      entity.setClassname({}, "otherclass");
+      CHECK(*entity.property(EntityPropertyKeys::Classname) == "otherclass");
+      CHECK(entity.classname() == "otherclass");
+    }
   }
 
-  SECTION("addOrUpdateProperty updates cached classname property")
+  SECTION("origin")
   {
-    entity.addOrUpdateProperty({}, EntityPropertyKeys::Classname, "newclass");
-    CHECK(*entity.property(EntityPropertyKeys::Classname) == "newclass");
-    CHECK(entity.classname() == "newclass");
-  }
+    auto entity = Entity{};
+    REQUIRE(!entity.hasProperty(EntityPropertyKeys::Origin));
 
-  SECTION("setProperties updates cached classname property")
-  {
-    entity.setProperties({}, {{EntityPropertyKeys::Classname, "newclass"}});
-    CHECK(*entity.property(EntityPropertyKeys::Classname) == "newclass");
-    CHECK(entity.classname() == "newclass");
-  }
-}
+    SECTION("Entities without an origin property return 0,0,0")
+    {
+      CHECK(entity.origin() == vm::vec3::zero());
+    }
 
-TEST_CASE("EntityTest.setClassname")
-{
-  Entity entity;
-  REQUIRE(entity.classname() == EntityPropertyValues::NoClassname);
-
-  entity.setClassname({}, "testclass");
-  CHECK(*entity.property(EntityPropertyKeys::Classname) == "testclass");
-  CHECK(entity.classname() == "testclass");
-
-  SECTION("Updates cached classname property")
-  {
-    entity.setClassname({}, "otherclass");
-    CHECK(*entity.property(EntityPropertyKeys::Classname) == "otherclass");
-    CHECK(entity.classname() == "otherclass");
-  }
-}
-
-TEST_CASE("EntityTest.origin")
-{
-  Entity entity;
-  REQUIRE(!entity.hasProperty(EntityPropertyKeys::Origin));
-
-  SECTION("Entities without an origin property return 0,0,0")
-  {
-    CHECK(entity.origin() == vm::vec3::zero());
-  }
-
-  entity.addOrUpdateProperty({}, EntityPropertyKeys::Origin, "1 2 3");
-  SECTION("Entities with an origin property return the value")
-  {
-    CHECK(*entity.property(EntityPropertyKeys::Origin) == "1 2 3");
-    CHECK(entity.origin() == vm::vec3(1, 2, 3));
-  }
-
-  SECTION("addOrUpdateProperty updates cached classname property")
-  {
     entity.addOrUpdateProperty({}, EntityPropertyKeys::Origin, "1 2 3");
+    SECTION("Entities with an origin property return the value")
+    {
+      CHECK(*entity.property(EntityPropertyKeys::Origin) == "1 2 3");
+      CHECK(entity.origin() == vm::vec3{1, 2, 3});
+    }
+
+    SECTION("addOrUpdateProperty updates cached classname property")
+    {
+      entity.addOrUpdateProperty({}, EntityPropertyKeys::Origin, "1 2 3");
+      CHECK(*entity.property(EntityPropertyKeys::Origin) == "1 2 3");
+      CHECK(entity.origin() == vm::vec3{1, 2, 3});
+    }
+
+    SECTION("setProperties updates cached classname property")
+    {
+      entity.setProperties({}, {{EntityPropertyKeys::Origin, "3 4 5"}});
+      CHECK(*entity.property(EntityPropertyKeys::Origin) == "3 4 5");
+      CHECK(entity.origin() == vm::vec3{3, 4, 5});
+    }
+  }
+
+  SECTION("setOrigin")
+  {
+    // needs to be created here so that it is destroyed last
+    auto definition = Assets::PointEntityDefinition{
+      "some_name",
+      Color{},
+      vm::bbox3{32.0},
+      "",
+      {},
+      Assets::ModelDefinition{
+        {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
+         0,
+         0}},
+      {}};
+
+    auto entity = Entity{};
+    REQUIRE(entity.origin() == vm::vec3::zero());
+
+    entity.setOrigin({}, vm::vec3{1, 2, 3});
     CHECK(*entity.property(EntityPropertyKeys::Origin) == "1 2 3");
-    CHECK(entity.origin() == vm::vec3(1, 2, 3));
+    CHECK(entity.origin() == vm::vec3{1, 2, 3});
+
+    SECTION("Updates cached origin property")
+    {
+      entity.setOrigin({}, vm::vec3{3, 4, 5});
+      CHECK(*entity.property(EntityPropertyKeys::Origin) == "3 4 5");
+      CHECK(entity.origin() == vm::vec3{3, 4, 5});
+    }
+
+    SECTION("Updates cached model transformation")
+    {
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+
+      entity.setDefinition(config, &definition);
+      REQUIRE(
+        entity.modelTransformation()
+        == vm::translation_matrix(vm::vec3{1, 2, 3})
+             * vm::scaling_matrix(vm::vec3{2, 2, 2}));
+
+      entity.setOrigin(config, vm::vec3{9, 8, 7});
+      REQUIRE(
+        entity.modelTransformation()
+        == vm::translation_matrix(vm::vec3{9, 8, 7})
+             * vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    }
   }
 
-  SECTION("setProperties updates cached classname property")
+  SECTION("transform")
   {
-    entity.setProperties({}, {{EntityPropertyKeys::Origin, "3 4 5"}});
-    CHECK(*entity.property(EntityPropertyKeys::Origin) == "3 4 5");
-    CHECK(entity.origin() == vm::vec3(3, 4, 5));
-  }
-}
+    // need to be created here so that they are destroyed last
+    auto definition = Assets::PointEntityDefinition(
+      "some_name",
+      Color{},
+      vm::bbox3{16.0}.translate(vm::vec3{16, 16, 0}),
+      "",
+      {},
+      {},
+      {});
+    auto otherDefinition = Assets::PointEntityDefinition{
+      "some_class", Color{}, vm::bbox3{32.0}, "", {}, {}, {}};
 
-TEST_CASE("EntityTest.setOrigin")
-{
-  // needs to be created here so that it is destroyed last
-  auto definition = Assets::PointEntityDefinition{
-    "some_name",
-    Color{},
-    vm::bbox3{32.0},
-    "",
-    {},
-    Assets::ModelDefinition{
-      {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
-       0,
-       0}},
-    {}};
-
-  Entity entity;
-  REQUIRE(entity.origin() == vm::vec3::zero());
-
-  entity.setOrigin({}, vm::vec3(1, 2, 3));
-  CHECK(*entity.property(EntityPropertyKeys::Origin) == "1 2 3");
-  CHECK(entity.origin() == vm::vec3(1, 2, 3));
-
-  SECTION("Updates cached origin property")
-  {
-    entity.setOrigin({}, vm::vec3(3, 4, 5));
-    CHECK(*entity.property(EntityPropertyKeys::Origin) == "3 4 5");
-    CHECK(entity.origin() == vm::vec3(3, 4, 5));
-  }
-
-  SECTION("Updates cached model transformation")
-  {
-    auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
-
-    entity.setDefinition(config, &definition);
-    REQUIRE(
-      entity.modelTransformation()
-      == vm::translation_matrix(vm::vec3{1, 2, 3})
-           * vm::scaling_matrix(vm::vec3{2, 2, 2}));
-
-    entity.setOrigin(config, vm::vec3{9, 8, 7});
-    REQUIRE(
-      entity.modelTransformation()
-      == vm::translation_matrix(vm::vec3{9, 8, 7})
-           * vm::scaling_matrix(vm::vec3{2, 2, 2}));
-  }
-}
-
-TEST_CASE("EntityTest.transform")
-{
-  // need to be created here so that they are destroyed last
-  auto definition = Assets::PointEntityDefinition(
-    "some_name", Color(), vm::bbox3(16.0).translate(vm::vec3(16, 16, 0)), "", {}, {}, {});
-  auto otherDefinition =
-    Assets::PointEntityDefinition{"some_class", Color{}, vm::bbox3{32.0}, "", {}, {}, {}};
-
-  Entity entity;
-  REQUIRE(entity.rotation() == vm::mat4x4::identity());
-
-  SECTION("Requires classname for rotation")
-  {
-    const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
-    entity.transform({}, rotation);
-
-    // rotation had no effect
-    CHECK(entity.rotation() == vm::mat4x4::identity());
-  }
-
-  SECTION("Requires point entity for rotation")
-  {
-    entity.setClassname({}, "some_class");
-    entity.setPointEntity({}, false);
+    auto entity = Entity{};
     REQUIRE(entity.rotation() == vm::mat4x4::identity());
 
-    const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
-    entity.transform({}, rotation);
-
-    // rotation had no effect
-    CHECK(entity.rotation() == vm::mat4x4::identity());
-  }
-
-  SECTION("Rotate - without offset")
-  {
-    entity.setClassname({}, "some_class");
-    entity.setOrigin({}, vm::vec3(10, 20, 30));
-
-    const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
-    entity.transform({}, rotation);
-
-    CHECK(entity.rotation() == rotation);
-    CHECK(entity.origin() == vm::vec3(-20, 10, 30));
-  }
-
-  SECTION("Rotate - with offset")
-  {
-    entity.setClassname({}, "some_class");
-    entity.setOrigin({}, vm::vec3(32, 32, 0));
-
-    entity.setDefinition({}, &definition);
-
-    const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
-    entity.transform({}, rotation);
-
-    CHECK(entity.rotation() == vm::mat4x4::identity());
-    CHECK(entity.origin() == vm::vec3(-64, 32, 0));
-  }
-
-  SECTION("Rotate - with subsequent translation")
-  {
-    entity.setClassname({}, "some_class");
-
-    const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
-    entity.transform({}, rotation);
-    REQUIRE(entity.rotation() == rotation);
-
-    entity.transform({}, vm::translation_matrix(vm::vec3(100, 0, 0)));
-    CHECK(entity.rotation() == rotation);
-  }
-
-  SECTION("Updates cached model transformation")
-  {
-    entity.setClassname({}, "some_class");
-
-    auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
-
-    entity.setDefinition(config, &otherDefinition);
-    REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
-
-    entity.transform(config, vm::translation_matrix(vm::vec3{8, 7, 6}));
-    CHECK(
-      entity.modelTransformation()
-      == vm::translation_matrix(vm::vec3{8, 7, 6})
-           * vm::scaling_matrix(vm::vec3{2, 2, 2}));
-  }
-
-  SECTION("Updates angle property")
-  {
-    auto entityPropertyConfig = EntityPropertyConfig{};
-
-    entity.setClassname(entityPropertyConfig, "light");
-    entity.addOrUpdateProperty(entityPropertyConfig, EntityPropertyKeys::Angle, "0");
-
-    const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
-
-    SECTION("If property update after transform is enabled")
+    SECTION("Requires classname for rotation")
     {
-      entity.transform(entityPropertyConfig, rotation);
-      CHECK(*entity.property(EntityPropertyKeys::Angle) == "90");
+      const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
+      entity.transform({}, rotation);
+
+      // rotation had no effect
+      CHECK(entity.rotation() == vm::mat4x4::identity());
     }
 
-    SECTION("If property update after transform is disabled")
+    SECTION("Requires point entity for rotation")
     {
-      entityPropertyConfig.updateAnglePropertyAfterTransform = false;
+      entity.setClassname({}, "some_class");
+      entity.setPointEntity({}, false);
+      REQUIRE(entity.rotation() == vm::mat4x4::identity());
 
-      entity.transform(entityPropertyConfig, rotation);
-      CHECK(*entity.property(EntityPropertyKeys::Angle) == "0");
+      const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
+      entity.transform({}, rotation);
+
+      // rotation had no effect
+      CHECK(entity.rotation() == vm::mat4x4::identity());
+    }
+
+    SECTION("Rotate - without offset")
+    {
+      entity.setClassname({}, "some_class");
+      entity.setOrigin({}, vm::vec3{10, 20, 30});
+
+      const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
+      entity.transform({}, rotation);
+
+      CHECK(entity.rotation() == rotation);
+      CHECK(entity.origin() == vm::vec3{-20, 10, 30});
+    }
+
+    SECTION("Rotate - with offset")
+    {
+      entity.setClassname({}, "some_class");
+      entity.setOrigin({}, vm::vec3{32, 32, 0});
+
+      entity.setDefinition({}, &definition);
+
+      const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
+      entity.transform({}, rotation);
+
+      CHECK(entity.rotation() == vm::mat4x4::identity());
+      CHECK(entity.origin() == vm::vec3{-64, 32, 0});
+    }
+
+    SECTION("Rotate - with subsequent translation")
+    {
+      entity.setClassname({}, "some_class");
+
+      const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
+      entity.transform({}, rotation);
+      REQUIRE(entity.rotation() == rotation);
+
+      entity.transform({}, vm::translation_matrix(vm::vec3{100, 0, 0}));
+      CHECK(entity.rotation() == rotation);
+    }
+
+    SECTION("Updates cached model transformation")
+    {
+      entity.setClassname({}, "some_class");
+
+      auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
+
+      entity.setDefinition(config, &otherDefinition);
+      REQUIRE(entity.modelTransformation() == vm::scaling_matrix(vm::vec3{2, 2, 2}));
+
+      entity.transform(config, vm::translation_matrix(vm::vec3{8, 7, 6}));
+      CHECK(
+        entity.modelTransformation()
+        == vm::translation_matrix(vm::vec3{8, 7, 6})
+             * vm::scaling_matrix(vm::vec3{2, 2, 2}));
+    }
+
+    SECTION("Updates angle property")
+    {
+      auto entityPropertyConfig = EntityPropertyConfig{};
+
+      entity.setClassname(entityPropertyConfig, "light");
+      entity.addOrUpdateProperty(entityPropertyConfig, EntityPropertyKeys::Angle, "0");
+
+      const auto rotation = vm::rotation_matrix(0.0, 0.0, vm::to_radians(90.0));
+
+      SECTION("If property update after transform is enabled")
+      {
+        entity.transform(entityPropertyConfig, rotation);
+        CHECK(*entity.property(EntityPropertyKeys::Angle) == "90");
+      }
+
+      SECTION("If property update after transform is disabled")
+      {
+        entityPropertyConfig.updateAnglePropertyAfterTransform = false;
+
+        entity.transform(entityPropertyConfig, rotation);
+        CHECK(*entity.property(EntityPropertyKeys::Angle) == "0");
+      }
     }
   }
 }
-} // namespace Model
-} // namespace TrenchBroom
+} // namespace TrenchBroom::Model

--- a/common/test/src/Model/tst_Entity.cpp
+++ b/common/test/src/Model/tst_Entity.cpp
@@ -66,7 +66,8 @@ TEST_CASE("EntityTest.setProperties")
       Assets::ModelDefinition{
         {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
          0,
-         0}}};
+         0}},
+      {}};
 
     auto entity = Entity{};
     entity.setDefinition(config, &definition);
@@ -93,6 +94,7 @@ TEST_CASE("EntityTest.setDefaultProperties")
       std::make_shared<Assets::StringPropertyDefinition>(
         "some_default_prop", "", "", !true(readOnly), "value"),
     },
+    {},
     {}};
 
   using T = std::tuple<
@@ -124,7 +126,7 @@ TEST_CASE("EntityTest.setDefaultProperties")
 TEST_CASE("EntityTest.definitionBounds")
 {
   auto pointEntityDefinition =
-    Assets::PointEntityDefinition("some_name", Color(), vm::bbox3(32.0), "", {}, {});
+    Assets::PointEntityDefinition("some_name", Color(), vm::bbox3(32.0), "", {}, {}, {});
   Entity entity;
 
   SECTION("Returns default bounds if no definition is set")
@@ -150,7 +152,8 @@ TEST_CASE("EntityTest.setDefinition")
       vm::bbox3(32.0),
       "",
       {},
-      Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}}};
+      Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}},
+      {}};
 
     auto entity = Entity{};
     REQUIRE(entity.modelTransformation() == vm::mat4x4::identity());
@@ -174,7 +177,8 @@ TEST_CASE("EntityTest.modelSpecification")
     vm::bbox3(32.0),
     "",
     {},
-    Assets::ModelDefinition{modelExpression}};
+    Assets::ModelDefinition{modelExpression},
+    {}};
 
   auto entity = Entity{};
   entity.setDefinition({}, &definition);
@@ -186,6 +190,27 @@ TEST_CASE("EntityTest.modelSpecification")
     entity.modelSpecification() == Assets::ModelSpecification{"maps/b_shell1.bsp", 0, 0});
 }
 
+TEST_CASE("EntityTest.decalSpecification")
+{
+  auto decalExpression = IO::ELParser::parseStrict(R"({ texture: texture })");
+
+  auto definition = Assets::PointEntityDefinition{
+    "some_name",
+    Color(),
+    vm::bbox3(32.0),
+    "",
+    {},
+    {},
+    Assets::DecalDefinition{decalExpression}};
+
+  auto entity = Entity{};
+  entity.setDefinition({}, &definition);
+  CHECK(entity.decalSpecification() == Assets::DecalSpecification{""});
+
+  entity.addOrUpdateProperty({}, "texture", "decal1");
+  CHECK(entity.decalSpecification() == Assets::DecalSpecification{"decal1"});
+}
+
 TEST_CASE("EntityTest.unsetEntityDefinitionAndModel")
 {
   auto config = EntityPropertyConfig{{{EL::LiteralExpression{EL::Value{2.0}}, 0, 0}}};
@@ -195,7 +220,8 @@ TEST_CASE("EntityTest.unsetEntityDefinitionAndModel")
     vm::bbox3(32.0),
     "",
     {},
-    Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}}};
+    Assets::ModelDefinition{{EL::MapExpression{{}}, 0, 0}},
+    {}};
 
   auto entity = Entity{};
   entity.setDefinition(config, &definition);
@@ -210,7 +236,7 @@ TEST_CASE("EntityTest.addOrUpdateProperty")
 {
   // needs to be created here so that it is destroyed last
   auto definition =
-    Assets::PointEntityDefinition{"some_name", Color{}, vm::bbox3{32.0}, "", {}, {}};
+    Assets::PointEntityDefinition{"some_name", Color{}, vm::bbox3{32.0}, "", {}, {}, {}};
 
   Entity entity;
   REQUIRE(entity.property("test") == nullptr);
@@ -258,7 +284,8 @@ TEST_CASE("EntityTest.renameProperty")
     Assets::ModelDefinition{
       {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
        0,
-       0}}};
+       0}},
+    {}};
 
   Entity entity;
 
@@ -326,7 +353,8 @@ TEST_CASE("EntityTest.removeProperty")
     Assets::ModelDefinition{
       {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
        0,
-       0}}};
+       0}},
+    {}};
 
   Entity entity;
 
@@ -528,7 +556,8 @@ TEST_CASE("EntityTest.setOrigin")
     Assets::ModelDefinition{
       {EL::MapExpression{{{"scale", {EL::VariableExpression{"modelscale"}, 0, 0}}}},
        0,
-       0}}};
+       0}},
+    {}};
 
   Entity entity;
   REQUIRE(entity.origin() == vm::vec3::zero());
@@ -566,9 +595,9 @@ TEST_CASE("EntityTest.transform")
 {
   // need to be created here so that they are destroyed last
   auto definition = Assets::PointEntityDefinition(
-    "some_name", Color(), vm::bbox3(16.0).translate(vm::vec3(16, 16, 0)), "", {}, {});
+    "some_name", Color(), vm::bbox3(16.0).translate(vm::vec3(16, 16, 0)), "", {}, {}, {});
   auto otherDefinition =
-    Assets::PointEntityDefinition{"some_class", Color{}, vm::bbox3{32.0}, "", {}, {}};
+    Assets::PointEntityDefinition{"some_class", Color{}, vm::bbox3{32.0}, "", {}, {}, {}};
 
   Entity entity;
   REQUIRE(entity.rotation() == vm::mat4x4::identity());

--- a/common/test/src/Model/tst_EntityNode.cpp
+++ b/common/test/src/Model/tst_EntityNode.cpp
@@ -138,6 +138,7 @@ TEST_CASE("EntityNodeTest.area")
     vm::bbox3(vm::vec3::zero(), vm::vec3(1.0, 2.0, 3.0)),
     "",
     {},
+    {},
     {});
   auto entityNode = EntityNode{Entity{}};
   entityNode.setDefinition(&definition);

--- a/common/test/src/Model/tst_EntityRegression.cpp
+++ b/common/test/src/Model/tst_EntityRegression.cpp
@@ -56,7 +56,8 @@ TEST_CASE("EntityTest.modelScaleExpressionThrows")
     vm::bbox3{32.0},
     "",
     {},
-    Assets::ModelDefinition{modelExpression}};
+    Assets::ModelDefinition{modelExpression},
+    {}};
   const auto propertyConfig = EntityPropertyConfig{};
 
   auto entity = Entity{};

--- a/common/test/src/Model/tst_EntityRotation.cpp
+++ b/common/test/src/Model/tst_EntityRotation.cpp
@@ -66,7 +66,8 @@ std::unique_ptr<Assets::EntityDefinition> createEntityDefinition(
       info->bounds,
       "",
       info->propertyDefinitions,
-      Assets::ModelDefinition{});
+      Assets::ModelDefinition{},
+      Assets::DecalDefinition{});
   case Assets::EntityDefinitionType::BrushEntity:
     return std::make_unique<Assets::BrushEntityDefinition>(
       "", Color{}, "", info->propertyDefinitions);

--- a/common/test/src/View/tst_MapDocument.cpp
+++ b/common/test/src/View/tst_MapDocument.cpp
@@ -71,7 +71,7 @@ void MapDocumentTest::SetUp()
 
   // create two entity definitions
   m_pointEntityDef = new Assets::PointEntityDefinition(
-    "point_entity", Color(), vm::bbox3(16.0), "this is a point entity", {}, {});
+    "point_entity", Color(), vm::bbox3(16.0), "this is a point entity", {}, {}, {});
   m_brushEntityDef = new Assets::BrushEntityDefinition(
     "brush_entity", Color(), "this is a brush entity", {});
 
@@ -509,6 +509,7 @@ TEST_CASE_METHOD(MapDocumentTest, "createPointEntity")
         std::make_shared<Assets::StringPropertyDefinition>(
           "some_default_prop", "", "", !true(readOnly), "value"),
       },
+      {},
       {}};
     document->setEntityDefinitions({definitionWithDefaults});
 
@@ -616,6 +617,7 @@ TEST_CASE_METHOD(MapDocumentTest, "resetDefaultProperties")
       std::make_shared<Assets::StringPropertyDefinition>(
         "default_prop_b", "", "", !true(readOnly), "default_value_b"),
     },
+    {},
     {}};
   document->setEntityDefinitions({definitionWithDefaults});
 

--- a/common/test/src/View/tst_SetEntityProperties.cpp
+++ b/common/test/src/View/tst_SetEntityProperties.cpp
@@ -46,10 +46,10 @@ TEST_CASE_METHOD(ValveMapDocumentTest, "SetEntityPropertiesTest.changeClassname"
   // need to recreate these because document->setEntityDefinitions will delete the old
   // ones
   m_pointEntityDef = new Assets::PointEntityDefinition(
-    "point_entity", Color(), vm::bbox3(16.0), "this is a point entity", {}, {});
+    "point_entity", Color(), vm::bbox3(16.0), "this is a point entity", {}, {}, {});
 
   Assets::PointEntityDefinition* largeEntityDef = new Assets::PointEntityDefinition(
-    "large_entity", Color(), vm::bbox3(64.0), "this is a point entity", {}, {});
+    "large_entity", Color(), vm::bbox3(64.0), "this is a point entity", {}, {}, {});
   document->setEntityDefinitions(
     std::vector<Assets::EntityDefinition*>{m_pointEntityDef, largeEntityDef});
 

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -455,8 +455,8 @@ TEST_CASE("PreferencesTest.testWxViewShortcutsAndMenuShortcutsRecognized")
 
 TEST_CASE("PreferencesTest.testWxEntityShortcuts")
 {
-  auto hellKnight = Assets::PointEntityDefinition{
-    "monster_hell_knight", {0, 0, 0}, {}, "", {}, Assets::ModelDefinition{}};
+  auto hellKnight =
+    Assets::PointEntityDefinition{"monster_hell_knight", {0, 0, 0}, {}, "", {}, {}, {}};
   const auto defs = std::vector<Assets::EntityDefinition*>{&hellKnight};
 
   const auto actions =

--- a/lib/vecmath/test/src/tst_intersection.cpp
+++ b/lib/vecmath/test/src/tst_intersection.cpp
@@ -460,4 +460,32 @@ TEST_CASE("intersection.polygon_clip_by_plane")
       });
   }
 }
+
+TEST_CASE("intersection.intersect_bbox_polygon")
+{
+  constexpr auto poly = square();
+
+  constexpr auto bbox1 = bbox3d{{-10, -10, -10}, {-5, -5, -5}};
+
+  constexpr auto bbox2 = bbox3d{{-1.1, -1.1, -1}, {-0.9, -0.9, 1}};
+  constexpr auto bbox3 = bbox3d{{0, 0, 0}, {2, 2, 2}};
+  constexpr auto bbox4 = bbox3d{{0.9, -0.1, -1}, {1.1, 0.1, 1}};
+
+  SECTION("no intersection")
+  {
+    CHECK_FALSE(intersect_bbox_polygon(bbox1, std::begin(poly), std::end(poly)));
+  }
+
+  SECTION("intersection")
+  {
+    // polygon point inside bbox
+    CHECK(intersect_bbox_polygon(bbox2, std::begin(poly), std::end(poly)));
+
+    // bbox edge intersects polygon
+    CHECK(intersect_bbox_polygon(bbox3, std::begin(poly), std::end(poly)));
+
+    // polygon edge intersects bbox
+    CHECK(intersect_bbox_polygon(bbox4, std::begin(poly), std::end(poly)));
+  }
+}
 } // namespace vm


### PR DESCRIPTION
Creating this PR as draft for now, I haven't created any tests for the new vecmath methods yet, plus I think their implementations are somewhat brute-force and might need some revisions. Just wanting to get some feedback on the general approach and so on.

Resolves #4303

example map file to test with:

```
// Game: Half-Life
// Format: Valve
// entity 0
{
"mapversion" "220"
"classname" "worldspawn"
"wad" "F:\Steam\steamapps\common\Half-Life\valve\decals.wad"
// brush 0
{
( -40 -72 -16 ) ( -40 -71 -16 ) ( -40 -72 -15 ) __TB_empty [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
( -48 -72 -16 ) ( -48 -72 -15 ) ( -47 -72 -16 ) __TB_empty [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( -48 -72 -16 ) ( -47 -72 -16 ) ( -48 -71 -16 ) __TB_empty [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 80 56 16 ) ( 80 57 16 ) ( 81 56 16 ) REFLECT1 [ 1 0 0 -16 ] [ 0 -1 0 -8 ] 0 1 1
( 80 56 16 ) ( 81 56 16 ) ( 80 56 17 ) __TB_empty [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( 44 56 16 ) ( 44 56 17 ) ( 44 57 16 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
}
}
// entity 1
{
"classname" "infodecal"
"spawnflags" "0"
"origin" "0 -16 16"
"texture" "{target2"
}
```

What it should look like:
![image](https://github.com/TrenchBroom/TrenchBroom/assets/3071180/8d71936b-6cc7-4366-9284-a5001165e94d)
