### PR TITLE
Add portable flag to store config in app directory

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2390,6 +2390,8 @@ Windows   `C:\Users\<username>\AppData\Roaming\TrenchBroom`
 macOS     `~/Library/Application Support/TrenchBroom`
 Linux     `~/.TrenchBroom`
 
+Running TrenchBroom with the `--portable` argument will instead put the `<UserDataPath>` in the current directory. This is intended to be run from within the `<ResourcePath>` directory to provide a fully self-contained instance of the application.  
+
 To add a new game configuration to TrenchBroom, place it into a folder under `<UserDataPath>/games` -- note that you might need to create that folder if it does not exist. You will need to write your own `GameConfig.cfg` file, or you can copy one of the builtin files and base your game configuration on that. Additionally, you can place additional resources in the folder you created. As an example, suppose you want to add a game configuration for a game called "Example". For this, you would create a new folder `<UserDataPath>/games/Example`, and within that folder, you would create a game configuration file called `GameConfig.cfg`. If you need additional resource such as an icon or entity definition files, you would place those files into this newly created folder as well.
 
 You can also access this directory using the folder icon button below the game list in the [game configuration dialog](#game_configuration).

--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -19,9 +19,11 @@
 
 #include <QApplication>
 #include <QSettings>
+#include <QString>
 #include <QSurfaceFormat>
 #include <QtGlobal>
 
+#include "IO/SystemPaths.h"
 #include "Model/GameFactory.h"
 #include "PreferenceManager.h"
 #include "TrenchBroomApp.h"
@@ -46,7 +48,6 @@ int main(int argc, char* argv[])
   // a context.) see: http://doc.qt.io/qt-5/qopenglwidget.html#context-sharing
   QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
   QSettings::setDefaultFormat(QSettings::IniFormat);
-
   // Set up Hi DPI scaling
   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -66,6 +67,20 @@ int main(int argc, char* argv[])
   // having Qt disable it (also we've had reports of some Intel drivers being blocked that
   // actually work with TB.)
   qputenv("QT_OPENGL_BUGLIST", ":/opengl_buglist.json");
+
+  // parse portable arg out manually at first to ensure it's set before any settings load
+  if (argc > 1)
+  {
+    for (int i = 1; i < argc; i++)
+    {
+      if (strcmp(argv[i], "--portable") == 0)
+      {
+        TrenchBroom::IO::SystemPaths::setPortable();
+        QSettings::setPath(
+          QSettings::IniFormat, QSettings::UserScope, QString("./config"));
+      }
+    }
+  }
 
   // PreferenceManager is destroyed by TrenchBroomApp::~TrenchBroomApp()
   TrenchBroom::PreferenceManager::createInstance<TrenchBroom::AppPreferenceManager>();

--- a/common/src/IO/SystemPaths.cpp
+++ b/common/src/IO/SystemPaths.cpp
@@ -33,10 +33,22 @@
 
 namespace TrenchBroom::IO::SystemPaths
 {
-bool isPortable = false;
+
+bool portableState = false;
+
+bool isPortable()
+{
+  return portableState;
+}
+
 void setPortable()
 {
-  isPortable = true;
+  setPortable(true);
+}
+
+void setPortable(bool newState)
+{
+  portableState = newState;
 }
 
 std::filesystem::path appDirectory()
@@ -46,7 +58,7 @@ std::filesystem::path appDirectory()
 
 std::filesystem::path userDataDirectory()
 {
-  if (isPortable)
+  if (isPortable())
   {
     return appDirectory() / "config";
   }

--- a/common/src/IO/SystemPaths.cpp
+++ b/common/src/IO/SystemPaths.cpp
@@ -33,6 +33,12 @@
 
 namespace TrenchBroom::IO::SystemPaths
 {
+bool isPortable = false;
+void setPortable()
+{
+  isPortable = true;
+}
+
 std::filesystem::path appDirectory()
 {
   return IO::pathFromQString(QCoreApplication::applicationDirPath());
@@ -40,6 +46,10 @@ std::filesystem::path appDirectory()
 
 std::filesystem::path userDataDirectory()
 {
+  if (isPortable)
+  {
+    return appDirectory() / "config";
+  }
 #if defined __linux__ || defined __FreeBSD__
   // Compatibility with wxWidgets
   return IO::pathFromQString(QDir::homePath()) / ".TrenchBroom";

--- a/common/src/IO/SystemPaths.h
+++ b/common/src/IO/SystemPaths.h
@@ -29,6 +29,7 @@ namespace TrenchBroom::IO::SystemPaths
  * .app bundle on macOS).
  */
 std::filesystem::path appDirectory();
+
 /**
  * Returns the directory where configs should be written
  * e.g. `C:\\Users\\<user>\\AppData\\Roaming\\TrenchBroom`
@@ -44,4 +45,7 @@ std::filesystem::path findResourceFile(const std::filesystem::path& file);
  */
 std::vector<std::filesystem::path> findResourceDirectories(
   const std::filesystem::path& directory);
+
+void setPortable();
+
 } // namespace TrenchBroom::IO::SystemPaths

--- a/common/src/IO/SystemPaths.h
+++ b/common/src/IO/SystemPaths.h
@@ -47,5 +47,6 @@ std::vector<std::filesystem::path> findResourceDirectories(
   const std::filesystem::path& directory);
 
 void setPortable();
-
+void setPortable(bool newState);
+bool isPortable();
 } // namespace TrenchBroom::IO::SystemPaths

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -215,6 +215,7 @@ TrenchBroomApp::~TrenchBroomApp()
 void TrenchBroomApp::parseCommandLineAndShowFrame()
 {
   auto parser = QCommandLineParser{};
+  parser.addOption(QCommandLineOption("portable"));
   parser.process(*this);
   openFilesOrWelcomeFrame(parser.positionalArguments());
 }

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -59,6 +59,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_ReadQuake3ShaderTexture.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_ReadWalTexture.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_ResourceUtils.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/IO/tst_SystemPaths.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_TestFileSystem.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_TextureUtils.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/tst_Tokenizer.cpp"

--- a/common/test/src/IO/tst_SystemPaths.cpp
+++ b/common/test/src/IO/tst_SystemPaths.cpp
@@ -1,0 +1,53 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "IO/SystemPaths.h"
+
+#include "Catch2.h"
+
+
+namespace TrenchBroom
+{
+namespace IO
+{
+TEST_CASE("Portable flag begins false")
+{
+  CHECK(SystemPaths::isPortable() == false);
+}
+
+TEST_CASE("Portable flag is changed by setPortable")
+{
+  CHECK(SystemPaths::isPortable() == false);
+  SystemPaths::setPortable();
+  CHECK(SystemPaths::isPortable() == true);
+  // cleanup
+  SystemPaths::setPortable(false);
+}
+
+TEST_CASE("userDataDirectory is changed by setPortable")
+{
+  auto initialDataDir = SystemPaths::userDataDirectory().string();
+  SystemPaths::setPortable();
+  CHECK(SystemPaths::userDataDirectory() != initialDataDir);
+  // cleanup
+  SystemPaths::setPortable(false);
+}
+} // namespace IO
+} // namespace TrenchBroom


### PR DESCRIPTION
Redirects the config files to the app directory when the `--portable` flag is passed at runtime.

This has been requested informally a couple of times in Discord - if there's a formal feature request issue I could not find it but I would be glad to link to it.

I took a very simple approach to make this work. If there's a more preferable way to handle bool for the portable state I would be glad to modify it.