### PR TITLE
4369: Introduce automatic dark mode (TrenchBroom Manual)

### DIFF
--- a/app/resources/documentation/manual/_reset.css
+++ b/app/resources/documentation/manual/_reset.css
@@ -1,17 +1,17 @@
 /* ##### Reset ########## */
 
 html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-size: 100%;
-    font: unset;
-    vertical-align: baseline;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: unset;
+  vertical-align: baseline;
+  box-sizing: border-box;
 }
 
 body {
-    line-height: 1;
+  line-height: 1;
 }
 
 ol, ul {
@@ -28,6 +28,6 @@ blockquote::before, blockquote::after, q::before, q::after {
 }
 
 table {
-    border-collapse: collapse;
-    border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }

--- a/app/resources/documentation/manual/_responsive.css
+++ b/app/resources/documentation/manual/_responsive.css
@@ -1,89 +1,95 @@
 /* ##### Responsive ########## */
 
-@media only screen and (max-width: 930px) {
-    /* Code, Figure and Table */
+@media only screen and (max-width: 1024px) {
+  /* Code, Figure and Table */
 
-    pre, figure, table {
-        max-width: max-content;
-        margin-left: auto;
-        margin-right: auto;
-    }
+  pre, figure, table {
+    max-width: max-content;
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-    /* List */
+  /* List */
 
-    dl dd {
-        margin-left: var(--spacing-x15000);
-    }
-    
-    ol, ul {
-        margin-left: var(--spacing-x15000);
-    }
+  dl dd {
+    margin-left: var(--spacing-x15000);
+  }
+  
+  ol, ul {
+    margin-left: var(--spacing-x15000);
+  }
 
-    /* Figure */
+  /* Figure */
 
-    figure {
-        display: block;
-    }
+  figure {
+    display: block;
+  }
 
-    /* Image */
+  /* Image */
 
-    p img {
-        display: block;
-        float: inherit;
-        margin: 0 auto var(--spacing-x10000);
-    }
+  p img {
+    display: block;
+    float: inherit;
+    margin: 0 auto var(--spacing-x10000);
+  }
 
-    /* Table of Contents & Content */
+  /* Table of Contents and Content */
 
-    body #toc, body #content {
-        margin-left: 50px;
-    }
+  body #toc_toggler, body #toc, body #content {
+    padding: var(--spacing-x10000);
+  }
 
-    /* Table of Contents */
+  /* Table of Contents & Content */
 
-    body #toc_toggler {
-        display: flex;
-    }
+  body #toc, body #content {
+    margin-left: 50px;
+  }
 
-    body #toc {
-        display: none;
-        min-width: calc(100vw - 50px);
-        max-width: calc(100vw - 50px);
-        right: 0;
-    }
+  /* Table of Contents */
 
-    body.toc_toggled #toc {
-        display: block;
-    }
+  body #toc_toggler {
+    display: flex;
+  }
 
-    /* Content Version */
+  body #toc {
+    display: none;
+    min-width: calc(100vw - 50px);
+    max-width: calc(100vw - 50px);
+    right: 0;
+  }
 
-    body #content_version #content_version_details img {
-        display: none;
-    }
+  body.toc_toggled #toc {
+    display: block;
+  }
 
-    body #content_version #content_version_details div, body #content_version #content_version_links {
-        align-items: center;
-    }
+  /* Content Version */
 
-    body #content_version {
-        flex-direction: column;
-    }
+  body #content_version #content_version_details img {
+    display: none;
+  }
 
-    body #content_version #content_version_links {
-        margin-top: var(--spacing-x05000);
-        margin-left: inherit;
-    }
+  body #content_version #content_version_details div, body #content_version #content_version_links {
+    align-items: center;
+  }
 
-    /* Table of Contents and Content */
+  body #content_version {
+    flex-direction: column;
+  }
 
-    body #toc_toggler, body #toc, body #content {
-        padding: var(--spacing-x10000);
-    }
+  body #content_version #content_version_links {
+    margin-top: var(--spacing-x05000);
+    margin-left: inherit;
+  }
 
-    /* Back to Top */
+  /* Content Body */
+  
+  body #content_body {
+    margin: 0;
+  }
 
-    body #content a[href="#"] {
-        display: none;
-    }
+  /* Back to Top */
+
+  body #content a[href="#"] {
+    display: none;
+  }
 }

