### PR TITLE
Primitive tool (take 2).

### DIFF
--- a/app/resources/graphics/images/PrimitiveBrushTool.svg
+++ b/app/resources/graphics/images/PrimitiveBrushTool.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24.000001 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   sodipodi:docname="PrimitiveBrushTool.svg"
+   inkscape:export-filename="/media/psf/Home/Documents/Code/TrenchBroom_qt/app/resources/graphics/images/BrushTool.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-20.000001 : 28 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="44.000002 : 28 : 1"
+       inkscape:persp3d-origin="12.000001 : 8 : 1"
+       id="perspective4155" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="19.666407"
+     inkscape:cy="4.2426407"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     showguides="false"
+     inkscape:snap-grids="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="false"
+     inkscape:bbox-paths="true"
+     objecttolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4272"
+       empspacing="4"
+       originx="-0.50000002"
+       originy="-0.5"
+       dotted="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1028.3623)">
+    <path
+       style="fill:#7f7f7f;fill-opacity:0.247059;stroke:#ff7f01;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.5,1031.8623 4,2 v 13 l -4,2 h -5 l -4,-2.5 v -12.5 l 4,-2 z"
+       id="rect826"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:none;fill-opacity:0.247059;stroke:#ff7f01;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.5,1035.8623 -4,2 h -5 l -4,-2 m 9,13 v -11 m -5,11 v -11"
+       id="rect826-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/app/resources/graphics/images/RadiusModeEdge.svg
+++ b/app/resources/graphics/images/RadiusModeEdge.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24.000001 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   sodipodi:docname="RadiusModeEdge.svg"
+   inkscape:export-filename="/media/psf/Home/Documents/Code/TrenchBroom_qt/app/resources/graphics/images/BrushTool.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-20.000001 : 28 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="44.000002 : 28 : 1"
+       inkscape:persp3d-origin="12.000001 : 8 : 1"
+       id="perspective4155" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="15.666834"
+     inkscape:cy="13.125669"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     showguides="false"
+     inkscape:snap-grids="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="false"
+     inkscape:bbox-paths="true"
+     objecttolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4272"
+       empspacing="4"
+       originx="-0.50000002"
+       originy="-0.5"
+       dotted="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="border">
+    <rect
+       style="fill:none;stroke:#a00000;stroke-width:1.01504;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect2416"
+       width="17"
+       height="17"
+       x="3.5"
+       y="3.5" />
+  </g>
+  <g
+     inkscape:label="shape"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1028.3623)"
+     style="display:inline">
+    <path
+       style="fill:#7f7f7f;fill-opacity:0.247059;stroke:#ff7f01;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.5,1031.8623 5,5 v 7 l -5,5 h -7 l -5,-5 v -7 l 5,-5 z"
+       id="rect826"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+</svg>

--- a/app/resources/graphics/images/RadiusModeVertex.svg
+++ b/app/resources/graphics/images/RadiusModeVertex.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24.000001 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   sodipodi:docname="RadiusModeVertex.svg"
+   inkscape:export-filename="/media/psf/Home/Documents/Code/TrenchBroom_qt/app/resources/graphics/images/BrushTool.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-20.000001 : 28 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="44.000002 : 28 : 1"
+       inkscape:persp3d-origin="12.000001 : 8 : 1"
+       id="perspective4155" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16.000001"
+     inkscape:cx="6.8437497"
+     inkscape:cy="6.6249997"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     showguides="false"
+     inkscape:snap-grids="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="false"
+     inkscape:bbox-paths="true"
+     objecttolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4272"
+       empspacing="4"
+       originx="-0.50000002"
+       originy="-0.5"
+       dotted="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="border">
+    <rect
+       style="fill:none;stroke:#a00000;stroke-width:1.01504;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect2416"
+       width="17"
+       height="17"
+       x="3.5"
+       y="3.5" />
+  </g>
+  <g
+     inkscape:label="shape"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1028.3623)"
+     style="display:inline">
+    <path
+       style="fill:#7f7f7f;fill-opacity:0.247059;stroke:#ff7f01;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18,1034.3623 2.5,6 -2.5,6 -6,2.5 -6,-2.5 -2.5,-6 2.5,-6 6,-2.5 z"
+       id="rect826"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+</svg>

--- a/app/resources/stylesheets/base.qss
+++ b/app/resources/stylesheets/base.qss
@@ -18,6 +18,14 @@ QToolButton#toolButton_borderless {
   border: none;
 }
 
+QToolButton#toolButton_borderOnCheck {
+  border: none;
+}
+
+QToolButton#toolButton_borderOnCheck:checked {
+  border: 1px solid black;
+}
+
 QToolButton#toolButton_borderless::menu-indicator {
  image: none;
 }

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -311,6 +311,9 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/CreateComplexBrushToolController3D.cpp
         ${COMMON_SOURCE_DIR}/View/CreateEntityTool.cpp
         ${COMMON_SOURCE_DIR}/View/CreateEntityToolController.cpp
+        ${COMMON_SOURCE_DIR}/View/CreatePrimitiveBrushTool.cpp
+        ${COMMON_SOURCE_DIR}/View/CreatePrimitiveBrushToolController3D.cpp
+        ${COMMON_SOURCE_DIR}/View/CreatePrimitiveBrushToolPage.cpp
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushTool.cpp
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController2D.cpp
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController3D.cpp
@@ -830,6 +833,9 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/CreateComplexBrushToolController3D.h
         ${COMMON_SOURCE_DIR}/View/CreateEntityTool.h
         ${COMMON_SOURCE_DIR}/View/CreateEntityToolController.h
+        ${COMMON_SOURCE_DIR}/View/CreatePrimitiveBrushTool.h
+        ${COMMON_SOURCE_DIR}/View/CreatePrimitiveBrushToolPage.h
+        ${COMMON_SOURCE_DIR}/View/CreatePrimitiveBrushToolController3D.h
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushTool.h
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController2D.h
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController3D.h

--- a/common/src/View/ActionContext.cpp
+++ b/common/src/View/ActionContext.cpp
@@ -108,6 +108,10 @@ std::string actionContextName(const ActionContext::Type actionContext)
     {
       actionContexts.emplace_back("brush tool");
     }
