### PR TITLE
Add support for parsing boolean literals in ENT files

### DIFF
--- a/common/src/Assets/EntityDefinitionGroup.cpp
+++ b/common/src/Assets/EntityDefinitionGroup.cpp
@@ -25,14 +25,13 @@
 
 #include <string>
 
-namespace TrenchBroom
+namespace TrenchBroom::Assets
 {
-namespace Assets
-{
+
 EntityDefinitionGroup::EntityDefinitionGroup(
-  const std::string& name, std::vector<EntityDefinition*> definitions)
-  : m_name(name)
-  , m_definitions(std::move(definitions))
+  std::string name, std::vector<EntityDefinition*> definitions)
+  : m_name{std::move(name)}
+  , m_definitions{std::move(definitions)}
 {
 }
 
@@ -43,9 +42,7 @@ const std::string& EntityDefinitionGroup::name() const
 
 const std::string EntityDefinitionGroup::displayName() const
 {
-  if (m_name.empty())
-    return "Misc";
-  return kdl::str_capitalize(m_name);
+  return !m_name.empty() ? kdl::str_capitalize(m_name) : "Misc";
 }
 
 const std::vector<EntityDefinition*>& EntityDefinitionGroup::definitions() const
@@ -58,5 +55,5 @@ std::vector<EntityDefinition*> EntityDefinitionGroup::definitions(
 {
   return EntityDefinition::filterAndSort(m_definitions, type, order);
 }
-} // namespace Assets
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::Assets

--- a/common/src/Assets/EntityDefinitionGroup.h
+++ b/common/src/Assets/EntityDefinitionGroup.h
@@ -22,9 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace TrenchBroom
-{
-namespace Assets
+namespace TrenchBroom::Assets
 {
 class EntityDefinition;
 enum class EntityDefinitionSortOrder;
@@ -37,8 +35,7 @@ private:
   std::vector<EntityDefinition*> m_definitions;
 
 public:
-  EntityDefinitionGroup(
-    const std::string& name, std::vector<EntityDefinition*> definitions);
+  EntityDefinitionGroup(std::string name, std::vector<EntityDefinition*> definitions);
 
   size_t index() const;
   const std::string& name() const;
@@ -47,5 +44,5 @@ public:
   std::vector<EntityDefinition*> definitions(
     EntityDefinitionType type, EntityDefinitionSortOrder order) const;
 };
-} // namespace Assets
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::Assets

--- a/common/src/Assets/EntityDefinitionManager.h
+++ b/common/src/Assets/EntityDefinitionManager.h
@@ -49,7 +49,7 @@ class EntityDefinitionManager
 {
 private:
   using Cache = std::map<std::string, EntityDefinition*>;
-  std::vector<EntityDefinition*> m_definitions;
+  std::vector<std::unique_ptr<EntityDefinition>> m_definitions;
   std::vector<EntityDefinitionGroup> m_groups;
   Cache m_cache;
 
@@ -60,14 +60,14 @@ public:
     const std::filesystem::path& path,
     const IO::EntityDefinitionLoader& loader,
     IO::ParserStatus& status);
-  void setDefinitions(const std::vector<EntityDefinition*>& newDefinitions);
+  void setDefinitions(std::vector<std::unique_ptr<EntityDefinition>> newDefinitions);
   void clear();
 
   EntityDefinition* definition(const Model::EntityNodeBase* node) const;
   EntityDefinition* definition(const std::string& classname) const;
   std::vector<EntityDefinition*> definitions(
     EntityDefinitionType type, EntityDefinitionSortOrder order) const;
-  const std::vector<EntityDefinition*>& definitions() const;
+  std::vector<EntityDefinition*> definitions() const;
 
   const std::vector<EntityDefinitionGroup>& groups() const;
 

--- a/common/src/Assets/ModelDefinition.cpp
+++ b/common/src/Assets/ModelDefinition.cpp
@@ -68,18 +68,17 @@ ModelDefinition::ModelDefinition(const size_t line, const size_t column)
 {
 }
 
-ModelDefinition::ModelDefinition(const EL::Expression& expression)
-  : m_expression{expression}
+ModelDefinition::ModelDefinition(EL::Expression expression)
+  : m_expression{std::move(expression)}
 {
 }
 
-void ModelDefinition::append(const ModelDefinition& other)
+void ModelDefinition::append(ModelDefinition other)
 {
   const size_t line = m_expression.line();
   const size_t column = m_expression.column();
 
-  auto cases = std::vector<EL::Expression>{std::move(m_expression), other.m_expression};
-
+  auto cases = std::vector{std::move(m_expression), std::move(other.m_expression)};
   m_expression = EL::Expression{EL::SwitchExpression{std::move(cases)}, line, column};
 }
 

--- a/common/src/Assets/ModelDefinition.h
+++ b/common/src/Assets/ModelDefinition.h
@@ -64,9 +64,10 @@ private:
 public:
   ModelDefinition();
   ModelDefinition(size_t line, size_t column);
-  explicit ModelDefinition(const EL::Expression& expression);
 
-  void append(const ModelDefinition& other);
+  explicit ModelDefinition(EL::Expression expression);
+
+  void append(ModelDefinition other);
 
   /**
    * Evaluates the model expresion, using the given variable store to interpolate

--- a/common/src/Assets/PropertyDefinition.h
+++ b/common/src/Assets/PropertyDefinition.h
@@ -23,14 +23,14 @@
 
 #include <kdl/reflection_decl.h>
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
-namespace TrenchBroom
+namespace TrenchBroom::Assets
 {
-namespace Assets
-{
+
 enum class PropertyDefinitionType
 {
   TargetSourceProperty,
@@ -55,10 +55,10 @@ private:
 
 public:
   PropertyDefinition(
-    const std::string& key,
+    std::string key,
     PropertyDefinitionType type,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly);
   virtual ~PropertyDefinition();
 
@@ -73,18 +73,18 @@ public:
 
   static std::string defaultValue(const PropertyDefinition& definition);
 
-  PropertyDefinition* clone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> clone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const;
 
 private:
   virtual bool doEquals(const PropertyDefinition* other) const;
-  virtual PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  virtual std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const;
 };
 
@@ -105,10 +105,10 @@ public:
 
 protected:
   PropertyDefinitionWithDefaultValue(
-    const std::string& key,
+    std::string key,
     PropertyDefinitionType type,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly,
     std::optional<T> defaultValue = std::nullopt)
     : PropertyDefinition(key, type, shortDescription, longDescription, readOnly)
@@ -121,17 +121,17 @@ class StringPropertyDefinition : public PropertyDefinitionWithDefaultValue<std::
 {
 public:
   StringPropertyDefinition(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly,
     std::optional<std::string> defaultValue = std::nullopt);
 
 private:
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
 
@@ -139,17 +139,17 @@ class BooleanPropertyDefinition : public PropertyDefinitionWithDefaultValue<bool
 {
 public:
   BooleanPropertyDefinition(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly,
     std::optional<bool> defaultValue = std::nullopt);
 
 private:
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
 
@@ -157,17 +157,17 @@ class IntegerPropertyDefinition : public PropertyDefinitionWithDefaultValue<int>
 {
 public:
   IntegerPropertyDefinition(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly,
     std::optional<int> defaultValue = std::nullopt);
 
 private:
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
 
@@ -175,17 +175,17 @@ class FloatPropertyDefinition : public PropertyDefinitionWithDefaultValue<float>
 {
 public:
   FloatPropertyDefinition(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly,
     std::optional<float> defaultValue = std::nullopt);
 
 private:
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
 
@@ -199,7 +199,7 @@ private:
   std::string m_description;
 
 public:
-  ChoicePropertyOption(const std::string& value, const std::string& description);
+  ChoicePropertyOption(std::string value, std::string description);
   const std::string& value() const;
   const std::string& description() const;
 
@@ -213,20 +213,20 @@ private:
 
 public:
   ChoicePropertyDefinition(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
-    const ChoicePropertyOption::List& options,
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
+    ChoicePropertyOption::List options,
     bool readOnly,
     std::optional<std::string> defaultValue = std::nullopt);
   const ChoicePropertyOption::List& options() const;
 
 private:
   bool doEquals(const PropertyDefinition* other) const override;
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
 
@@ -243,10 +243,7 @@ private:
 
 public:
   FlagsPropertyOption(
-    int value,
-    const std::string& shortDescription,
-    const std::string& longDescription,
-    bool isDefault);
+    int value, std::string shortDescription, std::string longDescription, bool isDefault);
   int value() const;
   const std::string& shortDescription() const;
   const std::string& longDescription() const;
@@ -262,23 +259,20 @@ private:
   FlagsPropertyOption::List m_options;
 
 public:
-  explicit FlagsPropertyDefinition(const std::string& key);
+  explicit FlagsPropertyDefinition(std::string key);
 
   int defaultValue() const;
   const FlagsPropertyOption::List& options() const;
   const FlagsPropertyOption* option(int value) const;
   void addOption(
-    int value,
-    const std::string& shortDescription,
-    const std::string& longDescription,
-    bool isDefault);
+    int value, std::string shortDescription, std::string longDescription, bool isDefault);
 
 private:
   bool doEquals(const PropertyDefinition* other) const override;
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
 
@@ -286,18 +280,18 @@ class UnknownPropertyDefinition : public StringPropertyDefinition
 {
 public:
   UnknownPropertyDefinition(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly,
     std::optional<std::string> defaultValue = std::nullopt);
 
 private:
-  PropertyDefinition* doClone(
-    const std::string& key,
-    const std::string& shortDescription,
-    const std::string& longDescription,
+  std::unique_ptr<PropertyDefinition> doClone(
+    std::string key,
+    std::string shortDescription,
+    std::string longDescription,
     bool readOnly) const override;
 };
-} // namespace Assets
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::Assets

--- a/common/src/IO/DefParser.h
+++ b/common/src/IO/DefParser.h
@@ -34,11 +34,7 @@
 #include <string>
 #include <vector>
 
-namespace TrenchBroom
-{
-namespace IO
-{
-namespace DefToken
+namespace TrenchBroom::IO::DefToken
 {
 using Type = unsigned int;
 static const Type Integer = 1 << 0;      // integer number
@@ -57,7 +53,10 @@ static const Type Comma = 1 << 13;       // comma: ,
 static const Type Equality = 1 << 14;    // equality sign: =
 static const Type Minus = 1 << 15;       // minus sign: -
 static const Type Eof = 1 << 16;         // end of file
-} // namespace DefToken
+} // namespace TrenchBroom::IO::DefToken
+
+namespace TrenchBroom::IO
+{
 
 class DefTokenizer : public Tokenizer<DefToken::Type>
 {
@@ -85,13 +84,14 @@ private:
   std::vector<EntityDefinitionClassInfo> parseClassInfos(ParserStatus& status) override;
 
   std::optional<EntityDefinitionClassInfo> parseClassInfo(ParserStatus& status);
-  PropertyDefinitionPtr parseSpawnflags(ParserStatus& status);
+  std::unique_ptr<Assets::PropertyDefinition> parseSpawnflags(ParserStatus& status);
   void parseProperties(ParserStatus& status, EntityDefinitionClassInfo& classInfo);
   bool parseProperty(ParserStatus& status, EntityDefinitionClassInfo& classInfo);
 
   void parseDefaultProperty(ParserStatus& status);
   std::string parseBaseProperty(ParserStatus& status);
-  PropertyDefinitionPtr parseChoicePropertyDefinition(ParserStatus& status);
+  std::unique_ptr<Assets::PropertyDefinition> parseChoicePropertyDefinition(
+    ParserStatus& status);
   Assets::ModelDefinition parseModelDefinition(ParserStatus& status);
 
   std::string parseDescription();
@@ -102,5 +102,5 @@ private:
 
   Token nextTokenIgnoringNewlines();
 };
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -30,6 +30,7 @@
 #include "IO/ParserStatus.h"
 #include "Model/EntityProperties.h"
 
+#include "kdl/string_compare.h"
 #include <kdl/string_utils.h>
 
 #include <vecmath/vec_io.h>
@@ -134,6 +135,31 @@ std::optional<int> parseInteger(
   return kdl::str_to_int(getAttribute(element, attributeName));
 }
 
+std::optional<bool> parseBoolean(
+  const tinyxml2::XMLElement& element, const std::string& attributeName)
+{
+  const auto strValue = getAttribute(element, attributeName);
+  if (kdl::ci::str_is_equal(strValue, "true"))
+  {
+    return true;
+  }
+  if (kdl::ci::str_is_equal(strValue, "false"))
+  {
+    return false;
+  }
+
+  const auto intValue = kdl::str_to_int(strValue);
+  if (intValue != 0)
+  {
+    return true;
+  }
+  if (intValue == 0)
+  {
+    return false;
+  }
+
+  return std::nullopt;
+}
 
 std::optional<float> parseFloat(
   const tinyxml2::XMLElement& element, const std::string& attributeName)
@@ -346,14 +372,14 @@ std::unique_ptr<Assets::PropertyDefinition> parseBooleanPropertyDefinition(
     -> std::unique_ptr<Assets::PropertyDefinition> {
     if (hasAttribute(element, "value"))
     {
-      if (const auto boolDefaultValue = parseInteger(element, "value"))
+      if (const auto boolDefaultValue = parseBoolean(element, "value"))
       {
         return std::make_unique<Assets::BooleanPropertyDefinition>(
           std::move(name),
           std::move(shortDesc),
           std::move(longDesc),
           false,
-          *boolDefaultValue != 0);
+          *boolDefaultValue);
       }
 
       auto strDefaultValue = parseString(element, "value");

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -34,671 +34,72 @@
 
 #include <vecmath/vec_io.h>
 
+#include <fmt/format.h>
+
 #include <cstdlib>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tinyxml2.h>
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
+
+namespace
 {
-EntParser::EntParser(std::string_view str, const Color& defaultEntityColor)
-  : EntityDefinitionParser(defaultEntityColor)
-  , m_begin(str.data())
-  , m_end(str.data() + str.size())
+
+std::string_view getName(const tinyxml2::XMLElement& element)
 {
+  return element.Name() ? std::string_view{element.Name()} : std::string_view{};
 }
 
-std::vector<EntityDefinitionClassInfo> EntParser::parseClassInfos(ParserStatus& status)
+bool hasAttribute(
+  const tinyxml2::XMLElement& element, const std::string_view attributeName)
 {
-  tinyxml2::XMLDocument doc;
-  doc.Parse(m_begin, static_cast<size_t>(m_end - m_begin));
-  if (doc.Error())
-  {
-    if (doc.ErrorID() == tinyxml2::XML_ERROR_EMPTY_DOCUMENT)
-    {
-      // we allow empty documents
-      return {};
-    }
-    else
-    {
-      const auto lineNum = static_cast<size_t>(doc.ErrorLineNum());
-      const auto error = std::string(doc.ErrorStr());
-      throw ParserException(lineNum, error);
-    }
-  }
-  return parseClassInfos(doc, status);
+  return element.Attribute(attributeName.data()) != nullptr;
 }
 
-std::vector<EntityDefinitionClassInfo> EntParser::parseClassInfos(
-  const tinyxml2::XMLDocument& document, ParserStatus& status)
+std::string_view getAttribute(
+  const tinyxml2::XMLElement& element, const std::string_view attributeName)
 {
-  std::vector<EntityDefinitionClassInfo> result;
-  PropertyDefinitionList propertyDeclarations;
-
-  const auto* classesNode = document.FirstChildElement("classes");
-  if (classesNode != nullptr)
-  {
-    const auto* currentElement = classesNode->FirstChildElement();
-    while (currentElement != nullptr)
-    {
-      if (
-        !std::strcmp(currentElement->Name(), "point")
-        || !std::strcmp(currentElement->Name(), "group"))
-      {
-        if (
-          auto classInfo = parseClassInfo(*currentElement, propertyDeclarations, status))
-        {
-          result.push_back(std::move(*classInfo));
-        }
-      }
-      else
-      {
-        // interpret this as an property declaration
-        parsePropertyDeclaration(*currentElement, propertyDeclarations, status);
-      }
-      currentElement = currentElement->NextSiblingElement();
-    }
-  }
-  return result;
+  const auto* attribute = element.Attribute(attributeName.data());
+  return attribute ? std::string_view{attribute} : std::string_view{};
 }
 
-std::optional<EntityDefinitionClassInfo> EntParser::parseClassInfo(
-  const tinyxml2::XMLElement& element,
-  const PropertyDefinitionList& propertyDeclarations,
-  ParserStatus& status)
+void warn(
+  const tinyxml2::XMLElement& element, const std::string_view msg, ParserStatus& status)
 {
-  if (!std::strcmp(element.Name(), "point"))
+  const auto str = fmt::format("{}: {}", msg, getName(element));
+  if (element.GetLineNum() > 0)
   {
-    return parsePointClassInfo(element, propertyDeclarations, status);
-  }
-  else if (!std::strcmp(element.Name(), "group"))
-  {
-    return parseBrushClassInfo(element, propertyDeclarations, status);
+    status.warn(static_cast<size_t>(element.GetLineNum()), str);
   }
   else
   {
-    warn(element, "Unexpected XML element", status);
-    return std::nullopt;
+    status.warn(str);
   }
 }
 
-EntityDefinitionClassInfo EntParser::parsePointClassInfo(
-  const tinyxml2::XMLElement& element,
-  const PropertyDefinitionList& propertyDeclarations,
-  ParserStatus& status)
-{
-  EntityDefinitionClassInfo classInfo;
-  ;
-  classInfo.type = EntityDefinitionClassType::PointClass;
-  classInfo.line = static_cast<size_t>(element.GetLineNum());
-  classInfo.column = 0;
-  classInfo.name = parseString(element, "name", status);
-  classInfo.description = getText(element);
-  classInfo.color = parseColor(element, "color", status);
-  classInfo.size = parseBounds(element, "box", status);
-  classInfo.modelDefinition = parseModel(element, status);
-
-  parseSpawnflags(element, classInfo.propertyDefinitions, status);
-  parsePropertyDefinitions(
-    element, propertyDeclarations, classInfo.propertyDefinitions, status);
-
-  return classInfo;
-}
-
-EntityDefinitionClassInfo EntParser::parseBrushClassInfo(
-  const tinyxml2::XMLElement& element,
-  const PropertyDefinitionList& propertyDeclarations,
-  ParserStatus& status)
-{
-  EntityDefinitionClassInfo classInfo;
-  ;
-  classInfo.type = EntityDefinitionClassType::BrushClass;
-  classInfo.line = static_cast<size_t>(element.GetLineNum());
-  classInfo.column = 0;
-  classInfo.name = parseString(element, "name", status);
-  classInfo.description = getText(element);
-  classInfo.color = parseColor(element, "color", status);
-
-  parseSpawnflags(element, classInfo.propertyDefinitions, status);
-  parsePropertyDefinitions(
-    element, propertyDeclarations, classInfo.propertyDefinitions, status);
-
-  return classInfo;
-}
-
-Assets::ModelDefinition EntParser::parseModel(
-  const tinyxml2::XMLElement& element, ParserStatus& status)
-{
-  if (!hasAttribute(element, "model"))
-  {
-    return Assets::ModelDefinition();
-  }
-
-  const auto model = parseString(element, "model", status);
-
-  try
-  {
-    ELParser parser(ELParser::Mode::Lenient, model);
-    auto expression = parser.parse();
-    expression.optimize();
-    return Assets::ModelDefinition(expression);
-  }
-  catch (const ParserException&)
-  {
-    const auto lineNum = static_cast<size_t>(element.GetLineNum());
-    auto expression = EL::Expression(
-      EL::LiteralExpression(EL::Value(
-        EL::MapType({{Assets::ModelSpecificationKeys::Path, EL::Value{model}}}))),
-      lineNum,
-      0);
-    return Assets::ModelDefinition(expression);
-  }
-  catch (const EL::EvaluationError& evaluationError)
-  {
-    const auto line = static_cast<size_t>(element.GetLineNum());
-    throw ParserException{line, evaluationError.what()};
-  }
-}
-
-void EntParser::parseSpawnflags(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  const auto* flagElement = element.FirstChildElement("flag");
-  if (flagElement != nullptr)
-  {
-    auto result = std::make_shared<Assets::FlagsPropertyDefinition>(
-      Model::EntityPropertyKeys::Spawnflags);
-    do
-    {
-      const auto bit = parseSize(*flagElement, "bit", status);
-      if (!bit.has_value())
-      {
-        const auto strValue = parseString(*flagElement, "bit", status);
-        warn(
-          *flagElement,
-          "Invalid value '" + strValue + "' for bit property definition",
-          status);
-      }
-      else
-      {
-        const auto value = 1 << *bit;
-        const auto shortDesc = parseString(*flagElement, "key", status);
-        const auto longDesc = parseString(*flagElement, "name", status);
-        result->addOption(value, shortDesc, longDesc, false);
-      }
-
-      flagElement = flagElement->NextSiblingElement("flag");
-    } while (flagElement != nullptr);
-
-    if (!addPropertyDefinition(propertyDefinitions, std::move(result)))
-    {
-      const auto line = static_cast<size_t>(element.GetLineNum());
-      status.warn(line, 0, "Skipping duplicate spawnflags property definition");
-    }
-  }
-}
-
-void EntParser::parsePropertyDefinitions(
-  const tinyxml2::XMLElement& parent,
-  const PropertyDefinitionList& propertyDeclarations,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  const auto* element = parent.FirstChildElement();
-  while (element != nullptr)
-  {
-    if (!std::strcmp(element->Name(), "angle"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "angles"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "direction"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "boolean"))
-    {
-      parseBooleanPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "integer"))
-    {
-      parseIntegerPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "real"))
-    {
-      parseRealPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "string"))
-    {
-      parseStringPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "target"))
-    {
-      parseTargetPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "targetname"))
-    {
-      parseTargetNamePropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "texture"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "sound"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "model"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else if (!std::strcmp(element->Name(), "color"))
-    {
-      parseUnknownPropertyDefinition(*element, propertyDefinitions, status);
-    }
-    else
-    {
-      const auto* name = element->Name();
-      if (name)
-      {
-        for (const auto& propertyDeclaration : propertyDeclarations)
-        {
-          if (!std::strcmp(name, propertyDeclaration->key().c_str()))
-          {
-            parseDeclaredPropertyDefinition(
-              *element, propertyDeclaration, propertyDefinitions, status);
-          }
-        }
-      }
-    }
-    element = element->NextSiblingElement();
-  }
-}
-
-void EntParser::parseUnknownPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory = [this, &element, &status](
-                   const std::string& name,
-                   const std::string& shortDesc,
-                   const std::string& longDesc) {
-    auto defaultValue = hasAttribute(element, "value")
-                          ? std::make_optional(parseString(element, "value", status))
-                          : std::nullopt;
-    return std::make_shared<Assets::UnknownPropertyDefinition>(
-      name, shortDesc, longDesc, false, std::move(defaultValue));
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseStringPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory = [this, &element, &status](
-                   const std::string& name,
-                   const std::string& shortDesc,
-                   const std::string& longDesc) {
-    auto defaultValue = hasAttribute(element, "value")
-                          ? std::make_optional(parseString(element, "value", status))
-                          : std::nullopt;
-    return std::make_shared<Assets::StringPropertyDefinition>(
-      name, shortDesc, longDesc, false, std::move(defaultValue));
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseBooleanPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory =
-    [this, &element, &status](
-      const std::string& name,
-      const std::string& shortDesc,
-      const std::string& longDesc) -> std::shared_ptr<Assets::PropertyDefinition> {
-    if (hasAttribute(element, "value"))
-    {
-      const auto boolDefaultValue = parseInteger(element, "value", status);
-      if (boolDefaultValue.has_value())
-      {
-        return std::make_shared<Assets::BooleanPropertyDefinition>(
-          name, shortDesc, longDesc, false, *boolDefaultValue != 0);
-      }
-      else
-      {
-        auto strDefaultValue = parseString(element, "value", status);
-        warn(
-          element,
-          "Invalid default value '" + strDefaultValue
-            + "' for boolean property definition",
-          status);
-        return std::make_shared<Assets::UnknownPropertyDefinition>(
-          name, shortDesc, longDesc, false, std::move(strDefaultValue));
-      }
-    }
-    else
-    {
-      return std::make_shared<Assets::BooleanPropertyDefinition>(
-        name, shortDesc, longDesc, false);
-    }
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseIntegerPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory =
-    [this, &element, &status](
-      const std::string& name,
-      const std::string& shortDesc,
-      const std::string& longDesc) -> std::shared_ptr<Assets::PropertyDefinition> {
-    if (hasAttribute(element, "value"))
-    {
-      auto intDefaultValue = parseInteger(element, "value", status);
-      if (intDefaultValue.has_value())
-      {
-        return std::make_shared<Assets::IntegerPropertyDefinition>(
-          name, shortDesc, longDesc, false, std::move(intDefaultValue));
-      }
-      else
-      {
-        auto strDefaultValue = parseString(element, "value", status);
-        warn(
-          element,
-          "Invalid default value '" + strDefaultValue
-            + "' for integer property definition",
-          status);
-        return std::make_shared<Assets::UnknownPropertyDefinition>(
-          name, shortDesc, longDesc, false, std::move(strDefaultValue));
-      }
-    }
-    else
-    {
-      return std::make_shared<Assets::IntegerPropertyDefinition>(
-        name, shortDesc, longDesc, false);
-    }
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseRealPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory =
-    [this, &element, &status](
-      const std::string& name,
-      const std::string& shortDesc,
-      const std::string& longDesc) -> std::shared_ptr<Assets::PropertyDefinition> {
-    if (hasAttribute(element, "value"))
-    {
-      auto floatDefaultValue = parseFloat(element, "value", status);
-      if (floatDefaultValue.has_value())
-      {
-        return std::make_shared<Assets::FloatPropertyDefinition>(
-          name, shortDesc, longDesc, false, std::move(floatDefaultValue));
-      }
-      else
-      {
-        auto strDefaultValue = parseString(element, "value", status);
-        warn(
-          element,
-          "Invalid default value '" + strDefaultValue + "' for float property definition",
-          status);
-        return std::make_shared<Assets::UnknownPropertyDefinition>(
-          name, shortDesc, longDesc, false, std::move(strDefaultValue));
-      }
-    }
-    else
-    {
-      return std::make_shared<Assets::FloatPropertyDefinition>(
-        name, shortDesc, longDesc, false);
-    }
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseTargetPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory = [](
-                   const std::string& name,
-                   const std::string& shortDesc,
-                   const std::string& longDesc) {
-    return std::make_shared<Assets::PropertyDefinition>(
-      name,
-      Assets::PropertyDefinitionType::TargetDestinationProperty,
-      shortDesc,
-      longDesc,
-      false);
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseTargetNamePropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory = [](
-                   const std::string& name,
-                   const std::string& shortDesc,
-                   const std::string& longDesc) {
-    return std::make_shared<Assets::PropertyDefinition>(
-      name,
-      Assets::PropertyDefinitionType::TargetSourceProperty,
-      shortDesc,
-      longDesc,
-      false);
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parseDeclaredPropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  const std::shared_ptr<Assets::PropertyDefinition>& propertyDeclaration,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  auto factory = [&propertyDeclaration](
-                   const std::string& name,
-                   const std::string& shortDesc,
-                   const std::string& longDesc) {
-    return std::shared_ptr<Assets::PropertyDefinition>(
-      propertyDeclaration->clone(name, shortDesc, longDesc, false));
-  };
-  parsePropertyDefinition(element, factory, propertyDefinitions, status);
-}
-
-void EntParser::parsePropertyDefinition(
-  const tinyxml2::XMLElement& element,
-  EntParser::PropertyDefinitionFactory factory,
-  PropertyDefinitionList& propertyDefinitions,
-  ParserStatus& status)
-{
-  if (expectAttribute(element, "key", status) && expectAttribute(element, "name", status))
-  {
-    const auto name = parseString(element, "key", status);
-    const auto shortDesc = parseString(element, "name", status);
-    const auto longDesc = getText(element);
-
-    if (!addPropertyDefinition(propertyDefinitions, factory(name, shortDesc, longDesc)))
-    {
-      const auto line = static_cast<size_t>(element.GetLineNum());
-      status.warn(line, 0, "Skipping duplicate property definition: '" + name + "'");
-    }
-  }
-}
-
-void EntParser::parsePropertyDeclaration(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDeclarations,
-  ParserStatus& status)
-{
-  const auto* name = element.Name();
-  if (name && !std::strcmp(name, "list"))
-  {
-    parseListDeclaration(element, propertyDeclarations, status);
-  }
-}
-
-void EntParser::parseListDeclaration(
-  const tinyxml2::XMLElement& element,
-  PropertyDefinitionList& propertyDeclarations,
-  ParserStatus& status)
-{
-  if (expectAttribute(element, "name", status))
-  {
-    const auto name = parseString(element, "name", status);
-    Assets::ChoicePropertyOption::List options;
-
-    const auto* itemElement = element.FirstChildElement("item");
-    while (itemElement != nullptr)
-    {
-      if (
-        expectAttribute(*itemElement, "name", status)
-        && expectAttribute(*itemElement, "value", status))
-      {
-        const auto itemName = parseString(*itemElement, "name", status);
-        const auto itemValue = parseString(*itemElement, "value", status);
-        options.push_back(Assets::ChoicePropertyOption(itemValue, itemName));
-      }
-      itemElement = itemElement->NextSiblingElement("item");
-    }
-    propertyDeclarations.push_back(
-      std::make_shared<Assets::ChoicePropertyDefinition>(name, "", "", options, false));
-  }
-}
-
-std::optional<vm::bbox3> EntParser::parseBounds(
+bool expectAttribute(
   const tinyxml2::XMLElement& element,
   const std::string& attributeName,
   ParserStatus& status)
 {
-  const auto parts = kdl::str_split(parseString(element, attributeName, status), " ");
-  if (parts.size() == 6)
+  if (!hasAttribute(element, attributeName))
   {
-    const auto it = std::begin(parts);
-    if (
-      const auto min = vm::parse<FloatType, 3>(kdl::str_join(it, std::next(it, 3), " ")))
-    {
-      if (
-        const auto max =
-          vm::parse<FloatType, 3>(kdl::str_join(std::next(it, 3), std::end(parts), " ")))
-      {
-        return vm::bbox3{*min, *max};
-      }
-    }
+    warn(element, fmt::format("Expected attribute '{}'", attributeName), status);
+    return false;
   }
-
-  warn(element, "Invalid bounding box", status);
-  return std::nullopt;
+  return true;
 }
 
-std::optional<Color> EntParser::parseColor(
-  const tinyxml2::XMLElement& element,
-  const std::string& attributeName,
-  ParserStatus& status)
-{
-  return Color::parse(parseString(element, attributeName, status));
-}
-
-std::optional<int> EntParser::parseInteger(
-  const tinyxml2::XMLElement& element,
-  const std::string& attributeName,
-  ParserStatus& /* status */)
-{
-  const auto* strValue = element.Attribute(attributeName.c_str());
-  if (strValue != nullptr)
-  {
-    char* end;
-    const auto longValue = std::strtol(strValue, &end, 10);
-    if (
-      *end == '\0' && errno != ERANGE && longValue >= std::numeric_limits<int>::min()
-      && longValue <= std::numeric_limits<int>::max())
-    {
-      return {static_cast<int>(longValue)};
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<float> EntParser::parseFloat(
-  const tinyxml2::XMLElement& element,
-  const std::string& attributeName,
-  ParserStatus& /* status */)
-{
-  const auto* strValue = element.Attribute(attributeName.c_str());
-  if (strValue != nullptr)
-  {
-    char* end;
-    const auto floatValue = std::strtof(strValue, &end);
-    if (*end == '\0' && errno != ERANGE)
-    {
-      return floatValue;
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<size_t> EntParser::parseSize(
-  const tinyxml2::XMLElement& element,
-  const std::string& attributeName,
-  ParserStatus& /* status */)
-{
-  const auto* strValue = element.Attribute(attributeName.c_str());
-  if (strValue != nullptr)
-  {
-    char* end;
-    const auto intValue = std::strtoul(strValue, &end, 10);
-    if (*end == '\0' && errno != ERANGE)
-    {
-      return static_cast<size_t>(intValue);
-    }
-  }
-  return std::nullopt;
-}
-
-std::string EntParser::parseString(
-  const tinyxml2::XMLElement& element,
-  const std::string& attributeName,
-  ParserStatus& /* status */)
-{
-  const auto* value = element.Attribute(attributeName.c_str());
-  if (value == nullptr)
-  {
-    return std::string();
-  }
-  else
-  {
-    return std::string(value);
-  }
-}
-
-std::string EntParser::getText(const tinyxml2::XMLElement& element)
+std::string getText(const tinyxml2::XMLElement& element)
 {
   // I assume that only the initial and the last text is meaningful.
 
-  std::stringstream str;
+  auto str = std::stringstream{};
   const auto* first = element.FirstChild();
   const auto* last = element.LastChild();
 
@@ -715,40 +116,599 @@ std::string EntParser::getText(const tinyxml2::XMLElement& element)
   return str.str();
 }
 
-bool EntParser::expectAttribute(
+std::string parseString(
+  const tinyxml2::XMLElement& element, const std::string& attributeName)
+{
+  return std::string{getAttribute(element, attributeName)};
+}
+
+std::optional<size_t> parseSize(
+  const tinyxml2::XMLElement& element, const std::string& attributeName)
+{
+  return kdl::str_to_size(getAttribute(element, attributeName));
+}
+
+std::optional<int> parseInteger(
+  const tinyxml2::XMLElement& element, const std::string& attributeName)
+{
+  return kdl::str_to_int(getAttribute(element, attributeName));
+}
+
+
+std::optional<float> parseFloat(
+  const tinyxml2::XMLElement& element, const std::string& attributeName)
+{
+  return kdl::str_to_float(getAttribute(element, attributeName));
+}
+
+std::optional<Color> parseColor(
+  const tinyxml2::XMLElement& element, const std::string& attributeName)
+{
+  return Color::parse(parseString(element, attributeName));
+}
+
+std::optional<vm::bbox3> parseBounds(
   const tinyxml2::XMLElement& element,
   const std::string& attributeName,
   ParserStatus& status)
 {
-  if (!hasAttribute(element, attributeName))
+  const auto parts = kdl::str_split(parseString(element, attributeName), " ");
+  if (parts.size() == 6)
   {
-    warn(element, "Expected attribute '" + attributeName + "'", status);
-    return false;
+    const auto it = std::begin(parts);
+    const auto mid = std::next(it, 3);
+    const auto end = std::end(parts);
+
+    const auto min = vm::parse<FloatType, 3>(kdl::str_join(it, mid, " "));
+    const auto max = vm::parse<FloatType, 3>(kdl::str_join(mid, end, " "));
+    if (min && max)
+    {
+      return vm::bbox3{*min, *max};
+    }
   }
-  else
+
+  warn(element, "Invalid bounding box", status);
+  return std::nullopt;
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseListDeclaration(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  if (expectAttribute(element, "name", status))
   {
-    return true;
+    auto name = parseString(element, "name");
+    auto options = Assets::ChoicePropertyOption::List{};
+
+    const auto* itemElement = element.FirstChildElement("item");
+    while (itemElement)
+    {
+      if (
+        expectAttribute(*itemElement, "name", status)
+        && expectAttribute(*itemElement, "value", status))
+      {
+        auto itemName = parseString(*itemElement, "name");
+        auto itemValue = parseString(*itemElement, "value");
+        options.emplace_back(std::move(itemValue), std::move(itemName));
+      }
+      itemElement = itemElement->NextSiblingElement("item");
+    }
+    return std::make_unique<Assets::ChoicePropertyDefinition>(
+      std::move(name), "", "", std::move(options), false);
+  }
+  return nullptr;
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parsePropertyDeclaration(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  return getName(element) == "list" ? parseListDeclaration(element, status) : nullptr;
+}
+
+using PropertyDefinitionFactory =
+  std::function<std::unique_ptr<Assets::PropertyDefinition>(
+    std::string, std::string, std::string)>;
+
+std::unique_ptr<Assets::PropertyDefinition> parsePropertyDefinition(
+  const tinyxml2::XMLElement& element,
+  const PropertyDefinitionFactory& factory,
+  ParserStatus& status)
+{
+  if (expectAttribute(element, "key", status) && expectAttribute(element, "name", status))
+  {
+    auto name = parseString(element, "key");
+    auto shortDesc = parseString(element, "name");
+    auto longDesc = getText(element);
+
+    return factory(std::move(name), std::move(shortDesc), std::move(longDesc));
+  }
+  return nullptr;
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseDeclaredPropertyDefinition(
+  const tinyxml2::XMLElement& element,
+  const Assets::PropertyDefinition& propertyDeclaration,
+  ParserStatus& status)
+{
+  auto factory = [&propertyDeclaration](
+                   std::string name, std::string shortDesc, std::string longDesc) {
+    return propertyDeclaration.clone(name, shortDesc, longDesc, false);
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseTargetNamePropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [](std::string name, std::string shortDesc, std::string longDesc) {
+    return std::make_unique<Assets::PropertyDefinition>(
+      std::move(name),
+      Assets::PropertyDefinitionType::TargetSourceProperty,
+      std::move(shortDesc),
+      std::move(longDesc),
+      false);
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseTargetPropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [](std::string name, std::string shortDesc, std::string longDesc) {
+    return std::make_unique<Assets::PropertyDefinition>(
+      std::move(name),
+      Assets::PropertyDefinitionType::TargetDestinationProperty,
+      std::move(shortDesc),
+      std::move(longDesc),
+      false);
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseRealPropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [&](std::string name, std::string shortDesc, std::string longDesc)
+    -> std::unique_ptr<Assets::PropertyDefinition> {
+    if (hasAttribute(element, "value"))
+    {
+      auto floatDefaultValue = parseFloat(element, "value");
+      if (floatDefaultValue)
+      {
+        return std::make_unique<Assets::FloatPropertyDefinition>(
+          std::move(name),
+          std::move(shortDesc),
+          std::move(longDesc),
+          false,
+          std::move(floatDefaultValue));
+      }
+
+      auto strDefaultValue = parseString(element, "value");
+      warn(
+        element,
+        fmt::format(
+          "Invalid default value '{}' for float property definition", strDefaultValue),
+        status);
+      return std::make_unique<Assets::UnknownPropertyDefinition>(
+        std::move(name),
+        std::move(shortDesc),
+        std::move(longDesc),
+        false,
+        std::move(strDefaultValue));
+    }
+    return std::make_unique<Assets::FloatPropertyDefinition>(
+      std::move(name), std::move(shortDesc), std::move(longDesc), false);
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseIntegerPropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [&](std::string name, std::string shortDesc, std::string longDesc)
+    -> std::unique_ptr<Assets::PropertyDefinition> {
+    if (hasAttribute(element, "value"))
+    {
+      auto intDefaultValue = parseInteger(element, "value");
+      if (intDefaultValue)
+      {
+        return std::make_unique<Assets::IntegerPropertyDefinition>(
+          std::move(name),
+          std::move(shortDesc),
+          std::move(longDesc),
+          false,
+          std::move(intDefaultValue));
+      }
+
+      auto strDefaultValue = parseString(element, "value");
+      warn(
+        element,
+        fmt::format(
+          "Invalid default value '{}' for integer property definition", strDefaultValue),
+        status);
+      return std::make_unique<Assets::UnknownPropertyDefinition>(
+        std::move(name),
+        std::move(shortDesc),
+        std::move(longDesc),
+        false,
+        std::move(strDefaultValue));
+    }
+
+    return std::make_unique<Assets::IntegerPropertyDefinition>(
+      std::move(name), std::move(shortDesc), std::move(longDesc), false);
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseBooleanPropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [&](std::string name, std::string shortDesc, std::string longDesc)
+    -> std::unique_ptr<Assets::PropertyDefinition> {
+    if (hasAttribute(element, "value"))
+    {
+      if (const auto boolDefaultValue = parseInteger(element, "value"))
+      {
+        return std::make_unique<Assets::BooleanPropertyDefinition>(
+          std::move(name),
+          std::move(shortDesc),
+          std::move(longDesc),
+          false,
+          *boolDefaultValue != 0);
+      }
+
+      auto strDefaultValue = parseString(element, "value");
+      warn(
+        element,
+        fmt::format(
+          "Invalid default value '{}' for boolean property definition", strDefaultValue),
+        status);
+      return std::make_unique<Assets::UnknownPropertyDefinition>(
+        std::move(name),
+        std::move(shortDesc),
+        std::move(longDesc),
+        false,
+        std::move(strDefaultValue));
+    }
+
+    return std::make_unique<Assets::BooleanPropertyDefinition>(
+      std::move(name), std::move(shortDesc), std::move(longDesc), false);
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseStringPropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [&](std::string name, std::string shortDesc, std::string longDesc) {
+    auto defaultValue = hasAttribute(element, "value")
+                          ? std::optional(parseString(element, "value"))
+                          : std::nullopt;
+    return std::make_unique<Assets::StringPropertyDefinition>(
+      std::move(name),
+      std::move(shortDesc),
+      std::move(longDesc),
+      false,
+      std::move(defaultValue));
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseUnknownPropertyDefinition(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  auto factory = [&](std::string name, std::string shortDesc, std::string longDesc) {
+    auto defaultValue = hasAttribute(element, "value")
+                          ? std::optional(parseString(element, "value"))
+                          : std::nullopt;
+    return std::make_unique<Assets::UnknownPropertyDefinition>(
+      std::move(name),
+      std::move(shortDesc),
+      std::move(longDesc),
+      false,
+      std::move(defaultValue));
+  };
+  return parsePropertyDefinition(element, factory, status);
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parsePropertyDefinition(
+  const tinyxml2::XMLElement& element,
+  const std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDeclarations,
+  ParserStatus& status)
+{
+  if (getName(element) == "angle")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+  if (getName(element) == "angles")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+  if (getName(element) == "direction")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+  if (getName(element) == "boolean")
+  {
+    return parseBooleanPropertyDefinition(element, status);
+  }
+  if (getName(element) == "integer")
+  {
+    return parseIntegerPropertyDefinition(element, status);
+  }
+  if (getName(element) == "real")
+  {
+    return parseRealPropertyDefinition(element, status);
+  }
+  if (getName(element) == "string")
+  {
+    return parseStringPropertyDefinition(element, status);
+  }
+  if (getName(element) == "target")
+  {
+    return parseTargetPropertyDefinition(element, status);
+  }
+  if (getName(element) == "targetname")
+  {
+    return parseTargetNamePropertyDefinition(element, status);
+  }
+  if (getName(element) == "texture")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+  if (getName(element) == "sound")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+  if (getName(element) == "model")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+  if (getName(element) == "color")
+  {
+    return parseUnknownPropertyDefinition(element, status);
+  }
+
+  for (const auto& propertyDeclaration : propertyDeclarations)
+  {
+    if (getName(element) == propertyDeclaration->key())
+    {
+      return parseDeclaredPropertyDefinition(element, *propertyDeclaration, status);
+    }
+  }
+
+  return nullptr;
+}
+
+std::vector<std::shared_ptr<Assets::PropertyDefinition>> parsePropertyDefinitions(
+  const tinyxml2::XMLElement& parent,
+  const std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDeclarations,
+  ParserStatus& status)
+{
+  auto result = std::vector<std::shared_ptr<Assets::PropertyDefinition>>{};
+
+  const auto* element = parent.FirstChildElement();
+  while (element)
+  {
+    if (
+      auto propertyDefinition =
+        parsePropertyDefinition(*element, propertyDeclarations, status))
+    {
+      result.push_back(std::move(propertyDefinition));
+    }
+    element = element->NextSiblingElement();
+  }
+
+  return result;
+}
+
+std::unique_ptr<Assets::PropertyDefinition> parseSpawnflags(
+  const tinyxml2::XMLElement& element, ParserStatus& status)
+{
+  if (const auto* flagElement = element.FirstChildElement("flag"))
+  {
+    auto result = std::make_unique<Assets::FlagsPropertyDefinition>(
+      Model::EntityPropertyKeys::Spawnflags);
+    do
+    {
+      const auto bit = parseSize(*flagElement, "bit");
+      if (!bit)
+      {
+        const auto strValue = parseString(*flagElement, "bit");
+        warn(
+          *flagElement,
+          fmt::format("Invalid value '{}' for bit property definition", strValue),
+          status);
+      }
+      else
+      {
+        const auto value = 1 << *bit;
+        auto shortDesc = parseString(*flagElement, "key");
+        auto longDesc = parseString(*flagElement, "name");
+        result->addOption(value, std::move(shortDesc), std::move(longDesc), false);
+      }
+
+      flagElement = flagElement->NextSiblingElement("flag");
+    } while (flagElement);
+
+    return result;
+  }
+  return nullptr;
+}
+
+void parsePropertyDefinitions(
+  const tinyxml2::XMLElement& element,
+  const std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDeclarations,
+  EntityDefinitionClassInfo& classInfo,
+  ParserStatus& status)
+{
+  if (auto spawnflags = parseSpawnflags(element, status))
+  {
+    addPropertyDefinition(classInfo.propertyDefinitions, std::move(spawnflags));
+  }
+
+  for (auto propertyDefinition :
+       parsePropertyDefinitions(element, propertyDeclarations, status))
+  {
+    if (!addPropertyDefinition(
+          classInfo.propertyDefinitions, std::move(propertyDefinition)))
+    {
+      const auto line = static_cast<size_t>(element.GetLineNum());
+      status.warn(line, 0, "Skipping duplicate entity property definition");
+    }
   }
 }
 
-bool EntParser::hasAttribute(
-  const tinyxml2::XMLElement& element, const std::string& attributeName)
+Assets::ModelDefinition parseModel(const tinyxml2::XMLElement& element)
 {
-  return element.Attribute(attributeName.c_str()) != nullptr;
+  if (!hasAttribute(element, "model"))
+  {
+    return Assets::ModelDefinition{};
+  }
+
+  const auto model = parseString(element, "model");
+  try
+  {
+    auto parser = ELParser{ELParser::Mode::Lenient, model};
+    auto expression = parser.parse();
+    expression.optimize();
+    return Assets::ModelDefinition{std::move(expression)};
+  }
+  catch (const ParserException&)
+  {
+    const auto lineNum = static_cast<size_t>(element.GetLineNum());
+    auto expression = EL::Expression{
+      EL::LiteralExpression{EL::Value{EL::MapType{{
+        {Assets::ModelSpecificationKeys::Path, EL::Value{model}},
+      }}}},
+      lineNum,
+      0};
+    return Assets::ModelDefinition{std::move(expression)};
+  }
+  catch (const EL::EvaluationError& evaluationError)
+  {
+    const auto line = static_cast<size_t>(element.GetLineNum());
+    throw ParserException{line, evaluationError.what()};
+  }
 }
 
-void EntParser::warn(
-  const tinyxml2::XMLElement& element, const std::string& msg, ParserStatus& status)
+EntityDefinitionClassInfo parsePointClassInfo(
+  const tinyxml2::XMLElement& element,
+  const std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDeclarations,
+  ParserStatus& status)
 {
-  const auto str = msg + std::string(": ") + std::string(element.Name());
-  if (element.GetLineNum() > 0)
-  {
-    status.warn(static_cast<size_t>(element.GetLineNum()), str);
-  }
-  else
-  {
-    status.warn(str);
-  }
+  auto classInfo = EntityDefinitionClassInfo{};
+  classInfo.type = EntityDefinitionClassType::PointClass;
+  classInfo.line = static_cast<size_t>(element.GetLineNum());
+  classInfo.column = 0;
+  classInfo.name = parseString(element, "name");
+  classInfo.description = getText(element);
+  classInfo.color = parseColor(element, "color");
+  classInfo.size = parseBounds(element, "box", status);
+  classInfo.modelDefinition = parseModel(element);
+  parsePropertyDefinitions(element, propertyDeclarations, classInfo, status);
+
+  return classInfo;
 }
-} // namespace IO
-} // namespace TrenchBroom
+
+EntityDefinitionClassInfo parseBrushClassInfo(
+  const tinyxml2::XMLElement& element,
+  const std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDeclarations,
+  ParserStatus& status)
+{
+  auto classInfo = EntityDefinitionClassInfo{};
+  classInfo.type = EntityDefinitionClassType::BrushClass;
+  classInfo.line = static_cast<size_t>(element.GetLineNum());
+  classInfo.column = 0;
+  classInfo.name = parseString(element, "name");
+  classInfo.description = getText(element);
+  classInfo.color = parseColor(element, "color");
+  parsePropertyDefinitions(element, propertyDeclarations, classInfo, status);
+
+  return classInfo;
+}
+
+std::optional<EntityDefinitionClassInfo> parseClassInfo(
+  const tinyxml2::XMLElement& element,
+  const std::vector<std::shared_ptr<Assets::PropertyDefinition>>& propertyDeclarations,
+  ParserStatus& status)
+{
+  if (getName(element) == "point")
+  {
+    return parsePointClassInfo(element, propertyDeclarations, status);
+  }
+
+  if (getName(element) == "group")
+  {
+    return parseBrushClassInfo(element, propertyDeclarations, status);
+  }
+
+  warn(element, "Unexpected XML element", status);
+  return std::nullopt;
+}
+
+std::vector<EntityDefinitionClassInfo> parseClassInfosFromDocument(
+  const tinyxml2::XMLDocument& document, ParserStatus& status)
+{
+  auto result = std::vector<EntityDefinitionClassInfo>{};
+  auto propertyDeclarations = std::vector<std::shared_ptr<Assets::PropertyDefinition>>{};
+
+  if (const auto* classesNode = document.FirstChildElement("classes"))
+  {
+    const auto* currentElement = classesNode->FirstChildElement();
+    while (currentElement)
+    {
+      if (getName(*currentElement) == "point" || getName(*currentElement) == "group")
+      {
+        if (
+          auto classInfo = parseClassInfo(*currentElement, propertyDeclarations, status))
+        {
+          result.push_back(std::move(*classInfo));
+        }
+      }
+      else
+      {
+        if (auto propertyDeclaration = parsePropertyDeclaration(*currentElement, status))
+        {
+          if (!addPropertyDefinition(
+                propertyDeclarations, std::move(propertyDeclaration)))
+          {
+            const auto line = static_cast<size_t>(currentElement->GetLineNum());
+            status.warn(line, 0, "Skipping duplicate entity property declaration");
+          }
+        }
+      }
+      currentElement = currentElement->NextSiblingElement();
+    }
+  }
+  return result;
+}
+
+} // namespace
+
+EntParser::EntParser(std::string_view str, const Color& defaultEntityColor)
+  : EntityDefinitionParser{defaultEntityColor}
+  , m_str{str}
+{
+}
+
+std::vector<EntityDefinitionClassInfo> EntParser::parseClassInfos(ParserStatus& status)
+{
+  auto doc = tinyxml2::XMLDocument{};
+  doc.Parse(m_str.data(), m_str.length());
+
+  if (doc.Error())
+  {
+    if (doc.ErrorID() == tinyxml2::XML_ERROR_EMPTY_DOCUMENT)
+    {
+      // we allow empty documents
+      return {};
+    }
+    const auto lineNum = static_cast<size_t>(doc.ErrorLineNum());
+    throw ParserException{lineNum, doc.ErrorStr()};
+  }
+
+  return parseClassInfosFromDocument(doc, status);
+}
+
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/EntParser.h
+++ b/common/src/IO/EntParser.h
@@ -19,33 +19,12 @@
 
 #pragma once
 
-#include "Color.h"
-#include "FloatType.h"
 #include "IO/EntityDefinitionParser.h"
 
-#include <vecmath/forward.h>
-
-#include <functional>
-#include <memory>
-#include <optional>
-#include <string>
 #include <string_view>
 #include <vector>
 
-namespace tinyxml2
-{
-class XMLDocument;
-class XMLElement;
-} // namespace tinyxml2
-
-namespace TrenchBroom
-{
-namespace Assets
-{
-class ModelDefinition;
-}
-
-namespace IO
+namespace TrenchBroom::IO
 {
 struct EntityDefinitionClassInfo;
 class ParserStatus;
@@ -53,130 +32,13 @@ class ParserStatus;
 class EntParser : public EntityDefinitionParser
 {
 private:
-  using PropertyDefinitionFactory =
-    std::function<std::shared_ptr<Assets::PropertyDefinition>(
-      const std::string&, const std::string&, const std::string&)>;
-
-  const char* m_begin;
-  const char* m_end;
+  std::string_view m_str;
 
 public:
   EntParser(std::string_view str, const Color& defaultEntityColor);
 
 private:
   std::vector<EntityDefinitionClassInfo> parseClassInfos(ParserStatus& status) override;
-
-  std::vector<EntityDefinitionClassInfo> parseClassInfos(
-    const tinyxml2::XMLDocument& document, ParserStatus& status);
-  std::optional<EntityDefinitionClassInfo> parseClassInfo(
-    const tinyxml2::XMLElement& element,
-    const PropertyDefinitionList& propertyDeclarations,
-    ParserStatus& status);
-  EntityDefinitionClassInfo parsePointClassInfo(
-    const tinyxml2::XMLElement& element,
-    const PropertyDefinitionList& propertyDeclarations,
-    ParserStatus& status);
-  EntityDefinitionClassInfo parseBrushClassInfo(
-    const tinyxml2::XMLElement& element,
-    const PropertyDefinitionList& propertyDeclarations,
-    ParserStatus& status);
-
-  Assets::ModelDefinition parseModel(
-    const tinyxml2::XMLElement& element, ParserStatus& status);
-
-  void parseSpawnflags(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-
-  void parsePropertyDefinitions(
-    const tinyxml2::XMLElement& parent,
-    const PropertyDefinitionList& propertyDeclarations,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseUnknownPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseStringPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseBooleanPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseIntegerPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseRealPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseTargetPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parseTargetNamePropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-
-  void parseDeclaredPropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    const std::shared_ptr<Assets::PropertyDefinition>& propertyDeclaration,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-  void parsePropertyDefinition(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionFactory factory,
-    PropertyDefinitionList& propertyDefinitions,
-    ParserStatus& status);
-
-  void parsePropertyDeclaration(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDeclarations,
-    ParserStatus& status);
-  void parseListDeclaration(
-    const tinyxml2::XMLElement& element,
-    PropertyDefinitionList& propertyDeclarations,
-    ParserStatus& status);
-
-  std::optional<vm::bbox3> parseBounds(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  std::optional<Color> parseColor(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  std::optional<int> parseInteger(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  std::optional<float> parseFloat(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  std::optional<size_t> parseSize(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  std::string parseString(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  std::string getText(const tinyxml2::XMLElement& element);
-
-  bool expectAttribute(
-    const tinyxml2::XMLElement& element,
-    const std::string& attributeName,
-    ParserStatus& status);
-  bool hasAttribute(
-    const tinyxml2::XMLElement& element, const std::string& attributeName);
-  void warn(
-    const tinyxml2::XMLElement& element, const std::string& msg, ParserStatus& status);
 };
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/EntityDefinitionLoader.cpp
+++ b/common/src/IO/EntityDefinitionLoader.cpp
@@ -19,17 +19,9 @@
 
 #include "EntityDefinitionLoader.h"
 
-#include "Error.h"
-
-#include <kdl/result.h>
-
 namespace TrenchBroom::IO
 {
-EntityDefinitionLoader::~EntityDefinitionLoader() {}
 
-Result<std::vector<Assets::EntityDefinition*>> EntityDefinitionLoader::
-  loadEntityDefinitions(ParserStatus& status, const std::filesystem::path& path) const
-{
-  return doLoadEntityDefinitions(status, path);
-}
+EntityDefinitionLoader::~EntityDefinitionLoader() = default;
+
 } // namespace TrenchBroom::IO

--- a/common/src/IO/EntityDefinitionLoader.h
+++ b/common/src/IO/EntityDefinitionLoader.h
@@ -22,6 +22,7 @@
 #include "Result.h"
 
 #include <filesystem>
+#include <memory>
 #include <vector>
 
 namespace TrenchBroom::Assets
@@ -37,11 +38,8 @@ class EntityDefinitionLoader
 {
 public:
   virtual ~EntityDefinitionLoader();
-  Result<std::vector<Assets::EntityDefinition*>> loadEntityDefinitions(
-    ParserStatus& status, const std::filesystem::path& path) const;
-
-private:
-  virtual Result<std::vector<Assets::EntityDefinition*>> doLoadEntityDefinitions(
+  virtual Result<std::vector<std::unique_ptr<Assets::EntityDefinition>>>
+  loadEntityDefinitions(
     ParserStatus& status, const std::filesystem::path& path) const = 0;
 };
 } // namespace TrenchBroom::IO

--- a/common/src/IO/EntityDefinitionParser.cpp
+++ b/common/src/IO/EntityDefinitionParser.cpp
@@ -453,7 +453,7 @@ std::unique_ptr<Assets::EntityDefinition> createDefinition(
   };
 }
 
-std::vector<Assets::EntityDefinition*> createDefinitions(
+std::vector<std::unique_ptr<Assets::EntityDefinition>> createDefinitions(
   ParserStatus& status,
   const std::vector<EntityDefinitionClassInfo>& classInfos,
   const Color& defaultEntityColor)
@@ -461,12 +461,12 @@ std::vector<Assets::EntityDefinition*> createDefinitions(
   const auto resolvedClasses =
     resolveInheritance(status, filterRedundantClasses(status, classInfos));
 
-  auto result = std::vector<Assets::EntityDefinition*>{};
+  auto result = std::vector<std::unique_ptr<Assets::EntityDefinition>>{};
   for (auto classInfo : resolvedClasses)
   {
     if (auto definition = createDefinition(std::move(classInfo), defaultEntityColor))
     {
-      result.push_back(definition.release());
+      result.push_back(std::move(definition));
     }
   }
 
@@ -475,8 +475,8 @@ std::vector<Assets::EntityDefinition*> createDefinitions(
 
 } // namespace
 
-std::vector<Assets::EntityDefinition*> EntityDefinitionParser::parseDefinitions(
-  ParserStatus& status)
+std::vector<std::unique_ptr<Assets::EntityDefinition>> EntityDefinitionParser::
+  parseDefinitions(ParserStatus& status)
 {
   const auto classInfos = parseClassInfos(status);
   return createDefinitions(status, classInfos, m_defaultEntityColor);

--- a/common/src/IO/EntityDefinitionParser.cpp
+++ b/common/src/IO/EntityDefinitionParser.cpp
@@ -32,14 +32,12 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace TrenchBroom
-{
-namespace IO
+namespace TrenchBroom::IO
 {
 static const auto DefaultSize = vm::bbox3(-8, +8);
 
 EntityDefinitionParser::EntityDefinitionParser(const Color& defaultEntityColor)
-  : m_defaultEntityColor(defaultEntityColor)
+  : m_defaultEntityColor{defaultEntityColor}
 {
 }
 
@@ -420,47 +418,53 @@ std::vector<EntityDefinitionClassInfo> resolveInheritance(
   return result;
 }
 
-std::unique_ptr<Assets::EntityDefinition> EntityDefinitionParser::createDefinition(
-  const EntityDefinitionClassInfo& classInfo) const
+namespace
 {
-  const auto& name = classInfo.name;
-  const auto color = classInfo.color.value_or(m_defaultEntityColor);
-  const auto size = classInfo.size.value_or(DefaultSize);
-  auto description = classInfo.description.value_or("");
-  auto& attributes = classInfo.propertyDefinitions;
-  auto modelDefinition = classInfo.modelDefinition.value_or(Assets::ModelDefinition{});
-  auto decalDefinition = classInfo.decalDefinition.value_or(Assets::DecalDefinition{});
+std::unique_ptr<Assets::EntityDefinition> createDefinition(
+  EntityDefinitionClassInfo classInfo, const Color& defaultEntityColor)
+{
+  auto name = std::move(classInfo.name);
+  auto color = std::move(classInfo.color).value_or(defaultEntityColor);
+  auto size = std::move(classInfo.size).value_or(DefaultSize);
+  auto description = std::move(classInfo.description).value_or("");
+  auto propertyDefinitions = std::move(classInfo.propertyDefinitions);
+  auto modelDefinition =
+    std::move(classInfo.modelDefinition).value_or(Assets::ModelDefinition{});
+  auto decalDefinition =
+    std::move(classInfo.decalDefinition).value_or(Assets::DecalDefinition{});
 
   switch (classInfo.type)
   {
   case EntityDefinitionClassType::PointClass:
     return std::make_unique<Assets::PointEntityDefinition>(
-      name,
+      std::move(name),
       color,
       size,
       std::move(description),
-      std::move(attributes),
+      std::move(propertyDefinitions),
       std::move(modelDefinition),
       std::move(decalDefinition));
   case EntityDefinitionClassType::BrushClass:
     return std::make_unique<Assets::BrushEntityDefinition>(
-      name, color, std::move(description), std::move(attributes));
+      std::move(name), color, std::move(description), std::move(propertyDefinitions));
   case EntityDefinitionClassType::BaseClass:
     return nullptr;
     switchDefault();
   };
 }
 
-std::vector<Assets::EntityDefinition*> EntityDefinitionParser::createDefinitions(
-  ParserStatus& status, const std::vector<EntityDefinitionClassInfo>& classInfos) const
+std::vector<Assets::EntityDefinition*> createDefinitions(
+  ParserStatus& status,
+  const std::vector<EntityDefinitionClassInfo>& classInfos,
+  const Color& defaultEntityColor)
 {
   const auto resolvedClasses =
     resolveInheritance(status, filterRedundantClasses(status, classInfos));
 
-  std::vector<Assets::EntityDefinition*> result;
-  for (const auto& classInfo : resolvedClasses)
+  auto result = std::vector<Assets::EntityDefinition*>{};
+  for (auto classInfo : resolvedClasses)
   {
-    if (auto definition = createDefinition(classInfo))
+    if (auto definition = createDefinition(std::move(classInfo), defaultEntityColor))
     {
       result.push_back(definition.release());
     }
@@ -469,11 +473,13 @@ std::vector<Assets::EntityDefinition*> EntityDefinitionParser::createDefinitions
   return result;
 }
 
-EntityDefinitionParser::EntityDefinitionList EntityDefinitionParser::parseDefinitions(
+} // namespace
+
+std::vector<Assets::EntityDefinition*> EntityDefinitionParser::parseDefinitions(
   ParserStatus& status)
 {
-  auto classInfos = parseClassInfos(status);
-  return createDefinitions(status, std::move(classInfos));
+  const auto classInfos = parseClassInfos(status);
+  return createDefinitions(status, classInfos, m_defaultEntityColor);
 }
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/EntityDefinitionParser.h
+++ b/common/src/IO/EntityDefinitionParser.h
@@ -26,15 +26,13 @@
 #include <unordered_map>
 #include <vector>
 
-namespace TrenchBroom
-{
-namespace Assets
+namespace TrenchBroom::Assets
 {
 class PropertyDefinition;
 class EntityDefinition;
-} // namespace Assets
+} // namespace TrenchBroom::Assets
 
-namespace IO
+namespace TrenchBroom::IO
 {
 struct EntityDefinitionClassInfo;
 class ParserStatus;
@@ -48,26 +46,15 @@ class EntityDefinitionParser
 private:
   Color m_defaultEntityColor;
 
-protected:
-  using EntityDefinitionList = std::vector<Assets::EntityDefinition*>;
-  using PropertyDefinitionPtr = std::shared_ptr<Assets::PropertyDefinition>;
-  using PropertyDefinitionList = std::vector<PropertyDefinitionPtr>;
-  using PropertyDefinitionMap = std::unordered_map<std::string, PropertyDefinitionPtr>;
-
 public:
-  EntityDefinitionParser(const Color& defaultEntityColor);
+  explicit EntityDefinitionParser(const Color& defaultEntityColor);
   virtual ~EntityDefinitionParser();
 
-  EntityDefinitionList parseDefinitions(ParserStatus& status);
+  std::vector<Assets::EntityDefinition*> parseDefinitions(ParserStatus& status);
 
 private:
-  std::unique_ptr<Assets::EntityDefinition> createDefinition(
-    const EntityDefinitionClassInfo& classInfo) const;
-  std::vector<Assets::EntityDefinition*> createDefinitions(
-    ParserStatus& status, const std::vector<EntityDefinitionClassInfo>& classInfos) const;
-
   virtual std::vector<EntityDefinitionClassInfo> parseClassInfos(
     ParserStatus& status) = 0;
 };
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/EntityDefinitionParser.h
+++ b/common/src/IO/EntityDefinitionParser.h
@@ -50,7 +50,8 @@ public:
   explicit EntityDefinitionParser(const Color& defaultEntityColor);
   virtual ~EntityDefinitionParser();
 
-  std::vector<Assets::EntityDefinition*> parseDefinitions(ParserStatus& status);
+  std::vector<std::unique_ptr<Assets::EntityDefinition>> parseDefinitions(
+    ParserStatus& status);
 
 private:
   virtual std::vector<EntityDefinitionClassInfo> parseClassInfos(

--- a/common/src/IO/FgdParser.h
+++ b/common/src/IO/FgdParser.h
@@ -122,29 +122,30 @@ private:
   std::string parseNamedValue(ParserStatus& status, const std::string& name);
   void skipClassProperty(ParserStatus& status);
 
-  PropertyDefinitionList parsePropertyDefinitions(ParserStatus& status);
-  PropertyDefinitionPtr parsePropertyDefinition(
+  std::vector<std::shared_ptr<Assets::PropertyDefinition>> parsePropertyDefinitions(
+    ParserStatus& status);
+  std::unique_ptr<Assets::PropertyDefinition> parsePropertyDefinition(
     ParserStatus& status,
-    const std::string& propertyKey,
+    std::string propertyKey,
     const std::string& typeName,
     size_t line,
     size_t column);
-  PropertyDefinitionPtr parseTargetSourcePropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseTargetDestinationPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseStringPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseIntegerPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseFloatPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseChoicesPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseFlagsPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
-  PropertyDefinitionPtr parseUnknownPropertyDefinition(
-    ParserStatus& status, const std::string& propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseTargetSourcePropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseTargetDestinationPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseStringPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseIntegerPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseFloatPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseChoicesPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseFlagsPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
+  std::unique_ptr<Assets::PropertyDefinition> parseUnknownPropertyDefinition(
+    ParserStatus& status, std::string propertyKey);
 
   bool parseReadOnlyFlag(ParserStatus& status);
   std::string parsePropertyDescription(ParserStatus& status);

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -121,8 +121,6 @@ private:
   Result<void> doReloadShaders() override;
 
   bool doIsEntityDefinitionFile(const std::filesystem::path& path) const override;
-  Result<std::vector<Assets::EntityDefinition*>> doLoadEntityDefinitions(
-    IO::ParserStatus& status, const std::filesystem::path& path) const override;
   std::vector<Assets::EntityDefinitionFileSpec> doAllEntityDefinitionFiles()
     const override;
   Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(
@@ -131,6 +129,9 @@ private:
   std::filesystem::path doFindEntityDefinitionFile(
     const Assets::EntityDefinitionFileSpec& spec,
     const std::vector<std::filesystem::path>& searchPaths) const override;
+
+  Result<std::vector<std::unique_ptr<Assets::EntityDefinition>>> loadEntityDefinitions(
+    IO::ParserStatus& status, const std::filesystem::path& path) const override;
 
   std::unique_ptr<Assets::EntityModel> doInitializeModel(
     const std::filesystem::path& path, Logger& logger) const override;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -4346,9 +4346,9 @@ void MapDocument::setEntityDefinitionFile(const Assets::EntityDefinitionFileSpec
 }
 
 void MapDocument::setEntityDefinitions(
-  const std::vector<Assets::EntityDefinition*>& definitions)
+  std::vector<std::unique_ptr<Assets::EntityDefinition>> definitions)
 {
-  m_entityDefinitionManager->setDefinitions(definitions);
+  m_entityDefinitionManager->setDefinitions(std::move(definitions));
 }
 
 void MapDocument::reloadTextureCollections()

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -702,7 +702,8 @@ public: // asset management
   void setEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec);
 
   // For testing
-  void setEntityDefinitions(const std::vector<Assets::EntityDefinition*>& definitions);
+  void setEntityDefinitions(
+    std::vector<std::unique_ptr<Assets::EntityDefinition>> definitions);
 
   void reloadTextureCollections();
   void reloadEntityDefinitions();

--- a/common/test/src/Assets/EntityDefinitionTestUtils.cpp
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.cpp
@@ -46,23 +46,21 @@ void assertModelDefinition(
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == EntityDefinitionType::PointEntity);
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == EntityDefinitionType::PointEntity);
 
   assertModelDefinition(expected, definition, entityPropertiesStr);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 void assertModelDefinition(
   const ModelSpecification& expected,
-  const EntityDefinition* definition,
+  const EntityDefinition& definition,
   const std::string& entityPropertiesStr)
 {
-  assert(definition->type() == EntityDefinitionType::PointEntity);
+  assert(definition.type() == EntityDefinitionType::PointEntity);
 
-  const auto* pointDefinition = dynamic_cast<const PointEntityDefinition*>(definition);
-  const auto& modelDefinition = pointDefinition->modelDefinition();
+  const auto& pointDefinition = static_cast<const PointEntityDefinition&>(definition);
+  const auto& modelDefinition = pointDefinition.modelDefinition();
   assertModelDefinition(expected, modelDefinition, entityPropertiesStr);
 }
 
@@ -87,23 +85,21 @@ void assertDecalDefinition(
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == EntityDefinitionType::PointEntity);
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == EntityDefinitionType::PointEntity);
 
   assertDecalDefinition(expected, definition, entityPropertiesStr);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 void assertDecalDefinition(
   const DecalSpecification& expected,
-  const EntityDefinition* definition,
+  const EntityDefinition& definition,
   const std::string& entityPropertiesStr)
 {
-  assert(definition->type() == EntityDefinitionType::PointEntity);
+  assert(definition.type() == EntityDefinitionType::PointEntity);
 
-  const auto* pointDefinition = dynamic_cast<const PointEntityDefinition*>(definition);
-  const auto& modelDefinition = pointDefinition->decalDefinition();
+  const auto& pointDefinition = static_cast<const PointEntityDefinition&>(definition);
+  const auto& modelDefinition = pointDefinition.decalDefinition();
   assertDecalDefinition(expected, modelDefinition, entityPropertiesStr);
 }
 

--- a/common/test/src/Assets/EntityDefinitionTestUtils.h
+++ b/common/test/src/Assets/EntityDefinitionTestUtils.h
@@ -44,7 +44,7 @@ void assertModelDefinition(
   const std::string& entityPropertiesStr = "{}");
 void assertModelDefinition(
   const ModelSpecification& expected,
-  const EntityDefinition* definition,
+  const EntityDefinition& definition,
   const std::string& entityPropertiesStr = "{}");
 void assertModelDefinition(
   const ModelSpecification& expected,
@@ -69,7 +69,7 @@ void assertDecalDefinition(
   const std::string& entityPropertiesStr = "{}");
 void assertDecalDefinition(
   const DecalSpecification& expected,
-  const EntityDefinition* definition,
+  const EntityDefinition& definition,
   const std::string& entityPropertiesStr = "{}");
 void assertDecalDefinition(
   const DecalSpecification& expected,

--- a/common/test/src/IO/tst_DefParser.cpp
+++ b/common/test/src/IO/tst_DefParser.cpp
@@ -102,7 +102,6 @@ TEST_CASE("DefParserTest.parseEmptyFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parseWhitespaceFile")
@@ -116,7 +115,6 @@ TEST_CASE("DefParserTest.parseWhitespaceFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parseCommentsFile")
@@ -130,7 +128,6 @@ TEST_CASE("DefParserTest.parseCommentsFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parseSolidClass")
@@ -158,19 +155,17 @@ Set sounds to the cd track to play.
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::BrushEntity);
-  CHECK(definition->name() == "worldspawn");
-  CHECK(definition->color() == Color{0.0f, 0.0f, 0.0f, 1.0f});
-  CHECK(definition->description() == R"(Only used for the world entity. 
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::BrushEntity);
+  CHECK(definition.name() == "worldspawn");
+  CHECK(definition.color() == Color{0.0f, 0.0f, 0.0f, 1.0f});
+  CHECK(definition.description() == R"(Only used for the world entity. 
 Set message to the level name. 
 Set sounds to the cd track to play. 
 "worldtype"	type of world)");
 
-  const auto& properties = definition->propertyDefinitions();
+  const auto& properties = definition.propertyDefinitions();
   CHECK(properties.size() == 1u);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parsePointClass")
@@ -187,26 +182,25 @@ TEST_CASE("DefParserTest.parsePointClass")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "monster_zombie");
-  CHECK(definition->color() == Color{1.0f, 0.0f, 0.0f, 1.0f});
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "monster_zombie");
+  CHECK(definition.color() == Color{1.0f, 0.0f, 0.0f, 1.0f});
   CHECK(
-    definition->description()
+    definition.description()
     == R"(If crucified, stick the bounding box 12 pixels back into a wall to look right.)");
 
-  const auto* pointDefinition =
-    static_cast<const Assets::PointEntityDefinition*>(definition);
-  CHECK(
-    pointDefinition->bounds() == vm::bbox3{{-16.0, -16.0, -24.0}, {16.0, 16.0, 32.0}});
+  const auto& pointDefinition =
+    static_cast<const Assets::PointEntityDefinition&>(definition);
+  CHECK(pointDefinition.bounds() == vm::bbox3{{-16.0, -16.0, -24.0}, {16.0, 16.0, 32.0}});
 
-  const auto& properties = definition->propertyDefinitions();
+  const auto& properties = definition.propertyDefinitions();
   CHECK(properties.size() == 1u); // spawnflags
 
   const auto property = properties[0];
   CHECK(property->type() == Assets::PropertyDefinitionType::FlagsProperty);
 
-  const auto* spawnflags = definition->spawnflags();
+  const auto* spawnflags = definition.spawnflags();
   CHECK(spawnflags != nullptr);
   CHECK(spawnflags->defaultValue() == 0);
 
@@ -216,8 +210,6 @@ TEST_CASE("DefParserTest.parsePointClass")
       {1, "Crucified", "", false},
       {2, "ambush", "", false},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parseSpawnflagWithSkip")
@@ -233,24 +225,23 @@ TEST_CASE("DefParserTest.parseSpawnflagWithSkip")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "item_health");
-  CHECK(definition->color() == Color{0.3f, 0.3f, 1.0f, 1.0f});
-  CHECK(definition->description() == "some desc");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "item_health");
+  CHECK(definition.color() == Color{0.3f, 0.3f, 1.0f, 1.0f});
+  CHECK(definition.description() == "some desc");
 
-  const auto* pointDefinition =
-    static_cast<const Assets::PointEntityDefinition*>(definition);
-  CHECK(
-    pointDefinition->bounds() == vm::bbox3{{-16.0, -16.0, -16.0}, {16.0, 16.0, 16.0}});
+  const auto& pointDefinition =
+    static_cast<const Assets::PointEntityDefinition&>(definition);
+  CHECK(pointDefinition.bounds() == vm::bbox3{{-16.0, -16.0, -16.0}, {16.0, 16.0, 16.0}});
 
-  const auto& properties = definition->propertyDefinitions();
+  const auto& properties = definition.propertyDefinitions();
   CHECK(properties.size() == 1u); // spawnflags
 
   const auto property = properties[0];
   CHECK(property->type() == Assets::PropertyDefinitionType::FlagsProperty);
 
-  const auto* spawnflags = definition->spawnflags();
+  const auto* spawnflags = definition.spawnflags();
   CHECK(spawnflags != nullptr);
   CHECK(spawnflags->defaultValue() == 0);
 
@@ -263,8 +254,6 @@ TEST_CASE("DefParserTest.parseSpawnflagWithSkip")
       {8, "", "", false},
       {16, "RESPAWN", "", false},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parseBrushEntityWithMissingBBoxAndNoQuestionMark")
@@ -280,19 +269,19 @@ TEST_CASE("DefParserTest.parseBrushEntityWithMissingBBoxAndNoQuestionMark")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::BrushEntity);
-  CHECK(definition->name() == "item_health");
-  CHECK(definition->color() == Color{0.3f, 0.3f, 1.0f, 1.0f});
-  CHECK(definition->description() == "some desc");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::BrushEntity);
+  CHECK(definition.name() == "item_health");
+  CHECK(definition.color() == Color{0.3f, 0.3f, 1.0f, 1.0f});
+  CHECK(definition.description() == "some desc");
 
-  const auto& properties = definition->propertyDefinitions();
+  const auto& properties = definition.propertyDefinitions();
   CHECK(properties.size() == 1u); // spawnflags
 
   const auto property = properties[0];
   CHECK(property->type() == Assets::PropertyDefinitionType::FlagsProperty);
 
-  const auto* spawnflags = definition->spawnflags();
+  const auto* spawnflags = definition.spawnflags();
   CHECK(spawnflags != nullptr);
   CHECK(spawnflags->defaultValue() == 0);
 
@@ -304,8 +293,6 @@ TEST_CASE("DefParserTest.parseBrushEntityWithMissingBBoxAndNoQuestionMark")
       {4, "", "", false},
       {8, "RESPAWN", "", false},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("DefParserTest.parsePointClassWithBaseClasses")
@@ -347,20 +334,20 @@ TEST_CASE("DefParserTest.parsePointClassWithBaseClasses")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "light");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "light");
 
-  CHECK(definition->propertyDefinitions().size() == 2u);
+  CHECK(definition.propertyDefinitions().size() == 2u);
 
-  const auto* stylePropertyDefinition = definition->propertyDefinition("style");
+  const auto* stylePropertyDefinition = definition.propertyDefinition("style");
   CHECK(stylePropertyDefinition != nullptr);
   CHECK(stylePropertyDefinition->key() == "style");
   CHECK(
     stylePropertyDefinition->type() == Assets::PropertyDefinitionType::ChoiceProperty);
 
   const auto* spawnflagsPropertyDefinition =
-    definition->propertyDefinition(Model::EntityPropertyKeys::Spawnflags);
+    definition.propertyDefinition(Model::EntityPropertyKeys::Spawnflags);
   CHECK(spawnflagsPropertyDefinition != nullptr);
   CHECK(spawnflagsPropertyDefinition->key() == Model::EntityPropertyKeys::Spawnflags);
   CHECK(
@@ -386,8 +373,6 @@ TEST_CASE("DefParserTest.parsePointClassWithBaseClasses")
       {"10", "fluorescent flicker"},
       {"11", "slow pulse not fade to black"},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 static const auto DefModelDefinitionTemplate = R"(
@@ -462,10 +447,8 @@ TEST_CASE("DefParserTest.parseInvalidBounds")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto definition = static_cast<Assets::PointEntityDefinition*>(definitions[0]);
-  CHECK(definition->bounds() == vm::bbox3d{8.0});
-
-  kdl::vec_clear_and_delete(definitions);
+  const auto& definition = static_cast<Assets::PointEntityDefinition&>(*definitions[0]);
+  CHECK(definition.bounds() == vm::bbox3d{8.0});
 }
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/IO/tst_EntParser.cpp
+++ b/common/test/src/IO/tst_EntParser.cpp
@@ -415,6 +415,54 @@ TEST_CASE("EntParserTest.parseListPropertyDefinition")
   kdl::vec_clear_and_delete(definitions);
 }
 
+TEST_CASE("EntParserTest.parseBooleanProperty")
+{
+  const auto file = R"(
+<?xml version="1.0"?>
+<classes>
+  <point name="_skybox" color="0.77 0.88 1.0" box="-4 -4 -4 4 4 4">
+    <boolean key="prop_true"  name="true"  value="true" />
+    <boolean key="prop_false" name="false" value="false" />
+    <boolean key="prop_True"  name="True"  value="true" />
+    <boolean key="prop_False" name="False" value="false" />
+    <boolean key="prop_0"     name="0"     value="0" />
+    <boolean key="prop_1"     name="1"     value="1" />
+    <boolean key="prop_2"     name="2"     value="2" />
+    <boolean key="prop_n1"    name="-1"    value="-1" />
+  </point>
+</classes>
+)";
+
+  auto parser = EntParser{file, Color{1.0f, 1.0f, 1.0f, 1.0f}};
+
+  auto status = TestParserStatus{};
+  auto definitions = parser.parseDefinitions(status);
+  REQUIRE(definitions.size() == 1u);
+
+  const auto* pointDefinition =
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+  REQUIRE(pointDefinition != nullptr);
+
+  const auto getDefaultValue = [&](const auto& key) -> std::optional<bool> {
+    const auto* propertyDefinition =
+      dynamic_cast<const Assets::BooleanPropertyDefinition*>(
+        pointDefinition->propertyDefinition(key));
+    return propertyDefinition ? std::optional{propertyDefinition->defaultValue()}
+                              : std::nullopt;
+  };
+
+  CHECK(getDefaultValue("prop_true") == true);
+  CHECK(getDefaultValue("prop_false") == false);
+  CHECK(getDefaultValue("prop_True") == true);
+  CHECK(getDefaultValue("prop_False") == false);
+  CHECK(getDefaultValue("prop_0") == false);
+  CHECK(getDefaultValue("prop_1") == true);
+  CHECK(getDefaultValue("prop_2") == true);
+  CHECK(getDefaultValue("prop_n1") == true);
+
+  kdl::vec_clear_and_delete(definitions);
+}
+
 TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition")
 {
   const std::string file = R"(

--- a/common/test/src/IO/tst_EntParser.cpp
+++ b/common/test/src/IO/tst_EntParser.cpp
@@ -98,7 +98,6 @@ TEST_CASE("EntParserTest.parseEmptyFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseWhitespaceFile")
@@ -112,7 +111,6 @@ TEST_CASE("EntParserTest.parseWhitespaceFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseMalformedXML")
@@ -174,7 +172,7 @@ Updated: 2011-03-02
   CHECK(definitions.size() == 1u);
 
   const auto* pointDefinition =
-    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front().get());
   UNSCOPED_INFO("Definition must be a point entity definition");
   CHECK(pointDefinition != nullptr);
 
@@ -252,8 +250,6 @@ Updated: 2011-03-02
   CHECK(
     scaleDefinition->longDescription()
     == "Scaling factor (default 64), good values are between 50 and 300, depending on the map.");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseSimpleGroupEntityDefinition")
@@ -289,7 +285,7 @@ Target this entity with a misc_model to have the model attached to the entity (s
   CHECK(definitions.size() == 1u);
 
   const auto* brushDefinition =
-    dynamic_cast<const Assets::BrushEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::BrushEntityDefinition*>(definitions.front().get());
   UNSCOPED_INFO("Definition must be a brush entity definition");
   CHECK(brushDefinition != nullptr);
 
@@ -336,8 +332,6 @@ Target this entity with a misc_model to have the model attached to the entity (s
       {1, "X_AXIS", "X Axis", false},
       {2, "Y_AXIS", "Y Axis", false},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseListPropertyDefinition")
@@ -372,7 +366,7 @@ TEST_CASE("EntParserTest.parseListPropertyDefinition")
   CHECK(definitions.size() == 1u);
 
   const auto* pointDefinition =
-    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front().get());
   UNSCOPED_INFO("Definition must be a point entity definition");
   CHECK(pointDefinition != nullptr);
 
@@ -411,8 +405,6 @@ TEST_CASE("EntParserTest.parseListPropertyDefinition")
       {"1", "red"},
       {"2", "green"},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseBooleanProperty")
@@ -440,7 +432,7 @@ TEST_CASE("EntParserTest.parseBooleanProperty")
   REQUIRE(definitions.size() == 1u);
 
   const auto* pointDefinition =
-    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front().get());
   REQUIRE(pointDefinition != nullptr);
 
   const auto getDefaultValue = [&](const auto& key) -> std::optional<bool> {
@@ -459,8 +451,6 @@ TEST_CASE("EntParserTest.parseBooleanProperty")
   CHECK(getDefaultValue("prop_1") == true);
   CHECK(getDefaultValue("prop_2") == true);
   CHECK(getDefaultValue("prop_n1") == true);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition")
@@ -482,7 +472,7 @@ TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition")
   CHECK(definitions.size() == 1u);
 
   const auto* pointDefinition =
-    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front().get());
   UNSCOPED_INFO("Definition must be a point entity definition");
   CHECK(pointDefinition != nullptr);
 
@@ -498,8 +488,6 @@ TEST_CASE("EntParserTest.parseInvalidRealPropertyDefinition")
 
   UNSCOPED_INFO("Expected correct default value for '_scale' property definition");
   CHECK(scaleDefinition->defaultValue() == "asdf");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseLegacyModelDefinition")
@@ -519,15 +507,13 @@ TEST_CASE("EntParserTest.parseLegacyModelDefinition")
   CHECK(definitions.size() == 1u);
 
   const auto* pointDefinition =
-    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front().get());
   UNSCOPED_INFO("Definition must be a point entity definition");
   CHECK(pointDefinition != nullptr);
 
   const auto& modelDefinition = pointDefinition->modelDefinition();
   CHECK(
     modelDefinition.defaultModelSpecification().path == "models/powerups/ammo/bfgam.md3");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parseELStaticModelDefinition")
@@ -547,7 +533,7 @@ TEST_CASE("EntParserTest.parseELStaticModelDefinition")
   CHECK(definitions.size() == 1u);
 
   const auto* pointDefinition =
-    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front());
+    dynamic_cast<const Assets::PointEntityDefinition*>(definitions.front().get());
   UNSCOPED_INFO("Definition must be a point entity definition");
   CHECK(pointDefinition != nullptr);
 
@@ -555,8 +541,6 @@ TEST_CASE("EntParserTest.parseELStaticModelDefinition")
   CHECK(
     modelDefinition.defaultModelSpecification().path
     == "models/powerups/ammo/bfgam2.md3");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("EntParserTest.parsePointEntityWithMissingBoxAttribute")
@@ -576,10 +560,8 @@ TEST_CASE("EntParserTest.parsePointEntityWithMissingBoxAttribute")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto definition = static_cast<Assets::PointEntityDefinition*>(definitions[0]);
-  CHECK(definition->bounds() == vm::bbox3d{{-8.0, -8.0, -8.0}, {8.0, 8.0, 8.0}});
-
-  kdl::vec_clear_and_delete(definitions);
+  const auto& definition = static_cast<Assets::PointEntityDefinition&>(*definitions[0]);
+  CHECK(definition.bounds() == vm::bbox3d{{-8.0, -8.0, -8.0}, {8.0, 8.0, 8.0}});
 }
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/IO/tst_FgdParser.cpp
+++ b/common/test/src/IO/tst_FgdParser.cpp
@@ -86,7 +86,6 @@ TEST_CASE("FgdParserTest.parseEmptyFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseWhitespaceFile")
@@ -97,7 +96,6 @@ TEST_CASE("FgdParserTest.parseWhitespaceFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseCommentsFile")
@@ -110,7 +108,6 @@ TEST_CASE("FgdParserTest.parseCommentsFile")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseEmptyFlagDescription")
@@ -131,7 +128,6 @@ TEST_CASE("FgdParserTest.parseEmptyFlagDescription")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseSolidClass")
@@ -158,16 +154,14 @@ TEST_CASE("FgdParserTest.parseSolidClass")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::BrushEntity);
-  CHECK(definition->name() == "worldspawn");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "World entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::BrushEntity);
+  CHECK(definition.name() == "worldspawn");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "World entity");
 
-  const auto& propertyDefinitions = definition->propertyDefinitions();
+  const auto& propertyDefinitions = definition.propertyDefinitions();
   CHECK(propertyDefinitions.size() == 6u);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parsePointClass")
@@ -188,16 +182,14 @@ TEST_CASE("FgdParserTest.parsePointClass")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  const auto& propertyDefinitions = definition->propertyDefinitions();
+  const auto& propertyDefinitions = definition.propertyDefinitions();
   CHECK(propertyDefinitions.size() == 5u);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseBaseProperty")
@@ -219,7 +211,6 @@ TEST_CASE("FgdParserTest.parseBaseProperty")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.empty());
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parsePointClassWithBaseClasses")
@@ -255,16 +246,14 @@ TEST_CASE("FgdParserTest.parsePointClassWithBaseClasses")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  const auto& propertyDefinitions = definition->propertyDefinitions();
+  const auto& propertyDefinitions = definition.propertyDefinitions();
   CHECK(propertyDefinitions.size() == 9u);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parsePointClassWithUnknownClassProperties")
@@ -286,16 +275,14 @@ TEST_CASE("FgdParserTest.parsePointClassWithUnknownClassProperties")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  const auto& propertyDefinitions = definition->propertyDefinitions();
+  const auto& propertyDefinitions = definition.propertyDefinitions();
   CHECK(propertyDefinitions.size() == 5u);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseType_TargetSourcePropertyDefinition")
@@ -313,13 +300,13 @@ TEST_CASE("FgdParserTest.parseType_TargetSourcePropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  const auto& propertyDefinitions = definition->propertyDefinitions();
+  const auto& propertyDefinitions = definition.propertyDefinitions();
   CHECK(propertyDefinitions.size() == 1u);
 
   auto propertyDefinition = propertyDefinitions[0];
@@ -328,8 +315,6 @@ TEST_CASE("FgdParserTest.parseType_TargetSourcePropertyDefinition")
   CHECK(propertyDefinition->key() == "targetname");
   CHECK(propertyDefinition->shortDescription() == "Source");
   CHECK(propertyDefinition->longDescription() == "A long description");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseType_TargetDestinationPropertyDefinition")
@@ -347,13 +332,13 @@ TEST_CASE("FgdParserTest.parseType_TargetDestinationPropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  const auto& propertyDefinitions = definition->propertyDefinitions();
+  const auto& propertyDefinitions = definition.propertyDefinitions();
   CHECK(propertyDefinitions.size() == 1u);
 
   auto propertyDefinition = propertyDefinitions[0];
@@ -363,8 +348,6 @@ TEST_CASE("FgdParserTest.parseType_TargetDestinationPropertyDefinition")
   CHECK(propertyDefinition->key() == "target");
   CHECK(propertyDefinition->shortDescription() == "Target");
   CHECK(propertyDefinition->longDescription().empty());
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseStringPropertyDefinition")
@@ -383,15 +366,15 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  CHECK(definition->propertyDefinitions().size() == 2u);
+  CHECK(definition.propertyDefinitions().size() == 2u);
 
-  const auto* propertyDefinition1 = definition->propertyDefinition("message");
+  const auto* propertyDefinition1 = definition.propertyDefinition("message");
   CHECK(propertyDefinition1 != nullptr);
   CHECK(propertyDefinition1->type() == Assets::PropertyDefinitionType::StringProperty);
 
@@ -402,7 +385,7 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition")
   CHECK(stringPropertyDefinition1->longDescription() == "Long description 1");
   CHECK_FALSE(stringPropertyDefinition1->hasDefaultValue());
 
-  const auto* propertyDefinition2 = definition->propertyDefinition("message2");
+  const auto* propertyDefinition2 = definition.propertyDefinition("message2");
   CHECK(propertyDefinition2 != nullptr);
   CHECK(propertyDefinition2->type() == Assets::PropertyDefinitionType::StringProperty);
 
@@ -413,8 +396,6 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition")
   CHECK(stringPropertyDefinition2->longDescription() == "Long description 2");
   CHECK(stringPropertyDefinition2->hasDefaultValue());
   CHECK(stringPropertyDefinition2->defaultValue() == "DefaultValue");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 /**
@@ -436,15 +417,15 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition_IntDefault")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  CHECK(definition->propertyDefinitions().size() == 2u);
+  CHECK(definition.propertyDefinitions().size() == 2u);
 
-  const auto* propertyDefinition1 = definition->propertyDefinition("name");
+  const auto* propertyDefinition1 = definition.propertyDefinition("name");
   CHECK(propertyDefinition1 != nullptr);
   CHECK(propertyDefinition1->type() == Assets::PropertyDefinitionType::StringProperty);
 
@@ -456,7 +437,7 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition_IntDefault")
   CHECK(stringPropertyDefinition1->hasDefaultValue());
   CHECK(stringPropertyDefinition1->defaultValue() == "3");
 
-  const auto* propertyDefinition2 = definition->propertyDefinition("other");
+  const auto* propertyDefinition2 = definition.propertyDefinition("other");
   CHECK(propertyDefinition2 != nullptr);
   CHECK(propertyDefinition2->type() == Assets::PropertyDefinitionType::StringProperty);
 
@@ -467,8 +448,6 @@ TEST_CASE("FgdParserTest.parseStringPropertyDefinition_IntDefault")
   CHECK(stringPropertyDefinition2->longDescription().empty());
   CHECK(stringPropertyDefinition2->hasDefaultValue());
   CHECK(stringPropertyDefinition2->defaultValue() == "1.5");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition")
@@ -486,15 +465,15 @@ TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
-  CHECK(definition->description() == "Wildcard entity");
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  CHECK(definition.description() == "Wildcard entity");
 
-  CHECK(definition->propertyDefinitions().size() == 2u);
+  CHECK(definition.propertyDefinitions().size() == 2u);
 
-  const auto* propertyDefinition1 = definition->propertyDefinition("sounds");
+  const auto* propertyDefinition1 = definition.propertyDefinition("sounds");
   CHECK(propertyDefinition1 != nullptr);
   CHECK(propertyDefinition1->type() == Assets::PropertyDefinitionType::IntegerProperty);
 
@@ -505,7 +484,7 @@ TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition")
   CHECK(intPropertyDefinition1->longDescription() == "Longer description");
   CHECK_FALSE(intPropertyDefinition1->hasDefaultValue());
 
-  const auto* propertyDefinition2 = definition->propertyDefinition("sounds2");
+  const auto* propertyDefinition2 = definition.propertyDefinition("sounds2");
   CHECK(propertyDefinition2 != nullptr);
   CHECK(propertyDefinition2->type() == Assets::PropertyDefinitionType::IntegerProperty);
 
@@ -516,8 +495,6 @@ TEST_CASE("FgdParserTest.parseIntegerPropertyDefinition")
   CHECK(intPropertyDefinition2->longDescription() == "Longer description");
   CHECK(intPropertyDefinition2->hasDefaultValue());
   CHECK(intPropertyDefinition2->defaultValue() == 2);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseReadOnlyPropertyDefinition")
@@ -536,16 +513,14 @@ TEST_CASE("FgdParserTest.parseReadOnlyPropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->propertyDefinitions().size() == 2u);
+  const auto& definition = *definitions[0];
+  CHECK(definition.propertyDefinitions().size() == 2u);
 
-  const auto* propertyDefinition1 = definition->propertyDefinition("sounds");
+  const auto* propertyDefinition1 = definition.propertyDefinition("sounds");
   CHECK(propertyDefinition1->readOnly());
 
-  const auto* propertyDefinition2 = definition->propertyDefinition("sounds2");
+  const auto* propertyDefinition2 = definition.propertyDefinition("sounds2");
   CHECK_FALSE(propertyDefinition2->readOnly());
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseFloatPropertyDefinition")
@@ -564,16 +539,16 @@ TEST_CASE("FgdParserTest.parseFloatPropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
   ;
-  CHECK(definition->description() == "Wildcard entity");
+  CHECK(definition.description() == "Wildcard entity");
 
-  CHECK(definition->propertyDefinitions().size() == 2u);
+  CHECK(definition.propertyDefinitions().size() == 2u);
 
-  const auto* propertyDefinition1 = definition->propertyDefinition("test");
+  const auto* propertyDefinition1 = definition.propertyDefinition("test");
   CHECK(propertyDefinition1 != nullptr);
   CHECK(propertyDefinition1->type() == Assets::PropertyDefinitionType::FloatProperty);
 
@@ -584,7 +559,7 @@ TEST_CASE("FgdParserTest.parseFloatPropertyDefinition")
   CHECK(floatPropertyDefinition1->longDescription() == "Longer description 1");
   CHECK_FALSE(floatPropertyDefinition1->hasDefaultValue());
 
-  const auto* propertyDefinition2 = definition->propertyDefinition("test2");
+  const auto* propertyDefinition2 = definition.propertyDefinition("test2");
   CHECK(propertyDefinition2 != nullptr);
   CHECK(propertyDefinition2->type() == Assets::PropertyDefinitionType::FloatProperty);
 
@@ -597,8 +572,6 @@ TEST_CASE("FgdParserTest.parseFloatPropertyDefinition")
   CHECK(floatPropertyDefinition2->longDescription() == "Longer description 2");
   CHECK(floatPropertyDefinition2->hasDefaultValue());
   CHECK(floatPropertyDefinition2->defaultValue() == 2.7f);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
@@ -644,16 +617,16 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
   ;
-  CHECK(definition->description() == "Wildcard entity");
+  CHECK(definition.description() == "Wildcard entity");
 
-  CHECK(definition->propertyDefinitions().size() == 5u);
+  CHECK(definition.propertyDefinitions().size() == 5u);
 
-  const auto* propertyDefinition1 = definition->propertyDefinition("worldtype");
+  const auto* propertyDefinition1 = definition.propertyDefinition("worldtype");
   CHECK(propertyDefinition1 != nullptr);
   CHECK(propertyDefinition1->type() == Assets::PropertyDefinitionType::ChoiceProperty);
 
@@ -672,7 +645,7 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
       {"2", "Base"},
     });
 
-  const auto* propertyDefinition2 = definition->propertyDefinition("worldtype2");
+  const auto* propertyDefinition2 = definition.propertyDefinition("worldtype2");
   CHECK(propertyDefinition2 != nullptr);
   CHECK(propertyDefinition2->type() == Assets::PropertyDefinitionType::ChoiceProperty);
 
@@ -691,7 +664,7 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
       {"1", "Metal (runic)"},
     });
 
-  const auto* propertyDefinition3 = definition->propertyDefinition("puzzle_id");
+  const auto* propertyDefinition3 = definition.propertyDefinition("puzzle_id");
   const auto* choicePropertyDefinition3 =
     static_cast<const Assets::ChoicePropertyDefinition*>(propertyDefinition3);
   CHECK(choicePropertyDefinition3->key() == "puzzle_id");
@@ -708,7 +681,7 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
       {"scrol", "Disrupt Magic Scroll"},
     });
 
-  const auto* propertyDefinition4 = definition->propertyDefinition("floaty");
+  const auto* propertyDefinition4 = definition.propertyDefinition("floaty");
   const auto* choicePropertyDefinition4 =
     static_cast<const Assets::ChoicePropertyDefinition*>(propertyDefinition4);
   CHECK(choicePropertyDefinition4->key() == "floaty");
@@ -725,7 +698,7 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
       {"0.1", "Yet more"},
     });
 
-  const auto* propertyDefinition5 = definition->propertyDefinition("negative");
+  const auto* propertyDefinition5 = definition.propertyDefinition("negative");
   const auto* choicePropertyDefinition5 =
     static_cast<const Assets::ChoicePropertyDefinition*>(propertyDefinition5);
   CHECK(choicePropertyDefinition5->key() == "negative");
@@ -741,8 +714,6 @@ TEST_CASE("FgdParserTest.parseChoicePropertyDefinition")
       {"-1", "Something else"},
       {"1", "Yet more"},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 TEST_CASE("FgdParserTest.parseFlagsPropertyDefinition")
@@ -766,16 +737,16 @@ TEST_CASE("FgdParserTest.parseFlagsPropertyDefinition")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions[0];
-  CHECK(definition->type() == Assets::EntityDefinitionType::PointEntity);
-  CHECK(definition->name() == "info_notnull");
-  CHECK(definition->color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
+  const auto& definition = *definitions[0];
+  CHECK(definition.type() == Assets::EntityDefinitionType::PointEntity);
+  CHECK(definition.name() == "info_notnull");
+  CHECK(definition.color() == Color{1.0f, 1.0f, 1.0f, 1.0f});
   ;
-  CHECK(definition->description() == "Wildcard entity");
+  CHECK(definition.description() == "Wildcard entity");
 
-  CHECK(definition->propertyDefinitions().size() == 1u);
+  CHECK(definition.propertyDefinitions().size() == 1u);
 
-  const auto* propertyDefinition = definition->propertyDefinition("spawnflags");
+  const auto* propertyDefinition = definition.propertyDefinition("spawnflags");
   CHECK(propertyDefinition != nullptr);
   CHECK(propertyDefinition->type() == Assets::PropertyDefinitionType::FlagsProperty);
 
@@ -793,8 +764,6 @@ TEST_CASE("FgdParserTest.parseFlagsPropertyDefinition")
       {1024, "Not on Hard", "", false},
       {2048, "Not in Deathmatch", "", true},
     });
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 static const auto FgdModelDefinitionTemplate =
@@ -863,8 +832,6 @@ TEST_CASE("FgdParserTest.parseLegacyModelWithParseError")
   auto status = TestParserStatus{};
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
-
-  kdl::vec_clear_and_delete(definitions);
 }
 
 static const auto FgdDecalDefinitionTemplate =
@@ -893,10 +860,9 @@ decor_goddess_statue : "Goddess Statue" []
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto definition = static_cast<Assets::PointEntityDefinition*>(definitions[0]);
-  CHECK(definition->bounds() == vm::bbox3d{{-8.0, -8.0, -8.0}, {8.0, 8.0, 8.0}});
-
-  kdl::vec_clear_and_delete(definitions);
+  const auto& definition =
+    static_cast<const Assets::PointEntityDefinition&>(*definitions[0]);
+  CHECK(definition.bounds() == vm::bbox3d{{-8.0, -8.0, -8.0}, {8.0, 8.0, 8.0}});
 }
 
 TEST_CASE("FgdParserTest.parseInvalidBounds")
@@ -911,10 +877,9 @@ decor_goddess_statue : "Goddess Statue" [])";
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = static_cast<Assets::PointEntityDefinition*>(definitions[0]);
-  CHECK(definition->bounds() == vm::bbox3d{{-32.0, -32.0, 0.0}, {32.0, 32.0, 256.0}});
-
-  kdl::vec_clear_and_delete(definitions);
+  const auto& definition =
+    static_cast<const Assets::PointEntityDefinition&>(*definitions[0]);
+  CHECK(definition.bounds() == vm::bbox3d{{-32.0, -32.0, 0.0}, {32.0, 32.0, 256.0}});
 }
 
 TEST_CASE("FgdParserTest.parseInvalidModel")
@@ -929,8 +894,7 @@ decor_goddess_statue : "Goddess Statue" [])";
   CHECK_THROWS_WITH(
     [&]() {
       auto status = TestParserStatus{};
-      auto definitions = parser.parseDefinitions(status);
-      kdl::vec_clear_and_delete(definitions);
+      parser.parseDefinitions(status);
     }(),
     Catch::Matchers::StartsWith("At line 3, column 8:"));
 }
@@ -947,8 +911,7 @@ model({"path"
   CHECK_THROWS_WITH(
     [&]() {
       auto status = TestParserStatus{};
-      auto definitions = parser.parseDefinitions(status);
-      kdl::vec_clear_and_delete(definitions);
+      parser.parseDefinitions(status);
     }(),
     Catch::Matchers::StartsWith("At line 4, column 64:"));
 }
@@ -965,14 +928,12 @@ TEST_CASE("FgdParserTest.parseInclude")
   auto status = TestParserStatus{};
   auto defs = parser.parseDefinitions(status);
   CHECK(defs.size() == 2u);
-  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto* def) {
+  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto& def) {
     return def->name() == "worldspawn";
   }));
-  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto* def) {
+  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto& def) {
     return def->name() == "info_player_start";
   }));
-
-  kdl::vec_clear_and_delete(defs);
 }
 
 TEST_CASE("FgdParserTest.parseNestedInclude")
@@ -987,17 +948,15 @@ TEST_CASE("FgdParserTest.parseNestedInclude")
   auto status = TestParserStatus{};
   auto defs = parser.parseDefinitions(status);
   CHECK(defs.size() == 3u);
-  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto* def) {
+  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto& def) {
     return def->name() == "worldspawn";
   }));
-  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto* def) {
+  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto& def) {
     return def->name() == "info_player_start";
   }));
-  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto* def) {
+  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto& def) {
     return def->name() == "info_player_coop";
   }));
-
-  kdl::vec_clear_and_delete(defs);
 }
 
 TEST_CASE("FgdParserTest.parseRecursiveInclude")
@@ -1012,11 +971,9 @@ TEST_CASE("FgdParserTest.parseRecursiveInclude")
   auto status = TestParserStatus{};
   auto defs = parser.parseDefinitions(status);
   CHECK(defs.size() == 1u);
-  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto* def) {
+  CHECK(std::any_of(std::begin(defs), std::end(defs), [](const auto& def) {
     return def->name() == "worldspawn";
   }));
-
-  kdl::vec_clear_and_delete(defs);
 }
 
 TEST_CASE("FgdParserTest.parseStringContinuations")
@@ -1034,12 +991,10 @@ TEST_CASE("FgdParserTest.parseStringContinuations")
   auto definitions = parser.parseDefinitions(status);
   CHECK(definitions.size() == 1u);
 
-  const auto* definition = definitions.front();
+  const auto& definition = *definitions.front();
   CHECK(
-    definition->description()
+    definition.description()
     == R"(This is an example description for this example entity. It will appear in the help dialog for this entity)");
-
-  kdl::vec_clear_and_delete(definitions);
 }
 } // namespace IO
 } // namespace TrenchBroom

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -19,6 +19,7 @@
 
 #include "TestGame.h"
 
+#include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionFileSpec.h"
 #include "Assets/EntityModel.h"
 #include "Assets/TextureManager.h"
@@ -304,11 +305,12 @@ const std::vector<CompilationTool>& TestGame::doCompilationTools() const
   return m_compilationTools;
 }
 
-Result<std::vector<Assets::EntityDefinition*>> TestGame::doLoadEntityDefinitions(
-  IO::ParserStatus& /* status */, const std::filesystem::path& /* path */) const
+Result<std::vector<std::unique_ptr<Assets::EntityDefinition>>> TestGame::
+  loadEntityDefinitions(
+    IO::ParserStatus& /* status */, const std::filesystem::path& /* path */) const
 {
-  return Result<std::vector<Assets::EntityDefinition*>>{
-    std::vector<Assets::EntityDefinition*>{}};
+  return Result<std::vector<std::unique_ptr<Assets::EntityDefinition>>>{
+    std::vector<std::unique_ptr<Assets::EntityDefinition>>{}};
 }
 
 std::unique_ptr<Assets::EntityModel> TestGame::doInitializeModel(

--- a/common/test/src/Model/TestGame.h
+++ b/common/test/src/Model/TestGame.h
@@ -135,8 +135,9 @@ private:
   const BrushFaceAttributes& doDefaultFaceAttribs() const override;
   const std::vector<CompilationTool>& doCompilationTools() const override;
 
-  Result<std::vector<Assets::EntityDefinition*>> doLoadEntityDefinitions(
+  Result<std::vector<std::unique_ptr<Assets::EntityDefinition>>> loadEntityDefinitions(
     IO::ParserStatus& status, const std::filesystem::path& path) const override;
+
   std::unique_ptr<Assets::EntityModel> doInitializeModel(
     const std::filesystem::path& path, Logger& logger) const override;
   void doLoadFrame(

--- a/lib/kdl/include/kdl/string_utils.h
+++ b/lib/kdl/include/kdl/string_utils.h
@@ -24,6 +24,7 @@
 
 #include <algorithm> // for std::search
 #include <cassert>
+#include <charconv>
 #include <iterator>
 #include <optional>
 #include <sstream>
@@ -283,6 +284,15 @@ std::string str_to_string(Args&&... args)
   return str.str();
 }
 
+namespace detail
+{
+inline auto skip_whitespace(const std::string_view str)
+{
+  const auto first = str.find_first_not_of(Whitespace);
+  return first != std::string::npos ? str.substr(first) : std::string_view{};
+}
+} // namespace detail
+
 /**
  * Interprets the given string as a signed integer and returns it. If the given string
  * cannot be parsed, returns an empty optional.
@@ -291,20 +301,13 @@ std::string str_to_string(Args&&... args)
  * @return the signed integer value or an empty optional if the given string cannot be
  * interpreted as a signed integer
  */
-inline std::optional<int> str_to_int(const std::string& str)
+inline std::optional<int> str_to_int(std::string_view str)
 {
-  try
-  {
-    return stoi(str);
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
+  str = detail::skip_whitespace(str);
+  int value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
 }
 
 /**
@@ -315,20 +318,13 @@ inline std::optional<int> str_to_int(const std::string& str)
  * @return the signed long integer value or an empty optional if the given string cannot
  * be interpreted as a signed long integer
  */
-inline std::optional<long> str_to_long(const std::string& str)
+inline std::optional<long> str_to_long(std::string_view str)
 {
-  try
-  {
-    return stol(str);
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
+  str = detail::skip_whitespace(str);
+  long value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
 }
 
 /**
@@ -339,20 +335,13 @@ inline std::optional<long> str_to_long(const std::string& str)
  * @return the signed long long integer value or an empty optional if the given string
  * cannot be interpreted as a signed long long integer
  */
-inline std::optional<long long> str_to_long_long(const std::string& str)
+inline std::optional<long long> str_to_long_long(std::string_view str)
 {
-  try
-  {
-    return stoll(str);
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
+  str = detail::skip_whitespace(str);
+  long long value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
 }
 
 /**
@@ -363,20 +352,13 @@ inline std::optional<long long> str_to_long_long(const std::string& str)
  * @return the unsigned long integer value or an empty optional if the given string cannot
  * be interpreted as an unsigned long integer
  */
-inline std::optional<unsigned long> str_to_u_long(const std::string& str)
+inline std::optional<unsigned long> str_to_u_long(std::string_view str)
 {
-  try
-  {
-    return stoul(str);
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
+  str = detail::skip_whitespace(str);
+  unsigned long value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
 }
 
 /**
@@ -387,20 +369,13 @@ inline std::optional<unsigned long> str_to_u_long(const std::string& str)
  * @return the unsigned long long integer value or an empty optional if the given string
  * cannot be interpreted as an unsigned long long integer
  */
-inline std::optional<unsigned long long> str_to_u_long_long(const std::string& str)
+inline std::optional<unsigned long long> str_to_u_long_long(std::string_view str)
 {
-  try
-  {
-    return stoull(str);
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
+  str = detail::skip_whitespace(str);
+  unsigned long long value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
 }
 
 /**
@@ -411,20 +386,13 @@ inline std::optional<unsigned long long> str_to_u_long_long(const std::string& s
  * @return the std::size_t value or an empty optional if the given string cannot be
  * interpreted as an std::size_t
  */
-inline std::optional<std::size_t> str_to_size(const std::string& str)
+inline std::optional<std::size_t> str_to_size(std::string_view str)
 {
-  try
-  {
-    return static_cast<std::size_t>(stoul(str));
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
+  str = detail::skip_whitespace(str);
+  size_t value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
 }
 
 /**
@@ -435,11 +403,14 @@ inline std::optional<std::size_t> str_to_size(const std::string& str)
  * @return the 32 bit floating point value value or an empty optional if the given string
  * cannot be interpreted as an 32 bit floating point value
  */
-inline std::optional<float> str_to_float(const std::string& str)
+inline std::optional<float> str_to_float(std::string_view str)
 {
+  str = detail::skip_whitespace(str);
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 11)
+  // std::from_chars is not yet implemented for float
   try
   {
-    return stof(str);
+    return stof(std::string{str});
   }
   catch (std::invalid_argument&)
   {
@@ -449,6 +420,12 @@ inline std::optional<float> str_to_float(const std::string& str)
   {
     return std::nullopt;
   }
+#else
+  float value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
+#endif
 }
 
 /**
@@ -459,11 +436,14 @@ inline std::optional<float> str_to_float(const std::string& str)
  * @return the 64 bit floating point value value or an empty optional if the given string
  * cannot be interpreted as an 64 bit floating point value
  */
-inline std::optional<double> str_to_double(const std::string& str)
+inline std::optional<double> str_to_double(std::string_view str)
 {
+  str = detail::skip_whitespace(str);
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 11)
+  // std::from_chars is not yet implemented for double
   try
   {
-    return stod(str);
+    return stod(std::string{str});
   }
   catch (std::invalid_argument&)
   {
@@ -473,6 +453,12 @@ inline std::optional<double> str_to_double(const std::string& str)
   {
     return std::nullopt;
   }
+#else
+  double value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
+#endif
 }
 
 /**
@@ -483,11 +469,14 @@ inline std::optional<double> str_to_double(const std::string& str)
  * @return the long double value value value or an empty optional if the given string
  * cannot be interpreted as an long double value value
  */
-inline std::optional<long double> str_to_long_double(const std::string& str)
+inline std::optional<long double> str_to_long_double(std::string_view str)
 {
+  str = detail::skip_whitespace(str);
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 11)
+  // std::from_chars is not yet implemented for double
   try
   {
-    return stold(str);
+    return stold(std::string{str});
   }
   catch (std::invalid_argument&)
   {
@@ -497,5 +486,11 @@ inline std::optional<long double> str_to_long_double(const std::string& str)
   {
     return std::nullopt;
   }
+#else
+  long double value;
+  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
+#endif
 }
 } // namespace kdl

--- a/lib/kdl/test/src/catch2.h
+++ b/lib/kdl/test/src/catch2.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2010-2019 Kristian Duske
+ Copyright (C) 2023 Kristian Duske
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of this
  software and associated documentation files (the "Software"), to deal in the Software
@@ -16,75 +16,17 @@
  FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  DEALINGS IN THE SOFTWARE.
-*/
+ */
 
-#include "kdl/set_temp.h"
+#pragma once
 
-#include "catch2.h"
+// The catch2 header must be included only when all stream insertion
+// operators used in assertions are visible. We add this new wrapper header
+// that includes these operators for the vecmath types to ensure that they
+// work consistently.
 
-namespace kdl
-{
-TEST_CASE("set_temp_test.set_unset")
-{
-  int value = 0;
-  {
-    set_temp s(value, 1);
-    CHECK(value == 1);
-  }
-  CHECK(value == 0);
-}
+// Include this header instead of <catch2/catch.hpp> to ensure that vecmath
+// stream operators work consistently.
 
-TEST_CASE("set_temp_test.set_unset_bool")
-{
-  bool value = false;
-  {
-    set_temp s(value, true);
-    CHECK(value);
-  }
-  CHECK_FALSE(value);
-
-  {
-    set_temp s(value);
-    CHECK(value);
-
-    {
-      set_temp t(value, false);
-      CHECK_FALSE(value);
-    }
-    CHECK(value);
-  }
-  CHECK_FALSE(value);
-}
-
-TEST_CASE("set_later_test.set")
-{
-  int value = 0;
-
-  {
-    set_later s(value, 1);
-    CHECK(value == 0);
-  }
-  CHECK(value == 1);
-}
-
-TEST_CASE("inc_temp.inc_dec")
-{
-  int value = 0;
-
-  {
-    inc_temp i(value);
-    CHECK(value == 1);
-  }
-  CHECK(value == 0);
-}
-
-TEST_CASE("dec_temp.dec_inc")
-{
-  int value = 0;
-  {
-    dec_temp d(value);
-    CHECK(value == -1);
-  }
-  CHECK(value == 0);
-}
-} // namespace kdl
+#define CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS 1
+#include <catch2/catch.hpp>

--- a/lib/kdl/test/src/run_all.cpp
+++ b/lib/kdl/test/src/run_all.cpp
@@ -27,7 +27,7 @@
 #pragma warning(disable : 4365)
 #endif
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/lib/kdl/test/src/tst_binary_relation.cpp
+++ b/lib/kdl/test/src/tst_binary_relation.cpp
@@ -22,7 +22,7 @@
 
 #include <algorithm>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_collection_utils.cpp
+++ b/lib/kdl/test/src/tst_collection_utils.cpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_compact_trie.cpp
+++ b/lib/kdl/test/src/tst_compact_trie.cpp
@@ -23,7 +23,7 @@
 
 #include <iterator>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_deref_iterator.cpp
+++ b/lib/kdl/test/src/tst_deref_iterator.cpp
@@ -23,7 +23,7 @@
 #include <memory>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_functional.cpp
+++ b/lib/kdl/test/src/tst_functional.cpp
@@ -22,7 +22,7 @@
 
 #include <functional>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_grouped_range.cpp
+++ b/lib/kdl/test/src/tst_grouped_range.cpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_intrusive_circular_list.cpp
+++ b/lib/kdl/test/src/tst_intrusive_circular_list.cpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_invoke.cpp
+++ b/lib/kdl/test/src/tst_invoke.cpp
@@ -20,7 +20,7 @@
 
 #include "kdl/invoke.h"
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_map_utils.cpp
+++ b/lib/kdl/test/src/tst_map_utils.cpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_meta_utils.cpp
+++ b/lib/kdl/test/src/tst_meta_utils.cpp
@@ -20,7 +20,7 @@
 
 #include "kdl/meta_utils.h"
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_parallel.cpp
+++ b/lib/kdl/test/src/tst_parallel.cpp
@@ -29,7 +29,7 @@
 #include <string>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_path_utils.cpp
+++ b/lib/kdl/test/src/tst_path_utils.cpp
@@ -20,7 +20,7 @@
 
 #include "kdl/path_utils.h"
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_reflection.cpp
+++ b/lib/kdl/test/src/tst_reflection.cpp
@@ -25,7 +25,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_resource.cpp
+++ b/lib/kdl/test/src/tst_resource.cpp
@@ -20,7 +20,7 @@
 
 #include "kdl/resource.h"
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_result.cpp
+++ b/lib/kdl/test/src/tst_result.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <string>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_set_adapter.cpp
+++ b/lib/kdl/test/src/tst_set_adapter.cpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_skip_iterator.cpp
+++ b/lib/kdl/test/src/tst_skip_iterator.cpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_std_io.cpp
+++ b/lib/kdl/test/src/tst_std_io.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <variant>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace some_ns
 {

--- a/lib/kdl/test/src/tst_string_compare.cpp
+++ b/lib/kdl/test/src/tst_string_compare.cpp
@@ -21,7 +21,7 @@
 #include "kdl/collection_utils.h"
 #include "kdl/string_compare.h"
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_string_format.cpp
+++ b/lib/kdl/test/src/tst_string_format.cpp
@@ -20,7 +20,7 @@
 
 #include <kdl/string_format.h>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_string_utils.cpp
+++ b/lib/kdl/test/src/tst_string_utils.cpp
@@ -23,7 +23,7 @@
 #include <optional>
 #include <ostream>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_string_utils.cpp
+++ b/lib/kdl/test/src/tst_string_utils.cpp
@@ -123,12 +123,12 @@ TEST_CASE("string_format_test.str_to_string")
 
 TEST_CASE("string_format_test.str_to_int")
 {
-  CHECK(str_to_int("0") == std::optional<int>{0});
-  CHECK(str_to_int("1") == std::optional<int>{1});
-  CHECK(str_to_int("123231") == std::optional<int>{123231});
-  CHECK(str_to_int("-123231") == std::optional<int>{-123231});
-  CHECK(str_to_int("123231b") == std::optional<int>{123231});
-  CHECK(str_to_int("   123231   ") == std::optional<int>{123231});
+  CHECK(str_to_int("0") == 0);
+  CHECK(str_to_int("1") == 1);
+  CHECK(str_to_int("123231") == 123231);
+  CHECK(str_to_int("-123231") == -123231);
+  CHECK(str_to_int("123231b") == 123231);
+  CHECK(str_to_int("   123231   ") == 123231);
   CHECK(str_to_int("a123231") == std::nullopt);
   CHECK(str_to_int(" ") == std::nullopt);
   CHECK(str_to_int("") == std::nullopt);
@@ -136,14 +136,14 @@ TEST_CASE("string_format_test.str_to_int")
 
 TEST_CASE("string_format_test.str_to_long")
 {
-  CHECK(str_to_long("0") == std::optional<long>{0l});
-  CHECK(str_to_long("1") == std::optional<long>{1l});
-  CHECK(str_to_long("123231") == std::optional<long>{123231l});
-  CHECK(str_to_long("-123231") == std::optional<long>{-123231l});
-  CHECK(str_to_long("2147483647") == std::optional<long>{2147483647l});
-  CHECK(str_to_long("-2147483646") == std::optional<long>{-2147483646l});
-  CHECK(str_to_long("123231b") == std::optional<long>{123231l});
-  CHECK(str_to_long("   123231   ") == std::optional<long>{123231l});
+  CHECK(str_to_long("0") == 0l);
+  CHECK(str_to_long("1") == 1l);
+  CHECK(str_to_long("123231") == 123231l);
+  CHECK(str_to_long("-123231") == -123231l);
+  CHECK(str_to_long("2147483647") == 2147483647l);
+  CHECK(str_to_long("-2147483646") == -2147483646l);
+  CHECK(str_to_long("123231b") == 123231l);
+  CHECK(str_to_long("   123231   ") == 123231l);
   CHECK(str_to_long("a123231") == std::nullopt);
   CHECK(str_to_long(" ") == std::nullopt);
   CHECK(str_to_long("") == std::nullopt);
@@ -151,20 +151,16 @@ TEST_CASE("string_format_test.str_to_long")
 
 TEST_CASE("string_format_test.str_to_long_long")
 {
-  CHECK(str_to_long_long("0") == std::optional<long long>{0ll});
-  CHECK(str_to_long_long("1") == std::optional<long long>{1ll});
-  CHECK(str_to_long_long("123231") == std::optional<long long>{123231ll});
-  CHECK(str_to_long_long("-123231") == std::optional<long long>{-123231ll});
-  CHECK(str_to_long_long("2147483647") == std::optional<long long>{2147483647ll});
-  CHECK(str_to_long_long("-2147483646") == std::optional<long long>{-2147483646ll});
-  CHECK(
-    str_to_long_long("9223372036854775807")
-    == std::optional<long long>{9'223'372'036'854'775'807ll});
-  CHECK(
-    str_to_long_long("-9223372036854775806")
-    == std::optional<long long>{-9'223'372'036'854'775'806ll});
-  CHECK(str_to_long_long("123231b") == std::optional<long long>{123231ll});
-  CHECK(str_to_long_long("   123231   ") == std::optional<long long>{123231ll});
+  CHECK(str_to_long_long("0") == 0ll);
+  CHECK(str_to_long_long("1") == 1ll);
+  CHECK(str_to_long_long("123231") == 123231ll);
+  CHECK(str_to_long_long("-123231") == -123231ll);
+  CHECK(str_to_long_long("2147483647") == 2147483647ll);
+  CHECK(str_to_long_long("-2147483646") == -2147483646ll);
+  CHECK(str_to_long_long("9223372036854775807") == 9'223'372'036'854'775'807ll);
+  CHECK(str_to_long_long("-9223372036854775806") == -9'223'372'036'854'775'806ll);
+  CHECK(str_to_long_long("123231b") == 123231ll);
+  CHECK(str_to_long_long("   123231   ") == 123231ll);
   CHECK(str_to_long_long("a123231") == std::nullopt);
   CHECK(str_to_long_long(" ") == std::nullopt);
   CHECK(str_to_long_long("") == std::nullopt);
@@ -173,12 +169,12 @@ TEST_CASE("string_format_test.str_to_long_long")
 TEST_CASE("string_format_test.str_to_u_long")
 {
 
-  CHECK(str_to_u_long("0") == std::optional<unsigned long>{0ul});
-  CHECK(str_to_u_long("1") == std::optional<unsigned long>{1ul});
-  CHECK(str_to_u_long("123231") == std::optional<unsigned long>{123231ul});
-  CHECK(str_to_u_long("2147483647") == std::optional<unsigned long>{2147483647ul});
-  CHECK(str_to_u_long("123231b") == std::optional<unsigned long>{123231ul});
-  CHECK(str_to_u_long("   123231   ") == std::optional<unsigned long>{123231ul});
+  CHECK(str_to_u_long("0") == 0ul);
+  CHECK(str_to_u_long("1") == 1ul);
+  CHECK(str_to_u_long("123231") == 123231ul);
+  CHECK(str_to_u_long("2147483647") == 2147483647ul);
+  CHECK(str_to_u_long("123231b") == 123231ul);
+  CHECK(str_to_u_long("   123231   ") == 123231ul);
   CHECK(str_to_u_long("a123231") == std::nullopt);
   CHECK(str_to_u_long(" ") == std::nullopt);
   CHECK(str_to_u_long("") == std::nullopt);
@@ -186,17 +182,13 @@ TEST_CASE("string_format_test.str_to_u_long")
 
 TEST_CASE("string_format_test.str_to_u_long_long")
 {
-  CHECK(str_to_u_long_long("0") == std::optional<unsigned long long>{0ull});
-  CHECK(str_to_u_long_long("1") == std::optional<unsigned long long>{1ull});
-  CHECK(str_to_u_long_long("123231") == std::optional<unsigned long long>{123231ull});
-  CHECK(
-    str_to_u_long_long("2147483647") == std::optional<unsigned long long>{2147483647ull});
-  CHECK(
-    str_to_u_long_long("9223372036854775807")
-    == std::optional<unsigned long long>{9'223'372'036'854'775'807ull});
-  CHECK(str_to_u_long_long("123231b") == std::optional<unsigned long long>{123231ull});
-  CHECK(
-    str_to_u_long_long("   123231   ") == std::optional<unsigned long long>{123231ull});
+  CHECK(str_to_u_long_long("0") == 0ull);
+  CHECK(str_to_u_long_long("1") == 1ull);
+  CHECK(str_to_u_long_long("123231") == 123231ull);
+  CHECK(str_to_u_long_long("2147483647") == 2147483647ull);
+  CHECK(str_to_u_long_long("9223372036854775807") == 9'223'372'036'854'775'807ull);
+  CHECK(str_to_u_long_long("123231b") == 123231ull);
+  CHECK(str_to_u_long_long("   123231   ") == 123231ull);
   CHECK(str_to_u_long_long("a123231") == std::nullopt);
   CHECK(str_to_u_long_long(" ") == std::nullopt);
   CHECK(str_to_u_long_long("") == std::nullopt);
@@ -204,12 +196,12 @@ TEST_CASE("string_format_test.str_to_u_long_long")
 
 TEST_CASE("string_format_test.str_to_size")
 {
-  CHECK(str_to_size("0") == std::optional<std::size_t>{0u});
-  CHECK(str_to_size("1") == std::optional<std::size_t>{1u});
-  CHECK(str_to_size("123231") == std::optional<std::size_t>{123231u});
-  CHECK(str_to_size("2147483647") == std::optional<std::size_t>{2147483647u});
-  CHECK(str_to_size("123231b") == std::optional<std::size_t>{123231u});
-  CHECK(str_to_size("   123231   ") == std::optional<std::size_t>{123231u});
+  CHECK(str_to_size("0") == 0u);
+  CHECK(str_to_size("1") == 1u);
+  CHECK(str_to_size("123231") == 123231u);
+  CHECK(str_to_size("2147483647") == 2147483647u);
+  CHECK(str_to_size("123231b") == 123231u);
+  CHECK(str_to_size("   123231   ") == 123231u);
   CHECK(str_to_size("a123231") == std::nullopt);
   CHECK(str_to_size(" ") == std::nullopt);
   CHECK(str_to_size("") == std::nullopt);
@@ -217,8 +209,9 @@ TEST_CASE("string_format_test.str_to_size")
 
 TEST_CASE("string_format_test.str_to_float")
 {
-  CHECK(str_to_float("0") == std::optional<float>{0.0f});
-  CHECK(str_to_float("1.0") == std::optional<float>{1.0f});
+  CHECK(str_to_float("0") == 0.0f);
+  CHECK(str_to_float("1.0") == 1.0f);
+  CHECK(str_to_float("  1.0     ") == 1.0f);
   CHECK(str_to_float("a123231.0") == std::nullopt);
   CHECK(str_to_float(" ") == std::nullopt);
   CHECK(str_to_float("") == std::nullopt);
@@ -226,8 +219,9 @@ TEST_CASE("string_format_test.str_to_float")
 
 TEST_CASE("string_format_test.str_to_double")
 {
-  CHECK(str_to_double("0") == std::optional<double>{0.0});
-  CHECK(str_to_double("1.0") == std::optional<double>{1.0});
+  CHECK(str_to_double("0") == 0.0);
+  CHECK(str_to_double("1.0") == 1.0);
+  CHECK(str_to_double("  1.0     ") == 1.0);
   CHECK(str_to_double("a123231.0") == std::nullopt);
   CHECK(str_to_double(" ") == std::nullopt);
   CHECK(str_to_double("") == std::nullopt);
@@ -235,8 +229,9 @@ TEST_CASE("string_format_test.str_to_double")
 
 TEST_CASE("string_format_test.str_to_long_double")
 {
-  CHECK(str_to_long_double("0") == std::optional<long double>{0.0L});
-  CHECK(str_to_long_double("1.0") == std::optional<long double>{1.0L});
+  CHECK(str_to_long_double("0") == 0.0L);
+  CHECK(str_to_long_double("1.0") == 1.0L);
+  CHECK(str_to_long_double("  1.0     ") == 1.0L);
   CHECK(str_to_long_double("a123231.0") == std::nullopt);
   CHECK(str_to_long_double(" ") == std::nullopt);
   CHECK(str_to_long_double("") == std::nullopt);

--- a/lib/kdl/test/src/tst_struct_io.cpp
+++ b/lib/kdl/test/src/tst_struct_io.cpp
@@ -26,7 +26,7 @@
 #include <tuple>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_transform_range.cpp
+++ b/lib/kdl/test/src/tst_transform_range.cpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_tuple_utils.cpp
+++ b/lib/kdl/test/src/tst_tuple_utils.cpp
@@ -20,7 +20,7 @@
 
 #include <kdl/tuple_utils.h>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_vector_set.cpp
+++ b/lib/kdl/test/src/tst_vector_set.cpp
@@ -20,7 +20,7 @@
 
 #include "kdl/vector_set.h"
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_vector_utils.cpp
+++ b/lib/kdl/test/src/tst_vector_utils.cpp
@@ -26,7 +26,7 @@
 #include <set>
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {

--- a/lib/kdl/test/src/tst_zip_iterator.cpp
+++ b/lib/kdl/test/src/tst_zip_iterator.cpp
@@ -23,7 +23,7 @@
 
 #include <vector>
 
-#include <catch2/catch.hpp>
+#include "catch2.h"
 
 namespace kdl
 {


### PR DESCRIPTION
Supersedes https://github.com/TrenchBroom/TrenchBroom/pull/4401

Refactors `EntParser` heavily and then adds the ability to parse boolean literals for boolean properties.