--- a/app/resources/documentation/manual/_specific.css
+++ b/app/resources/documentation/manual/_specific.css
@@ -3,221 +3,221 @@
 /* All */
 
 * {
-    outline: none;
+  outline: none;
 }
 
 /* Code */
 
 pre {
-    max-width: max-content;
-    padding: var(--spacing-x10000);
-    margin-left: var(--spacing-x10000);
-    margin-right: var(--spacing-x10000);
-    line-height: var(--typography-line-height-tight);
-    overflow-x: auto;
-    overflow-y: hidden;
-    border: var(--border);
-    border-radius: var(--border-radius-25);
-    background-color: var(--color-gray-97);
+  max-width: max-content;
+  padding: var(--spacing-x10000);
+  margin-left: var(--spacing-x10000);
+  margin-right: var(--spacing-x10000);
+  line-height: var(--typography-line-height-tight);
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: var(--border);
+  border-radius: var(--border-radius-25);
+  background-color: var(--color-gray-97);
 }
 
 code {
-    font-family: var(--typography-font-family-code);
-    font-size: var(--typography-font-size-x07500);
-    word-break: break-word;
+  font-family: var(--typography-font-family-code);
+  font-size: var(--typography-font-size-x07500);
+  word-break: break-word;
 }
 
 /* Typography */
 
 h1, h2, h3, h4 {
-    font-weight: var(--typography-font-weight-bold);
+  font-weight: var(--typography-font-weight-bold);
 }
 
 h1 {
-    font-size: var(--typography-font-size-x20000);
+  font-size: var(--typography-font-size-x20000);
 }
 
 h2 {
-    font-size: var(--typography-font-size-x15000);
+  font-size: var(--typography-font-size-x15000);
 }
 
 h3, h4 {
-    font-size: var(--typography-font-size-x12500);
+  font-size: var(--typography-font-size-x12500);
 }
 
 p {
-    text-align: justify;
+  text-align: justify;
 }
 
 b, strong {
-    font-weight: var(--typography-font-weight-bold);
+  font-weight: var(--typography-font-weight-bold);
 }
 
 i, em {
-    font-style: italic;
+  font-style: italic;
 }
 
 /* List */
 
 dl dt {
-    font-weight: var(--typography-font-weight-bold);
+  font-weight: var(--typography-font-weight-bold);
 }
 
 dl dd {
-    margin-left: var(--spacing-x20000);
+  margin-left: var(--spacing-x20000);
 }
 
 ol, ul {
-    margin-left: var(--spacing-x20000);
+  margin-left: var(--spacing-x20000);
 }
 
 ol {
-    list-style-type: decimal;
+  list-style-type: decimal;
 }
 
 ul {
-    list-style-type: disc;
+  list-style-type: disc;
 }
 
 ul > li > ul:not(:first-child) {
-    margin-top: var(--spacing-x05000);
-    margin-bottom: var(--spacing-x05000);
+  margin-top: var(--spacing-x05000);
+  margin-bottom: var(--spacing-x05000);
 }
 
 ul > li > ul > li {
-    list-style-type: circle;
+  list-style-type: circle;
 }
 
 ul > li > ul > li > ul > li {
-    list-style-type: square;
+  list-style-type: square;
 }
 
 /* Link */
 
 a:link, a:visited {
-    text-decoration: none;
-    color: var(--color-azureradiance);
+  text-decoration: none;
+  color: var(--color-azureradiance);
 }
 
 a:hover, a:focus {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 /* Figure */
 
 figure {
-    display: inline-block;
-    margin-left: var(--spacing-x10000);
-    margin-right: var(--spacing-x10000);
-    border-radius: var(--border-radius-25);
-    background-color: var(--color-gray-97);
+  display: inline-block;
+  margin-left: var(--spacing-x10000);
+  margin-right: var(--spacing-x10000);
+  border-radius: var(--border-radius-25);
+  background-color: var(--color-gray-97);
 }
 
 figure figcaption {
-    padding: var(--spacing-x05000) 0;
-    font-size: var(--typography-font-size-x07500);
-    font-weight: var(--typography-font-weight-bold);
-    text-align: center;
-    color: var(--color-gray-20);
+  padding: var(--spacing-x05000) 0;
+  font-size: var(--typography-font-size-x07500);
+  font-weight: var(--typography-font-weight-bold);
+  text-align: center;
+  color: var(--color-gray-20);
 }
 
 /* Image */
 
 figure img {
-    display: block;
-    max-width: 100%;
-    margin: 0;
-    border-radius: var(--border-radius-25);
-    background-color: var(--color-gray-97);
+  display: block;
+  max-width: 100%;
+  margin: 0;
+  border-radius: var(--border-radius-25);
+  background-color: var(--color-gray-97);
 }
 
 p img {
-    float: left;
-    max-width: 100%;
-    margin: 0 var(--spacing-x10000) var(--spacing-x10000) 0;
+  float: left;
+  max-width: 100%;
+  margin: 0 var(--spacing-x10000) var(--spacing-x10000) 0;
 }
 
 /* Table */
 
 table {
-    display: block;
-    margin-left: var(--spacing-x10000);
-    margin-right: var(--spacing-x10000);
-    white-space: nowrap;
-    overflow-x: auto;
+  display: block;
+  margin-left: var(--spacing-x10000);
+  margin-right: var(--spacing-x10000);
+  white-space: nowrap;
+  overflow-x: auto;
 }
 
 table colgroup col {
-    width: unset !important;
+  width: unset !important;
 }
 
 table tr th, table tr td {
-    padding: var(--spacing-x05000);
-    vertical-align: middle;
-    border: var(--border);
+  padding: var(--spacing-x05000);
+  vertical-align: middle;
+  border: var(--border);
 }
 
 table thead tr th {
-    font-weight: var(--typography-font-weight-bold);
-    text-align: left;
+  font-weight: var(--typography-font-weight-bold);
+  text-align: left;
 }
 
 table tbody tr.odd {
-    background-color: var(--color-gray-97);
+  background-color: var(--color-gray-97);
 }
 
 /* Shortcut */
 
 .shortcut {
-    display: inline-block;
-    min-width: var(--sizing-x15000);
-    margin: 0 var(--spacing-x00625);
-    padding: var(--spacing-x00625) var(--spacing-x02500);
-    font-size: var(--typography-font-size-x07500);
-    font-family: var(--typography-font-family-base);
-    font-weight: var(--typography-font-weight-bold);
-    text-align: center;
-    border: var(--border);
-    border-radius: var(--border-radius-25);
-    background-color: var(--color-gray-97);
+  display: inline-block;
+  min-width: var(--sizing-x15000);
+  margin: 0 var(--spacing-x00625);
+  padding: var(--spacing-x00625) var(--spacing-x02500);
+  font-size: var(--typography-font-size-x07500);
+  font-family: var(--typography-font-family-base);
+  font-weight: var(--typography-font-weight-bold);
+  text-align: center;
+  border: var(--border);
+  border-radius: var(--border-radius-25);
+  background-color: var(--color-gray-97);
 }
 
-/* Line break */
+/* Line Break */
 
 br {
-    display: none;
+  display: none;
 }
 
 /* Space */
 
 h1, h2, h3, h4, img, ul, ol, dl, p, pre, table, figure {
-    margin-bottom: var(--spacing-x10000);
+  margin-bottom: var(--spacing-x10000);
 }
 
 /* Back to Top & Table of Contents anchors */
 
 .toc_toggler_button {
-    cursor: pointer;
-    border: none;
+  cursor: pointer;
+  border: none;
 }
 
 a[href="#"], .toc_toggler_button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: var(--sizing-x20000);
-    height: var(--sizing-x20000);
-    font-size: var(--typography-font-size-x12500);
-    text-decoration: none;
-    border-radius: 50%;
-    background-color: var(--color-gray-100);
-    color: var(--color-gray-20);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--sizing-x20000);
+  height: var(--sizing-x20000);
+  font-size: var(--typography-font-size-x12500);
+  text-decoration: none;
+  border-radius: 50%;
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-20);
 }
 
 a[href="#"]:hover, a[href="#"]:focus, .toc_toggler_button:hover, .toc_toggler_button:focus {
-    background-color: var(--color-gray-97);
+  background-color: var(--color-gray-97);
 }
 
 a[href="#"] span, .toc_toggler_button span {
-    line-height: var(--typography-line-height-reset);
+  line-height: var(--typography-line-height-reset);
 }

