### PR TITLE
Draw Half-Life env_sprite and env_glow

### DIFF
--- a/app/resources/games/Halflife/HalfLife.fgd
+++ b/app/resources/games/Halflife/HalfLife.fgd
@@ -869,7 +869,7 @@
 	]
 ]
 
-@PointClass sprite() base(Targetname, RenderFields) size(-4 -4 -4, 4 4 4) color(30 100 0) = env_glow : "Light Glow/Haze" 
+@PointClass sprite() base(Targetname, RenderFields) size(-4 -4 -4, 4 4 4) color(30 100 0) model({"path":model,"scale":scale}) = env_glow : "Light Glow/Haze" 
 [
 	model(sprite) : "Sprite Name" : "sprites/glow01.spr"
 	scale(integer) : "Scale" : 1
@@ -1032,7 +1032,7 @@
 	]
 ]
 
-@PointClass sprite() base(Targetname, RenderFields, Angles) size(-4 -4 -4, 4 4 4) = env_sprite : "Sprite Effect" 
+@PointClass sprite() base(Targetname, RenderFields, Angles) size(-4 -4 -4, 4 4 4) model({"path":model,"scale":scale}) = env_sprite : "Sprite Effect" 
 [
 	framerate(string) : "Framerate" : "10.0"
 	model(sprite) : "Sprite Name" : "sprites/glow01.spr"


### PR DESCRIPTION

[Example](https://github.com/TrenchBroom/TrenchBroom/assets/947312/643b3907-d5fa-4b1b-a309-b86ef6253c1f).



Oriented sprites are not handled, it's a flag set in the `.spr` itself.
The real issue is having their bounding box (and thus their selectable area) spanning a large invisible region in the wrong axis.

[Mis-rendered oriented sprite example](https://github.com/TrenchBroom/TrenchBroom/assets/947312/f6d6d072-8197-4388-a1b6-191ae67c9f65). It should be horizontal.

There's 6 oriented sprites out of 384 in the base Half-Life game so it shouldn't matter too much.