### PR TITLE
Implement feature request  #4325 (split views horizontally)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -345,6 +345,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/FlyModeHelper.cpp
         ${COMMON_SOURCE_DIR}/View/FormWithSectionsLayout.cpp
         ${COMMON_SOURCE_DIR}/View/FourPaneMapView.cpp
+	${COMMON_SOURCE_DIR}/View/FourPaneAlternativeMapView.cpp
         ${COMMON_SOURCE_DIR}/View/FrameManager.cpp
         ${COMMON_SOURCE_DIR}/View/GameDialog.cpp
         ${COMMON_SOURCE_DIR}/View/GameEngineDialog.cpp
@@ -864,6 +865,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/FlyModeHelper.h
         ${COMMON_SOURCE_DIR}/View/FormWithSectionsLayout.h
         ${COMMON_SOURCE_DIR}/View/FourPaneMapView.h
+	${COMMON_SOURCE_DIR}/View/FourPaneAlternativeMapView.h
         ${COMMON_SOURCE_DIR}/View/FrameManager.h
         ${COMMON_SOURCE_DIR}/View/GameDialog.h
         ${COMMON_SOURCE_DIR}/View/GameEngineDialog.h

--- a/common/src/View/FourPaneAlternativeMapView.cpp
+++ b/common/src/View/FourPaneAlternativeMapView.cpp
@@ -1,0 +1,146 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "FourPaneAlternativeMapView.h"
+
+#include <QHBoxLayout>
+#include <QSettings>
+
+#include "View/Grid.h"
+#include "View/MapDocument.h"
+#include "View/MapView2D.h"
+#include "View/MapView3D.h"
+#include "View/QtUtils.h"
+#include "View/Splitter.h"
+
+namespace TrenchBroom::View
+{
+FourPaneAlternativeMapView::FourPaneAlternativeMapView(
+  bool verticalLayout,
+  std::weak_ptr<MapDocument> document,
+  MapViewToolBox& toolBox,
+  Renderer::MapRenderer& mapRenderer,
+  GLContextManager& contextManager,
+  Logger* logger,
+  QWidget* parent)
+  : MultiPaneMapView{parent}
+  , m_logger{logger}
+  , m_document{std::move(document)}
+{
+  createGui(verticalLayout, toolBox, mapRenderer, contextManager);
+}
+
+FourPaneAlternativeMapView::~FourPaneAlternativeMapView()
+{
+  saveWindowState(m_bigSplitter);
+  saveWindowState(m_smallSplitter);
+}
+
+void FourPaneAlternativeMapView::createGui(
+  bool verticalLayout,
+  MapViewToolBox& toolBox,
+  Renderer::MapRenderer& mapRenderer,
+  GLContextManager& contextManager)
+{
+  m_bigSplitter = new Splitter{};
+  m_bigSplitter->setObjectName("FourPaneAlternativeMapView_BigSplitter");
+
+  m_smallSplitter = new Splitter{};
+  m_smallSplitter->setObjectName("FourPaneAlternativeMapView_SmallSplitter");
+
+  m_mapView3D = new MapView3D{m_document, toolBox, mapRenderer, contextManager, m_logger};
+  m_mapViewXY = new MapView2D{
+    m_document, toolBox, mapRenderer, contextManager, MapView2D::ViewPlane_XY, m_logger};
+  m_mapViewXZ = new MapView2D{
+    m_document, toolBox, mapRenderer, contextManager, MapView2D::ViewPlane_XZ, m_logger};
+  m_mapViewYZ = new MapView2D{
+    m_document, toolBox, mapRenderer, contextManager, MapView2D::ViewPlane_YZ, m_logger};
+
+  m_mapView3D->linkCamera(m_linkHelper);
+  m_mapViewXY->linkCamera(m_linkHelper);
+  m_mapViewXZ->linkCamera(m_linkHelper);
+  m_mapViewYZ->linkCamera(m_linkHelper);
+
+  addMapView(m_mapView3D);
+  addMapView(m_mapViewXY);
+  addMapView(m_mapViewXZ);
+  addMapView(m_mapViewYZ);
+
+  // See comment in CyclingMapView::createGui
+  auto* layout = new QHBoxLayout{};
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setSpacing(0);
+  setLayout(layout);
+  layout->addWidget(m_bigSplitter);
+
+  // left and right columns
+  m_bigSplitter->addWidget(m_mapView3D);
+  m_bigSplitter->addWidget(m_smallSplitter);
+
+  // add children
+  m_smallSplitter->addWidget(m_mapViewXY);
+  m_smallSplitter->addWidget(m_mapViewXZ);
+  m_smallSplitter->addWidget(m_mapViewYZ);
+
+  // Configure minimum child sizes and initial splitter position at 50%
+  m_mapView3D->setMinimumSize(100, 100);
+  m_mapViewYZ->setMinimumSize(100, 100);
+  m_mapViewXY->setMinimumSize(100, 100);
+  m_mapViewXZ->setMinimumSize(100, 100);
+
+  m_bigSplitter->setSizes(QList<int>{1, 1});
+  m_smallSplitter->setSizes(QList<int>{1, 1, 1});
+
+  restoreWindowState(m_bigSplitter);
+  restoreWindowState(m_smallSplitter);
+
+  if (verticalLayout)
+  {
+    m_bigSplitter->setOrientation(Qt::Horizontal);
+    m_smallSplitter->setOrientation(Qt::Vertical);
+  }
+  else
+  {
+    m_bigSplitter->setOrientation(Qt::Vertical);
+    m_smallSplitter->setOrientation(Qt::Horizontal);
+  }
+}
+
+void FourPaneAlternativeMapView::doMaximizeView(MapView* view)
+{
+  assert(
+    view == m_mapView3D || view == m_mapViewXY || view == m_mapViewXZ
+    || view == m_mapViewYZ);
+
+  m_mapView3D->hide();
+  m_mapViewXY->hide();
+  m_mapViewXZ->hide();
+  m_mapViewYZ->hide();
+
+  dynamic_cast<MapViewBase*>(view)->show();
+}
+
+void FourPaneAlternativeMapView::doRestoreViews()
+{
+  m_mapView3D->show();
+  m_mapViewYZ->show();
+  m_mapViewXY->show();
+  m_mapViewXZ->show();
+}
+} // namespace TrenchBroom::View

