### PR TITLE
Fix install instructions for Qt5

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -97,7 +97,7 @@ TrenchBroom depends on:
 If you have a debian-based distribution, open a command prompt and execute this command to install required dependencies:
 
 ```bash
-sudo apt-get install g++ qt5-default libqt5svg5-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libglew-dev libxrandr-dev build-essential libglm-dev libxxf86vm-dev libfreetype6-dev libfreeimage-dev libtinyxml2-dev pandoc cmake p7zip-full ninja-build curl
+sudo apt-get install g++ qtbase5-dev libqt5svg5-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libglew-dev libxrandr-dev build-essential libglm-dev libxxf86vm-dev libfreetype6-dev libfreeimage-dev libtinyxml2-dev pandoc cmake p7zip-full ninja-build curl
 ```
 
 ### Build TrenchBroom


### PR DESCRIPTION
qt5-default is missing from Debian-based distributions since Debian 12 (Bookworm) and its derivatives (including Ubuntu ≥ 21.04 cf. [launchpad bug 1926802][1]).

The CI was fixed in 3a5670ac2a850885d3962d9cf5cb99141604ece3 but the install instructions were not updated.

[1]: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1926802