### PR TITLE
ADHOC: Add Dockerized TrenchBroom reference to the Build.md file

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -20,10 +20,13 @@ git submodule update --init --recursive
 
 ## Dependencies
 
-TrenchBroom uses [vcpkg](https://vcpkg.io/) to manage build dependencies except for Qt. vcpkg is
-integrated into TrenchBroom's build system and will download and build all dependencies once during
-Cmake's configure phase. This is an automatic process, but it can take a little while when it
-happens for the first time.
+TrenchBroom uses [vcpkg](https://vcpkg.io/) to manage build dependencies except for Qt. vcpkg is integrated into TrenchBroom's build system and will download and build all dependencies once  during cmake's configure phase. This is an automatic process, but it can take a little while when it happens for the first time.
+
+---
+
+## Docker
+
+An external unofficial project called [Dockerized TrenchBroom](https://github.com/jonathanlinat/dockerized-trenchbroom) is available for developers. It facilitates the compilation of TrenchBroom's source code and the creation of binaries using [Docker](https://www.docker.com/).
 
 ---
 


### PR DESCRIPTION
[Following the suggestion of @kduske](https://github.com/TrenchBroom/TrenchBroom/pull/4367#issuecomment-1806505595), I have moved the Docker support for the TrenchBroom source code and build process to a dedicated repository: https://github.com/jonathanlinat/dockerized-trenchbroom

The purpose of this PR is to modify the `Build.md` documentation to include a mention of this external, unofficial project.