--- a/app/resources/documentation/manual/_specific.darkmode.css
+++ b/app/resources/documentation/manual/_specific.darkmode.css
@@ -10,7 +10,7 @@
     /* Link */
 
     a:link, a:visited {
-        color: var(--color-orange);
+        color: var(--color-maximumyellowred);
     }
 
     /* Figure */

--- a/app/resources/documentation/manual/_specific.darkmode.css
+++ b/app/resources/documentation/manual/_specific.darkmode.css
@@ -1,0 +1,54 @@
+/* ##### Specific ########## */
+
+@media (prefers-color-scheme: dark) {
+    /* Code */
+
+    pre {
+        background-color: var(--color-gray-15);
+    }
+
+    /* Link */
+
+    a:link, a:visited {
+        color: var(--color-orange);
+    }
+
+    /* Figure */
+
+    figure {
+        background-color: var(--color-gray-15);
+    }
+
+    figure figcaption {
+        color: var(--color-gray-90);
+    }
+
+    /* Image */
+
+    figure img {
+        background-color: var(--color-gray-15);
+    }
+
+    /* Table */
+
+    table tbody tr.odd {
+        background-color: var(--color-gray-15);
+    }
+
+    /* Shortcut */
+
+    .shortcut {
+        background-color: var(--color-gray-15);
+    }
+
+    /* Back to Top & Table of Contents anchors */
+
+    a[href="#"], .toc_toggler_button {
+        background-color: var(--color-gray-15);
+        color: var(--color-gray-90);
+    }
+
+    a[href="#"]:hover, a[href="#"]:focus, .toc_toggler_button:hover, .toc_toggler_button:focus {
+        background-color: var(--color-gray-20);
+    }
+}

--- a/app/resources/documentation/manual/_specific.darkmode.css
+++ b/app/resources/documentation/manual/_specific.darkmode.css
@@ -1,54 +1,54 @@
-/* ##### Specific ########## */
+/* ##### Specific: Dark Mode ########## */
 
 @media (prefers-color-scheme: dark) {
-    /* Code */
+  /* Code */
 
-    pre {
-        background-color: var(--color-gray-15);
-    }
+  pre {
+    background-color: var(--color-gray-15);
+  }
 
-    /* Link */
+  /* Link */
 
-    a:link, a:visited {
-        color: var(--color-maximumyellowred);
-    }
+  a:link, a:visited {
+    color: var(--color-maximumyellowred);
+  }
 
-    /* Figure */
+  /* Figure */
 
-    figure {
-        background-color: var(--color-gray-15);
-    }
+  figure {
+    background-color: var(--color-gray-15);
+  }
 
-    figure figcaption {
-        color: var(--color-gray-90);
-    }
+  figure figcaption {
+    color: var(--color-gray-90);
+  }
 
-    /* Image */
+  /* Image */
 
-    figure img {
-        background-color: var(--color-gray-15);
-    }
+  figure img {
+    background-color: var(--color-gray-15);
+  }
 
-    /* Table */
+  /* Table */
 
-    table tbody tr.odd {
-        background-color: var(--color-gray-15);
-    }
+  table tbody tr.odd {
+    background-color: var(--color-gray-15);
+  }
 
-    /* Shortcut */
+  /* Shortcut */
 
-    .shortcut {
-        background-color: var(--color-gray-15);
-    }
+  .shortcut {
+    background-color: var(--color-gray-15);
+  }
 
-    /* Back to Top & Table of Contents anchors */
+  /* Back to Top & Table of Contents anchors */
 
-    a[href="#"], .toc_toggler_button {
-        background-color: var(--color-gray-15);
-        color: var(--color-gray-90);
-    }
+  a[href="#"], .toc_toggler_button {
+    background-color: var(--color-gray-15);
+    color: var(--color-gray-90);
+  }
 
-    a[href="#"]:hover, a[href="#"]:focus, .toc_toggler_button:hover, .toc_toggler_button:focus {
-        background-color: var(--color-gray-20);
-    }
+  a[href="#"]:hover, a[href="#"]:focus, .toc_toggler_button:hover, .toc_toggler_button:focus {
+    background-color: var(--color-gray-20);
+  }
 }

