### PR TITLE
4372: Upgrade macOS version from 11 to 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
       # Don't cancel the macOS build if the Linux build fails, etc.
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, windows-2019]
         tb-build-type: [release]
         tb-arch: [default-arch]
         exclude:
           - os: windows-2019
             tb-arch: default-arch
         include:
-          - os: macos-11
+          - os: macos-12
             tb-build-type: asan
           - os: windows-2019
             tb-arch: x64
@@ -109,7 +109,7 @@ jobs:
           arch: 'win32_msvc2019'
 
       - name: Install macOS dependencies
-        if: ${{ matrix.os == 'macos-11' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           brew install cmake p7zip pandoc qt5 ninja autoconf automake
 
@@ -119,7 +119,7 @@ jobs:
         run: ./CI-linux.sh
 
       - name: macOS build
-        if: ${{ matrix.os == 'macos-11' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           if [ '${{ matrix.tb-build-type }}' = 'asan' ]; then
             export TB_DEBUG_BUILD=true
@@ -175,7 +175,7 @@ jobs:
       # macOS
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.os == 'macos-11' && matrix.tb-build-type != 'asan' }}
+        if: ${{ matrix.os == 'macos-12' && matrix.tb-build-type != 'asan' }}
         with:
           name: macos
           path: |


### PR DESCRIPTION
Resolves #4372 

---

This PR aims to upgrade the version of macOS from version `11` to `12`.

This is likely a **breaking change** as the end users will need macOS 12 to run the application.