### PR TITLE
Fix minizip warning

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "assimp",
-      "version>=": "5.2.4"
+      "version>=": "5.3.1#2"
     },
     {
       "name": "catch2",


### PR DESCRIPTION
This fixes a configure warning by updating to the latest assimp package from upstream.