--- a/app/resources/documentation/manual/_variables.css
+++ b/app/resources/documentation/manual/_variables.css
@@ -1,59 +1,60 @@
 /* ##### Variables ########## */
 
 :root {
-    /* Typography */
+  /* Typography */
 
-    --typography-font-family-base: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-    --typography-font-family-code: 'Lucida Console', Monaco, monospace;
-    --typography-font-size-x07500: calc(var(--typography-font-size-x10000) * 0.75);
-    --typography-font-size-x08750: calc(var(--typography-font-size-x10000) * 0.875);
-    --typography-font-size-x10000: 16px;
-    --typography-font-size-x12500: calc(var(--typography-font-size-x10000) * 1.25);
-    --typography-font-size-x15000: calc(var(--typography-font-size-x10000) * 1.5);
-    --typography-font-size-x20000: calc(var(--typography-font-size-x10000) * 2);
-    --typography-font-weight-regular: 400;
-    --typography-font-weight-bold: 700;
-    --typography-line-height-reset: 1;
-    --typography-line-height-tight: 1.2;
-    --typography-line-height-normal: 1.6;
+  --typography-font-family-base: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  --typography-font-family-code: 'Lucida Console', Monaco, monospace;
+  --typography-font-size-x07500: calc(var(--typography-font-size-x10000) * 0.75);
+  --typography-font-size-x08750: calc(var(--typography-font-size-x10000) * 0.875);
+  --typography-font-size-x10000: 16px;
+  --typography-font-size-x12500: calc(var(--typography-font-size-x10000) * 1.25);
+  --typography-font-size-x15000: calc(var(--typography-font-size-x10000) * 1.5);
+  --typography-font-size-x20000: calc(var(--typography-font-size-x10000) * 2);
+  --typography-font-weight-regular: 400;
+  --typography-font-weight-bold: 700;
+  --typography-line-height-reset: 1;
+  --typography-line-height-tight: 1.2;
+  --typography-line-height-normal: 1.6;
 
-    /* Colors */
+  /* Colors */
 
-    --color-gray-20: hsl(0, 0%, 20%);
-    --color-gray-40: hsl(0, 0%, 40%);
-    --color-gray-60: hsl(0, 0%, 60%);
-    --color-gray-80: hsl(0, 0%, 80%);
-    --color-gray-97: hsl(0, 0%, 97%);
-    --color-gray-100: hsl(0, 0%, 100%);
-    --color-azureradiance: hsl(210, 100%, 50%);
+  --color-gray-5: hsl(0, 0%, 5%);
+  --color-gray-20: hsl(0, 0%, 20%);
+  --color-gray-40: hsl(0, 0%, 40%);
+  --color-gray-60: hsl(0, 0%, 60%);
+  --color-gray-80: hsl(0, 0%, 80%);
+  --color-gray-97: hsl(0, 0%, 97%);
+  --color-gray-100: hsl(0, 0%, 100%);
+  --color-azureradiance: hsl(210, 100%, 50%);
 
-    /* Borders */
+  /* Borders */
 
-    --border: var(--sizing-x00625) solid var(--color-gray-80);
-    --border-radius-25: var(--sizing-x02500);
+  --border: var(--sizing-x00625) solid var(--color-gray-80);
+  --border-radius-25: var(--sizing-x02500);
 
-    /* Sizing */
+  /* Sizing */
 
-    --sizing-x00625: calc(var(--sizing-x10000) * 0.0625);
-    --sizing-x02500: calc(var(--sizing-x10000) * 0.25);
-    --sizing-x05000: calc(var(--sizing-x10000) * 0.5);
-    --sizing-x10000: 16px;
-    --sizing-x12500: calc(var(--sizing-x10000) * 1.25);
-    --sizing-x15000: calc(var(--sizing-x10000) * 1.5);
-    --sizing-x20000: calc(var(--sizing-x10000) * 2);
-    --sizing-x30000: calc(var(--sizing-x10000) * 3);
+  --sizing-x00625: calc(var(--sizing-x10000) * 0.0625);
+  --sizing-x02500: calc(var(--sizing-x10000) * 0.25);
+  --sizing-x05000: calc(var(--sizing-x10000) * 0.5);
+  --sizing-x10000: 16px;
+  --sizing-x12500: calc(var(--sizing-x10000) * 1.25);
+  --sizing-x15000: calc(var(--sizing-x10000) * 1.5);
+  --sizing-x20000: calc(var(--sizing-x10000) * 2);
+  --sizing-x30000: calc(var(--sizing-x10000) * 3);
 
-    /* Spacing */
+  /* Spacing */
 
-    --spacing-x00625: calc(var(--spacing-x10000) * 0.0625);
-    --spacing-x02500: calc(var(--spacing-x10000) * 0.25);
-    --spacing-x05000: calc(var(--spacing-x10000) * 0.5);
-    --spacing-x10000: 16px;
-    --spacing-x15000: calc(var(--spacing-x10000) * 1.5);
-    --spacing-x20000: calc(var(--spacing-x10000) * 2);
+  --spacing-x00625: calc(var(--spacing-x10000) * 0.0625);
+  --spacing-x02500: calc(var(--spacing-x10000) * 0.25);
+  --spacing-x05000: calc(var(--spacing-x10000) * 0.5);
+  --spacing-x10000: 16px;
+  --spacing-x15000: calc(var(--spacing-x10000) * 1.5);
+  --spacing-x20000: calc(var(--spacing-x10000) * 2);
 
-    /* Custom sizes */
+  /* Custom Sizes */
 
-    --toc-width: 340px;
-    --content-max-width: 1024px;
+  --toc-width: max-content;
+  --content-max-width: 1280px;
 }

--- a/app/resources/documentation/manual/_variables.css
+++ b/app/resources/documentation/manual/_variables.css
@@ -8,6 +8,7 @@
   --typography-font-size-x07500: calc(var(--typography-font-size-x10000) * 0.75);
   --typography-font-size-x08750: calc(var(--typography-font-size-x10000) * 0.875);
   --typography-font-size-x10000: 16px;