+    if (actionContext & ActionContext::CreatePrimitiveBrushTool)
+    {
+      actionContexts.emplace_back("primitive brush tool");
+    }
     if (actionContext & ActionContext::ClipTool)
     {
       actionContexts.emplace_back("clip tool");

--- a/common/src/View/ActionContext.h
+++ b/common/src/View/ActionContext.h
@@ -38,12 +38,13 @@ static const Type RotateTool = 1u << 5u;
 static const Type ScaleTool = 1u << 6u;
 static const Type ShearTool = 1u << 7u;
 static const Type AnyVertexTool = 1u << 8u;
-static const Type AnyTool =
-  AnyVertexTool | CreateComplexBrushTool | ClipTool | RotateTool | ScaleTool | ShearTool;
+static const Type CreatePrimitiveBrushTool = 1u << 9u;
+static const Type AnyTool = AnyVertexTool | CreateComplexBrushTool | ClipTool | RotateTool
+                            | ScaleTool | ShearTool | CreatePrimitiveBrushTool;
 static const Type AnyOrNoTool = AnyTool | NoTool;
-static const Type NoSelection = 1u << 9u;
-static const Type NodeSelection = 1u << 10u;
-static const Type FaceSelection = 1u << 11u;
+static const Type NoSelection = 1u << 10u;
+static const Type NodeSelection = 1u << 11u;
+static const Type FaceSelection = 1u << 12u;
 static const Type AnySelection = NodeSelection | FaceSelection;
 static const Type AnyOrNoSelection = AnySelection | NoSelection;
 static const Type Any = AnyView | AnyOrNoSelection | AnyOrNoTool;

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -439,6 +439,16 @@ void ActionManager::createViewActions()
       return context.hasDocument() && context.frame()->createComplexBrushToolActive();
     });
   createAction(
+    std::filesystem::path("Controls/Map view/Create primitive brush"),
+    QObject::tr("Create Primitive Brush"),
+    ActionContext::View3D | ActionContext::AnyOrNoSelection
+      | ActionContext::CreateComplexBrushTool,
+    QKeySequence(Qt::Key_Return),
+    [](ActionExecutionContext& context) { context.view()->createPrimitiveBrush(); },
+    [](ActionExecutionContext& context) {
+      return context.hasDocument() && context.frame()->createPrimitiveBrushToolActive();
+    });
+  createAction(
     std::filesystem::path{"Controls/Map view/Toggle clip side"},
     QObject::tr("Toggle Clip Side"),
     ActionContext::AnyView | ActionContext::AnyOrNoSelection | ActionContext::ClipTool,
@@ -1438,6 +1448,21 @@ void ActionManager::createEditMenu()
     },
     std::filesystem::path{"BrushTool.svg"}));
   toolMenu.addItem(createMenuAction(
+    std::filesystem::path("Menu/Edit/Tools/Primitive Brush Tool"),
+    QObject::tr("Primitive Brush Tool"),
+    Qt::Key_P,
+    [](ActionExecutionContext& context) {
+      context.frame()->toggleCreatePrimitiveBrushTool();
+    },
+    [](ActionExecutionContext& context) {
+      return context.hasDocument()
+             && context.frame()->canToggleCreatePrimitiveBrushTool();
+    },
+    [](ActionExecutionContext& context) {
+      return context.hasDocument() && context.frame()->createPrimitiveBrushToolActive();
+    },
+    std::filesystem::path{"PrimitiveBrushTool.svg"}));
+  toolMenu.addItem(createMenuAction(
     std::filesystem::path{"Menu/Edit/Tools/Clip Tool"},
     QObject::tr("Clip Tool"),
     Qt::Key_C,
@@ -2020,6 +2045,8 @@ void ActionManager::createToolbar()
   m_toolBar->addItem(
     existingAction(std::filesystem::path{"Controls/Map view/Deactivate current tool"}));
   m_toolBar->addItem(existingAction(std::filesystem::path{"Menu/Edit/Tools/Brush Tool"}));
+  m_toolBar->addItem(
+    existingAction(std::filesystem::path{"Menu/Edit/Tools/Primitive Brush Tool"}));
   m_toolBar->addItem(existingAction(std::filesystem::path{"Menu/Edit/Tools/Clip Tool"}));
   m_toolBar->addItem(
     existingAction(std::filesystem::path{"Menu/Edit/Tools/Vertex Tool"}));

--- a/common/src/View/CreatePrimitiveBrushTool.cpp
+++ b/common/src/View/CreatePrimitiveBrushTool.cpp
@@ -1,0 +1,141 @@
+/*
+ Copyright (C) 2010-2023 Kristian Duske, Nathan "jitspoe" Wulf
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CreatePrimitiveBrushTool.h"
+
+#include "CreatePrimitiveBrushToolPage.h"
+#include "Error.h"
+#include "Exceptions.h"
+#include "FloatType.h"
+#include "Model/Brush.h"
+#include "Model/BrushBuilder.h"
+#include "Model/BrushNode.h"
+#include "Model/Game.h"
+#include "Model/WorldNode.h"
+#include "View/Grid.h"
+#include "View/MapDocument.h"
+
+#include <kdl/memory_utils.h>
+#include <kdl/result.h>
+
+namespace TrenchBroom
+{
+namespace View
+{
+CreatePrimitiveBrushTool::CreatePrimitiveBrushTool(std::weak_ptr<MapDocument> document)
+  : CreateBrushToolBase(false, document)
+{
+}
+
+void CreatePrimitiveBrushTool::update(const vm::bbox3& bounds)
+{
+  auto document = kdl::mem_lock(m_document);
+  const auto game = document->game();
+  const Model::BrushBuilder builder(
+    document->world()->mapFormat(), document->worldBounds(), game->defaultFaceAttribs());
+
+  m_previousBounds = bounds;
+  std::vector<vm::vec3> positions;
+
+  vm::vec3 size;
+  vm::vec3 position = vm::vec3(0.0, 0.0, 0.0);
+
+  position = bounds.center();
+  size = bounds.max - bounds.min;
+  position[2] = bounds.min[2];
+
+  int numSides = m_primitiveBrushData.numSides;
+  int snapType = m_primitiveBrushData.snapType;
+  FloatType snap = 0.0;
+  if (snapType == PrimitiveBrushData::SNAP_TYPE_INTEGER)
+  {
+    snap = 1.0f;
+  }
+  else if (snapType == PrimitiveBrushData::SNAP_TYPE_GRID)
+  {
+    snap = document->grid().actualSize();
+  }
+
+  positions.reserve(((unsigned int)numSides) * 2);
+
+  // Create cylinder or cone verts
+  for (int i = 0; i < 2; ++i)
+  {
+    for (int j = 0; j < numSides; ++j)
+    {
+      vm::vec3 v;
+
+      // If it's a cone, we only need a single point, so create that and bail.
+      if (m_primitiveBrushData.shapeType == PrimitiveBrushData::SHAPE_TYPE_CONE && i == 1)
+      {
+        v = position;
+        v[2] += size[2];
+        positions.push_back(v);
+        break;
+      }
+
+      if (m_primitiveBrushData.radiusMode == PrimitiveBrushData::RADIUS_MODE_EDGE)
+      {
+        FloatType angle =
+          FloatType(j + 0.5) * vm::Cf::two_pi() / FloatType(numSides) - vm::Cf::half_pi();
+        FloatType a = vm::Cf::pi() / FloatType(numSides); // Half angle
+        FloatType ca = std::cos(a);
+        v[0] = std::cos(angle) * 0.5 * size[0] / ca;
+        v[1] = std::sin(angle) * 0.5 * size[1] / ca;
+      }
+      else
+      {
+        FloatType angle =
+          FloatType(j) * vm::Cf::two_pi() / FloatType(numSides) - vm::Cf::half_pi();
+        v[0] = std::cos(angle) * 0.5 * size[0];
+        v[1] = std::sin(angle) * 0.5 * size[1];
+      }
+
+      v[2] = i * size[2];
+      v = v + position;
+
+      if (snap > 0.0f)
+      {
+        v = round(v / snap) * snap;
+      }
+
+      positions.push_back(v);
+    }
+  }
+
+  builder.createBrush(positions, document->currentTextureName())
+    .transform([&](auto b) { updateBrush(new Model::BrushNode(std::move(b))); })
+    .transform_error([&](auto e) {
+      updateBrush(nullptr);
+      document->error() << "Could not update brush: " << e.msg;
+    });
+}
+
+void CreatePrimitiveBrushTool::update()
+{
+  update(m_previousBounds);
+}
+
+QWidget* CreatePrimitiveBrushTool::doCreatePage(QWidget* parent)
+{
+  return new CreatePrimitiveBrushToolPage(m_document, *this, parent);
+}
+
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/CreatePrimitiveBrushTool.h
+++ b/common/src/View/CreatePrimitiveBrushTool.h
@@ -1,0 +1,78 @@
+/*
+ Copyright (C) 2010-2023 Kristian Duske, Nathan "jitspoe" Wulf
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "FloatType.h"
+#include "View/CreateBrushToolBase.h"
+
+#include <vecmath/bbox.h>
+
+#include <memory>
+
+
+namespace TrenchBroom
+{
+namespace View
+{
+class MapDocument;
+
+struct PrimitiveBrushData
+{
+  enum SnapType
+  {
+    SNAP_TYPE_DISABLED = 0,
+    SNAP_TYPE_INTEGER = 1,
+    SNAP_TYPE_GRID = 2
+  };
+
+  enum ShapeType
+  {
+    SHAPE_TYPE_CYLINDER = 0,
+    SHAPE_TYPE_CONE = 1
+  };
+
+  enum RadiusMode
+  {
+    RADIUS_MODE_EDGE = 0,
+    RADIUS_MODE_VERTEX = 1
+  };
+
+  int numSides = 8;
+  SnapType snapType = SNAP_TYPE_INTEGER;
+  ShapeType shapeType = SHAPE_TYPE_CYLINDER;
+  RadiusMode radiusMode = RADIUS_MODE_EDGE;
+  bool uniformAspect = true;
+};
+
+class CreatePrimitiveBrushTool : public CreateBrushToolBase
+{
+public:
+  explicit CreatePrimitiveBrushTool(std::weak_ptr<MapDocument> document);
+  void update(const vm::bbox3& bounds);
+  void update();
+
+  PrimitiveBrushData m_primitiveBrushData;
+
+private:
+  vm::bbox3 m_previousBounds;
+  QWidget* doCreatePage(QWidget* parent) override;
+};
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/CreatePrimitiveBrushToolController3D.cpp
+++ b/common/src/View/CreatePrimitiveBrushToolController3D.cpp
@@ -1,0 +1,277 @@
+/*
+ Copyright (C) 2010-2023 Kristian Duske, Nathan "jitspoe" Wulf
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CreatePrimitiveBrushToolController3D.h"
+
+#include "FloatType.h"
+#include "Model/BrushFace.h"
+#include "Model/BrushNode.h"
+#include "Model/Hit.h"
+#include "Model/HitFilter.h"
+#include "Model/PickResult.h"
+#include "PreferenceManager.h"
+#include "Renderer/Camera.h"
+#include "View/CreatePrimitiveBrushTool.h"
+#include "View/Grid.h"
+#include "View/HandleDragTracker.h"
+#include "View/InputState.h"
+#include "View/MapDocument.h"
+
+#include <kdl/memory_utils.h>
+
+#include <vecmath/bbox.h>
+#include <vecmath/line.h>
+#include <vecmath/plane.h>
+#include <vecmath/vec.h>
+
+#include <cassert>
+
+namespace TrenchBroom
+{
+namespace View
+{
+CreatePrimitiveBrushToolController3D::CreatePrimitiveBrushToolController3D(
+  CreatePrimitiveBrushTool& tool, std::weak_ptr<MapDocument> document)
+  : m_tool{tool}
+  , m_document{document}
+{
+}
+
+Tool& CreatePrimitiveBrushToolController3D::tool()
+{
+  return m_tool;
+}
+
+const Tool& CreatePrimitiveBrushToolController3D::tool() const
+{
+  return m_tool;
+}
+
+namespace
+{
+class CreatePrimitiveBrushDragDelegate : public HandleDragTrackerDelegate
+{
+private:
+  CreatePrimitiveBrushTool& m_tool;
+  vm::bbox3 m_worldBounds;
+
+public:
+  CreatePrimitiveBrushDragDelegate(
+    CreatePrimitiveBrushTool& tool, const vm::bbox3& worldBounds)
+    : m_tool{tool}
+    , m_worldBounds{worldBounds}
+  {
+  }
+
+  HandlePositionProposer start(
+    const InputState& inputState,
+    const vm::vec3& initialHandlePosition,
+    const vm::vec3& handleOffset)
+  {
+    const auto currentBounds =
+      makeBounds(inputState, initialHandlePosition, initialHandlePosition);
+    m_tool.update(currentBounds);
+    m_tool.refreshViews();
+
+    return makeHandlePositionProposer(
+      makePlaneHandlePicker(vm::horizontal_plane(initialHandlePosition), handleOffset),
+      makeIdentityHandleSnapper());
+  }
+
+  std::optional<UpdateDragConfig> modifierKeyChange(
+    const InputState& inputState, const DragState& dragState)
+  {
+    if (inputState.modifierKeys() == ModifierKeys::MKAlt)
+    {
+      return UpdateDragConfig{
+        makeHandlePositionProposer(
+          makeLineHandlePicker(
+            vm::line3{dragState.currentHandlePosition, vm::vec3::pos_z()},
+            dragState.handleOffset),
+          makeIdentityHandleSnapper()),
+        ResetInitialHandlePosition::Keep};
+    }
+
+    return UpdateDragConfig{
+      makeHandlePositionProposer(
+        makePlaneHandlePicker(
+          vm::horizontal_plane(dragState.currentHandlePosition), dragState.handleOffset),
+        makeIdentityHandleSnapper()),
+      ResetInitialHandlePosition::Keep};
+  }
+
+  DragStatus drag(
+    const InputState& inputState,
+    const DragState& dragState,
+    const vm::vec3& proposedHandlePosition)
+  {
+    if (updateBounds(
+          inputState,
+          dragState.initialHandlePosition,
+          dragState.currentHandlePosition,
+          proposedHandlePosition))
+    {
+      m_tool.refreshViews();
+      return DragStatus::Continue;
+    }
+    return DragStatus::Deny;
+  }
+
+  void end(const InputState&, const DragState&) { m_tool.createBrush(); }
+
+  void cancel(const DragState&) { m_tool.cancel(); }
+
+  void render(
+    const InputState&,
+    const DragState&,
+    Renderer::RenderContext& renderContext,
+    Renderer::RenderBatch& renderBatch) const
+  {
+    m_tool.render(renderContext, renderBatch);
+  }
+
+private:
+  bool updateBounds(
+    const InputState& inputState,
+    const vm::vec3& initialHandlePosition,
+    const vm::vec3& lastHandlePosition,
+    const vm::vec3& currentHandlePosition)
+  {
+    const auto lastBounds =
+      makeBounds(inputState, initialHandlePosition, lastHandlePosition);
+    const auto currentBounds =
+      makeBounds(inputState, initialHandlePosition, currentHandlePosition);
+
+    if (currentBounds.is_empty() || currentBounds == lastBounds)
+    {
+      return false;
+    }
+
+    m_tool.update(currentBounds);
+    return true;
+  }
+
+  vm::bbox3 makeBounds(
+    const InputState& inputState,
+    const vm::vec3& initialHandlePosition,
+    const vm::vec3& currentHandlePosition) const
+  {
+    auto bounds = vm::bbox3{
+      vm::min(initialHandlePosition, currentHandlePosition),
+      vm::max(initialHandlePosition, currentHandlePosition)};
+    // prevent flickering due to very small rounding errors
+    bounds.min = vm::correct(bounds.min);
+    bounds.max = vm::correct(bounds.max);
+    const auto& grid = m_tool.grid();
+    bounds.min = grid.snapDown(bounds.min);
+    bounds.max = grid.snapUp(bounds.max);
+
+    // if uniform aspect is set, we need to make the width and height the same.
+    bool uniformAspect = m_tool.m_primitiveBrushData.uniformAspect;
+    if (inputState.checkModifierKey(MK_Yes, ModifierKeys::MKShift))
+    {
+      uniformAspect = !uniformAspect;
+    }
+    if (uniformAspect)
+    {
+      // TODO: Handle different axes, but for now, just match X and Y.
+      FloatType xDiff = bounds.max[0] - bounds.min[0];
+      FloatType yDiff = bounds.max[1] - bounds.min[1];
+      FloatType maxDiff = fmax(fabs(xDiff), fabs(yDiff));
+      vm::vec3 handleDiff = currentHandlePosition - initialHandlePosition;
+      if (handleDiff[0] >= 0)
+      {
+        bounds.max[0] = bounds.min[0] + maxDiff;
+      }
+      else
+      {
+        bounds.min[0] = bounds.max[0] - maxDiff;
+      }
+      if (handleDiff[1] >= 0)
+      {
+        bounds.max[1] = bounds.min[1] + maxDiff;
+      }
+      else
+      {
+        bounds.min[1] = bounds.max[1] - maxDiff;
+      }
+    }
+
+    const auto& camera = inputState.camera();
+    const auto cameraPosition = vm::vec3{camera.position()};
+
+    for (size_t i = 0; i < 3; i++)
+    {
+      if (bounds.max[i] <= bounds.min[i])
+      {
+        if (bounds.min[i] < cameraPosition[i])
+        {
+          bounds.max[i] = bounds.min[i] + grid.actualSize();
+        }
+        else
+        {
+          bounds.min[i] = bounds.max[i] - grid.actualSize();
+        }
+      }
+    }
+
+    return vm::intersect(bounds, m_worldBounds);
+  }
+};
+} // namespace
+
+std::unique_ptr<DragTracker> CreatePrimitiveBrushToolController3D::acceptMouseDrag(
+  const InputState& inputState)
+{
+  using namespace Model::HitFilters;
+
+  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  {
+    return nullptr;
+  }
+
+  if (!inputState.modifierKeysPressed(ModifierKeys::MKNone))
+  {
+    return nullptr;
+  }
+
+  auto document = kdl::mem_lock(m_document);
+
+  if (document->hasSelection())
+  {
+    document->deselectAll();
+  }
+
+  const auto& hit = inputState.pickResult().first(type(Model::BrushNode::BrushHitType));
+  const auto initialHandlePosition =
+    hit.isMatch() ? hit.hitPoint() : inputState.defaultPointUnderMouse();
+
+  return createHandleDragTracker(
+    CreatePrimitiveBrushDragDelegate{m_tool, document->worldBounds()},
+    inputState,
+    initialHandlePosition,
+    initialHandlePosition);
+}
+
+bool CreatePrimitiveBrushToolController3D::cancel()
+{
+  return false;
+}
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/CreatePrimitiveBrushToolController3D.h
+++ b/common/src/View/CreatePrimitiveBrushToolController3D.h
@@ -1,0 +1,58 @@
+/*
+ Copyright (C) 2010-2023 Kristian Duske, Nathan "jitspoe" Wulf
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "FloatType.h"
+#include "View/ToolController.h"
+
+#include <vecmath/vec.h>
+
+#include <memory>
+
+namespace TrenchBroom
+{
+namespace View
+{
+class CreatePrimitiveBrushTool;
+class DragTracker;
+class MapDocument;
+
+class CreatePrimitiveBrushToolController3D : public ToolController
+{
+private:
+  CreatePrimitiveBrushTool& m_tool;
+  std::weak_ptr<MapDocument> m_document;
+
+  vm::vec3 m_initialPoint;
+
+public:
+  CreatePrimitiveBrushToolController3D(
+    CreatePrimitiveBrushTool& tool, std::weak_ptr<MapDocument> document);
+
+private:
+  Tool& tool() override;
+  const Tool& tool() const override;
+
+  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+
+  bool cancel() override;
+};
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/CreatePrimitiveBrushToolPage.cpp
+++ b/common/src/View/CreatePrimitiveBrushToolPage.cpp
@@ -1,0 +1,168 @@
+/*
+ Copyright (C) 2010-2023 Kristian Duske, Nathan "jitspoe" Wulf
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CreatePrimitiveBrushToolPage.h"
+
+#include <QButtonGroup>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QToolButton>
+
+#include "CreatePrimitiveBrushTool.h"
+#include "View/MapDocument.h"
+#include "View/QtUtils.h"
+#include "View/ViewConstants.h"
+
+#include <kdl/memory_utils.h>
+
+#include <vecmath/vec.h>
+#include <vecmath/vec_io.h>
+
+namespace TrenchBroom
+{
+namespace View
+{
+CreatePrimitiveBrushToolPage::CreatePrimitiveBrushToolPage(
+  std::weak_ptr<MapDocument> document, CreatePrimitiveBrushTool& tool, QWidget* parent)
+  : QWidget(parent)
+  , m_document(document)
+  , m_tool(tool)
+{
+  createGui();
+  connectObservers();
+  updateGui();
+}
+
+void CreatePrimitiveBrushToolPage::connectObservers()
+{
+  auto document = kdl::mem_lock(m_document);
+  m_notifierConnection += document->selectionDidChangeNotifier.connect(
+    this, &CreatePrimitiveBrushToolPage::selectionDidChange);
+}
+
+void CreatePrimitiveBrushToolPage::createGui()
+{
+  QLabel* typeLabel = new QLabel(tr("Type: "));
+  QComboBox* typeComboBox = new QComboBox();
+  // NOTE: Make sure these 1:1 match TrenchBroom::View::PrimitiveBrushData::ShapeType
+  typeComboBox->addItem(tr("Cylinder"));
+  typeComboBox->addItem(tr("Cone"));
+  QLabel* numSidesLabel = new QLabel(tr("Number of Sides: "));
+  QSpinBox* numSidesBox = new QSpinBox();
+  numSidesBox->setRange(
+    3, 256); // set before connecting callbacks so values won't get overwritten
+  numSidesBox->setValue(m_tool.m_primitiveBrushData.numSides);
+  QLabel* snapLabel = new QLabel(tr("Snap: "));
+  QComboBox* snapComboBox = new QComboBox();
+  // NOTE: Make sure these 1:1 match TrenchBroom::View::PrimitiveBrushData::SnapType
+  snapComboBox->addItem(tr("Disabled"));
+  snapComboBox->addItem(tr("Integer"));
+  snapComboBox->addItem(tr("Grid"));
+  snapComboBox->setCurrentIndex(1);
+  QCheckBox* uniformAspectCheckbox = new QCheckBox(tr("Uniform Aspect"));
+  uniformAspectCheckbox->setChecked(m_tool.m_primitiveBrushData.uniformAspect);
+  QButtonGroup* radiusModeButtonGroup = new QButtonGroup();
+  QToolButton* radiusModeEdgeButton =
+    createBitmapToggleButton("RadiusModeEdge.svg", tr("Radius is to edge"));
+  radiusModeEdgeButton->setIconSize(QSize(24, 24));
+  QToolButton* radiusModeVertexButton =
+    createBitmapToggleButton("RadiusModeVertex.svg", tr("Radius is to vertex"));
+  radiusModeVertexButton->setIconSize(QSize(24, 24));
+  radiusModeEdgeButton->setObjectName(
+    "toolButton_borderOnCheck"); // Style sheet makes this have a border when checked,
+                                 // otherwise nothing.
+  radiusModeEdgeButton->setChecked(true);
+  radiusModeVertexButton->setObjectName("toolButton_borderOnCheck");
+  radiusModeButtonGroup->addButton(radiusModeEdgeButton);
+  radiusModeButtonGroup->addButton(radiusModeVertexButton);
+
+  connect(
+    numSidesBox,
+    QOverload<int>::of(&QSpinBox::valueChanged),
+    this,
+    [=](int numSidesValue) {
+      this->m_tool.m_primitiveBrushData.numSides = numSidesValue;
+      this->m_tool.update();
+    });
+  connect(
+    snapComboBox,
+    QOverload<int>::of(&QComboBox::currentIndexChanged),
+    this,
+    [=](int index) {
+      this->m_tool.m_primitiveBrushData.snapType = PrimitiveBrushData::SnapType(index);
+      this->m_tool.update();
+    });
+  connect(
+    typeComboBox,
+    QOverload<int>::of(&QComboBox::currentIndexChanged),
+    this,
+    [=](int index) {
+      this->m_tool.m_primitiveBrushData.shapeType = PrimitiveBrushData::ShapeType(index);
+      this->m_tool.update();
+    });
+  connect(uniformAspectCheckbox, &QCheckBox::toggled, this, [=](bool checked) {
+    this->m_tool.m_primitiveBrushData.uniformAspect = checked;
+    this->m_tool.update();
+  });
+  connect(radiusModeEdgeButton, &QToolButton::clicked, this, [=]() {
+    this->m_tool.m_primitiveBrushData.radiusMode = PrimitiveBrushData::RADIUS_MODE_EDGE;
+    this->m_tool.update();
+  });
+  connect(radiusModeVertexButton, &QToolButton::clicked, this, [=]() {
+    this->m_tool.m_primitiveBrushData.radiusMode = PrimitiveBrushData::RADIUS_MODE_VERTEX;
+    this->m_tool.update();
+  });
+
+  auto* layout = new QHBoxLayout();
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setSpacing(LayoutConstants::MediumHMargin);
+
+  layout->addWidget(typeLabel, 0, Qt::AlignVCenter);
+  layout->addWidget(typeComboBox, 0, Qt::AlignVCenter);
+  layout->addWidget(numSidesLabel, 0, Qt::AlignVCenter);
+  layout->addWidget(numSidesBox, 0, Qt::AlignVCenter);
+  layout->addWidget(uniformAspectCheckbox, 0, Qt::AlignVCenter);
+  layout->addWidget(snapLabel, 0, Qt::AlignVCenter);
+  layout->addWidget(snapComboBox, 0, Qt::AlignVCenter);
+  layout->addWidget(radiusModeEdgeButton, 0, Qt::AlignVCenter);
+  layout->addWidget(radiusModeVertexButton, 0, Qt::AlignVCenter);
+  layout->addStretch(1);
+
+  setLayout(layout);
+}
+
+void CreatePrimitiveBrushToolPage::updateGui()
+{
+  // NOTE: This gets called after creating a brush, so we can't consider this to only be
+  // called when selecting brushes manually.
+  auto document = kdl::mem_lock(m_document);
+}
+
+void CreatePrimitiveBrushToolPage::selectionDidChange(const Selection&)
+{
+  updateGui();
+}
+
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/CreatePrimitiveBrushToolPage.h
+++ b/common/src/View/CreatePrimitiveBrushToolPage.h
@@ -1,0 +1,62 @@
+/*
+ Copyright (C) 2010-2023 Kristian Duske, Nathan "jitspoe" Wulf
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QWidget>
+
+#include "NotifierConnection.h"
+
+#include <memory>
+
+class QAbstractButton;
+class QLineEdit;
+
+namespace TrenchBroom
+{
+namespace View
+{
+class MapDocument;
+class Selection;
+class CreatePrimitiveBrushTool;
+
+class CreatePrimitiveBrushToolPage : public QWidget
+{
+  Q_OBJECT
+private:
+  std::weak_ptr<MapDocument> m_document;
+  CreatePrimitiveBrushTool& m_tool;
+  NotifierConnection m_notifierConnection;
+
+public:
+  explicit CreatePrimitiveBrushToolPage(
+    std::weak_ptr<MapDocument> document,
+    CreatePrimitiveBrushTool& tool,
+    QWidget* parent = nullptr);
+
+private:
+  void connectObservers();
+
+  void createGui();
+  void updateGui();
+
+  void selectionDidChange(const Selection& selection);
+};
+} // namespace View
+} // namespace TrenchBroom

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1508,7 +1508,7 @@ void MapFrame::deleteSelection()
       m_mapView->edgeTool().removeSelection();
     else if (m_mapView->faceToolActive())
       m_mapView->faceTool().removeSelection();
-    else if (!m_mapView->anyToolActive())
+    else if (!m_mapView->anyToolActive() || m_mapView->toolAllowsObjectDeletion())
       m_document->deleteObjects();
   }
 }
@@ -1530,6 +1530,10 @@ bool MapFrame::canDeleteSelection() const
   else if (m_mapView->faceToolActive())
   {
     return m_mapView->faceTool().canRemoveSelection();
+  }
+  else if (m_mapView->createPrimitiveBrushToolActive())
+  {
+    return true;
   }
   else
   {
@@ -1736,6 +1740,24 @@ bool MapFrame::canToggleCreateComplexBrushTool() const
 bool MapFrame::createComplexBrushToolActive() const
 {
   return m_mapView->createComplexBrushToolActive();
+}
+
+void MapFrame::toggleCreatePrimitiveBrushTool()
+{
+  if (canToggleCreatePrimitiveBrushTool())
+  {
+    m_mapView->toggleCreatePrimitiveBrushTool();
+  }
+}
+
+bool MapFrame::canToggleCreatePrimitiveBrushTool() const
+{
+  return m_mapView->canToggleCreatePrimitiveBrushTool();
+}
+
+bool MapFrame::createPrimitiveBrushToolActive() const
+{
+  return m_mapView->createPrimitiveBrushToolActive();
 }
 
 void MapFrame::toggleClipTool()

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -79,6 +79,20 @@ class SignalDelayer;
 class SwitchableMapViewContainer;
 class Tool;
 
+struct PrimitiveData
+{
+  int primitiveType = 0;
+  int numSides = 8;
+  int radiusMode = 0;
+  int axis = 0;
+  float diameter = 64.0;
+  float height = 128.0;
+  bool snapToGrid = false;
+  bool snapToUnit = true;
+  bool useBrushBounds = true;
+  bool replaceSelectedBrush = true;
+};
+
 class MapFrame : public QMainWindow
 {
   Q_OBJECT
@@ -127,6 +141,9 @@ private:
   SignalDelayer* m_updateTitleSignalDelayer;
   SignalDelayer* m_updateActionStateSignalDelayer;
   SignalDelayer* m_updateStatusBarSignalDelayer;
+
+public: // For creating primitives (cylinders, etc)
+  PrimitiveData m_primitiveData;
 
 public:
   MapFrame(FrameManager* frameManager, std::shared_ptr<MapDocument> document);
@@ -285,6 +302,10 @@ public:
   void toggleCreateComplexBrushTool();
   bool canToggleCreateComplexBrushTool() const;
   bool createComplexBrushToolActive() const;
+
+  void toggleCreatePrimitiveBrushTool();
+  bool canToggleCreatePrimitiveBrushTool() const;
+  bool createPrimitiveBrushToolActive() const;
 
   void toggleClipTool();
   bool canToggleClipTool() const;

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -48,6 +48,7 @@
 #include "View/ClipToolController.h"
 #include "View/CreateComplexBrushToolController3D.h"
 #include "View/CreateEntityToolController.h"
+#include "View/CreatePrimitiveBrushToolController3D.h"
 #include "View/CreateSimpleBrushToolController3D.h"
 #include "View/EdgeTool.h"
 #include "View/EdgeToolController.h"
@@ -119,6 +120,8 @@ void MapView3D::initializeToolChain(MapViewToolBox& toolBox)
   addTool(std::make_unique<ExtrudeToolController3D>(toolBox.extrudeTool()));
   addTool(std::make_unique<CreateComplexBrushToolController3D>(
     toolBox.createComplexBrushTool()));
+  addTool(std::make_unique<CreatePrimitiveBrushToolController3D>(
+    toolBox.createPrimitiveBrushTool(), m_document));
   addTool(std::make_unique<ClipToolController3D>(toolBox.clipTool()));
   addTool(std::make_unique<VertexToolController>(toolBox.vertexTool()));
   addTool(std::make_unique<EdgeToolController>(toolBox.edgeTool()));

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -616,6 +616,14 @@ void MapViewBase::createComplexBrush()
   }
 }
 
+void MapViewBase::createPrimitiveBrush()
+{
+  if (m_toolBox.createPrimitiveBrushToolActive())
+  {
+    m_toolBox.performCreatePrimitiveBrush();
+  }
+}
+
 void MapViewBase::toggleClipSide()
 {
   m_toolBox.toggleClipSide();
@@ -940,13 +948,14 @@ ActionContext::Type MapViewBase::actionContext() const
 
   const auto derivedContext = doGetActionContext();
   const auto toolContext =
-    m_toolBox.createComplexBrushToolActive() ? ActionContext::CreateComplexBrushTool
-    : m_toolBox.clipToolActive()             ? ActionContext::ClipTool
-    : m_toolBox.anyVertexToolActive()        ? ActionContext::AnyVertexTool
-    : m_toolBox.rotateObjectsToolActive()    ? ActionContext::RotateTool
-    : m_toolBox.scaleObjectsToolActive()     ? ActionContext::ScaleTool
-    : m_toolBox.shearObjectsToolActive()     ? ActionContext::ShearTool
-                                             : ActionContext::NoTool;
+    m_toolBox.createComplexBrushToolActive()     ? ActionContext::CreateComplexBrushTool
+    : m_toolBox.createPrimitiveBrushToolActive() ? ActionContext::CreatePrimitiveBrushTool
+    : m_toolBox.clipToolActive()                 ? ActionContext::ClipTool
+    : m_toolBox.anyVertexToolActive()            ? ActionContext::AnyVertexTool
+    : m_toolBox.rotateObjectsToolActive()        ? ActionContext::RotateTool
+    : m_toolBox.scaleObjectsToolActive()         ? ActionContext::ScaleTool
+    : m_toolBox.shearObjectsToolActive()         ? ActionContext::ShearTool
+                                                 : ActionContext::NoTool;
   const auto selectionContext =
     document->hasSelectedNodes()        ? ActionContext::NodeSelection
     : document->hasSelectedBrushFaces() ? ActionContext::FaceSelection

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -210,7 +210,7 @@ public: // texture actions
 
 public: // tool mode actions
   void createComplexBrush();
-
+  void createPrimitiveBrush();
   void toggleClipSide();
   void performClip();
 

--- a/common/src/View/MapViewToolBox.cpp
+++ b/common/src/View/MapViewToolBox.cpp
@@ -23,6 +23,7 @@
 #include "View/ClipTool.h"
 #include "View/CreateComplexBrushTool.h"
 #include "View/CreateEntityTool.h"
+#include "View/CreatePrimitiveBrushTool.h"
 #include "View/CreateSimpleBrushTool.h"
 #include "View/EdgeTool.h"
 #include "View/ExtrudeTool.h"
@@ -56,6 +57,11 @@ ClipTool& MapViewToolBox::clipTool()
 CreateComplexBrushTool& MapViewToolBox::createComplexBrushTool()
 {
   return *m_createComplexBrushTool;
+}
+
+CreatePrimitiveBrushTool& MapViewToolBox::createPrimitiveBrushTool()
+{
+  return *m_createPrimitiveBrushTool;
 }
 
 CreateEntityTool& MapViewToolBox::createEntityTool()
@@ -121,6 +127,21 @@ bool MapViewToolBox::createComplexBrushToolActive() const
 void MapViewToolBox::performCreateComplexBrush()
 {
   m_createComplexBrushTool->createBrush();
+}
+
+void MapViewToolBox::toggleCreatePrimitiveBrushTool()
+{
+  toggleTool(createPrimitiveBrushTool());
+}
+
+bool MapViewToolBox::createPrimitiveBrushToolActive() const
+{
+  return m_createPrimitiveBrushTool->active();
+}
+
+void MapViewToolBox::performCreatePrimitiveBrush()
+{
+  m_createPrimitiveBrushTool->createBrush();
 }
 
 void MapViewToolBox::toggleClipTool()
@@ -251,6 +272,7 @@ void MapViewToolBox::createTools(
 {
   m_clipTool = std::make_unique<ClipTool>(document);
   m_createComplexBrushTool = std::make_unique<CreateComplexBrushTool>(document);
+  m_createPrimitiveBrushTool = std::make_unique<CreatePrimitiveBrushTool>(document);
   m_createEntityTool = std::make_unique<CreateEntityTool>(document);
   m_createSimpleBrushTool = std::make_unique<CreateSimpleBrushTool>(document);
   m_moveObjectsTool = std::make_unique<MoveObjectsTool>(document);
@@ -293,6 +315,7 @@ void MapViewToolBox::createTools(
   registerTool(shearObjectsTool(), bookCtrl);
   registerTool(extrudeTool(), bookCtrl);
   registerTool(createComplexBrushTool(), bookCtrl);
+  registerTool(createPrimitiveBrushTool(), bookCtrl);
   registerTool(clipTool(), bookCtrl);
   registerTool(vertexTool(), bookCtrl);
   registerTool(edgeTool(), bookCtrl);

--- a/common/src/View/MapViewToolBox.h
+++ b/common/src/View/MapViewToolBox.h
@@ -33,6 +33,7 @@ namespace View
 {
 class ClipTool;
 class CreateComplexBrushTool;
+class CreatePrimitiveBrushTool;
 class CreateEntityTool;
 class CreateSimpleBrushTool;
 class MoveObjectsTool;
@@ -52,6 +53,7 @@ private:
 
   std::unique_ptr<ClipTool> m_clipTool;
   std::unique_ptr<CreateComplexBrushTool> m_createComplexBrushTool;
+  std::unique_ptr<CreatePrimitiveBrushTool> m_createPrimitiveBrushTool;
   std::unique_ptr<CreateEntityTool> m_createEntityTool;
   std::unique_ptr<CreateSimpleBrushTool> m_createSimpleBrushTool;
   std::unique_ptr<MoveObjectsTool> m_moveObjectsTool;
@@ -72,6 +74,7 @@ public:
 public: // tools
   ClipTool& clipTool();
   CreateComplexBrushTool& createComplexBrushTool();
+  CreatePrimitiveBrushTool& createPrimitiveBrushTool();
   CreateEntityTool& createEntityTool();
   CreateSimpleBrushTool& createSimpleBrushTool();
   MoveObjectsTool& moveObjectsTool();
@@ -86,6 +89,10 @@ public: // tools
   void toggleCreateComplexBrushTool();
   bool createComplexBrushToolActive() const;
   void performCreateComplexBrush();
+
+  void toggleCreatePrimitiveBrushTool();
+  bool createPrimitiveBrushToolActive() const;
+  void performCreatePrimitiveBrush();
 
   void toggleClipTool();
   bool clipToolActive() const;

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -132,13 +132,19 @@ void SwitchableMapViewContainer::switchToMapView(const MapViewLayout viewId)
 
 bool SwitchableMapViewContainer::anyToolActive() const
 {
-  return createComplexBrushToolActive() || clipToolActive() || rotateObjectsToolActive()
-         || scaleObjectsToolActive() || shearObjectsToolActive() || anyVertexToolActive();
+  return createComplexBrushToolActive() || createPrimitiveBrushToolActive()
+         || clipToolActive() || rotateObjectsToolActive() || scaleObjectsToolActive()
+         || shearObjectsToolActive() || anyVertexToolActive();
 }
 
 void SwitchableMapViewContainer::deactivateTool()
 {
   m_toolBox->deactivateAllTools();
+}
+
+bool SwitchableMapViewContainer::toolAllowsObjectDeletion() const
+{
+  return createPrimitiveBrushToolActive();
 }
 
 bool SwitchableMapViewContainer::createComplexBrushToolActive() const
@@ -155,6 +161,22 @@ void SwitchableMapViewContainer::toggleCreateComplexBrushTool()
 {
   assert(canToggleCreateComplexBrushTool());
   m_toolBox->toggleCreateComplexBrushTool();
+}
+
+bool SwitchableMapViewContainer::createPrimitiveBrushToolActive() const
+{
+  return m_toolBox->createPrimitiveBrushToolActive();
+}
+
+bool SwitchableMapViewContainer::canToggleCreatePrimitiveBrushTool() const
+{
+  return true;
+}
+
+void SwitchableMapViewContainer::toggleCreatePrimitiveBrushTool()
+{
+  assert(canToggleCreatePrimitiveBrushTool());
+  m_toolBox->toggleCreatePrimitiveBrushTool();
 }
 
 bool SwitchableMapViewContainer::clipToolActive() const

--- a/common/src/View/SwitchableMapViewContainer.h
+++ b/common/src/View/SwitchableMapViewContainer.h
@@ -89,9 +89,15 @@ public:
   bool anyToolActive() const;
   void deactivateTool();
 
+  bool toolAllowsObjectDeletion() const;
+
   bool createComplexBrushToolActive() const;
   bool canToggleCreateComplexBrushTool() const;
   void toggleCreateComplexBrushTool();
+
+  bool createPrimitiveBrushToolActive() const;
+  bool canToggleCreatePrimitiveBrushTool() const;
+  void toggleCreatePrimitiveBrushTool();
 
   bool clipToolActive() const;
   bool canToggleClipTool() const;

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -394,6 +394,7 @@ TEST_CASE("PreferencesTest.testWxViewShortcutsAndMenuShortcutsRecognized")
     "Menu/Edit/Group",
     "Menu/Edit/Ungroup",
     "Menu/Edit/Tools/Brush Tool",
+    "Menu/Edit/Tools/Primitive Brush Tool",
     "Menu/Edit/Tools/Clip Tool",
     "Menu/Edit/Tools/Rotate Tool",
     "Menu/Edit/Tools/Scale Tool",


### PR DESCRIPTION
At the moment, it only creates cylinders and cones.  Also added the ability to delete brushes from within a tool (only used in primitive tool now, but could be useful in other cases).  Cleaner version of prior PR (no alternative way of creating primitives).  Also locks to a uniform aspect by default.  Can be toggled with a checkbox or by holding shift while dragging.

Addresses issue https://github.com/TrenchBroom/TrenchBroom/issues/398
Second pass at https://github.com/TrenchBroom/TrenchBroom/pull/4277