### PR TITLE
4455: Fix autosaver cleanup

### DIFF
--- a/common/src/View/Autosaver.cpp
+++ b/common/src/View/Autosaver.cpp
@@ -115,7 +115,7 @@ Result<std::vector<std::filesystem::path>> thinBackups(
     return backups;
   }
 
-  const auto toDelete = kdl::vec_slice_suffix(backups, backups.size() - maxBackups + 1);
+  const auto toDelete = kdl::vec_slice_prefix(backups, 1);
   return kdl::fold_results(
            kdl::vec_transform(
              toDelete,
@@ -127,7 +127,7 @@ Result<std::vector<std::filesystem::path>> thinBackups(
                  }
                });
              }))
-    .transform([&]() { return kdl::vec_slice_prefix(backups, maxBackups - 1); });
+    .transform([&]() { return kdl::vec_slice_suffix(backups, backups.size() - 1); });
 }
 
 std::filesystem::path makeBackupName(

--- a/common/src/View/Autosaver.h
+++ b/common/src/View/Autosaver.h
@@ -19,8 +19,7 @@
 
 #pragma once
 
-#include "IO/FileSystem.h"
-#include "Result.h"
+#include "IO/PathMatcher.h"
 
 #include <chrono>
 #include <filesystem>
@@ -30,12 +29,6 @@ namespace TrenchBroom
 {
 class Logger;
 } // namespace TrenchBroom
-
-namespace TrenchBroom::IO
-{
-class FileSystem;
-class WritableDiskFileSystem;
-} // namespace TrenchBroom::IO
 
 namespace TrenchBroom::View
 {
@@ -82,19 +75,5 @@ public:
 
 private:
   void autosave(Logger& logger, std::shared_ptr<View::MapDocument> document);
-  Result<IO::WritableDiskFileSystem> createBackupFileSystem(
-    const std::filesystem::path& mapPath) const;
-  Result<std::vector<std::filesystem::path>> collectBackups(
-    const IO::FileSystem& fs, const std::filesystem::path& mapBasename) const;
-  Result<std::vector<std::filesystem::path>> thinBackups(
-    Logger& logger,
-    IO::WritableDiskFileSystem& fs,
-    const std::vector<std::filesystem::path>& backups) const;
-  Result<void> cleanBackups(
-    IO::WritableDiskFileSystem& fs,
-    std::vector<std::filesystem::path>& backups,
-    const std::filesystem::path& mapBasename) const;
-  std::filesystem::path makeBackupName(
-    const std::filesystem::path& mapBasename, size_t index) const;
 };
 } // namespace TrenchBroom::View

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -91,6 +91,18 @@ bool TestEnvironment::fileExists(const std::filesystem::path& path) const
   return std::filesystem::is_regular_file(m_dir / path);
 }
 
+std::vector<std::filesystem::path> TestEnvironment::directoryContents(
+  const std::filesystem::path& path) const
+{
+  auto result = std::vector<std::filesystem::path>{};
+  for (const auto& entry : std::filesystem::directory_iterator{m_dir / path})
+  {
+    result.push_back(entry.path().lexically_relative(m_dir));
+  }
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
 std::string TestEnvironment::loadFile(const std::filesystem::path& path) const
 {
   auto stream = std::ifstream{m_dir / path, std::ios::in};

--- a/common/test/src/IO/TestEnvironment.cpp
+++ b/common/test/src/IO/TestEnvironment.cpp
@@ -27,10 +27,9 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
-{
+
 TestEnvironment::TestEnvironment(const std::string& dir, const SetupFunction& setup)
   : m_sandboxPath{std::filesystem::current_path() / generateUuid()}
   , m_dir{m_sandboxPath / dir}
@@ -98,5 +97,4 @@ std::string TestEnvironment::loadFile(const std::filesystem::path& path) const
   return std::string{std::istreambuf_iterator<char>{stream}, {}};
 }
 
-} // namespace IO
-} // namespace TrenchBroom
+} // namespace TrenchBroom::IO

--- a/common/test/src/IO/TestEnvironment.h
+++ b/common/test/src/IO/TestEnvironment.h
@@ -55,6 +55,8 @@ public:
 
   bool directoryExists(const std::filesystem::path& path) const;
   bool fileExists(const std::filesystem::path& path) const;
+  std::vector<std::filesystem::path> directoryContents(
+    const std::filesystem::path& path) const;
 
   std::string loadFile(const std::filesystem::path& path) const;
 

--- a/common/test/src/IO/TestEnvironment.h
+++ b/common/test/src/IO/TestEnvironment.h
@@ -28,10 +28,9 @@
 #include <functional>
 #include <string>
 