+  --typography-font-size-x11250: calc(var(--typography-font-size-x10000) * 1.125);
   --typography-font-size-x12500: calc(var(--typography-font-size-x10000) * 1.25);
   --typography-font-size-x15000: calc(var(--typography-font-size-x10000) * 1.5);
   --typography-font-size-x20000: calc(var(--typography-font-size-x10000) * 2);

--- a/app/resources/documentation/manual/_variables.css
+++ b/app/resources/documentation/manual/_variables.css
@@ -3,7 +3,7 @@
 :root {
     /* Typography */
 
-    --typography-font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    --typography-font-family-base: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     --typography-font-family-code: 'Lucida Console', Monaco, monospace;
     --typography-font-size-x07500: calc(var(--typography-font-size-x10000) * 0.75);
     --typography-font-size-x08750: calc(var(--typography-font-size-x10000) * 0.875);
@@ -15,7 +15,7 @@
     --typography-font-weight-bold: 700;
     --typography-line-height-reset: 1;
     --typography-line-height-tight: 1.2;
-    --typography-line-height-normal: 1.5;
+    --typography-line-height-normal: 1.6;
 
     /* Colors */
 
@@ -23,6 +23,7 @@
     --color-gray-40: hsl(0, 0%, 40%);
     --color-gray-60: hsl(0, 0%, 60%);
     --color-gray-80: hsl(0, 0%, 80%);
+    --color-gray-90: hsl(0, 0%, 90%);
     --color-gray-97: hsl(0, 0%, 97%);
     --color-gray-100: hsl(0, 0%, 100%);
     --color-azureradiance: hsl(210, 100%, 50%);

--- a/app/resources/documentation/manual/_variables.css
+++ b/app/resources/documentation/manual/_variables.css
@@ -23,7 +23,6 @@
     --color-gray-40: hsl(0, 0%, 40%);
     --color-gray-60: hsl(0, 0%, 60%);
     --color-gray-80: hsl(0, 0%, 80%);
-    --color-gray-90: hsl(0, 0%, 90%);
     --color-gray-97: hsl(0, 0%, 97%);
     --color-gray-100: hsl(0, 0%, 100%);
     --color-azureradiance: hsl(210, 100%, 50%);

--- a/app/resources/documentation/manual/_variables.darkmode.css
+++ b/app/resources/documentation/manual/_variables.darkmode.css
@@ -1,16 +1,16 @@
-/* ##### Variables ########## */
+/* ##### Variables: Dark Mode ########## */
 
 @media (prefers-color-scheme: dark) {
-    :root {
-        /* Colors */
+  :root {
+    /* Colors */
 
-        --color-gray-10: hsl(0, 0%, 10%);
-        --color-gray-15: hsl(0, 0%, 15%);
-        --color-gray-90: hsl(0, 0%, 90%);
-        --color-maximumyellowred: hsl(40, 90%, 60%);
+    --color-gray-10: hsl(0, 0%, 10%);
+    --color-gray-15: hsl(0, 0%, 15%);
+    --color-gray-90: hsl(0, 0%, 90%);
+    --color-maximumyellowred: hsl(40, 90%, 60%);
 
-        /* Borders */
-    
-        --border: var(--sizing-x00625) solid var(--color-gray-40);
-    }
+    /* Borders */
+
+    --border: var(--sizing-x00625) solid var(--color-gray-40);
+  }
 }

--- a/app/resources/documentation/manual/_variables.darkmode.css
+++ b/app/resources/documentation/manual/_variables.darkmode.css
@@ -1,0 +1,11 @@
+/* ##### Variables ########## */
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        /* Colors */
+
+        --color-gray-10: hsl(0, 0%, 10%);
+        --color-gray-15: hsl(0, 0%, 15%);
+        --color-orange: hsl(40, 90%, 60%);
+    }
+}

--- a/app/resources/documentation/manual/_variables.darkmode.css
+++ b/app/resources/documentation/manual/_variables.darkmode.css
@@ -6,7 +6,8 @@
 
         --color-gray-10: hsl(0, 0%, 10%);
         --color-gray-15: hsl(0, 0%, 15%);
-        --color-orange: hsl(40, 90%, 60%);
+        --color-gray-90: hsl(0, 0%, 90%);
+        --color-maximumyellowred: hsl(40, 90%, 60%);
 
         /* Borders */
     

--- a/app/resources/documentation/manual/_variables.darkmode.css
+++ b/app/resources/documentation/manual/_variables.darkmode.css
@@ -7,5 +7,9 @@
         --color-gray-10: hsl(0, 0%, 10%);
         --color-gray-15: hsl(0, 0%, 15%);
         --color-orange: hsl(40, 90%, 60%);
+
+        /* Borders */
+    
+        --border: var(--sizing-x00625) solid var(--color-gray-40);
     }
 }

--- a/app/resources/documentation/manual/default.css
+++ b/app/resources/documentation/manual/default.css
@@ -3,134 +3,146 @@
 /* Body */
 
 body {
-    font-family: var(--typography-font-family-base);
-    font-size: var(--typography-font-size-x10000);
-    font-weight: var(--typography-font-weight-regular);
-    line-height: var(--typography-line-height-normal);
-    background-color: var(--color-gray-100);
-    color: var(--color-gray-20);
+  display: flex;
+  font-family: var(--typography-font-family-base);
+  font-size: var(--typography-font-size-x10000);
+  font-weight: var(--typography-font-weight-regular);
+  line-height: var(--typography-line-height-normal);
+  background-color: var(--color-gray-100);
+  color: var(--color-gray-20);
 }
 
 body.toc_toggled {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 /* Table of Contents and Content */
 
 body #toc_toggler, body #toc, body #content {
-    padding: var(--spacing-x20000);
+  padding: var(--spacing-x20000);
 }
 
 /* Table of Contents */
 
 body #toc_toggler, body #toc {
