### PR TITLE
Make splitters wider and draw a handle for selected splitters

### DIFF
--- a/common/src/View/FourPaneMapView.cpp
+++ b/common/src/View/FourPaneMapView.cpp
@@ -57,13 +57,13 @@ void FourPaneMapView::createGui(
   Renderer::MapRenderer& mapRenderer,
   GLContextManager& contextManager)
 {
-  m_hSplitter = new Splitter{};
+  m_hSplitter = new Splitter{DrawKnob::No};
   m_hSplitter->setObjectName("FourPaneMapView_HorizontalSplitter");
 
-  m_leftVSplitter = new Splitter{Qt::Vertical};
+  m_leftVSplitter = new Splitter{Qt::Vertical, DrawKnob::No};
   m_leftVSplitter->setObjectName("FourPaneMapView_LeftVerticalSplitter");
 
-  m_rightVSplitter = new Splitter{Qt::Vertical};
+  m_rightVSplitter = new Splitter{Qt::Vertical, DrawKnob::No};
   m_rightVSplitter->setObjectName("FourPaneMapView_RightVerticalSplitter");
 
   m_mapView3D = new MapView3D{m_document, toolBox, mapRenderer, contextManager, m_logger};

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -366,11 +366,11 @@ void MapFrame::createGui()
   setWindowIconTB(this);
   setWindowTitle("TrenchBroom");
 
-  m_hSplitter = new Splitter(Qt::Horizontal);
+  m_hSplitter = new Splitter(Qt::Horizontal, DrawKnob::No);
   m_hSplitter->setChildrenCollapsible(false);
   m_hSplitter->setObjectName("MapFrame_HorizontalSplitter");
 
-  m_vSplitter = new Splitter(Qt::Vertical);
+  m_vSplitter = new Splitter(Qt::Vertical, DrawKnob::No);
   m_vSplitter->setChildrenCollapsible(false);
   m_vSplitter->setObjectName("MapFrame_VerticalSplitterSplitter");
 

--- a/common/src/View/Splitter.cpp
+++ b/common/src/View/Splitter.cpp
@@ -23,29 +23,28 @@
 #include <QPaintEvent>
 #include <QPainter>
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 SplitterHandle::SplitterHandle(const Qt::Orientation orientation, QSplitter* parent)
-  : QSplitterHandle(orientation, parent)
+  : QSplitterHandle{orientation, parent}
 {
 }
 
 QSize SplitterHandle::sizeHint() const
 {
-  return QSize(3, 3);
+  return {3, 3};
 }
 
 void SplitterHandle::paintEvent(QPaintEvent* event)
 {
-  QPainter painter(this);
+  auto painter = QPainter{this};
   painter.setPen(Qt::NoPen);
-  painter.fillRect(event->rect(), QBrush(palette().color(QPalette::Mid)));
+  painter.fillRect(event->rect(), QBrush{palette().color(QPalette::Mid)});
 }
 
 Splitter::Splitter(const Qt::Orientation orientation, QWidget* parent)
-  : QSplitter(orientation, parent)
+  : QSplitter{orientation, parent}
 {
 #ifdef __APPLE__
   connect(this, &QSplitter::splitterMoved, this, &Splitter::doSplitterMoved);
@@ -53,7 +52,7 @@ Splitter::Splitter(const Qt::Orientation orientation, QWidget* parent)
 }
 
 Splitter::Splitter(QWidget* parent)
-  : QSplitter(parent)
+  : QSplitter{parent}
 {
 #ifdef __APPLE__
   connect(this, &QSplitter::splitterMoved, this, &Splitter::doSplitterMoved);
@@ -62,7 +61,7 @@ Splitter::Splitter(QWidget* parent)
 
 QSplitterHandle* Splitter::createHandle()
 {
-  return new SplitterHandle(orientation(), this);
+  return new SplitterHandle{orientation(), this};
 }
 
 #ifdef __APPLE__
@@ -75,5 +74,5 @@ void Splitter::doSplitterMoved()
   }
 }
 #endif
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/Splitter.cpp
+++ b/common/src/View/Splitter.cpp
@@ -26,25 +26,53 @@
 namespace TrenchBroom::View
 {
 
-SplitterHandle::SplitterHandle(const Qt::Orientation orientation, QSplitter* parent)
+SplitterHandle::SplitterHandle(
+  const Qt::Orientation orientation, const DrawKnob drawKnob, QSplitter* parent)
   : QSplitterHandle{orientation, parent}
+  , m_drawKnob{drawKnob == DrawKnob::Yes}
 {
 }
 
 QSize SplitterHandle::sizeHint() const
 {
-  return {3, 3};
+  return {6, 6};
 }
 
 void SplitterHandle::paintEvent(QPaintEvent* event)
 {
+  const auto rect = event->rect();
+
   auto painter = QPainter{this};
   painter.setPen(Qt::NoPen);
-  painter.fillRect(event->rect(), QBrush{palette().color(QPalette::Mid)});
+  painter.fillRect(rect, QBrush{palette().color(QPalette::Mid)});
+
+  if (m_drawKnob)
+  {
+    const auto knob = QRect{rect.center() - QPoint{20, 20}, QSize{40, 40}};
+    painter.fillRect(
+      knob.intersected(rect.adjusted(+1, +1, -1, -1)),
+      QBrush{palette().color(QPalette::Midlight)});
+  }
+}
+
+Splitter::Splitter(
+  const Qt::Orientation orientation, const DrawKnob drawKnob, QWidget* parent)
+  : QSplitter{orientation, parent}
+  , m_drawKnob{drawKnob}
+{
+#ifdef __APPLE__
+  connect(this, &QSplitter::splitterMoved, this, &Splitter::doSplitterMoved);
+#endif
 }
 
 Splitter::Splitter(const Qt::Orientation orientation, QWidget* parent)
-  : QSplitter{orientation, parent}
+  : Splitter{orientation, DrawKnob::Yes, parent}
+{
+}
+
+Splitter::Splitter(const DrawKnob drawKnob, QWidget* parent)
+  : QSplitter{parent}
+  , m_drawKnob{drawKnob}
 {
 #ifdef __APPLE__
   connect(this, &QSplitter::splitterMoved, this, &Splitter::doSplitterMoved);
@@ -52,16 +80,13 @@ Splitter::Splitter(const Qt::Orientation orientation, QWidget* parent)
 }
 
 Splitter::Splitter(QWidget* parent)
-  : QSplitter{parent}
+  : Splitter{DrawKnob::Yes, parent}
 {
-#ifdef __APPLE__
-  connect(this, &QSplitter::splitterMoved, this, &Splitter::doSplitterMoved);
-#endif
 }
 
 QSplitterHandle* Splitter::createHandle()
 {
-  return new SplitterHandle{orientation(), this};
+  return new SplitterHandle{orientation(), m_drawKnob, this};
 }
 
 #ifdef __APPLE__

--- a/common/src/View/Splitter.h
+++ b/common/src/View/Splitter.h
@@ -21,10 +21,9 @@
 
 #include <QSplitter>
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 class SplitterHandle : public QSplitterHandle
 {
   Q_OBJECT
@@ -54,5 +53,5 @@ private slots:
   void doSplitterMoved();
 #endif
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/Splitter.h
+++ b/common/src/View/Splitter.h
@@ -24,11 +24,21 @@
 namespace TrenchBroom::View
 {
 
+enum class DrawKnob
+{
+  Yes,
+  No,
+};
+
 class SplitterHandle : public QSplitterHandle
 {
   Q_OBJECT
+private:
+  bool m_drawKnob;
+
 public:
-  explicit SplitterHandle(Qt::Orientation orientation, QSplitter* parent = nullptr);
+  explicit SplitterHandle(
+    Qt::Orientation orientation, DrawKnob drawKnob, QSplitter* parent = nullptr);
 
   QSize sizeHint() const override;
 
@@ -39,8 +49,13 @@ protected:
 class Splitter : public QSplitter
 {
   Q_OBJECT
+private:
+  DrawKnob m_drawKnob = DrawKnob::Yes;
+
 public:
+  Splitter(Qt::Orientation orientation, DrawKnob drawKnob, QWidget* parent = nullptr);
   explicit Splitter(Qt::Orientation orientation, QWidget* parent = nullptr);
+  explicit Splitter(DrawKnob drawKnob, QWidget* parent = nullptr);
   explicit Splitter(QWidget* parent = nullptr);
 
 protected:

--- a/common/src/View/ThreePaneMapView.cpp
+++ b/common/src/View/ThreePaneMapView.cpp
@@ -56,10 +56,10 @@ void ThreePaneMapView::createGui(
   Renderer::MapRenderer& mapRenderer,
   GLContextManager& contextManager)
 {
-  m_hSplitter = new Splitter{};
+  m_hSplitter = new Splitter{DrawKnob::No};
   m_hSplitter->setObjectName("ThreePaneMapView_HorizontalSplitter");
 
-  m_vSplitter = new Splitter{Qt::Vertical};
+  m_vSplitter = new Splitter{Qt::Vertical, DrawKnob::No};
   m_vSplitter->setObjectName("ThreePaneMapView_VerticalSplitter");
 
   m_mapView3D = new MapView3D{m_document, toolBox, mapRenderer, contextManager, m_logger};

--- a/common/src/View/TwoPaneMapView.cpp
+++ b/common/src/View/TwoPaneMapView.cpp
@@ -56,7 +56,7 @@ void TwoPaneMapView::createGui(
 {
 
   // See comment in CyclingMapView::createGui
-  m_splitter = new Splitter{};
+  m_splitter = new Splitter{DrawKnob::No};
   m_splitter->setObjectName("TwoPaneMapView_Splitter");
 
   auto* layout = new QHBoxLayout{};


### PR DESCRIPTION
The splitters are a bit hard to grab, so we make them wider. For selected splitters (mostly those in the inspectors), we add a little handle to make them more obvious, too.

<img width="373" alt="Screenshot 2024-01-27 at 00 32 14" src="https://github.com/TrenchBroom/TrenchBroom/assets/186061/56c9ef5d-dc7e-4aff-b798-b6f55096b31b">