-namespace TrenchBroom
+namespace TrenchBroom::IO
 {
-namespace IO
-{
+
 class TestEnvironment
 {
 private:
@@ -75,5 +74,5 @@ public:
     return f(path);
   }
 };
-} // namespace IO
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::IO

--- a/common/test/src/View/tst_Autosaver.cpp
+++ b/common/test/src/View/tst_Autosaver.cpp
@@ -34,10 +34,9 @@
 
 #include "Catch2.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 namespace
 {
 IO::TestEnvironment makeTestEnvironment()
@@ -78,15 +77,15 @@ TEST_CASE("AutosaverTest.makeBackupPathMatcher")
 
 TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverNoSaveUntilSaveInterval")
 {
-  using namespace std::literals::chrono_literals;
+  using namespace std::chrono_literals;
 
-  IO::TestEnvironment env;
-  NullLogger logger;
+  auto env = IO::TestEnvironment{};
+  auto logger = NullLogger{};
 
   document->saveDocumentAs(env.dir() / "test.map");
   assert(env.fileExists("test.map"));
 
-  Autosaver autosaver(document, 10s);
+  auto autosaver = Autosaver{document, 10s};
 
   // modify the map
   document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
@@ -99,15 +98,15 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverNoSaveUntilSaveInter
 
 TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverNoSaveOfUnchangedMap")
 {
-  using namespace std::literals::chrono_literals;
+  using namespace std::chrono_literals;
 
-  IO::TestEnvironment env;
-  NullLogger logger;
+  auto env = IO::TestEnvironment{};
+  auto logger = NullLogger{};
 
   document->saveDocumentAs(env.dir() / "test.map");
   assert(env.fileExists("test.map"));
 
-  Autosaver autosaver(document, 0s);
+  auto autosaver = Autosaver{document, 0s};
   autosaver.triggerAutosave(logger);
 
   CHECK_FALSE(env.fileExists("autosave/test.1.map"));
@@ -116,21 +115,19 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverNoSaveOfUnchangedMap
 
 TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAfterSaveInterval")
 {
-  using namespace std::literals::chrono_literals;
+  using namespace std::chrono_literals;
 
-  IO::TestEnvironment env;
-  NullLogger logger;
+  auto env = IO::TestEnvironment{};
+  auto logger = NullLogger{};
 
   document->saveDocumentAs(env.dir() / "test.map");
   assert(env.fileExists("test.map"));
 
-  Autosaver autosaver(document, 100ms);
+  auto autosaver = Autosaver{document, 100ms};
 
   // modify the map
   document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
-  // Wait for 2 seconds.
-  using namespace std::chrono_literals;
   std::this_thread::sleep_for(100ms);
 
   autosaver.triggerAutosave(logger);
@@ -141,21 +138,19 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAfterSaveInterv
 
 TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAgainAfterSaveInterval")
 {
-  using namespace std::literals::chrono_literals;
+  using namespace std::chrono_literals;
 
-  IO::TestEnvironment env;
-  NullLogger logger;
+  auto env = IO::TestEnvironment{};
+  auto logger = NullLogger{};
 
   document->saveDocumentAs(env.dir() / "test.map");
   assert(env.fileExists("test.map"));
 
-  Autosaver autosaver(document, 100ms);
+  auto autosaver = Autosaver{document, 100ms};
 
   // modify the map
   document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
 
-  // Wait for 2 seconds.
-  using namespace std::chrono_literals;
   std::this_thread::sleep_for(100ms);
 
   autosaver.triggerAutosave(logger);
@@ -181,19 +176,19 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesWhenCrashFilesP
 {
   // https://github.com/TrenchBroom/TrenchBroom/issues/2544
 
-  using namespace std::literals::chrono_literals;
+  using namespace std::chrono_literals;
 
-  IO::TestEnvironment env;
+  auto env = IO::TestEnvironment{};
   env.createDirectory("autosave");
   env.createFile("autosave/test.1.map", "some content");
   env.createFile("autosave/test.1-crash.map", "some content again");
 
-  NullLogger logger;
+  auto logger = NullLogger{};
 
   document->saveDocumentAs(env.dir() / "test.map");
   assert(env.fileExists("test.map"));
 
-  Autosaver autosaver(document, 0s);
+  auto autosaver = Autosaver{document, 0s};
 
   // modify the map
   document->addNodes({{document->currentLayer(), {createBrushNode("some_texture")}}});
@@ -202,5 +197,5 @@ TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesWhenCrashFilesP
 
   CHECK(env.fileExists("autosave/test.2.map"));
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -319,25 +319,25 @@ bool vec_contains(const std::vector<T, A>& v, const X& x)
 namespace detail
 {
 template <typename T, typename A>
-void vec_append(std::vector<T, A>&)
+void vec_concat(std::vector<T, A>&)
 {
 }
 
 template <typename T, typename A, typename Arg>
-void vec_append(std::vector<T, A>& v1, const Arg& arg)
+void vec_concat(std::vector<T, A>& v1, const Arg& arg)
 {
   v1.insert(std::end(v1), std::begin(arg), std::end(arg));
 }
 
 template <typename T, typename A, typename Arg, typename... Rest>
-void vec_append(std::vector<T, A>& v1, const Arg& arg, Rest&&... rest)
+void vec_concat(std::vector<T, A>& v1, const Arg& arg, Rest&&... rest)
 {
-  vec_append(v1, arg);
-  vec_append(v1, std::forward<Rest>(rest)...);
+  vec_concat(v1, arg);
+  vec_concat(v1, std::forward<Rest>(rest)...);
 }
 
 template <typename T, typename A, typename Arg>
-void vec_append(std::vector<T, A>& v1, Arg&& arg)
+void vec_concat(std::vector<T, A>& v1, Arg&& arg)
 {
   for (auto& x : arg)
   {
@@ -346,10 +346,10 @@ void vec_append(std::vector<T, A>& v1, Arg&& arg)
 }
 
 template <typename T, typename A, typename Arg, typename... Rest>
-void vec_append(std::vector<T, A>& v1, Arg&& arg, Rest&&... rest)
+void vec_concat(std::vector<T, A>& v1, Arg&& arg, Rest&&... rest)
 {
-  vec_append(v1, std::forward<Arg>(arg));
-  vec_append(v1, std::forward<Rest>(rest)...);
+  vec_concat(v1, std::forward<Arg>(arg));
+  vec_concat(v1, std::forward<Rest>(rest)...);
 }
 } // namespace detail
 
@@ -368,7 +368,9 @@ template <typename T, typename A, typename... Args>
 std::vector<T, A> vec_concat(std::vector<T, A> v, Args... args)
 {
   v.reserve(kdl::col_total_size(v, args...));
-  detail::vec_append(v, std::move(args)...);
+  detail::vec_concat(v, std::move(args)...);
+  return v;
+}
   return v;
 }
 

--- a/lib/kdl/include/kdl/vector_utils.h
+++ b/lib/kdl/include/kdl/vector_utils.h
@@ -371,6 +371,22 @@ std::vector<T, A> vec_concat(std::vector<T, A> v, Args... args)
   detail::vec_concat(v, std::move(args)...);
   return v;
 }
+
+/**
+ * Appends the given elements. Each element must be a type convertible to T and it is
+ * perfectly forwarded to std::vector<T, A>::push_back.
+ *
+ * @tparam T the element type
+ * @tparam A the allocator type
+ * @tparam Args parameter pack containing the elements to append to v
+ * @param v the first vector to append to
+ * @param args the elements to append
+ */
+template <typename T, typename A, typename... Args>
+auto vec_push_back(std::vector<T, A> v, Args... args)
+{
+  v.reserve(v.size() + sizeof...(args));
+  (..., v.push_back(std::forward<Args>(args)));
   return v;
 }
 

--- a/lib/kdl/test/src/tst_vector_utils.cpp
+++ b/lib/kdl/test/src/tst_vector_utils.cpp
@@ -162,6 +162,20 @@ TEST_CASE("vector_utils_test.vec_concat_move")
   CHECK(*v[1] == 2);
 }
 
+TEST_CASE("vector_utils_test.vec_push_back")
+{
+  using ivec = std::vector<int>;
+  using svec = std::vector<std::string>;
+
+  CHECK_THAT(vec_push_back(ivec{}), Catch::Equals(ivec{}));
+  CHECK_THAT(vec_push_back(ivec{}, 1), Catch::Equals(ivec{1}));
+  CHECK_THAT(vec_push_back(ivec{1}, 2, 3), Catch::Equals(ivec{1, 2, 3}));
+
+  CHECK_THAT(
+    vec_push_back(svec{}, "hey", std::string{"there"}),
+    Catch::Equals(svec{"hey", "there"}));
+}
+
 TEST_CASE("vector_utils_test.vec_slice")
 {
   using vec = std::vector<int>;


### PR DESCRIPTION
Closes #4455. `Autosaver` got broken during a recent refactoring in a way that would make some backups disappear.