-    background-color: var(--color-gray-97);
+  background-color: var(--color-gray-97);
+  box-shadow: 16px 0 24px -12px var(--color-gray-80);
 }
 
 body #toc_toggler {
-    display: none;
-    flex-direction: column;
-    align-items: center;
-    min-width: 50px;
-    max-width: 50px;
-    position: fixed;
-    top: 0;
-    bottom: 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  min-width: 50px;
+  max-width: 50px;
+  position: fixed;
+  top: 0;
+  bottom: 0;
 }
 
 body #toc_toggler img {
-    width: var(--sizing-x12500);
-    height: var(--sizing-x12500);
+  width: var(--sizing-x12500);
+  height: var(--sizing-x12500);
 }
 
 body #toc_toggler > a[href="#"] {
-    margin-top: auto;
+  margin-top: auto;
 }
 
 body #toc {
-    min-width: var(--toc-width);
-    max-width: var(--toc-width);
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    overflow-y: auto;
+  height: 100vh;
+  min-width: var(--toc-width);
+  max-width: var(--toc-width);
+  position: sticky;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  overflow-y: auto;
 }
 
 body #toc #toc_inner > ul {
-    margin-top: var(--spacing-x05000);
-    margin-bottom: 0;
-    margin-left: 0;
-    list-style-type: none;
+  margin-top: var(--spacing-x05000);
+  margin-bottom: 0;
+  margin-left: 0;
+  list-style-type: none;
 }
 
 body #toc #toc_inner > ul > li > a {
-    font-weight: var(--typography-font-weight-bold);
-}
-
-/* Content Version */
-
-body #content_version {
-    display: flex;
-    align-items: center;
-    margin-bottom: var(--spacing-x10000);
-    padding-bottom: var(--spacing-x05000);
-    font-size: var(--typography-font-size-x08750);
-    color: var(--color-gray-60);
-    border-bottom: var(--border);
-}
-
-body #content_version #content_version_details {
-    display: flex;
-    align-items: center;
-}
-
-body #content_version #content_version_details img {
-    max-width: var(--sizing-x30000);
-    margin: 0;
-    margin-right: var(--spacing-x05000);
-}
-
-body #content_version #content_version_details div {
-    display: flex;
-    flex-direction: column;
-}
-
-body #content_version #content_version_details div #content_version_heading {
-    font-size: var(--typography-font-size-x10000);
-    font-weight: var(--typography-font-weight-bold);
-    color: var(--color-gray-40);
-}
-
-body #content_version #content_version_links {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    margin-left: auto;
+  font-weight: var(--typography-font-weight-bold);
 }
 
 /* Content */
 
 body #content {
-    max-width: var(--content-max-width);
-    margin: 0 auto;
-    padding-left: calc(var(--toc-width) + var(--sizing-x20000));
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
 }
 
 body #content > :last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 body #content h1, body #content h2, body #content h3, body #content h4 {
-    display: inline-block;
-    width: 100%;
-    margin-top: var(--spacing-x05000);
+  display: inline-block;
+  width: 100%;
+  margin-top: var(--spacing-x05000);
+}
+
+/* Content Version */
+
+body #content_version {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--spacing-x10000);
+  padding-bottom: var(--spacing-x05000);
+  font-size: var(--typography-font-size-x08750);
+  color: var(--color-gray-60);
+  border-bottom: var(--border);
+}
+
+body #content_version #content_version_details {
+  display: flex;
+  align-items: center;
+}
+
+body #content_version #content_version_details img {
+  max-width: var(--sizing-x30000);
+  margin: 0;
+  margin-right: var(--spacing-x05000);
+}
+
+body #content_version #content_version_details div {
+  display: flex;
+  flex-direction: column;
+}
+
+body #content_version #content_version_details div #content_version_heading {
+  font-size: var(--typography-font-size-x10000);
+  font-weight: var(--typography-font-weight-bold);
+  color: var(--color-gray-40);
+}
+
+body #content_version #content_version_links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-left: auto;
+}
+
+/* Content Body */
+
+body #content_body {
+  width: 100%;
+  max-width: var(--content-max-width);
+  align-self: center;
 }
 
 /* Back to Top */
 
 body #content a[href="#"] {
-    position: fixed;
-    right: var(--spacing-x20000);
-    bottom: var(--spacing-x20000);
+  position: fixed;
+  right: var(--spacing-x20000);
+  bottom: var(--spacing-x20000);
 }

--- a/app/resources/documentation/manual/default.css
+++ b/app/resources/documentation/manual/default.css
@@ -68,6 +68,7 @@ body #toc #toc_inner > ul {
 }
 
 body #toc #toc_inner > ul > li > a {
+  font-size: var(--typography-font-size-x11250);
   font-weight: var(--typography-font-weight-bold);
 }
 
@@ -119,7 +120,7 @@ body #content_version #content_version_details div {
 }
 
 body #content_version #content_version_details div #content_version_heading {
-  font-size: var(--typography-font-size-x10000);
+  font-size: var(--typography-font-size-x11250);
   font-weight: var(--typography-font-weight-bold);
   color: var(--color-gray-40);
 }

--- a/app/resources/documentation/manual/default.darkmode.css
+++ b/app/resources/documentation/manual/default.darkmode.css
@@ -1,0 +1,16 @@
+/* ##### Dark Mode ########## */
+
+@media (prefers-color-scheme: dark) {
+  /* Body */
+
+  body {
+    background-color: var(--color-gray-10);
+    color: var(--color-gray-90);
+  }
+
+  /* Table of Contents */
+
+  body #toc_toggler, body #toc {
+    background-color: var(--color-gray-15);
+  }
+}