--- a/common/src/View/FourPaneAlternativeMapView.h
+++ b/common/src/View/FourPaneAlternativeMapView.h
@@ -1,0 +1,83 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "View/MultiPaneMapView.h"
+
+#include <memory>
+
+class QSplitter;
+
+namespace TrenchBroom
+{
+class Logger;
+}
+
+namespace TrenchBroom::Renderer
+{
+class MapRenderer;
+}
+
+namespace TrenchBroom::View
+{
+class GLContextManager;
+class MapDocument;
+class MapView2D;
+class MapView3D;
+class MapViewToolBox;
+
+class FourPaneAlternativeMapView : public MultiPaneMapView
+{
+  Q_OBJECT
+private:
+  Logger* m_logger;
+  std::weak_ptr<MapDocument> m_document;
+
+  QSplitter* m_bigSplitter = nullptr;
+  QSplitter* m_smallSplitter = nullptr;
+
+  MapView3D* m_mapView3D = nullptr;
+  MapView2D* m_mapViewXY = nullptr;
+  MapView2D* m_mapViewXZ = nullptr;
+  MapView2D* m_mapViewYZ = nullptr;
+
+public:
+  FourPaneAlternativeMapView(
+    bool verticalLayout,
+    std::weak_ptr<MapDocument> document,
+    MapViewToolBox& toolBox,
+    Renderer::MapRenderer& mapRenderer,
+    GLContextManager& contextManager,
+    Logger* logger,
+    QWidget* parent = nullptr);
+  ~FourPaneAlternativeMapView() override;
+
+private:
+  void createGui(
+    bool verticalLayout,
+    MapViewToolBox& toolBox,
+    Renderer::MapRenderer& mapRenderer,
+    GLContextManager& contextManager);
+
+private: // implement MultiPaneMapView subclassing interface
+  void doMaximizeView(MapView* view) override;
+  void doRestoreViews() override;
+};
+} // namespace TrenchBroom::View

--- a/common/src/View/MapViewLayout.h
+++ b/common/src/View/MapViewLayout.h
@@ -28,9 +28,11 @@ enum class MapViewLayout
   OnePane,
   TwoPanesVertical,
   ThreePanesVertical,
-  FourPanes,
+  FourPanesGrid,
   TwoPanesHorizontal,
