### PR TITLE
4451: Don't fail to load a texture collection if a single texture cannot be opened

### DIFF
--- a/common/src/IO/LoadTextureCollection.cpp
+++ b/common/src/IO/LoadTextureCollection.cpp
@@ -203,19 +203,20 @@ Result<Assets::TextureCollection> loadTextureCollection(
                kdl::vec_parallel_transform(
                  std::move(texturePaths),
                  [&](const auto texturePath) {
-                   return gameFS.openFile(texturePath).and_then([&](const auto& file) {
-                     return readTexture(*file, texturePath)
-                       .or_else(makeReadTextureErrorHandler(gameFS, nullLogger))
-                       .transform([&](auto texture) {
-                         gameFS.makeAbsolute(texturePath)
-                           .transform([&](auto absPath) {
-                             texture.setAbsolutePath(std::move(absPath));
-                           })
-                           .or_else([](auto) { return kdl::void_success; });
-                         texture.setRelativePath(texturePath);
-                         return texture;
-                       });
-                   });
+                   return gameFS.openFile(texturePath)
+                     .and_then([&](const auto& file) {
+                       return readTexture(*file, texturePath)
+                         .transform([&](auto texture) {
+                           gameFS.makeAbsolute(texturePath)
+                             .transform([&](auto absPath) {
+                               texture.setAbsolutePath(std::move(absPath));
+                             })
+                             .or_else([](auto) { return kdl::void_success; });
+                           texture.setRelativePath(texturePath);
+                           return texture;
+                         });
+                     })
+                     .or_else(makeReadTextureErrorHandler(gameFS, nullLogger));
                  }))
         .transform([&](auto textures) {
           return Assets::TextureCollection{path, std::move(textures)};

--- a/common/src/IO/Quake3ShaderParser.cpp
+++ b/common/src/IO/Quake3ShaderParser.cpp
@@ -29,12 +29,11 @@
 #include <filesystem>
 #include <string>
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
-{
+
 Quake3ShaderTokenizer::Quake3ShaderTokenizer(std::string_view str)
-  : Tokenizer(std::move(str), "", '\\')
+  : Tokenizer{std::move(str), "", '\\'}
 {
 }
 
@@ -49,12 +48,12 @@ Tokenizer<unsigned int>::Token Quake3ShaderTokenizer::emitToken()
     {
     case '{':
       advance();
-      return Token(
-        Quake3ShaderToken::OBrace, c, c + 1, offset(c), startLine, startColumn);
+      return Token{
+        Quake3ShaderToken::OBrace, c, c + 1, offset(c), startLine, startColumn};
     case '}':
       advance();
-      return Token(
-        Quake3ShaderToken::CBrace, c, c + 1, offset(c), startLine, startColumn);
+      return Token{
+        Quake3ShaderToken::CBrace, c, c + 1, offset(c), startLine, startColumn};
     case '\r':
       if (lookAhead() == '\n')
       {
@@ -65,20 +64,19 @@ Tokenizer<unsigned int>::Token Quake3ShaderTokenizer::emitToken()
       switchFallthrough();
     case '\n':
       discardWhile(Whitespace()); // handle empty lines and such
-      return Token(Quake3ShaderToken::Eol, c, c + 1, offset(c), startLine, startColumn);
+      return Token{Quake3ShaderToken::Eol, c, c + 1, offset(c), startLine, startColumn};
     case ' ':
     case '\t':
       advance();
       break;
-    case '$': {
-      const auto* e = readUntil(Whitespace());
-      if (e == nullptr)
+    case '$':
+      if (const auto* e = readUntil(Whitespace()))
       {
-        throw ParserException(
-          startLine, startColumn, "Unexpected character: " + std::string(c, 1));
+        return Token{
+          Quake3ShaderToken::Variable, c, e, offset(c), startLine, startColumn};
       }
-      return Token(Quake3ShaderToken::Variable, c, e, offset(c), startLine, startColumn);
-    }
+      throw ParserException{
+        startLine, startColumn, "Unexpected character: " + std::string{c, 1}};
     case '/':
       if (lookAhead() == '/')
       {
@@ -89,7 +87,7 @@ Tokenizer<unsigned int>::Token Quake3ShaderTokenizer::emitToken()
         // relevant e.g. for terminating a block entry
         break;
       }
-      else if (lookAhead() == '*')
+      if (lookAhead() == '*')
       {
         // parse multiline comment delimited by /* and */
         advance(2);
@@ -104,35 +102,34 @@ Tokenizer<unsigned int>::Token Quake3ShaderTokenizer::emitToken()
       // fall through into the default case to parse a string that starts with '/'
       switchFallthrough();
     default:
-      auto* e = readDecimal(Whitespace());
-      if (e != nullptr)
+      if (const auto* e = readDecimal(Whitespace()))
       {
-        return Token(Quake3ShaderToken::Number, c, e, offset(c), startLine, startColumn);
+        return Token{Quake3ShaderToken::Number, c, e, offset(c), startLine, startColumn};
       }
 
-      e = readUntil(Whitespace());
-      if (e == nullptr)
+      if (const auto* e = readUntil(Whitespace()))
       {
-        throw ParserException(
-          startLine, startColumn, "Unexpected character: " + std::string(c, 1));
+        return Token{Quake3ShaderToken::String, c, e, offset(c), startLine, startColumn};
       }
-      return Token(Quake3ShaderToken::String, c, e, offset(c), startLine, startColumn);
+
+      throw ParserException{
+        startLine, startColumn, "Unexpected character: " + std::string{c, 1}};
     }
   }
-  return Token(Quake3ShaderToken::Eof, nullptr, nullptr, length(), line(), column());
+  return Token{Quake3ShaderToken::Eof, nullptr, nullptr, length(), line(), column()};
 }
 
 Quake3ShaderParser::Quake3ShaderParser(std::string_view str)
-  : m_tokenizer(std::move(str))
+  : m_tokenizer{std::move(str)}
 {
 }
 
 std::vector<Assets::Quake3Shader> Quake3ShaderParser::parse(ParserStatus& status)
 {
-  std::vector<Assets::Quake3Shader> result;
+  auto result = std::vector<Assets::Quake3Shader>{};
   while (!m_tokenizer.peekToken(Quake3ShaderToken::Eol).hasType(Quake3ShaderToken::Eof))
   {
-    Assets::Quake3Shader shader;
+    auto shader = Assets::Quake3Shader{};
     parseTexture(shader, status);
     parseBody(shader, status);
     result.push_back(shader);
@@ -202,6 +199,7 @@ void Quake3ShaderParser::parseBodyEntry(
 {
   auto token = m_tokenizer.nextToken(Quake3ShaderToken::Eol);
   expect(Quake3ShaderToken::String, token);
+
   const auto key = token.data();
   if (key == "qer_editorimage")
   {
@@ -246,6 +244,7 @@ void Quake3ShaderParser::parseStageEntry(
 {
   auto token = m_tokenizer.nextToken(Quake3ShaderToken::Eol);
   expect(Quake3ShaderToken::String, token);
+
   const auto key = token.data();
   if (key == "map")
   {
@@ -269,7 +268,7 @@ void Quake3ShaderParser::parseStageEntry(
       stage.blendFunc.srcFactor = kdl::str_to_upper(param1);
       stage.blendFunc.destFactor = kdl::str_to_upper(param2);
 
-      bool valid = true;
+      auto valid = true;
       if (!stage.blendFunc.validateSrcFactor())
       {
         valid = false;
@@ -333,16 +332,16 @@ void Quake3ShaderParser::skipRemainderOfEntry()
 
 Quake3ShaderParser::TokenNameMap Quake3ShaderParser::tokenNames() const
 {
-  TokenNameMap result;
-  result[Quake3ShaderToken::Number] = "number";
-  result[Quake3ShaderToken::String] = "string";
-  result[Quake3ShaderToken::Variable] = "variable";
-  result[Quake3ShaderToken::OBrace] = "'{'";
-  result[Quake3ShaderToken::CBrace] = "'}'";
-  result[Quake3ShaderToken::Comment] = "comment";
-  result[Quake3ShaderToken::Eol] = "end of line";
-  result[Quake3ShaderToken::Eof] = "end of file";
-  return result;
+  return {
+    {Quake3ShaderToken::Number, "number"},
+    {Quake3ShaderToken::String, "string"},
+    {Quake3ShaderToken::Variable, "variable"},
+    {Quake3ShaderToken::OBrace, "'{'"},
+    {Quake3ShaderToken::CBrace, "'}'"},
+    {Quake3ShaderToken::Comment, "comment"},
+    {Quake3ShaderToken::Eol, "end of line"},
+    {Quake3ShaderToken::Eof, "end of file"},
+  };
 }
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/src/IO/Quake3ShaderParser.cpp
+++ b/common/src/IO/Quake3ShaderParser.cpp
@@ -201,34 +201,35 @@ void Quake3ShaderParser::parseBodyEntry(
   expect(Quake3ShaderToken::String, token);
 
   const auto key = token.data();
-  if (key == "qer_editorimage")
+  if (kdl::ci::str_is_equal(key, "qer_editorimage"))
   {
     token = expect(Quake3ShaderToken::String, m_tokenizer.nextToken());
     shader.editorImage = std::filesystem::path{token.data()};
   }
-  else if (key == "q3map_lightimage")
+  else if (kdl::ci::str_is_equal(key, "q3map_lightimage"))
   {
     token = expect(Quake3ShaderToken::String, m_tokenizer.nextToken());
     shader.lightImage = std::filesystem::path{token.data()};
   }
-  else if (key == "surfaceparm")
+  else if (kdl::ci::str_is_equal(key, "surfaceparm"))
   {
     token = expect(Quake3ShaderToken::String, m_tokenizer.nextToken());
     shader.surfaceParms.insert(token.data());
   }
-  else if (key == "cull")
+  else if (kdl::ci::str_is_equal(key, "cull"))
   {
     token = expect(Quake3ShaderToken::String, m_tokenizer.nextToken());
     const auto value = token.data();
-    if (value == "front")
+    if (kdl::ci::str_is_equal(value, "front"))
     {
       shader.culling = Assets::Quake3Shader::Culling::Front;
     }
-    else if (value == "back")
+    else if (kdl::ci::str_is_equal(value, "back"))
     {
       shader.culling = Assets::Quake3Shader::Culling::Back;
     }
-    else if (value == "none" || value == "disable")
+    else if (
+      kdl::ci::str_is_equal(value, "none") || kdl::ci::str_is_equal(value, "disable"))
     {
       shader.culling = Assets::Quake3Shader::Culling::None;
     }
@@ -246,13 +247,13 @@ void Quake3ShaderParser::parseStageEntry(
   expect(Quake3ShaderToken::String, token);
 
   const auto key = token.data();
-  if (key == "map")
+  if (kdl::ci::str_is_equal(key, "map"))
   {
     token = expect(
       Quake3ShaderToken::String | Quake3ShaderToken::Variable, m_tokenizer.nextToken());
     stage.map = std::filesystem::path{token.data()};
   }
-  else if (key == "blendFunc")
+  else if (kdl::ci::str_is_equal(key, "blendFunc"))
   {
     const auto line = token.line();
 

--- a/common/src/IO/Quake3ShaderParser.h
+++ b/common/src/IO/Quake3ShaderParser.h
@@ -24,15 +24,13 @@
 
 #include <string>
 
-namespace TrenchBroom
-{
-namespace Assets
+namespace TrenchBroom::Assets
 {
 class Quake3Shader;
 class Quake3ShaderStage;
-} // namespace Assets
+} // namespace TrenchBroom::Assets
 
-namespace IO
+namespace TrenchBroom::IO
 {
 class ParserStatus;
 
@@ -87,5 +85,5 @@ private:
 private:
   TokenNameMap tokenNames() const override;
 };
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/test/src/IO/tst_LoadTextureCollection.cpp
+++ b/common/test/src/IO/tst_LoadTextureCollection.cpp
@@ -40,9 +40,7 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
-{
-namespace IO
+namespace TrenchBroom::IO
 {
 
 namespace
@@ -219,5 +217,5 @@ TEST_CASE("loadTextureCollection")
       });
   }
 }
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/test/src/IO/tst_Quake3ShaderParser.cpp
+++ b/common/test/src/IO/tst_Quake3ShaderParser.cpp
@@ -30,28 +30,26 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
-{
+
 TEST_CASE("Quake3ShaderParserTest.parseEmptyShader")
 {
-  const std::string data("");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+  const auto data = "";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
-  CHECK_THAT(
-    parser.parse(status), Catch::UnorderedEquals(std::vector<Assets::Quake3Shader>{}));
+  CHECK(parser.parse(status).empty());
 }
 
 TEST_CASE("Quake3ShaderParserTest.parseSingleShaderWithEmptyBlock")
 {
-  const std::string data(R"(
+  const auto data = R"(
 textures/liquids/lavahell2 //path and name of new texture
 {}
-)");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+)";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
   CHECK_THAT(
     parser.parse(status),
@@ -67,7 +65,7 @@ textures/liquids/lavahell2 //path and name of new texture
 
 TEST_CASE("Quake3ShaderParserTest.parseSingleSimpleShaderWithoutEditorImage")
 {
-  const std::string data(R"(
+  const auto data = R"(
 textures/liquids/lavahell2 //path and name of new texture
 {
 
@@ -97,9 +95,9 @@ textures/liquids/lavahell2 //path and name of new texture
     //the turbulence is scrolled
     }
 
-})");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+})";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
   CHECK_THAT(
     parser.parse(status),
@@ -118,7 +116,7 @@ textures/liquids/lavahell2 //path and name of new texture
 
 TEST_CASE("Quake3ShaderParserTest.parseSingleSimpleShaderWithEditorImage")
 {
-  const std::string data(R"(
+  const auto data = R"(
 textures/liquids/lavahell2 //path and name of new texture
 {
 
@@ -149,9 +147,9 @@ textures/liquids/lavahell2 //path and name of new texture
     //the turbulence is scrolled
     }
 
-})");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+})";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
   CHECK_THAT(
     parser.parse(status),
@@ -170,7 +168,7 @@ textures/liquids/lavahell2 //path and name of new texture
 
 TEST_CASE("Quake3ShaderParserTest.parseSingleComplexShaderWithEditorImage")
 {
-  const std::string data(R"(
+  const auto data = R"(
 textures/eerie/ironcrosslt2_10000
 {
 
@@ -201,9 +199,9 @@ textures/eerie/ironcrosslt2_10000
     blendFunc add
     }
 
-})");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+})";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
   CHECK_THAT(
     parser.parse(status),
@@ -230,7 +228,7 @@ textures/eerie/ironcrosslt2_10000
 
 TEST_CASE("Quake3ShaderParserTest.parseTwoShaders")
 {
-  const std::string data(R"(
+  const auto data = R"(
 textures/eerie/ironcrosslt2_10000
 {
 
@@ -296,9 +294,9 @@ textures/liquids/lavahell2 //path and name of new texture
 
 }
 
-)");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+)";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
   CHECK_THAT(
     parser.parse(status),
@@ -337,7 +335,7 @@ textures/liquids/lavahell2 //path and name of new texture
 
 TEST_CASE("Quake3ShaderParserTest.parseShadersWithMultilineComment")
 {
-  const std::string data(R"(
+  const auto data = R"(
 /*
 This is a
 multiline comment.
@@ -356,9 +354,9 @@ waterBubble
     }
 }
 
-)");
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+)";
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
   CHECK_NOTHROW(parser.parse(status));
 }
 
@@ -366,7 +364,7 @@ TEST_CASE("Quake3ShaderParserTest.parseBlendFuncParameters")
 {
   // see
   // https://github.com/id-Software/Quake-III-Arena/blob/master/code/renderer/tr_shader.c#L176
-  const std::string data(R"(
+  const auto data = R"(
             waterBubble
             {
                 {
@@ -419,12 +417,12 @@ TEST_CASE("Quake3ShaderParserTest.parseBlendFuncParameters")
                 }
             }
 
-            )");
+            )";
 
   using BF = Assets::Quake3ShaderStage::BlendFunc;
 
-  Quake3ShaderParser parser(data);
-  TestParserStatus status;
+  auto parser = Quake3ShaderParser{data};
+  auto status = TestParserStatus{};
 
   CHECK_THAT(
     parser.parse(status),
@@ -486,5 +484,5 @@ TEST_CASE("Quake3ShaderParserTest.parseBlendFuncParameters")
       } // stages
     }}));
 }
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO


### PR DESCRIPTION
Closes #4451. This change also makes all shader keywords case insensitive.