--- a/app/resources/documentation/manual/default.darkmode.css
+++ b/app/resources/documentation/manual/default.darkmode.css
@@ -1,4 +1,4 @@
-/* ##### Dark Mode ########## */
+/* ##### Default: Dark Mode ########## */
 
 @media (prefers-color-scheme: dark) {
   /* Body */
@@ -11,12 +11,13 @@
   /* Content Version */
 
   body #content_version #content_version_details div #content_version_heading {
-      color: var(--color-gray-60);
+    color: var(--color-gray-60);
   }
 
   /* Table of Contents */
 
   body #toc_toggler, body #toc {
     background-color: var(--color-gray-15);
+    box-shadow: 16px 0 24px -12px var(--color-gray-5);
   }
 }

--- a/app/resources/documentation/manual/default.darkmode.css
+++ b/app/resources/documentation/manual/default.darkmode.css
@@ -11,7 +11,7 @@
   /* Content Version */
 
   body #content_version #content_version_details div #content_version_heading {
-    color: var(--color-gray-60);
+    color: var(--color-gray-80);
   }
 
   /* Table of Contents */

--- a/app/resources/documentation/manual/default.darkmode.css
+++ b/app/resources/documentation/manual/default.darkmode.css
@@ -8,6 +8,12 @@
     color: var(--color-gray-90);
   }
 
+  /* Content Version */
+
+  body #content_version #content_version_details div #content_version_heading {
+      color: var(--color-gray-60);
+  }
+
   /* Table of Contents */
 
   body #toc_toggler, body #toc {

--- a/app/resources/documentation/manual/template.html
+++ b/app/resources/documentation/manual/template.html
@@ -10,8 +10,11 @@ $for(author-meta)$
 <link rel="icon" href="images/icon.png">
 <link rel="stylesheet" href="_reset.css">
 <link rel="stylesheet" href="_variables.css">
+<link rel="stylesheet" href="_variables.darkmode.css">
 <link rel="stylesheet" href="_specific.css">
+<link rel="stylesheet" href="_specific.darkmode.css">
 <link rel="stylesheet" href="default.css">
+<link rel="stylesheet" href="default.darkmode.css">
 <link rel="stylesheet" href="_responsive.css">
 <script src="shortcuts.js"></script>
 <script src="shortcuts_helper.js"></script>

--- a/app/resources/documentation/manual/template.html
+++ b/app/resources/documentation/manual/template.html
@@ -1,52 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="pandoc">
-$for(author-meta)$
-<meta name="author" content="$author-meta$">$endfor$
-<title>$pagetitle$</title>
-<link rel="icon" href="images/icon.png">
-<link rel="stylesheet" href="_reset.css">
-<link rel="stylesheet" href="_variables.css">
-<link rel="stylesheet" href="_variables.darkmode.css">
-<link rel="stylesheet" href="_specific.css">
-<link rel="stylesheet" href="_specific.darkmode.css">
-<link rel="stylesheet" href="default.css">
-<link rel="stylesheet" href="default.darkmode.css">
-<link rel="stylesheet" href="_responsive.css">
-<script src="shortcuts.js"></script>
-<script src="shortcuts_helper.js"></script>
-<script src="toc_toggler.js"></script>
-</head>
-<body>
-$if(toc)$<div id="toc_toggler">
-<img src="images/icon.png" alt="TrenchBroom Icon">
-<button class="toc_toggler_button" title="Open Table of Contents"><span>&#9776;</span></button>
-<a href="#" title="Back to top"><span>&#8657;</span></a>
-</div>
-<nav id="toc">
-<div id="toc_inner">
-$toc$
-</div>
-</nav>$endif$
-<main id="content">
-<aside id="content_version">
-<div id="content_version_details">
-<img src="images/icon.png" alt="TrenchBroom Icon">
-<div>
-<span id="content_version_heading">$pagetitle$</span>
-<span><strong>Build:</strong> __TB_BUILD_ID__</span>
-</div>
-</div>
-<div id="content_version_links">
-<span><a href="https://trenchbroom.github.io/" target="_blank" rel="noopener noreferrer">Official website</a> - <a href="https://discord.com/invite/XaAuJVz" target="_blank" rel="noopener noreferrer">Keep in touch on Discord</a></span>
-<span><strong><a href="https://github.com/TrenchBroom/TrenchBroom/releases/latest" target="_blank" rel="noopener noreferrer">Download the latest available version</a></strong></span>
-</div>
-</aside>
-<a href="#" title="Back to top"><span>&#8657;</span></a>
-$body$
-</main>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="pandoc">
+    $for(author-meta)$
+    <meta name="author" content="$author-meta$">$endfor$
+    <title>$pagetitle$</title>
+    <link rel="icon" href="images/icon.png">
+    <link rel="stylesheet" href="_reset.css">
+    <link rel="stylesheet" href="_variables.css">
+    <link rel="stylesheet" href="_variables.darkmode.css">
+    <link rel="stylesheet" href="_specific.css">
+    <link rel="stylesheet" href="_specific.darkmode.css">
+    <link rel="stylesheet" href="default.css">
+    <link rel="stylesheet" href="default.darkmode.css">
+    <link rel="stylesheet" href="_responsive.css">
+    <script src="shortcuts.js"></script>
+    <script src="shortcuts_helper.js"></script>
+    <script src="toc_toggler.js"></script>
+  </head>
+  <body>
+    $if(toc)$<div id="toc_toggler">
+      <img src="images/icon.png" alt="TrenchBroom Icon">
+      <button class="toc_toggler_button" title="Open Table of Contents"><span>&#9776;</span></button>
+      <a href="#" title="Back to top"><span>&#8657;</span></a>
+    </div>
+    <nav id="toc">
+      <div id="toc_inner">
+        $toc$
+      </div>
+    </nav>$endif$
+    <main id="content">
+      <aside id="content_version">
+        <div id="content_version_details">
+          <img src="images/icon.png" alt="TrenchBroom Icon">
+          <div>
+            <span id="content_version_heading">$pagetitle$</span>
+            <span><strong>Build:</strong> __TB_BUILD_ID__</span>
+          </div>
+        </div>
+        <div id="content_version_links">
+          <span><a href="https://trenchbroom.github.io/" target="_blank" rel="noopener noreferrer">Official website</a> -
+            <a href="https://discord.com/invite/XaAuJVz" target="_blank" rel="noopener noreferrer">Keep in touch on
+              Discord</a></span>
+          <span><strong><a href="https://github.com/TrenchBroom/TrenchBroom/releases/latest" target="_blank"
+                rel="noopener noreferrer">Download the latest available version</a></strong></span>
+        </div>
+      </aside>
+      <article id="content_body">
+        $body$
+      </article>
+      <a href="#" title="Back to top"><span>&#8657;</span></a>
+    </main>
+  </body>
 </html>