-  ThreePanesHorizontal
+  ThreePanesHorizontal,
+  FourPanesVertical,
+  FourPanesHorizontal,
 };
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/MapViewLayout.h
+++ b/common/src/View/MapViewLayout.h
@@ -26,9 +26,11 @@ namespace View
 enum class MapViewLayout
 {
   OnePane,
-  TwoPanes,
-  ThreePanes,
-  FourPanes
+  TwoPanesVertical,
+  ThreePanesVertical,
+  FourPanes,
+  TwoPanesHorizontal,
+  ThreePanesHorizontal
 };
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -26,6 +26,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/MapRenderer.h"
+#include "View/FourPaneAlternativeMapView.h"
 #include "View/FourPaneMapView.h"
 #include "View/GLContextManager.h"
 #include "View/Inspector.h"
@@ -118,9 +119,17 @@ void SwitchableMapViewContainer::switchToMapView(const MapViewLayout viewId)
     m_mapView = new ThreePaneMapView{
       false, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
     break;
-  case MapViewLayout::FourPanes:
+  case MapViewLayout::FourPanesGrid:
     m_mapView = new FourPaneMapView{
       m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
+    break;
+  case MapViewLayout::FourPanesVertical:
+    m_mapView = new FourPaneAlternativeMapView{
+      true, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
+    break;
+  case MapViewLayout::FourPanesHorizontal:
+    m_mapView = new FourPaneAlternativeMapView{
+      false, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
     break;
     switchDefault();
   }

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -102,13 +102,21 @@ void SwitchableMapViewContainer::switchToMapView(const MapViewLayout viewId)
     m_mapView = new OnePaneMapView{
       m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
     break;
-  case MapViewLayout::TwoPanes:
+  case MapViewLayout::TwoPanesVertical:
     m_mapView = new TwoPaneMapView{
-      m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
+      true, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
     break;
-  case MapViewLayout::ThreePanes:
+  case MapViewLayout::TwoPanesHorizontal:
+    m_mapView = new TwoPaneMapView{
+      false, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
+    break;
+  case MapViewLayout::ThreePanesVertical:
     m_mapView = new ThreePaneMapView{
-      m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
+      true, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
+    break;
+  case MapViewLayout::ThreePanesHorizontal:
+    m_mapView = new ThreePaneMapView{
+      false, m_document, *m_toolBox, *m_mapRenderer, m_contextManager, m_logger};
     break;
   case MapViewLayout::FourPanes:
     m_mapView = new FourPaneMapView{

--- a/common/src/View/ThreePaneMapView.h
+++ b/common/src/View/ThreePaneMapView.h
@@ -53,14 +53,15 @@ private:
   Logger* m_logger;
   std::weak_ptr<MapDocument> m_document;
 
-  QSplitter* m_hSplitter = nullptr;
-  QSplitter* m_vSplitter = nullptr;
+  QSplitter* m_bigSplitter = nullptr;
+  QSplitter* m_smallSplitter = nullptr;
   MapView3D* m_mapView3D = nullptr;
   MapView2D* m_mapViewXY = nullptr;
   CyclingMapView* m_mapViewZZ = nullptr;
 
 public:
   ThreePaneMapView(
+    bool verticalLayout,
     std::weak_ptr<MapDocument> document,
     MapViewToolBox& toolBox,
     Renderer::MapRenderer& mapRenderer,
@@ -71,6 +72,7 @@ public:
 
 private:
   void createGui(
+    bool verticalLayout,
     MapViewToolBox& toolBox,
     Renderer::MapRenderer& mapRenderer,
     GLContextManager& contextManager);

--- a/common/src/View/TwoPaneMapView.cpp
+++ b/common/src/View/TwoPaneMapView.cpp
@@ -31,6 +31,7 @@
 namespace TrenchBroom::View
 {
 TwoPaneMapView::TwoPaneMapView(
+  bool verticalLayout,
   std::weak_ptr<MapDocument> document,
   MapViewToolBox& toolBox,
   Renderer::MapRenderer& mapRenderer,
@@ -41,7 +42,7 @@ TwoPaneMapView::TwoPaneMapView(
   , m_logger{logger}
   , m_document(std::move(document))
 {
-  createGui(toolBox, mapRenderer, contextManager);
+  createGui(verticalLayout, toolBox, mapRenderer, contextManager);
 }
 
 TwoPaneMapView::~TwoPaneMapView()
@@ -50,6 +51,7 @@ TwoPaneMapView::~TwoPaneMapView()
 }
 
 void TwoPaneMapView::createGui(
+  bool verticalLayout,
   MapViewToolBox& toolBox,
   Renderer::MapRenderer& mapRenderer,
   GLContextManager& contextManager)
@@ -84,6 +86,8 @@ void TwoPaneMapView::createGui(
   m_splitter->setSizes(QList<int>{1, 1});
 
   restoreWindowState(m_splitter);
+
+  m_splitter->setOrientation(verticalLayout ? Qt::Horizontal : Qt::Vertical);
 }
 
 void TwoPaneMapView::doMaximizeView(MapView* view)

--- a/common/src/View/TwoPaneMapView.h
+++ b/common/src/View/TwoPaneMapView.h
@@ -56,6 +56,7 @@ private:
 
 public:
   TwoPaneMapView(
+    bool verticalLayout,
     std::weak_ptr<MapDocument> document,
     MapViewToolBox& toolBox,
     Renderer::MapRenderer& mapRenderer,
@@ -66,6 +67,7 @@ public:
 
 private:
   void createGui(
+    bool verticalLayout,
     MapViewToolBox& toolBox,
     Renderer::MapRenderer& mapRenderer,
     GLContextManager& contextManager);

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -30,6 +30,7 @@
 #include "Renderer/GL.h"
 #include "View/ColorButton.h"
 #include "View/FormWithSectionsLayout.h"
+#include "View/MapViewLayout.h"
 #include "View/QtUtils.h"
 #include "View/SliderWithLabel.h"
 #include "View/ViewConstants.h"
@@ -121,10 +122,12 @@ QWidget* ViewPreferencePane::createViewPreferences()
 
   m_layoutCombo = new QComboBox{};
   m_layoutCombo->setToolTip("Sets the layout of the editing views.");
-  m_layoutCombo->addItem("One Pane");
-  m_layoutCombo->addItem("Two Panes");
-  m_layoutCombo->addItem("Three Panes");
-  m_layoutCombo->addItem("Four Panes");
+  m_layoutCombo->addItem("One Pane", QVariant::fromValue(static_cast<int>(MapViewLayout::OnePane)));
+  m_layoutCombo->addItem("Two Panes (vertical)", QVariant::fromValue(static_cast<int>(MapViewLayout::TwoPanesVertical)));
+  m_layoutCombo->addItem("Two Panes (horizontal)", QVariant::fromValue(static_cast<int>(MapViewLayout::TwoPanesHorizontal)));
+  m_layoutCombo->addItem("Three Panes (vertical)", QVariant::fromValue(static_cast<int>(MapViewLayout::ThreePanesVertical)));
+  m_layoutCombo->addItem("Three Panes (horizontal)", QVariant::fromValue(static_cast<int>(MapViewLayout::ThreePanesHorizontal)));
+  m_layoutCombo->addItem("Four Panes", QVariant::fromValue(static_cast<int>(MapViewLayout::FourPanes)));
 
   m_link2dCameras = new QCheckBox{"Sync 2D views"};
   m_link2dCameras->setToolTip("All 2D views pan and zoom together.");
@@ -284,7 +287,7 @@ void ViewPreferencePane::doResetToDefaults()
 
 void ViewPreferencePane::doUpdateControls()
 {
-  m_layoutCombo->setCurrentIndex(pref(Preferences::MapViewLayout));
+  m_layoutCombo->setCurrentIndex(m_layoutCombo->findData(QVariant::fromValue(pref(Preferences::MapViewLayout))));
   m_link2dCameras->setChecked(pref(Preferences::Link2DCameras));
   m_brightnessSlider->setValue(brightnessToUI(pref(Preferences::Brightness)));
   m_gridAlphaSlider->setRatio(pref(Preferences::GridAlpha));
@@ -363,10 +366,10 @@ int ViewPreferencePane::findThemeIndex(const QString& theme)
 
 void ViewPreferencePane::layoutChanged(const int index)
 {
-  assert(index >= 0 && index < 4);
-
+  assert(index >= 0 && index < 6);
+  const auto value = m_layoutCombo->currentData().value<int>();
   auto& prefs = PreferenceManager::instance();
-  prefs.set(Preferences::MapViewLayout, index);
+  prefs.set(Preferences::MapViewLayout, value);
 }
 
 void ViewPreferencePane::link2dCamerasChanged(const int state)

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -122,12 +122,29 @@ QWidget* ViewPreferencePane::createViewPreferences()
 
   m_layoutCombo = new QComboBox{};
   m_layoutCombo->setToolTip("Sets the layout of the editing views.");
-  m_layoutCombo->addItem("One Pane", QVariant::fromValue(static_cast<int>(MapViewLayout::OnePane)));
-  m_layoutCombo->addItem("Two Panes (vertical)", QVariant::fromValue(static_cast<int>(MapViewLayout::TwoPanesVertical)));
-  m_layoutCombo->addItem("Two Panes (horizontal)", QVariant::fromValue(static_cast<int>(MapViewLayout::TwoPanesHorizontal)));
-  m_layoutCombo->addItem("Three Panes (vertical)", QVariant::fromValue(static_cast<int>(MapViewLayout::ThreePanesVertical)));
-  m_layoutCombo->addItem("Three Panes (horizontal)", QVariant::fromValue(static_cast<int>(MapViewLayout::ThreePanesHorizontal)));
-  m_layoutCombo->addItem("Four Panes", QVariant::fromValue(static_cast<int>(MapViewLayout::FourPanes)));
+  m_layoutCombo->addItem(
+    "One Pane", QVariant::fromValue(static_cast<int>(MapViewLayout::OnePane)));
+  m_layoutCombo->addItem(
+    "Two Panes (vertical)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::TwoPanesVertical)));
+  m_layoutCombo->addItem(
+    "Two Panes (horizontal)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::TwoPanesHorizontal)));
+  m_layoutCombo->addItem(
+    "Three Panes (vertical)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::ThreePanesVertical)));
+  m_layoutCombo->addItem(
+    "Three Panes (horizontal)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::ThreePanesHorizontal)));
+  m_layoutCombo->addItem(
+    "Four Panes (grid)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::FourPanesGrid)));
+  m_layoutCombo->addItem(
+    "Four Panes (vertical)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::FourPanesVertical)));
+  m_layoutCombo->addItem(
+    "Four Panes (horizontal)",
+    QVariant::fromValue(static_cast<int>(MapViewLayout::FourPanesHorizontal)));
 
   m_link2dCameras = new QCheckBox{"Sync 2D views"};
   m_link2dCameras->setToolTip("All 2D views pan and zoom together.");
@@ -287,7 +304,8 @@ void ViewPreferencePane::doResetToDefaults()
 
 void ViewPreferencePane::doUpdateControls()
 {
-  m_layoutCombo->setCurrentIndex(m_layoutCombo->findData(QVariant::fromValue(pref(Preferences::MapViewLayout))));
+  m_layoutCombo->setCurrentIndex(
+    m_layoutCombo->findData(QVariant::fromValue(pref(Preferences::MapViewLayout))));
   m_link2dCameras->setChecked(pref(Preferences::Link2DCameras));
   m_brightnessSlider->setValue(brightnessToUI(pref(Preferences::Brightness)));
   m_gridAlphaSlider->setRatio(pref(Preferences::GridAlpha));
@@ -364,10 +382,10 @@ int ViewPreferencePane::findThemeIndex(const QString& theme)
   return 0;
 }
 
-void ViewPreferencePane::layoutChanged(const int index)
+void ViewPreferencePane::layoutChanged([[maybe_unused]] const int index)
 {
-  assert(index >= 0 && index < 6);
   const auto value = m_layoutCombo->currentData().value<int>();
+  assert(value >= 0 && value < 8);
   auto& prefs = PreferenceManager::instance();
   prefs.set(Preferences::MapViewLayout, value);
 }

--- a/common/src/View/ViewPreferencePane.h
+++ b/common/src/View/ViewPreferencePane.h
@@ -32,7 +32,8 @@ class ViewPreferencePane : public PreferencePane
 {
   Q_OBJECT
 private:
-  QComboBox* m_layoutCombo = nullptr;
+  QComboBox* m_viewCountCombo = nullptr;
+  QComboBox* m_viewArrangementCombo = nullptr;
   QCheckBox* m_link2dCameras = nullptr;
   SliderWithLabel* m_brightnessSlider = nullptr;
   SliderWithLabel* m_gridAlphaSlider = nullptr;
@@ -58,6 +59,7 @@ private:
   void doUpdateControls() override;
   bool doValidate() override;
 
+  void updateViewCombos();
   size_t findTextureMode(int minFilter, int magFilter) const;
   int findThemeIndex(const QString& theme);
 private slots:


### PR DESCRIPTION
Straightforward implementation of #4325, allows putting 2D views all either on the right side or on the bottom.
I've put the new layout options all into the same combo box; maybe this is a bit cluttered but I think it should still be fine (the original options correspond to Two Panes (vertical), Three Panes (vertical), and Four Panes (grid)) :
![image](https://github.com/TrenchBroom/TrenchBroom/assets/81391208/0f10216d-6311-4d62-b6ff-7d73e49b472e)