### PR TITLE
Initialize sprite vertices on YZ plane instead of XY plane, flip on Y

### DIFF
--- a/common/src/IO/SprParser.cpp
+++ b/common/src/IO/SprParser.cpp
@@ -298,23 +298,23 @@ std::unique_ptr<Assets::EntityModel> SprParser::doInitializeModel(Logger& /* log
 
     const auto w = static_cast<float>(pictureFrame.width);
     const auto h = static_cast<float>(pictureFrame.height);
-    const auto x1 = static_cast<float>(pictureFrame.x);
-    const auto y1 = static_cast<float>(pictureFrame.y) - h;
-    const auto x2 = x1 + w;
-    const auto y2 = y1 + h;
+    const auto y1 = static_cast<float>(pictureFrame.x);
+    const auto z1 = static_cast<float>(pictureFrame.y) - h;
+    const auto y2 = y1 + w;
+    const auto z2 = z1 + h;
 
-    const auto bboxMin = vm::vec3f{vm::min(x1, x2), vm::min(x1, x2), vm::min(y1, y2)};
-    const auto bboxMax = vm::vec3f{vm::max(x1, x2), vm::max(x1, x2), vm::max(y1, y2)};
+    const auto bboxMin = vm::vec3f{vm::min(y1, y2), vm::min(y1, y2), vm::min(z1, z2)};
+    const auto bboxMax = vm::vec3f{vm::max(y1, y2), vm::max(y1, y2), vm::max(z1, z2)};
     auto& modelFrame = model->loadFrame(i, std::to_string(i), {bboxMin, bboxMax});
 
     const auto triangles = std::vector<Assets::EntityModelVertex>{
-      Assets::EntityModelVertex{{x1, y1, 0}, {0, 1}},
-      Assets::EntityModelVertex{{x1, y2, 0}, {0, 0}},
-      Assets::EntityModelVertex{{x2, y2, 0}, {1, 0}},
+      Assets::EntityModelVertex{{0, y2, z1}, {0, 1}},
+      Assets::EntityModelVertex{{0, y2, z2}, {0, 0}},
+      Assets::EntityModelVertex{{0, y1, z2}, {1, 0}},
 
-      Assets::EntityModelVertex{{x2, y2, 0}, {1, 0}},
-      Assets::EntityModelVertex{{x2, y1, 0}, {1, 1}},
-      Assets::EntityModelVertex{{x1, y1, 0}, {0, 1}},
+      Assets::EntityModelVertex{{0, y1, z2}, {1, 0}},
+      Assets::EntityModelVertex{{0, y1, z1}, {1, 1}},
+      Assets::EntityModelVertex{{0, y2, z1}, {0, 1}},
     };
 
     auto size = Renderer::IndexRangeMap::Size{};


### PR DESCRIPTION
Related to #4441 

Sprite is initialized to the YZ plane while facing the X- direction.  When transformed to world space without rotation, this will result in a sprite matching the in-game (Quake and Half-Life) orientation with angles of `0 0 0`.

Shown below is a sprite in TB and Half-Life with angles of `45 90 180`

![screen_242](https://github.com/TrenchBroom/TrenchBroom/assets/3385021/4c68e58b-9ed6-442d-8b8c-e90a654c96ae)
![screen_245](https://github.com/TrenchBroom/TrenchBroom/assets/3385021/e23ca68c-b061-4d37-b1fd-727465d27c38)

Note that sprite will face the *opposite* direction the entity faces (as represented by the arrow).  One implication of this is that when the entity pitches *down*, the sprite will appear to pitch *up*.

![screen_244](https://github.com/TrenchBroom/TrenchBroom/assets/3385021/210d8eff-1b03-42db-aff5-eefd43255648)

This is more for illustrative purposes more than inclusion into the codebase as-is (hence "draft" pull request).