--- a/app/resources/documentation/manual/template.html
+++ b/app/resources/documentation/manual/template.html
@@ -18,22 +18,7 @@ $for(author-meta)$
 <link rel="stylesheet" href="_responsive.css">
 <script src="shortcuts.js"></script>
 <script src="shortcuts_helper.js"></script>
-<script>(() => {
-  window.addEventListener('DOMContentLoaded', () => {
-    const tocToggledClass = 'toc_toggled';
-
-    document.body.querySelector('div#toc_toggler .toc_toggler_button').addEventListener('click', (event) => {
-      event.preventDefault();
-      document.body.classList.toggle(tocToggledClass);
-    });
-
-    document.body.querySelectorAll('a').forEach((element) => {
-      element.addEventListener('click', (event) => {
-        document.body.classList.remove(tocToggledClass);
-      });
-    });
-  });
-})()</script>
+<script src="toc_toggler.js"></script>
 </head>
 <body>
 $if(toc)$<div id="toc_toggler">

--- a/app/resources/documentation/manual/template.html
+++ b/app/resources/documentation/manual/template.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="pandoc">
     $for(author-meta)$
-    <meta name="author" content="$author-meta$">$endfor$
+    <meta name="author" content="$author-meta$">
+    $endfor$
     <title>$pagetitle$</title>
     <link rel="icon" href="images/icon.png">
     <link rel="stylesheet" href="_reset.css">
@@ -21,7 +22,8 @@
     <script src="toc_toggler.js"></script>
   </head>
   <body>
-    $if(toc)$<div id="toc_toggler">
+    $if(toc)$
+    <div id="toc_toggler">
       <img src="images/icon.png" alt="TrenchBroom Icon">
       <button class="toc_toggler_button" title="Open Table of Contents"><span>&#9776;</span></button>
       <a href="#" title="Back to top"><span>&#8657;</span></a>
@@ -30,7 +32,8 @@
       <div id="toc_inner">
         $toc$
       </div>
-    </nav>$endif$
+    </nav>
+    $endif$
     <main id="content">
       <aside id="content_version">
         <div id="content_version_details">
@@ -41,11 +44,8 @@
           </div>
         </div>
         <div id="content_version_links">
-          <span><a href="https://trenchbroom.github.io/" target="_blank" rel="noopener noreferrer">Official website</a> -
-            <a href="https://discord.com/invite/XaAuJVz" target="_blank" rel="noopener noreferrer">Keep in touch on
-              Discord</a></span>
-          <span><strong><a href="https://github.com/TrenchBroom/TrenchBroom/releases/latest" target="_blank"
-                rel="noopener noreferrer">Download the latest available version</a></strong></span>
+          <span><a href="https://trenchbroom.github.io/" target="_blank" rel="noopener noreferrer">Official website</a> - <a href="https://discord.com/invite/XaAuJVz" target="_blank" rel="noopener noreferrer">Keep in touch on Discord</a></span>
+          <span><strong><a href="https://github.com/TrenchBroom/TrenchBroom/releases/latest" target="_blank" rel="noopener noreferrer">Download the latest available version</a></strong></span>
         </div>
       </aside>
       <article id="content_body">

--- a/app/resources/documentation/manual/toc_toggler.js
+++ b/app/resources/documentation/manual/toc_toggler.js
@@ -1,0 +1,16 @@
+(() => {
+  window.addEventListener("DOMContentLoaded", () => {
+    const tocToggledClass = "toc_toggled";
+
+    document.body.querySelector("div#toc_toggler .toc_toggler_button").addEventListener("click", (event) => {
+      event.preventDefault();
+      document.body.classList.toggle(tocToggledClass);
+    });
+
+    document.body.querySelectorAll("a").forEach((element) => {
+      element.addEventListener("click", (event) => {
+        document.body.classList.remove(tocToggledClass);
+      });
+    });
+  });
+})()


### PR DESCRIPTION
Resolves #4369

---

I've added a Dark Mode to the Reference Manual, making it easier to read at night. 

![image](https://github.com/TrenchBroom/TrenchBroom/assets/14064112/ccf321a9-beb7-4e6d-b323-0e22d152a257)

This mode changes automatically based on the computer's settings, thanks to a special feature in the coding. It tweaks some of the design elements without changing everything, keeping the overall look consistent.

![image](https://github.com/TrenchBroom/TrenchBroom/assets/14064112/e20e9887-a0a3-4193-9624-625ec020836c)

To test it:
- Switch to this new version by checking out the branch.
- Build the Reference Manual.
- Use your browser's tools to switch between Light and Dark Mode and see the changes.

If your computer is already set to Dark Mode, you'll see the changes right away. You can also switch using the native feature included in the DevTools of the browsers.

![image](https://github.com/TrenchBroom/TrenchBroom/assets/14064112/6f55f8b8-f576-486b-bb3c-becb96e5b913)

Plus, I've changed the main font to something that's easier on the eyes.

@kduske @ericwa Let me know if the colours are fine for you. I can change them easily if needed.