### PR TITLE
4461: Store link IDs in nodes

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -422,6 +422,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/SelectionTool.cpp
         ${COMMON_SOURCE_DIR}/View/SetBrushFaceAttributesTool.cpp
         ${COMMON_SOURCE_DIR}/View/SetCurrentLayerCommand.cpp
+        ${COMMON_SOURCE_DIR}/View/SetLinkIdsCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SetLockStateCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SetVisibilityCommand.cpp
         ${COMMON_SOURCE_DIR}/View/ShearObjectsTool.cpp
@@ -945,6 +946,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/SelectionTool.h
         ${COMMON_SOURCE_DIR}/View/SetBrushFaceAttributesTool.h
         ${COMMON_SOURCE_DIR}/View/SetCurrentLayerCommand.h
+        ${COMMON_SOURCE_DIR}/View/SetLinkIdsCommand.h
         ${COMMON_SOURCE_DIR}/View/SetLockStateCommand.h
         ${COMMON_SOURCE_DIR}/View/SetVisibilityCommand.h
         ${COMMON_SOURCE_DIR}/View/ShearObjectsTool.h

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -353,7 +353,7 @@ std::vector<Model::EntityProperty> NodeSerializer::groupProperties(
       Model::EntityPropertyKeys::GroupId, kdl::str_to_string(*groupNode->persistentId())),
   };
 
-  const auto& linkId = groupNode->group().linkId();
+  const auto& linkId = groupNode->linkId();
   result.emplace_back(Model::EntityPropertyKeys::LinkId, kdl::str_to_string(linkId));
 
   // write transformation matrix in column major format

--- a/common/src/Model/BezierPatch.cpp
+++ b/common/src/Model/BezierPatch.cpp
@@ -21,7 +21,6 @@
 
 #include "Assets/Texture.h"
 #include "Ensure.h"
-#include "Uuid.h"
 
 #include <kdl/reflection_impl.h>
 
@@ -58,7 +57,6 @@ BezierPatch::BezierPatch(
   , m_pointColumnCount{pointColumnCount}
   , m_controlPoints{std::move(controlPoints)}
   , m_bounds(computeBounds(m_controlPoints))
-  , m_linkId{generateUuid()}
   , m_textureName{std::move(textureName)}
 {
   ensure(
@@ -79,16 +77,6 @@ BezierPatch::BezierPatch(BezierPatch&& other) noexcept = default;
 
 BezierPatch& BezierPatch::operator=(const BezierPatch& other) = default;
 BezierPatch& BezierPatch::operator=(BezierPatch&& other) noexcept = default;
-
-const std::string& BezierPatch::linkId() const
-{
-  return m_linkId;
-}
-
-void BezierPatch::setLinkId(std::string linkId)
-{
-  m_linkId = std::move(linkId);
-}
 
 size_t BezierPatch::pointRowCount() const
 {

--- a/common/src/Model/BezierPatch.h
+++ b/common/src/Model/BezierPatch.h
@@ -49,7 +49,6 @@ private:
   size_t m_pointColumnCount;
   std::vector<Point> m_controlPoints;
   vm::bbox3 m_bounds;
-  std::string m_linkId;
 
   std::string m_textureName;
   Assets::AssetReference<Assets::Texture> m_textureReference;
@@ -60,8 +59,7 @@ private:
     m_pointColumnCount,
     m_bounds,
     m_controlPoints,
-    m_textureName,
-    m_linkId);
+    m_textureName);
 
 public:
   BezierPatch(
@@ -76,10 +74,6 @@ public:
 
   BezierPatch& operator=(const BezierPatch& other);
   BezierPatch& operator=(BezierPatch&& other) noexcept;
-
-public: // link ID:
-  const std::string& linkId() const;
-  void setLinkId(std::string linkId);
 
 public: // control points:
   size_t pointRowCount() const;

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -28,7 +28,6 @@
 #include "Model/TexCoordSystem.h"
 #include "Polyhedron.h"
 #include "Polyhedron_Matcher.h"
-#include "Uuid.h"
 
 #include <kdl/reflection_impl.h>
 #include <kdl/result.h>
@@ -70,8 +69,10 @@ Brush::Brush() {}
 
 Brush::Brush(const Brush& other)
   : m_faces{other.m_faces}
-  , m_geometry{other.m_geometry ? std::make_unique<BrushGeometry>(*other.m_geometry, CopyCallback()) : nullptr}
-  , m_linkId{other.m_linkId}
+  , m_geometry{
+      other.m_geometry
+        ? std::make_unique<BrushGeometry>(*other.m_geometry, CopyCallback())
+        : nullptr}
 {
   if (m_geometry)
   {
@@ -100,7 +101,6 @@ Brush::~Brush() = default;
 
 Brush::Brush(std::vector<BrushFace> faces)
   : m_faces{std::move(faces)}
-  , m_linkId{generateUuid()}
 {
 }
 
@@ -171,16 +171,6 @@ const vm::bbox3& Brush::bounds() const
 {
   ensure(m_geometry != nullptr, "geometry is null");
   return m_geometry->bounds();
-}
-
-const std::string& Brush::linkId() const
-{
-  return m_linkId;
-}
-
-void Brush::setLinkId(std::string linkId)
-{
-  m_linkId = std::move(linkId);
 }
 
 std::optional<size_t> Brush::findFace(const std::string& textureName) const

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -57,9 +57,8 @@ public:
 private:
   std::vector<BrushFace> m_faces;
   std::unique_ptr<BrushGeometry> m_geometry;
-  std::string m_linkId;
 
-  kdl_reflect_decl(Brush, m_faces, m_linkId);
+  kdl_reflect_decl(Brush, m_faces);
 
 public:
   Brush();
@@ -81,10 +80,6 @@ private:
 
 public:
   const vm::bbox3& bounds() const;
-
-public: // link ID:
-  const std::string& linkId() const;
-  void setLinkId(std::string linkId);
 
 public: // face management:
   std::optional<size_t> findFace(const std::string& textureName) const;

--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -317,10 +317,10 @@ FloatType BrushNode::doGetProjectedArea(const vm::axis::type axis) const
 Node* BrushNode::doClone(
   const vm::bbox3& /* worldBounds */, const SetLinkId setLinkIds) const
 {
-  auto* result =
-    new BrushNode{setNewLinkIdIf(m_brush, setLinkIds == SetLinkId::generate)};
-  cloneAttributes(result);
-  return result;
+  auto result = std::make_unique<BrushNode>(m_brush);
+  result->cloneLinkId(*this, setLinkIds);
+  cloneAttributes(result.get());
+  return result.release();
 }
 
 bool BrushNode::doCanAddChild(const Node* /* child */) const

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -26,7 +26,6 @@
 #include "Model/EntityProperties.h"
 #include "Model/EntityPropertiesVariableStore.h"
 #include "Model/EntityRotation.h"
-#include "Uuid.h"
 
 #include <kdl/reflection_impl.h>
 #include <kdl/string_utils.h>
@@ -74,16 +73,14 @@ kdl_reflect_impl(Entity);
 const vm::bbox3 Entity::DefaultBounds = vm::bbox3{8.0};
 
 Entity::Entity()
-  : m_linkId{generateUuid()}
-  , m_cachedProperties{
-      EntityPropertyValues::NoClassname, vm::vec3{}, vm::mat4x4{}, vm::mat4x4{}}
+  : m_cachedProperties{
+    EntityPropertyValues::NoClassname, vm::vec3{}, vm::mat4x4{}, vm::mat4x4{}}
 {
 }
 
 Entity::Entity(
   const EntityPropertyConfig& propertyConfig, std::vector<EntityProperty> properties)
   : m_properties{std::move(properties)}
-  , m_linkId{generateUuid()}
 {
   updateCachedProperties(propertyConfig);
 }
@@ -92,7 +89,6 @@ Entity::Entity(
   const EntityPropertyConfig& propertyConfig,
   std::initializer_list<EntityProperty> properties)
   : m_properties{std::move(properties)}
-  , m_linkId{generateUuid()}
 {
   updateCachedProperties(propertyConfig);
 }
@@ -109,16 +105,6 @@ Entity& Entity::operator=(const Entity& other) = default;
 Entity& Entity::operator=(Entity&& other) = default;
 
 Entity::~Entity() = default;
-
-const std::string& Entity::linkId() const
-{
-  return m_linkId;
-}
-
-void Entity::setLinkId(std::string linkId)
-{
-  m_linkId = std::move(linkId);
-}
 
 void Entity::setProperties(
   const EntityPropertyConfig& propertyConfig, std::vector<EntityProperty> properties)

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -93,9 +93,8 @@ public:
 private:
   std::vector<EntityProperty> m_properties;
   std::vector<std::string> m_protectedProperties;
-  std::string m_linkId;
 
-  kdl_reflect_decl(Entity, m_properties, m_protectedProperties, m_linkId);
+  kdl_reflect_decl(Entity, m_properties, m_protectedProperties);
 
   /**
    * Specifies whether this entity has children or not. This does not necessarily
@@ -134,10 +133,6 @@ public:
   Entity& operator=(Entity&& other);
 
   ~Entity();
-
-public: // link ID:
-  const std::string& linkId() const;
-  void setLinkId(std::string linkId);
 
 public: // property management
   const std::vector<EntityProperty>& properties() const;

--- a/common/src/Model/EntityNode.cpp
+++ b/common/src/Model/EntityNode.cpp
@@ -108,10 +108,10 @@ FloatType EntityNode::doGetProjectedArea(const vm::axis::type axis) const
 Node* EntityNode::doClone(
   const vm::bbox3& /* worldBounds */, const SetLinkId setLinkIds) const
 {
-  auto entity = std::make_unique<EntityNode>(
-    setNewLinkIdIf(m_entity, setLinkIds == SetLinkId::generate));
-  cloneAttributes(entity.get());
-  return entity.release();
+  auto result = std::make_unique<EntityNode>(m_entity);
+  result->cloneLinkId(*this, setLinkIds);
+  cloneAttributes(result.get());
+  return result.release();
 }
 
 bool EntityNode::doCanAddChild(const Node* child) const

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -19,8 +19,6 @@
 
 #include "Group.h"
 
-#include "Uuid.h"
-
 #include <kdl/reflection_impl.h>
 
 #include <vecmath/mat_io.h>
@@ -32,7 +30,6 @@ kdl_reflect_impl(Group);
 
 Group::Group(std::string name)
   : m_name{std::move(name)}
-  , m_linkId{generateUuid()}
 {
 }
 
@@ -44,16 +41,6 @@ const std::string& Group::name() const
 void Group::setName(std::string name)
 {
   m_name = std::move(name);
-}
-
-const std::string& Group::linkId() const
-{
-  return m_linkId;
-}
-
-void Group::setLinkId(std::string linkId)
-{
-  m_linkId = std::move(linkId);
 }
 
 const vm::mat4x4& Group::transformation() const

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -34,20 +34,16 @@ class Group
 {
 private:
   std::string m_name;
-  std::string m_linkId;
 
   vm::mat4x4 m_transformation;
 
-  kdl_reflect_decl(Group, m_name, m_linkId, m_transformation);
+  kdl_reflect_decl(Group, m_name, m_transformation);
 
 public:
   explicit Group(std::string name);
 
   const std::string& name() const;
   void setName(std::string name);
-
-  const std::string& linkId() const;
-  void setLinkId(std::string linkId);
 
   const vm::mat4x4& transformation() const;
   void setTransformation(const vm::mat4x4& transformation);

--- a/common/src/Model/GroupNode.cpp
+++ b/common/src/Model/GroupNode.cpp
@@ -186,10 +186,10 @@ FloatType GroupNode::doGetProjectedArea(const vm::axis::type) const
 Node* GroupNode::doClone(
   const vm::bbox3& /* worldBounds */, const SetLinkId setLinkIds) const
 {
-  auto groupNode = std::make_unique<GroupNode>(
-    setNewLinkIdIf(m_group, setLinkIds == SetLinkId::generate));
-  cloneAttributes(groupNode.get());
-  return groupNode.release();
+  auto result = std::make_unique<GroupNode>(m_group);
+  result->cloneLinkId(*this, setLinkIds);
+  cloneAttributes(result.get());
+  return result.release();
 }
 
 namespace
@@ -333,6 +333,6 @@ void GroupNode::doAcceptTagVisitor(ConstTagVisitor& visitor) const
 
 bool compareGroupNodesByLinkId(const GroupNode* lhs, const GroupNode* rhs)
 {
-  return lhs->group().linkId() < rhs->group().linkId();
+  return lhs->linkId() < rhs->linkId();
 }
 } // namespace TrenchBroom::Model

--- a/common/src/Model/LinkedGroupUtils.h
+++ b/common/src/Model/LinkedGroupUtils.h
@@ -51,17 +51,8 @@ std::vector<N*> collectLinkedNodes(const std::vector<Node*>& nodes, const N& nod
   return kdl::vec_static_cast<N*>(node.accept(kdl::overload(
     [](const WorldNode*) { return std::vector<Node*>{}; },
     [](const LayerNode*) { return std::vector<Node*>{}; },
-    [&](const GroupNode* groupNode) {
-      return collectNodesWithLinkId(nodes, groupNode->group().linkId());
-    },
-    [&](const EntityNode* entityNode) {
-      return collectNodesWithLinkId(nodes, entityNode->entity().linkId());
-    },
-    [&](const BrushNode* brushNode) {
-      return collectNodesWithLinkId(nodes, brushNode->brush().linkId());
-    },
-    [&](const PatchNode* patchNode) {
-      return collectNodesWithLinkId(nodes, patchNode->patch().linkId());
+    [&](const Object* object) {
+      return collectNodesWithLinkId(nodes, object->linkId());
     })));
 }
 
@@ -154,15 +145,5 @@ Result<std::unordered_map<Node*, std::string>> copyAndReturnLinkIds(
 
 std::vector<Error> copyAndSetLinkIds(
   const GroupNode& sourceGroupNode, const std::vector<GroupNode*>& targetGroupNodes);
-
-template <typename T>
-T setNewLinkIdIf(T x, const bool setNewLinkId)
-{
-  if (setNewLinkId)
-  {
-    x.setLinkId(generateUuid());
-  }
-  return x;
-}
 
 } // namespace TrenchBroom::Model

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -48,6 +48,7 @@ class Issue;
 class NodeVisitor;
 class PickResult;
 class Validator;
+class Object;
 
 struct NodePath
 {

--- a/common/src/Model/NodeVisitor.h
+++ b/common/src/Model/NodeVisitor.h
@@ -32,6 +32,11 @@ class Node;
 class PatchNode;
 class WorldNode;
 
+#ifdef _MSC_VER
+// silence apurious "C4702: unreachable code" warnings
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif
 class NodeVisitor
 {
 protected:
@@ -112,18 +117,7 @@ public:
   R&& result() { return std::move(m_result).value(); }
 
 protected:
-#ifdef _MSC_VER
-// silence a spurious "C4702: unreachable code" warning
-#pragma warning(push)
-#pragma warning(disable : 4702)
-#endif
-  void setResult(R&& result)
-  {
-    m_result = std::move(result);
-  }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+  void setResult(R&& result) { m_result = std::move(result); }
 };
 
 class NodeLambdaVisitorNoResult
@@ -268,5 +262,8 @@ private:
     }
   }
 };
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 } // namespace TrenchBroom::Model

--- a/common/src/Model/Object.cpp
+++ b/common/src/Model/Object.cpp
@@ -20,12 +20,40 @@
 #include "Object.h"
 
 #include "Model/GroupNode.h"
+#include "Uuid.h"
 
 namespace TrenchBroom::Model
 {
 
-Object::Object() = default;
+Object::Object()
+  : m_linkId{generateUuid()}
+{
+}
+
 Object::~Object() = default;
+
+const std::string& Object::linkId() const
+{
+  return m_linkId;
+}
+
+void Object::setLinkId(std::string linkId)
+{
+  m_linkId = std::move(linkId);
+}
+
+void Object::cloneLinkId(const Object& original, const SetLinkId linkIdPolicy)
+{
+  switch (linkIdPolicy)
+  {
+  case SetLinkId::keep:
+    setLinkId(original.linkId());
+    break;
+  case SetLinkId::generate:
+    setLinkId(generateUuid());
+    break;
+  }
+}
 
 Node* Object::container()
 {

--- a/common/src/Model/Object.h
+++ b/common/src/Model/Object.h
@@ -21,20 +21,29 @@
 
 #include "FloatType.h"
 
+#include <string>
+
 namespace TrenchBroom::Model
 {
 
 class GroupNode;
 class LayerNode;
 class Node;
+enum class SetLinkId;
 
 class Object
 {
 protected:
+  std::string m_linkId;
+
   Object();
 
 public:
   virtual ~Object();
+
+  const std::string& linkId() const;
+  void setLinkId(std::string linkId);
+  void cloneLinkId(const Object& original, SetLinkId linkIdPolicy);
 
   Node* container();
   const Node* container() const;

--- a/common/src/Model/PatchNode.cpp
+++ b/common/src/Model/PatchNode.cpp
@@ -388,7 +388,9 @@ FloatType PatchNode::doGetProjectedArea(const vm::axis::type axis) const
 
 Node* PatchNode::doClone(const vm::bbox3&, const SetLinkId setLinkIds) const
 {
-  return new PatchNode{setNewLinkIdIf(m_patch, setLinkIds == SetLinkId::generate)};
+  auto result = std::make_unique<PatchNode>(m_patch);
+  result->cloneLinkId(*this, setLinkIds);
+  return result.release();
 }
 
 bool PatchNode::doCanAddChild(const Node*) const

--- a/common/src/Renderer/GroupLinkRenderer.cpp
+++ b/common/src/Renderer/GroupLinkRenderer.cpp
@@ -58,7 +58,7 @@ std::vector<LinkRenderer::LineVertex> GroupLinkRenderer::getLinks()
 
   if (groupNode)
   {
-    const auto& linkId = groupNode->group().linkId();
+    const auto& linkId = groupNode->linkId();
     const auto linkedGroupNodes =
       Model::collectGroupsWithLinkId({document->world()}, linkId);
 

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -49,164 +49,86 @@
 #include <vecmath/vec.h>
 #include <vecmath/vec_io.h>
 
-#include <algorithm>
-#include <map>
-#include <optional>
-#include <vector>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
-namespace TrenchBroom
+#include <algorithm>
+#include <optional>
+
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 const Model::HitType::Type ClipTool::PointHitType = Model::HitType::freeType();
 
-ClipTool::ClipStrategy::~ClipStrategy() = default;
-
-void ClipTool::ClipStrategy::pick(
-  const vm::ray3& pickRay,
-  const Renderer::Camera& camera,
-  Model::PickResult& pickResult) const
+class ClipStrategy
 {
-  doPick(pickRay, camera, pickResult);
-}
+public:
+  virtual ~ClipStrategy() = default;
 
-void ClipTool::ClipStrategy::render(
-  Renderer::RenderContext& renderContext,
-  Renderer::RenderBatch& renderBatch,
-  const Model::PickResult& pickResult)
+  virtual void pick(
+    const vm::ray3& pickRay,
+    const Renderer::Camera& camera,
+    Model::PickResult& pickResult) const = 0;
+  virtual void render(
+    Renderer::RenderContext& renderContext,
+    Renderer::RenderBatch& renderBatch,
+    const Model::PickResult& pickResult) = 0;
+  virtual void renderFeedback(
+    Renderer::RenderContext& renderContext,
+    Renderer::RenderBatch& renderBatch,
+    const vm::vec3& point) const = 0;
+
+  virtual std::optional<vm::vec3> computeThirdPoint() const = 0;
+
+  virtual bool canClip() const = 0;
+  virtual bool hasPoints() const = 0;
+  virtual bool canAddPoint(const vm::vec3& point) const = 0;
+  virtual void addPoint(const vm::vec3& point, std::vector<vm::vec3> helpVectors) = 0;
+  virtual bool canRemoveLastPoint() const = 0;
+  virtual void removeLastPoint() = 0;
+
+  virtual std::optional<std::tuple<vm::vec3, vm::vec3>> canDragPoint(
+    const Model::PickResult& pickResult) const = 0;
+  virtual void beginDragPoint(const Model::PickResult& pickResult) = 0;
+  virtual void beginDragLastPoint() = 0;
+  virtual bool dragPoint(
+    const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors) = 0;
+  virtual void endDragPoint() = 0;
+  virtual void cancelDragPoint() = 0;
+
+  virtual bool setFace(const Model::BrushFaceHandle& faceHandle) = 0;
+  virtual void reset() = 0;
+  virtual std::vector<vm::vec3> getPoints() const = 0;
+};
+
+namespace
 {
-  doRender(renderContext, renderBatch, pickResult);
-}
 
-void ClipTool::ClipStrategy::renderFeedback(
-  Renderer::RenderContext& renderContext,
-  Renderer::RenderBatch& renderBatch,
-  const vm::vec3& point) const
-{
-  doRenderFeedback(renderContext, renderBatch, point);
-}
-
-bool ClipTool::ClipStrategy::computeThirdPoint(vm::vec3& point) const
-{
-  return doComputeThirdPoint(point);
-}
-
-bool ClipTool::ClipStrategy::canClip() const
-{
-  return doCanClip();
-}
-
-bool ClipTool::ClipStrategy::hasPoints() const
-{
-  return doHasPoints();
-}
-
-bool ClipTool::ClipStrategy::canAddPoint(const vm::vec3& point) const
-{
-  return doCanAddPoint(point);
-}
-
-void ClipTool::ClipStrategy::addPoint(
-  const vm::vec3& point, const std::vector<vm::vec3>& helpVectors)
-{
-  assert(canAddPoint(point));
-  return doAddPoint(point, helpVectors);
-}
-
-bool ClipTool::ClipStrategy::canRemoveLastPoint() const
-{
-  return doCanRemoveLastPoint();
-}
-
-void ClipTool::ClipStrategy::removeLastPoint()
-{
-  doRemoveLastPoint();
-}
-
-std::optional<std::tuple<vm::vec3, vm::vec3>> ClipTool::ClipStrategy::canDragPoint(
-  const Model::PickResult& pickResult) const
-{
-  return doCanDragPoint(pickResult);
-}
-
-void ClipTool::ClipStrategy::beginDragPoint(const Model::PickResult& pickResult)
-{
-  doBeginDragPoint(pickResult);
-}
-
-void ClipTool::ClipStrategy::beginDragLastPoint()
-{
-  doBeginDragLastPoint();
-}
-
-bool ClipTool::ClipStrategy::dragPoint(
-  const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors)
-{
-  return doDragPoint(newPosition, helpVectors);
-}
-
-void ClipTool::ClipStrategy::endDragPoint()
-{
-  doEndDragPoint();
-}
-
-void ClipTool::ClipStrategy::cancelDragPoint()
-{
-  doCancelDragPoint();
-}
-
-bool ClipTool::ClipStrategy::setFace(const Model::BrushFaceHandle& faceHandle)
-{
-  return doSetFace(faceHandle);
-}
-
-void ClipTool::ClipStrategy::reset()
-{
-  doReset();
-}
-
-size_t ClipTool::ClipStrategy::getPoints(
-  vm::vec3& point1, vm::vec3& point2, vm::vec3& point3) const
-{
-  return doGetPoints(point1, point2, point3);
-}
-
-class ClipTool::PointClipStrategy : public ClipTool::ClipStrategy
+class PointClipStrategy : public ClipStrategy
 {
 private:
   struct ClipPoint
   {
     vm::vec3 point;
     std::vector<vm::vec3> helpVectors;
-
-    ClipPoint() = default;
-
-    ClipPoint(const vm::vec3& i_point, const std::vector<vm::vec3>& i_helpVectors)
-      : point(i_point)
-      , helpVectors(i_helpVectors)
-    {
-    }
   };
 
-  ClipPoint m_points[3];
-  size_t m_numPoints;
-  size_t m_dragIndex;
-  ClipPoint m_originalPoint;
+  struct DragState
+  {
+    size_t index;
+    ClipPoint originalPoint;
+  };
+
+  std::vector<ClipPoint> m_points;
+  std::optional<DragState> m_dragState;
 
 public:
-  PointClipStrategy()
-    : m_numPoints(0)
-    , m_dragIndex(4)
-  {
-  }
-
-private:
-  void doPick(
+  void pick(
     const vm::ray3& pickRay,
     const Renderer::Camera& camera,
     Model::PickResult& pickResult) const override
   {
-    for (size_t i = 0; i < m_numPoints; ++i)
+    for (size_t i = 0; i < m_points.size(); ++i)
     {
       const auto& point = m_points[i].point;
       const auto distance = camera.pickPointHandle(
@@ -214,12 +136,12 @@ private:
       if (!vm::is_nan(distance))
       {
         const auto hitPoint = vm::point_at_distance(pickRay, distance);
-        pickResult.addHit(Model::Hit(PointHitType, distance, hitPoint, i));
+        pickResult.addHit(Model::Hit{ClipTool::PointHitType, distance, hitPoint, i});
       }
     }
   }
 
-  void doRender(
+  void render(
     Renderer::RenderContext& renderContext,
     Renderer::RenderBatch& renderBatch,
     const Model::PickResult& pickResult) override
@@ -228,21 +150,27 @@ private:
     renderHighlight(renderContext, renderBatch, pickResult);
   }
 
-  void doRenderFeedback(
+  void renderFeedback(
     Renderer::RenderContext& renderContext,
     Renderer::RenderBatch& renderBatch,
     const vm::vec3& point) const override
   {
-    Renderer::RenderService renderService(renderContext, renderBatch);
+    auto renderService = Renderer::RenderService{renderContext, renderBatch};
     renderService.setForegroundColor(pref(Preferences::ClipHandleColor));
-    renderService.renderHandle(vm::vec3f(point));
+    renderService.renderHandle(vm::vec3f{point});
   }
 
-  bool doComputeThirdPoint(vm::vec3& point) const override
+  std::optional<vm::vec3> computeThirdPoint() const override
   {
-    ensure(m_numPoints == 2, "invalid numPoints");
-    point = m_points[1].point + 128.0 * computeHelpVector();
-    return !vm::is_colinear(m_points[0].point, m_points[1].point, point);
+    if (m_points.size() == 2)
+    {
+      const auto point = m_points[1].point + 128.0 * computeHelpVector();
+      if (!vm::is_colinear(m_points[0].point, m_points[1].point, point))
+      {
+        return point;
+      }
+    }
+    return std::nullopt;
   }
 
   vm::vec3 computeHelpVector() const
@@ -266,101 +194,58 @@ private:
 
     if (counts[firstIndex] > counts[nextIndex])
     {
-      return vm::vec3::axis(static_cast<size_t>(firstIndex % 3));
+      return vm::vec3::axis(size_t(firstIndex % 3));
     }
-    else
+
+    // two counts are equal
+    if (firstIndex % 3 == 2 || nextIndex % 3 == 2)
     {
-      // two counts are equal
-      if (firstIndex % 3 == 2 || nextIndex % 3 == 2)
-      {
-        // prefer the Z axis if possible:
-        return vm::vec3::pos_z();
-      }
-      else
-      {
-        // Z axis cannot win, so X and Y axis are a tie, prefer the X axis:
-        return vm::vec3::pos_x();
-      }
+      // prefer the Z axis if possible:
+      return vm::vec3::pos_z();
     }
+
+    // Z axis cannot win, so X and Y axis are a tie, prefer the X axis:
+    return vm::vec3::pos_x();
   }
 
   std::vector<vm::vec3> combineHelpVectors() const
   {
-    std::vector<vm::vec3> result;
-    for (size_t i = 0; i < m_numPoints; ++i)
-    {
-      const std::vector<vm::vec3>& helpVectors = m_points[i].helpVectors;
-      result = kdl::vec_concat(std::move(result), helpVectors);
-    }
-
-    return result;
+    return kdl::vec_flatten(
+      kdl::vec_transform(m_points, [](const auto& point) { return point.helpVectors; }));
   }
 
-  bool doCanClip() const override
+  bool canClip() const override { return m_points.size() == 3 || computeThirdPoint(); }
+
+  bool hasPoints() const override { return !m_points.empty(); }
+
+  bool canAddPoint(const vm::vec3& point) const override
   {
-    if (m_numPoints < 2)
-    {
-      return false;
-    }
-    else if (m_numPoints == 2)
-    {
-      vm::vec3 point3;
-      if (!computeThirdPoint(point3))
-      {
-        return false;
-      }
-    }
-    return true;
+    return (m_points.size() < 2
+            || (m_points.size() == 2 && !vm::is_colinear(m_points[0].point, m_points[1].point, point)))
+           && kdl::none_of(m_points, [&](const auto& p) {
+                return vm::is_equal(p.point, point, vm::C::almost_zero());
+              });
   }
 
-  bool doHasPoints() const override { return m_numPoints > 0; }
-
-  bool doCanAddPoint(const vm::vec3& point) const override
+  void addPoint(const vm::vec3& point, std::vector<vm::vec3> helpVectors) override
   {
-    if (m_numPoints == 3)
-    {
-      return false;
-    }
-    else if (
-      m_numPoints == 2 && vm::is_colinear(m_points[0].point, m_points[1].point, point))
-    {
-      return false;
-    }
-    else
-    {
-      // Don't allow to place a point onto another point!
-      for (size_t i = 0; i < m_numPoints; ++i)
-      {
-        if (vm::is_equal(m_points[i].point, point, vm::C::almost_zero()))
-        {
-          return false;
-        }
-      }
-      return true;
-    }
+    m_points.push_back(ClipPoint{point, std::move(helpVectors)});
   }
 
-  void doAddPoint(
-    const vm::vec3& point, const std::vector<vm::vec3>& helpVectors) override
-  {
-    m_points[m_numPoints] = ClipPoint(point, helpVectors);
-    ++m_numPoints;
-  }
+  bool canRemoveLastPoint() const override { return hasPoints(); }
 
-  bool doCanRemoveLastPoint() const override { return m_numPoints > 0; }
-
-  void doRemoveLastPoint() override
+  void removeLastPoint() override
   {
     ensure(canRemoveLastPoint(), "can't remove last point");
-    --m_numPoints;
+    m_points.pop_back();
   }
 
-  std::optional<std::tuple<vm::vec3, vm::vec3>> doCanDragPoint(
+  std::optional<std::tuple<vm::vec3, vm::vec3>> canDragPoint(
     const Model::PickResult& pickResult) const override
   {
     using namespace Model::HitFilters;
 
-    const auto& hit = pickResult.first(type(PointHitType));
+    const auto& hit = pickResult.first(type(ClipTool::PointHitType));
     if (!hit.isMatch())
     {
       return std::nullopt;
@@ -371,58 +256,43 @@ private:
     return {{position, hit.hitPoint() - position}};
   }
 
-  void doBeginDragPoint(const Model::PickResult& pickResult) override
+  void beginDragPoint(const Model::PickResult& pickResult) override
   {
     using namespace Model::HitFilters;
-    const auto& hit = pickResult.first(type(PointHitType));
+
+    const auto& hit = pickResult.first(type(ClipTool::PointHitType));
     assert(hit.isMatch());
-    m_dragIndex = hit.target<size_t>();
-    m_originalPoint = m_points[m_dragIndex];
+
+    const auto dragIndex = hit.target<size_t>();
+    m_dragState = DragState{dragIndex, m_points[dragIndex]};
   }
 
-  void doBeginDragLastPoint() override
+  void beginDragLastPoint() override
   {
-    ensure(m_numPoints > 0, "invalid numPoints");
-    m_dragIndex = m_numPoints - 1;
-    m_originalPoint = m_points[m_dragIndex];
+    ensure(hasPoints(), "invalid numPoints");
+    m_dragState = DragState{m_points.size() - 1, m_points.back()};
   }
 
-  bool doDragPoint(
+  bool dragPoint(
     const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors) override
   {
-    ensure(m_dragIndex < m_numPoints, "drag index out of range");
+    ensure(m_dragState, "Clip tool is dragging");
 
     // Don't allow to drag a point onto another point!
-    for (size_t i = 0; i < m_numPoints; ++i)
+    for (size_t i = 0; i < m_points.size(); ++i)
     {
       if (
-        m_dragIndex != i
+        m_dragState->index != i
         && vm::is_equal(m_points[i].point, newPosition, vm::C::almost_zero()))
       {
         return false;
       }
     }
 
-    if (m_numPoints == 3)
+    if (m_points.size() == 3)
     {
-      size_t index0, index1;
-      switch (m_dragIndex)
-      {
-      case 0:
-        index0 = 1;
-        index1 = 2;
-        break;
-      case 1:
-        index0 = 0;
-        index1 = 2;
-        break;
-      case 2:
-      default:
-        index0 = 0;
-        index1 = 1;
-        break;
-      }
-
+      const auto index0 = m_dragState->index + 1 % 3;
+      const auto index1 = m_dragState->index + 2 % 3;
       if (vm::is_colinear(m_points[index0].point, m_points[index1].point, newPosition))
       {
         return false;
@@ -431,87 +301,70 @@ private:
 
     if (helpVectors.empty())
     {
-      m_points[m_dragIndex] = ClipPoint(newPosition, m_points[m_dragIndex].helpVectors);
+      m_points[m_dragState->index] =
+        ClipPoint{newPosition, m_points[m_dragState->index].helpVectors};
     }
     else
     {
-      m_points[m_dragIndex] = ClipPoint(newPosition, helpVectors);
+      m_points[m_dragState->index] = ClipPoint{newPosition, helpVectors};
     }
     return true;
   }
 
-  void doEndDragPoint() override { m_dragIndex = 4; }
+  void endDragPoint() override { m_dragState = std::nullopt; }
 
-  void doCancelDragPoint() override
+  void cancelDragPoint() override
   {
-    ensure(m_dragIndex < m_numPoints, "drag index out of range");
-    m_points[m_dragIndex] = m_originalPoint;
-    m_dragIndex = 4;
+    ensure(m_dragState, "Clip tool is dragging");
+    m_points[m_dragState->index] = m_dragState->originalPoint;
+    m_dragState = std::nullopt;
   }
 
-  bool doSetFace(const Model::BrushFaceHandle& /* faceHandle */) override
-  {
-    return false;
-  }
+  bool setFace(const Model::BrushFaceHandle& /* faceHandle */) override { return false; }
 
-  void doReset() override { m_numPoints = 0; }
+  void reset() override { m_points.clear(); }
 
-  size_t doGetPoints(vm::vec3& point1, vm::vec3& point2, vm::vec3& point3) const override
+  std::vector<vm::vec3> getPoints() const override
   {
-    switch (m_numPoints)
+    auto result = kdl::vec_transform(m_points, [](const auto& p) { return p.point; });
+    if (const auto thirdPoint = computeThirdPoint())
     {
-    case 0:
-      return 0;
-    case 1:
-      point1 = m_points[0].point;
-      return 1;
-    case 2:
-      point1 = m_points[0].point;
-      point2 = m_points[1].point;
-      if (computeThirdPoint(point3))
-        return 3;
-      return 2;
-    case 3:
-      point1 = m_points[0].point;
-      point2 = m_points[1].point;
-      point3 = m_points[2].point;
-      return 3;
-    default:
-      ensure(false, "invalid numPoints");
-      return 0;
+      result = kdl::vec_push_back(std::move(result), *thirdPoint);
     }
+    return result;
   }
 
 private:
   void renderPoints(
     Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch)
   {
-    Renderer::RenderService renderService(renderContext, renderBatch);
+    auto renderService = Renderer::RenderService{renderContext, renderBatch};
     renderService.setForegroundColor(pref(Preferences::ClipHandleColor));
     renderService.setShowOccludedObjects();
 
-    if (m_numPoints > 1)
+    if (m_points.size() > 1)
     {
       renderService.renderLine(
-        vm::vec3f(m_points[0].point), vm::vec3f(m_points[1].point));
-      if (m_numPoints > 2)
+        vm::vec3f{m_points[0].point}, vm::vec3f{m_points[1].point});
+
+      if (m_points.size() > 2)
       {
         renderService.renderLine(
-          vm::vec3f(m_points[1].point), vm::vec3f(m_points[2].point));
+          vm::vec3f{m_points[1].point}, vm::vec3f{m_points[2].point});
         renderService.renderLine(
-          vm::vec3f(m_points[2].point), vm::vec3f(m_points[0].point));
+          vm::vec3f{m_points[2].point}, vm::vec3f{m_points[0].point});
       }
     }
 
     renderService.setForegroundColor(pref(Preferences::ClipHandleColor));
     renderService.setBackgroundColor(pref(Preferences::InfoOverlayBackgroundColor));
 
-    for (size_t i = 0; i < m_numPoints; ++i)
+    for (size_t i = 0; i < m_points.size(); ++i)
     {
       const auto& point = m_points[i].point;
-      renderService.renderHandle(vm::vec3f(point));
+      renderService.renderHandle(vm::vec3f{point});
       renderService.renderString(
-        kdl::str_to_string(i + 1, ": ", point), vm::vec3f(point));
+        fmt::format("{}: {}", i + 1, fmt::streamed(point)), vm::vec3f{point});
     }
   }
 
@@ -520,14 +373,15 @@ private:
     Renderer::RenderBatch& renderBatch,
     const Model::PickResult& pickResult)
   {
-    if (m_dragIndex < m_numPoints)
+    if (m_dragState)
     {
-      renderHighlight(renderContext, renderBatch, m_dragIndex);
+      renderHighlight(renderContext, renderBatch, m_dragState->index);
     }
     else
     {
       using namespace Model::HitFilters;
-      const auto& hit = pickResult.first(type(PointHitType));
+
+      const auto& hit = pickResult.first(type(ClipTool::PointHitType));
       if (hit.isMatch())
       {
         const auto index = hit.target<size_t>();
@@ -541,43 +395,34 @@ private:
     Renderer::RenderBatch& renderBatch,
     const size_t index)
   {
-    Renderer::RenderService renderService(renderContext, renderBatch);
+    auto renderService = Renderer::RenderService{renderContext, renderBatch};
     renderService.setForegroundColor(pref(Preferences::SelectedHandleColor));
     renderService.renderHandleHighlight(vm::vec3f(m_points[index].point));
   }
 };
 
-class ClipTool::FaceClipStrategy : public ClipTool::ClipStrategy
+class FaceClipStrategy : public ClipStrategy
 {
 private:
   std::optional<Model::BrushFaceHandle> m_faceHandle;
 
-private:
-  void doPick(
-    const vm::ray3& /* pickRay */,
-    const Renderer::Camera& /* camera */,
-    Model::PickResult&) const override
+public:
+  void pick(const vm::ray3&, const Renderer::Camera&, Model::PickResult&) const override
   {
   }
 
-  void doRender(
+  void render(
     Renderer::RenderContext& renderContext,
     Renderer::RenderBatch& renderBatch,
     const Model::PickResult&) override
   {
     if (m_faceHandle)
     {
-      Renderer::RenderService renderService(renderContext, renderBatch);
+      auto renderService = Renderer::RenderService{renderContext, renderBatch};
 
-      const auto vertices = m_faceHandle->face().vertices();
-
-      std::vector<vm::vec3f> positions;
-      positions.reserve(vertices.size());
-
-      for (const Model::BrushVertex* vertex : vertices)
-      {
-        positions.push_back(vm::vec3f(vertex->position()));
-      }
+      const auto positions = kdl::vec_transform(
+        m_faceHandle->face().vertices(),
+        [](const auto& vertex) { return vm::vec3f{vertex->position()}; });
 
       renderService.setForegroundColor(pref(Preferences::ClipHandleColor));
       renderService.renderPolygonOutline(positions);
@@ -587,77 +432,65 @@ private:
     }
   }
 
-  void doRenderFeedback(
-    Renderer::RenderContext&,
-    Renderer::RenderBatch&,
-    const vm::vec3& /* point */) const override
+  void renderFeedback(
+    Renderer::RenderContext&, Renderer::RenderBatch&, const vm::vec3&) const override
   {
   }
 
-  vm::vec3 doGetHelpVector() const { return vm::vec3::zero(); }
+  vm::vec3 getHelpVector() const { return vm::vec3::zero(); }
 
-  bool doComputeThirdPoint(vm::vec3& /* point */) const override { return false; }
+  std::optional<vm::vec3> computeThirdPoint() const override { return std::nullopt; }
 
-  bool doCanClip() const override { return m_faceHandle.has_value(); }
-  bool doHasPoints() const override { return false; }
-  bool doCanAddPoint(const vm::vec3& /* point */) const override { return false; }
-  void doAddPoint(
-    const vm::vec3& /* point */, const std::vector<vm::vec3>& /* helpVectors */) override
-  {
-  }
-  bool doCanRemoveLastPoint() const override { return false; }
-  void doRemoveLastPoint() override {}
+  bool canClip() const override { return m_faceHandle.has_value(); }
+  bool hasPoints() const override { return false; }
+  bool canAddPoint(const vm::vec3&) const override { return false; }
+  void addPoint(const vm::vec3&, std::vector<vm::vec3>) override {}
+  bool canRemoveLastPoint() const override { return false; }
+  void removeLastPoint() override {}
 
-  std::optional<std::tuple<vm::vec3, vm::vec3>> doCanDragPoint(
+  std::optional<std::tuple<vm::vec3, vm::vec3>> canDragPoint(
     const Model::PickResult&) const override
   {
     return std::nullopt;
   }
-  void doBeginDragPoint(const Model::PickResult&) override {}
-  void doBeginDragLastPoint() override {}
-  bool doDragPoint(
+  void beginDragPoint(const Model::PickResult&) override {}
+  void beginDragLastPoint() override {}
+  bool dragPoint(
     const vm::vec3& /* newPosition */,
     const std::vector<vm::vec3>& /* helpVectors */) override
   {
     return false;
   }
-  void doEndDragPoint() override {}
-  void doCancelDragPoint() override {}
+  void endDragPoint() override {}
+  void cancelDragPoint() override {}
 
-  bool doSetFace(const Model::BrushFaceHandle& faceHandle) override
+  bool setFace(const Model::BrushFaceHandle& faceHandle) override
   {
     m_faceHandle = faceHandle;
     return true;
   }
 
-  void doReset() override { m_faceHandle = std::nullopt; }
+  void reset() override { m_faceHandle = std::nullopt; }
 
-  size_t doGetPoints(vm::vec3& point1, vm::vec3& point2, vm::vec3& point3) const override
+  std::vector<vm::vec3> getPoints() const override
   {
     if (m_faceHandle)
     {
       const auto& points = m_faceHandle->face().points();
-      point1 = points[0];
-      point2 = points[1];
-      point3 = points[2];
-      return 3;
+      return {points.begin(), points.end()};
     }
-    else
-    {
-      return 0;
-    }
+
+    return {};
   }
 };
 
+} // namespace
+
 ClipTool::ClipTool(std::weak_ptr<MapDocument> document)
-  : Tool(false)
-  , m_document(std::move(document))
-  , m_clipSide(ClipSide_Front)
-  , m_strategy(nullptr)
-  , m_remainingBrushRenderer(std::make_unique<Renderer::BrushRenderer>())
-  , m_clippedBrushRenderer(std::make_unique<Renderer::BrushRenderer>())
-  , m_ignoreNotifications(false)
-  , m_dragging(false)
+  : Tool{false}
+  , m_document{std::move(document)}
+  , m_remainingBrushRenderer{std::make_unique<Renderer::BrushRenderer>()}
+  , m_clippedBrushRenderer{std::make_unique<Renderer::BrushRenderer>()}
 {
 }
 
@@ -678,14 +511,14 @@ void ClipTool::toggleSide()
   {
     switch (m_clipSide)
     {
-    case ClipSide_Front:
-      m_clipSide = ClipSide_Both;
+    case ClipSide::Front:
+      m_clipSide = ClipSide::Both;
       break;
-    case ClipSide_Both:
-      m_clipSide = ClipSide_Back;
+    case ClipSide::Both:
+      m_clipSide = ClipSide::Back;
       break;
-    case ClipSide_Back:
-      m_clipSide = ClipSide_Front;
+    case ClipSide::Back:
+      m_clipSide = ClipSide::Front;
       break;
     }
     update();
@@ -695,7 +528,7 @@ void ClipTool::toggleSide()
 void ClipTool::pick(
   const vm::ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult)
 {
-  if (m_strategy != nullptr)
+  if (m_strategy)
   {
     m_strategy->pick(pickRay, camera, pickResult);
   }
@@ -737,7 +570,7 @@ void ClipTool::renderStrategy(
   Renderer::RenderBatch& renderBatch,
   const Model::PickResult& pickResult)
 {
-  if (m_strategy != nullptr)
+  if (m_strategy)
   {
     m_strategy->render(renderContext, renderBatch, pickResult);
   }
@@ -748,13 +581,13 @@ void ClipTool::renderFeedback(
   Renderer::RenderBatch& renderBatch,
   const vm::vec3& point) const
 {
-  if (m_strategy != nullptr)
+  if (m_strategy)
   {
     m_strategy->renderFeedback(renderContext, renderBatch, point);
   }
   else
   {
-    PointClipStrategy().renderFeedback(renderContext, renderBatch, point);
+    PointClipStrategy{}.renderFeedback(renderContext, renderBatch, point);
   }
 }
 
@@ -766,14 +599,14 @@ bool ClipTool::hasBrushes() const
 
 bool ClipTool::canClip() const
 {
-  return m_strategy != nullptr && m_strategy->canClip();
+  return m_strategy && m_strategy->canClip();
 }
 
 void ClipTool::performClip()
 {
   if (!m_dragging && canClip())
   {
-    const kdl::set_temp ignoreNotifications(m_ignoreNotifications);
+    const auto ignoreNotifications = kdl::set_temp{m_ignoreNotifications};
 
     auto document = kdl::mem_lock(m_document);
     auto transaction = Transaction{document, "Clip Brushes"};
@@ -794,7 +627,7 @@ void ClipTool::performClip()
 
 std::map<Model::Node*, std::vector<Model::Node*>> ClipTool::clipBrushes()
 {
-  std::map<Model::Node*, std::vector<Model::Node*>> result;
+  auto result = std::map<Model::Node*, std::vector<Model::Node*>>{};
   if (!m_frontBrushes.empty())
   {
     if (keepFrontBrushes())
@@ -833,18 +666,18 @@ vm::vec3 ClipTool::defaultClipPointPos() const
 
 bool ClipTool::canAddPoint(const vm::vec3& point) const
 {
-  return m_strategy == nullptr || m_strategy->canAddPoint(point);
+  return !m_strategy || m_strategy->canAddPoint(point);
 }
 
 bool ClipTool::hasPoints() const
 {
-  return m_strategy != nullptr && m_strategy->hasPoints();
+  return m_strategy && m_strategy->hasPoints();
 }
 
 void ClipTool::addPoint(const vm::vec3& point, const std::vector<vm::vec3>& helpVectors)
 {
   assert(canAddPoint(point));
-  if (m_strategy == nullptr)
+  if (!m_strategy)
   {
     m_strategy = std::make_unique<PointClipStrategy>();
   }
@@ -855,7 +688,7 @@ void ClipTool::addPoint(const vm::vec3& point, const std::vector<vm::vec3>& help
 
 bool ClipTool::canRemoveLastPoint() const
 {
-  return m_strategy != nullptr && m_strategy->canRemoveLastPoint();
+  return m_strategy && m_strategy->canRemoveLastPoint();
 }
 
 bool ClipTool::removeLastPoint()
@@ -866,6 +699,7 @@ bool ClipTool::removeLastPoint()
     update();
     return true;
   }
+
   return false;
 }
 
@@ -873,26 +707,24 @@ std::optional<std::tuple<vm::vec3, vm::vec3>> ClipTool::beginDragPoint(
   const Model::PickResult& pickResult)
 {
   assert(!m_dragging);
-  if (m_strategy == nullptr)
+  if (m_strategy)
   {
-    return std::nullopt;
+    const auto pointAndOffset = m_strategy->canDragPoint(pickResult);
+    if (pointAndOffset)
+    {
+      m_strategy->beginDragPoint(pickResult);
+      m_dragging = true;
+      return pointAndOffset;
+    }
   }
 
-  const auto pointAndOffset = m_strategy->canDragPoint(pickResult);
-  if (!pointAndOffset)
-  {
-    return std::nullopt;
-  }
-
-  m_strategy->beginDragPoint(pickResult);
-  m_dragging = true;
-  return pointAndOffset;
+  return std::nullopt;
 }
 
 void ClipTool::beginDragLastPoint()
 {
   assert(!m_dragging);
-  ensure(m_strategy != nullptr, "strategy is null");
+  ensure(m_strategy, "strategy is not null");
   m_strategy->beginDragLastPoint();
   m_dragging = true;
 }
@@ -901,22 +733,20 @@ bool ClipTool::dragPoint(
   const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors)
 {
   assert(m_dragging);
-  ensure(m_strategy != nullptr, "strategy is null");
+  ensure(m_strategy, "strategy is not null");
   if (!m_strategy->dragPoint(newPosition, helpVectors))
   {
     return false;
   }
-  else
-  {
-    update();
-    return true;
-  }
+
+  update();
+  return true;
 }
 
 void ClipTool::endDragPoint()
 {
   assert(m_dragging);
-  ensure(m_strategy != nullptr, "strategy is null");
+  ensure(m_strategy, "strategy is not null");
   m_strategy->endDragPoint();
   m_dragging = false;
   refreshViews();
@@ -925,7 +755,7 @@ void ClipTool::endDragPoint()
 void ClipTool::cancelDragPoint()
 {
   assert(m_dragging);
-  ensure(m_strategy != nullptr, "strategy is null");
+  ensure(m_strategy, "strategy is not null");
   m_strategy->cancelDragPoint();
   m_dragging = false;
   refreshViews();
@@ -940,15 +770,13 @@ void ClipTool::setFace(const Model::BrushFaceHandle& faceHandle)
 
 bool ClipTool::reset()
 {
-  if (m_strategy != nullptr)
+  if (m_strategy)
   {
     resetStrategy();
     return true;
   }
-  else
-  {
-    return false;
-  }
+
+  return false;
 }
 
 void ClipTool::resetStrategy()
@@ -1003,14 +831,13 @@ void ClipTool::updateBrushes()
 
   if (canClip())
   {
-    vm::vec3 point1, point2, point3;
-    const auto numPoints = m_strategy->getPoints(point1, point2, point3);
-    ensure(numPoints == 3, "invalid number of points");
+    const auto points = m_strategy->getPoints();
+    ensure(points.size() == 3, "invalid number of points");
 
     for (auto* brushNode : brushNodes)
     {
-      clip(brushNode, point1, point2, point3, m_frontBrushes);
-      clip(brushNode, point1, point3, point2, m_backBrushes);
+      clip(brushNode, points[0], points[1], points[2], m_frontBrushes);
+      clip(brushNode, points[0], points[2], points[1], m_backBrushes);
     }
   }
   else
@@ -1018,7 +845,7 @@ void ClipTool::updateBrushes()
     for (auto* brushNode : brushNodes)
     {
       auto* parent = brushNode->parent();
-      m_frontBrushes[parent].push_back(new Model::BrushNode(brushNode->brush()));
+      m_frontBrushes[parent].push_back(new Model::BrushNode{brushNode->brush()});
     }
   }
 }
@@ -1105,12 +932,12 @@ void ClipTool::addBrushesToRenderer(
 
 bool ClipTool::keepFrontBrushes() const
 {
-  return m_clipSide != ClipSide_Back;
+  return m_clipSide != ClipSide::Back;
 }
 
 bool ClipTool::keepBackBrushes() const
 {
-  return m_clipSide != ClipSide_Front;
+  return m_clipSide != ClipSide::Front;
 }
 
 bool ClipTool::doActivate()
@@ -1120,12 +947,10 @@ bool ClipTool::doActivate()
   {
     return false;
   }
-  else
-  {
-    connectObservers();
-    resetStrategy();
-    return true;
-  }
+
+  connectObservers();
+  resetStrategy();
+  return true;
 }
 
 bool ClipTool::doDeactivate()
@@ -1188,5 +1013,5 @@ void ClipTool::brushFacesDidChange(const std::vector<Model::BrushFaceHandle>&)
     update();
   }
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ClipTool.h
+++ b/common/src/View/ClipTool.h
@@ -29,29 +29,29 @@
 #include <optional>
 #include <vector>
 
-namespace TrenchBroom
-{
-namespace Model
+namespace TrenchBroom::Model
 {
 class BrushFace;
 class BrushFaceHandle;
 class Node;
 class PickResult;
-} // namespace Model
+} // namespace TrenchBroom::Model
 
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class BrushRenderer;
 class Camera;
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class Grid;
 class MapDocument;
 class Selection;
+
+class ClipStrategy;
 
 class ClipTool : public Tool
 {
@@ -59,98 +59,17 @@ public:
   static const Model::HitType::Type PointHitType;
 
 private:
-  enum ClipSide
+  enum class ClipSide
   {
-    ClipSide_Front,
-    ClipSide_Both,
-    ClipSide_Back
+    Front,
+    Both,
+    Back
   };
-
-  class ClipStrategy
-  {
-  public:
-    virtual ~ClipStrategy();
-    void pick(
-      const vm::ray3& pickRay,
-      const Renderer::Camera& camera,
-      Model::PickResult& pickResult) const;
-    void render(
-      Renderer::RenderContext& renderContext,
-      Renderer::RenderBatch& renderBatch,
-      const Model::PickResult& pickResult);
-    void renderFeedback(
-      Renderer::RenderContext& renderContext,
-      Renderer::RenderBatch& renderBatch,
-      const vm::vec3& point) const;
-
-    bool computeThirdPoint(vm::vec3& point) const;
-
-    bool canClip() const;
-    bool hasPoints() const;
-    bool canAddPoint(const vm::vec3& point) const;
-    void addPoint(const vm::vec3& point, const std::vector<vm::vec3>& helpVectors);
-    bool canRemoveLastPoint() const;
-    void removeLastPoint();
-
-    std::optional<std::tuple<vm::vec3, vm::vec3>> canDragPoint(
-      const Model::PickResult& pickResult) const;
-    void beginDragPoint(const Model::PickResult& pickResult);
-    void beginDragLastPoint();
-    bool dragPoint(const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors);
-    void endDragPoint();
-    void cancelDragPoint();
-
-    bool setFace(const Model::BrushFaceHandle& faceHandle);
-    void reset();
-    size_t getPoints(vm::vec3& point1, vm::vec3& point2, vm::vec3& point3) const;
-
-  private:
-    virtual void doPick(
-      const vm::ray3& pickRay,
-      const Renderer::Camera& camera,
-      Model::PickResult& pickResult) const = 0;
-    virtual void doRender(
-      Renderer::RenderContext& renderContext,
-      Renderer::RenderBatch& renderBatch,
-      const Model::PickResult& pickResult) = 0;
-
-    virtual void doRenderFeedback(
-      Renderer::RenderContext& renderContext,
-      Renderer::RenderBatch& renderBatch,
-      const vm::vec3& point) const = 0;
-
-    virtual bool doComputeThirdPoint(vm::vec3& point) const = 0;
-
-    virtual bool doCanClip() const = 0;
-    virtual bool doHasPoints() const = 0;
-    virtual bool doCanAddPoint(const vm::vec3& point) const = 0;
-    virtual void doAddPoint(
-      const vm::vec3& point, const std::vector<vm::vec3>& helpVectors) = 0;
-    virtual bool doCanRemoveLastPoint() const = 0;
-    virtual void doRemoveLastPoint() = 0;
-
-    virtual std::optional<std::tuple<vm::vec3, vm::vec3>> doCanDragPoint(
-      const Model::PickResult& pickResult) const = 0;
-    virtual void doBeginDragPoint(const Model::PickResult& pickResult) = 0;
-    virtual void doBeginDragLastPoint() = 0;
-    virtual bool doDragPoint(
-      const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors) = 0;
-    virtual void doEndDragPoint() = 0;
-    virtual void doCancelDragPoint() = 0;
-
-    virtual bool doSetFace(const Model::BrushFaceHandle& face) = 0;
-    virtual void doReset() = 0;
-    virtual size_t doGetPoints(
-      vm::vec3& point1, vm::vec3& point2, vm::vec3& point3) const = 0;
-  };
-
-  class PointClipStrategy;
-  class FaceClipStrategy;
 
 private:
   std::weak_ptr<MapDocument> m_document;
 
-  ClipSide m_clipSide;
+  ClipSide m_clipSide = ClipSide::Front;
   std::unique_ptr<ClipStrategy> m_strategy;
 
   std::map<Model::Node*, std::vector<Model::Node*>> m_frontBrushes;
@@ -159,8 +78,8 @@ private:
   std::unique_ptr<Renderer::BrushRenderer> m_remainingBrushRenderer;
   std::unique_ptr<Renderer::BrushRenderer> m_clippedBrushRenderer;
 
-  bool m_ignoreNotifications;
-  bool m_dragging;
+  bool m_ignoreNotifications = false;
+  bool m_dragging = false;
 
   NotifierConnection m_notifierConnection;
 
@@ -254,5 +173,5 @@ private:
   void nodesDidChange(const std::vector<Model::Node*>& nodes);
   void brushFacesDidChange(const std::vector<Model::BrushFaceHandle>& nodes);
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ExtrudeTool.cpp
+++ b/common/src/View/ExtrudeTool.cpp
@@ -534,7 +534,7 @@ bool splitBrushesInward(
       // Look up the new face index of the new drag handle
       if (const auto newDragFaceIndex = newBrushNode->brush().findFace(clipFace.normal()))
       {
-        newDragFaces.push_back(Model::BrushFaceHandle(newBrushNode, *newDragFaceIndex));
+        newDragFaces.emplace_back(newBrushNode, *newDragFaceIndex);
       }
     }
   }
@@ -551,7 +551,7 @@ bool splitBrushesInward(
   // Add the newly split off brushes and select them (keeping the original brushes
   // selected).
   // FIXME: deal with linked group update failure (needed for #3647)
-  const auto addedNodes = document.addNodes(std::move(newNodes));
+  const auto addedNodes = document.addNodes(newNodes);
   document.selectNodes(addedNodes);
 
   dragState.currentDragFaces = std::move(newDragFaces);

--- a/common/src/View/SetLinkIdsCommand.cpp
+++ b/common/src/View/SetLinkIdsCommand.cpp
@@ -20,16 +20,14 @@
 #include "SetLinkIdsCommand.h"
 
 #include "Ensure.h"
-#include "Model/BezierPatch.h"
-#include "Model/Brush.h"
 #include "Model/BrushNode.h"
-#include "Model/Entity.h"
 #include "Model/EntityNode.h"
-#include "Model/Group.h"
 #include "Model/GroupNode.h"
 #include "Model/LayerNode.h"
 #include "Model/Node.h"
+#include "Model/Object.h"
 #include "Model/PatchNode.h"
+#include "Model/WorldNode.h"
 #include "View/MapDocumentCommandFacade.h"
 
 #include <kdl/result.h>
@@ -61,28 +59,9 @@ auto setLinkIds(const std::vector<std::tuple<Model::Node*, std::string>>& linkId
       [](const Model::LayerNode*) -> std::tuple<Model::Node*, std::string> {
         ensure(false, "no unexpected layer node");
       },
-      [&](const Model::GroupNode* groupNode) -> std::tuple<Model::Node*, std::string> {
-        auto group = groupNode->group();
-        auto oldLinkId = group.linkId();
-        group.setLinkId(std::move(linkId));
-        return {node, std::move(oldLinkId)};
-      },
-      [&](const Model::EntityNode* entityNode) -> std::tuple<Model::Node*, std::string> {
-        auto entity = entityNode->entity();
-        auto oldLinkId = entity.linkId();
-        entity.setLinkId(std::move(linkId));
-        return {node, std::move(oldLinkId)};
-      },
-      [&](const Model::BrushNode* brushNode) -> std::tuple<Model::Node*, std::string> {
-        auto brush = brushNode->brush();
-        auto oldLinkId = brush.linkId();
-        brush.setLinkId(std::move(linkId));
-        return {node, std::move(oldLinkId)};
-      },
-      [&](const Model::PatchNode* patchNode) -> std::tuple<Model::Node*, std::string> {
-        auto patch = patchNode->patch();
-        auto oldLinkId = patch.linkId();
-        patch.setLinkId(std::move(linkId));
+      [&](Model::Object* object) -> std::tuple<Model::Node*, std::string> {
+        auto oldLinkId = object->linkId();
+        object->setLinkId(std::move(linkId));
         return {node, std::move(oldLinkId)};
       }));
   });

--- a/common/src/View/SetLinkIdsCommand.cpp
+++ b/common/src/View/SetLinkIdsCommand.cpp
@@ -1,0 +1,109 @@
+/*
+ Copyright (C) 2024 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "SetLinkIdsCommand.h"
+
+#include "Ensure.h"
+#include "Model/BezierPatch.h"
+#include "Model/Brush.h"
+#include "Model/BrushNode.h"
+#include "Model/Entity.h"
+#include "Model/EntityNode.h"
+#include "Model/Group.h"
+#include "Model/GroupNode.h"
+#include "Model/LayerNode.h"
+#include "Model/Node.h"
+#include "Model/PatchNode.h"
+#include "View/MapDocumentCommandFacade.h"
+
+#include <kdl/result.h>
+#include <kdl/vector_utils.h>
+
+namespace TrenchBroom::View
+{
+
+SetLinkIdsCommand::SetLinkIdsCommand(
+  const std::string& name, std::vector<std::tuple<Model::Node*, std::string>> linkIds)
+  : UndoableCommand{name, true}
+  , m_linkIds{std::move(linkIds)}
+{
+}
+
+SetLinkIdsCommand::~SetLinkIdsCommand() = default;
+
+namespace
+{
+auto setLinkIds(const std::vector<std::tuple<Model::Node*, std::string>>& linkIds)
+{
+  return kdl::vec_transform(linkIds, [](const auto& nodeAndLinkId) {
+    auto* node = std::get<Model::Node*>(nodeAndLinkId);
+    const auto& linkId = std::get<std::string>(nodeAndLinkId);
+    return node->accept(kdl::overload(
+      [&](const Model::WorldNode*) -> std::tuple<Model::Node*, std::string> {
+        ensure(false, "no unexpected world node");
+      },
+      [](const Model::LayerNode*) -> std::tuple<Model::Node*, std::string> {
+        ensure(false, "no unexpected layer node");
+      },
+      [&](const Model::GroupNode* groupNode) -> std::tuple<Model::Node*, std::string> {
+        auto group = groupNode->group();
+        auto oldLinkId = group.linkId();
+        group.setLinkId(std::move(linkId));
+        return {node, std::move(oldLinkId)};
+      },
+      [&](const Model::EntityNode* entityNode) -> std::tuple<Model::Node*, std::string> {
+        auto entity = entityNode->entity();
+        auto oldLinkId = entity.linkId();
+        entity.setLinkId(std::move(linkId));
+        return {node, std::move(oldLinkId)};
+      },
+      [&](const Model::BrushNode* brushNode) -> std::tuple<Model::Node*, std::string> {
+        auto brush = brushNode->brush();
+        auto oldLinkId = brush.linkId();
+        brush.setLinkId(std::move(linkId));
+        return {node, std::move(oldLinkId)};
+      },
+      [&](const Model::PatchNode* patchNode) -> std::tuple<Model::Node*, std::string> {
+        auto patch = patchNode->patch();
+        auto oldLinkId = patch.linkId();
+        patch.setLinkId(std::move(linkId));
+        return {node, std::move(oldLinkId)};
+      }));
+  });
+}
+} // namespace
+
+std::unique_ptr<CommandResult> SetLinkIdsCommand::doPerformDo(MapDocumentCommandFacade*)
+{
+  m_linkIds = setLinkIds(m_linkIds);
+  return std::make_unique<CommandResult>(true);
+}
+
+std::unique_ptr<CommandResult> SetLinkIdsCommand::doPerformUndo(MapDocumentCommandFacade*)
+{
+  m_linkIds = setLinkIds(m_linkIds);
+  return std::make_unique<CommandResult>(true);
+}
+
+bool SetLinkIdsCommand::doCollateWith(UndoableCommand&)
+{
+  return false;
+}
+
+} // namespace TrenchBroom::View

--- a/common/src/View/SetLinkIdsCommand.h
+++ b/common/src/View/SetLinkIdsCommand.h
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2024 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Macros.h"
+#include "View/UndoableCommand.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace TrenchBroom::Model
+{
+class Node;
+} // namespace TrenchBroom::Model
+
+namespace TrenchBroom::View
+{
+
+class SetLinkIdsCommand : public UndoableCommand
+{
+protected:
+  std::vector<std::tuple<Model::Node*, std::string>> m_linkIds;
+
+public:
+  SetLinkIdsCommand(
+    const std::string& name, std::vector<std::tuple<Model::Node*, std::string>> linkIds);
+  ~SetLinkIdsCommand() override;
+
+  std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
+  std::unique_ptr<CommandResult> doPerformUndo(
+    MapDocumentCommandFacade* document) override;
+
+  bool doCollateWith(UndoableCommand& command) override;
+
+  deleteCopyAndMove(SetLinkIdsCommand);
+};
+
+} // namespace TrenchBroom::View

--- a/common/src/View/UpdateLinkedGroupsCommand.h
+++ b/common/src/View/UpdateLinkedGroupsCommand.h
@@ -39,8 +39,8 @@ namespace View
 class UpdateLinkedGroupsCommand : public UpdateLinkedGroupsCommandBase
 {
 public:
-  UpdateLinkedGroupsCommand(std::vector<Model::GroupNode*> changedLinkedGroups);
-  ~UpdateLinkedGroupsCommand();
+  explicit UpdateLinkedGroupsCommand(std::vector<Model::GroupNode*> changedLinkedGroups);
+  ~UpdateLinkedGroupsCommand() override;
 
   std::unique_ptr<CommandResult> doPerformDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> doPerformUndo(

--- a/common/src/View/UpdateLinkedGroupsCommandBase.cpp
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.cpp
@@ -41,7 +41,7 @@ UpdateLinkedGroupsCommandBase::UpdateLinkedGroupsCommandBase(
 {
 }
 
-UpdateLinkedGroupsCommandBase::~UpdateLinkedGroupsCommandBase() {}
+UpdateLinkedGroupsCommandBase::~UpdateLinkedGroupsCommandBase() = default;
 
 std::unique_ptr<CommandResult> UpdateLinkedGroupsCommandBase::performDo(
   MapDocumentCommandFacade* document)

--- a/common/src/View/UpdateLinkedGroupsCommandBase.h
+++ b/common/src/View/UpdateLinkedGroupsCommandBase.h
@@ -44,7 +44,7 @@ protected:
     std::vector<Model::GroupNode*> changedLinkedGroups = {});
 
 public:
-  virtual ~UpdateLinkedGroupsCommandBase();
+  ~UpdateLinkedGroupsCommandBase() override;
 
   std::unique_ptr<CommandResult> performDo(MapDocumentCommandFacade* document) override;
   std::unique_ptr<CommandResult> performUndo(MapDocumentCommandFacade* document) override;

--- a/common/src/View/UpdateLinkedGroupsHelper.cpp
+++ b/common/src/View/UpdateLinkedGroupsHelper.cpp
@@ -52,10 +52,8 @@ auto compareByAncestry(const Model::GroupNode* lhs, const Model::GroupNode* rhs)
 
 bool checkLinkedGroupsToUpdate(const std::vector<Model::GroupNode*>& changedLinkedGroups)
 {
-  const auto linkedGroupIds =
-    kdl::vec_sort(kdl::vec_transform(changedLinkedGroups, [](const auto* groupNode) {
-      return groupNode->group().linkId();
-    }));
+  const auto linkedGroupIds = kdl::vec_sort(kdl::vec_transform(
+    changedLinkedGroups, [](const auto* groupNode) { return groupNode->linkId(); }));
 
   return std::adjacent_find(std::begin(linkedGroupIds), std::end(linkedGroupIds))
          == std::end(linkedGroupIds);
@@ -140,17 +138,17 @@ Result<UpdateLinkedGroupsHelper::LinkedGroupUpdates> UpdateLinkedGroupsHelper::
   }
 
   const auto& worldBounds = document.worldBounds();
-  return kdl::fold_results(kdl::vec_transform(
-                             changedLinkedGroups,
-                             [&](const auto* groupNode) {
-                               const auto groupNodesToUpdate = kdl::vec_erase(
-                                 Model::collectGroupsWithLinkId(
-                                   {document.world()}, groupNode->group().linkId()),
-                                 groupNode);
+  return kdl::fold_results(
+           kdl::vec_transform(
+             changedLinkedGroups,
+             [&](const auto* groupNode) {
+               const auto groupNodesToUpdate = kdl::vec_erase(
+                 Model::collectGroupsWithLinkId({document.world()}, groupNode->linkId()),
+                 groupNode);
 
-                               return Model::updateLinkedGroups(
-                                 *groupNode, groupNodesToUpdate, worldBounds);
-                             }))
+               return Model::updateLinkedGroups(
+                 *groupNode, groupNodesToUpdate, worldBounds);
+             }))
     .and_then([&](auto nestedUpdateLists) -> Result<LinkedGroupUpdates> {
       return kdl::vec_flatten(std::move(nestedUpdateLists));
     });

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/tst_AddNodes.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_Autosaver.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_ChangeBrushFaceAttributes.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/tst_ClipTool.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_ClipToolController.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_CommandProcessor.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/tst_CompilationRunner.cpp"

--- a/common/test/src/CatchUtils/Matchers.h
+++ b/common/test/src/CatchUtils/Matchers.h
@@ -23,6 +23,7 @@
 #include "Result.h"
 #include "StringMakers.h"
 
+#include "kdl/vector_utils.h"
 #include <kdl/overload.h>
 #include <kdl/result.h>
 #include <kdl/std_io.h>
@@ -157,6 +158,29 @@ template <typename T>
 NoneOfMatcher<T> MatchesNoneOf(std::initializer_list<T> expected)
 {
   return NoneOfMatcher<T>(std::vector<T>{expected});
+}
+
+template <typename T>
+class AllDifferentMatcher : public Catch::MatcherBase<T>
+{
+public:
+  bool match(const T& in) const override
+  {
+    return in.size() == kdl::vec_sort_and_remove_duplicates(in).size();
+  }
+
+  std::string describe() const override
+  {
+    auto str = std::stringstream{};
+    str << "contains no duplicates";
+    return str.str();
+  }
+};
+
+template <typename T>
+AllDifferentMatcher<T> AllDifferent()
+{
+  return AllDifferentMatcher<T>{};
 }
 
 class GlobMatcher : public Catch::MatcherBase<std::string>

--- a/common/test/src/CatchUtils/StringMakers.cpp
+++ b/common/test/src/CatchUtils/StringMakers.cpp
@@ -80,6 +80,7 @@ void printGroupNode(
   const auto childIndent = indent + "  ";
   str << indent << "GroupNode{\n";
   str << childIndent << "m_group: " << groupNode.group() << ",\n";
+  str << childIndent << "m_linkId: " << groupNode.linkId() << ",\n";
   printChildren(groupNode, childIndent, str);
   str << ",\n";
   str << indent << "}";
@@ -91,6 +92,7 @@ void printEntityNode(
   const auto childIndent = indent + "  ";
   str << indent << "EntityNode{\n";
   str << childIndent << "m_entity: " << entityNode.entity() << ",\n";
+  str << childIndent << "m_linkId: " << entityNode.linkId() << ",\n";
   printChildren(entityNode, childIndent, str);
   str << ",\n";
   str << indent << "}";
@@ -102,6 +104,7 @@ void printBrushNode(
   const auto childIndent = indent + "  ";
   str << indent << "BrushNode{\n";
   str << childIndent << "m_brush: " << brushNode.brush() << ",\n";
+  str << childIndent << "m_linkId: " << brushNode.linkId() << ",\n";
   printChildren(brushNode, childIndent, str);
   str << ",\n";
   str << indent << "}";
@@ -113,6 +116,7 @@ void printPatchNode(
   const auto childIndent = indent + "  ";
   str << indent << "PatchNode{\n";
   str << childIndent << "m_patch: " << patchNode.patch() << ",\n";
+  str << childIndent << "m_linkId: " << patchNode.linkId() << ",\n";
   printChildren(patchNode, childIndent, str);
   str << ",\n";
   str << indent << "}";

--- a/common/test/src/CatchUtils/tst_StringMakers.cpp
+++ b/common/test/src/CatchUtils/tst_StringMakers.cpp
@@ -50,7 +50,7 @@ TEST_CASE("convertToString")
   CHECK(convertToString(worldNode) == R"(WorldNode{
   m_entityPropertyConfig: EntityPropertyConfig{defaultModelScaleExpression: nullopt, setDefaultProperties: 0, updateAnglePropertyAfterTransform: 1},
   m_mapFormat: Quake3,
-  m_entity: Entity{m_properties: [EntityProperty{m_key: classname, m_value: worldspawn}], m_protectedProperties: [], m_linkId: world_link_id},
+  m_entity: Entity{m_properties: [EntityProperty{m_key: classname, m_value: worldspawn}], m_protectedProperties: []},
   m_children: [
     LayerNode{
       m_layer: Layer{m_defaultLayer: 1, m_name: Default Layer, m_sortIndex: nullopt, m_color: nullopt, m_omitFromExport: 0},
@@ -84,24 +84,28 @@ TEST_CASE("convertToString")
   CHECK(convertToString(worldNode) == R"(WorldNode{
   m_entityPropertyConfig: EntityPropertyConfig{defaultModelScaleExpression: nullopt, setDefaultProperties: 0, updateAnglePropertyAfterTransform: 1},
   m_mapFormat: Quake3,
-  m_entity: Entity{m_properties: [EntityProperty{m_key: classname, m_value: worldspawn}], m_protectedProperties: [], m_linkId: world_link_id},
+  m_entity: Entity{m_properties: [EntityProperty{m_key: classname, m_value: worldspawn}], m_protectedProperties: []},
   m_children: [
     LayerNode{
       m_layer: Layer{m_defaultLayer: 1, m_name: Default Layer, m_sortIndex: nullopt, m_color: nullopt, m_omitFromExport: 0},
       m_children: [
         GroupNode{
-          m_group: Group{m_name: group, m_linkId: group_link_id, m_transformation: 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1},
+          m_group: Group{m_name: group, m_transformation: 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1},
+          m_linkId: group_link_id,
           m_children: [
             EntityNode{
-              m_entity: Entity{m_properties: [], m_protectedProperties: [], m_linkId: entity_link_id},
+              m_entity: Entity{m_properties: [], m_protectedProperties: []},
+              m_linkId: entity_link_id,
               m_children: [],
             },
             BrushNode{
-              m_brush: Brush{m_faces: [BrushFace{m_points: [-32 -32 -32,-32 -31 -32,-32 -32 -31], m_boundary: { normal: (-1 0 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [-32 -32 -32,-32 -32 -31,-31 -32 -32], m_boundary: { normal: (0 -1 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [-32 -32 -32,-31 -32 -32,-32 -31 -32], m_boundary: { normal: (0 0 -1), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [32 32 32,32 33 32,33 32 32], m_boundary: { normal: (0 0 1), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [32 32 32,33 32 32,32 32 33], m_boundary: { normal: (0 1 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [32 32 32,32 32 33,32 33 32], m_boundary: { normal: (1 0 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}}], m_linkId: brush_link_id},
+              m_brush: Brush{m_faces: [BrushFace{m_points: [-32 -32 -32,-32 -31 -32,-32 -32 -31], m_boundary: { normal: (-1 0 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [-32 -32 -32,-32 -32 -31,-31 -32 -32], m_boundary: { normal: (0 -1 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [-32 -32 -32,-31 -32 -32,-32 -31 -32], m_boundary: { normal: (0 0 -1), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [32 32 32,32 33 32,33 32 32], m_boundary: { normal: (0 0 1), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [32 32 32,33 32 32,32 32 33], m_boundary: { normal: (0 1 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}},BrushFace{m_points: [32 32 32,32 32 33,32 33 32], m_boundary: { normal: (1 0 0), distance: 32 }, m_attributes: BrushFaceAttributes{m_textureName: texture, m_offset: 0 0, m_scale: 1 1, m_rotation: 0, m_surfaceContents: nullopt, m_surfaceFlags: nullopt, m_surfaceValue: nullopt, m_color: nullopt}, m_textureReference: AssetReference<T>{m_asset: null}}]},
+              m_linkId: brush_link_id,
               m_children: [],
             },
             PatchNode{
-              m_patch: BezierPatch{m_pointRowCount: 3, m_pointColumnCount: 3, m_bounds: { min: (0 0 0), max: (2 2 2) }, m_controlPoints: [0 0 0 0 0,1 0 1 0 0,2 0 0 0 0,0 1 1 0 0,1 1 2 0 0,2 1 1 0 0,0 2 0 0 0,1 2 1 0 0,2 2 0 0 0], m_textureName: texture, m_linkId: patch_link_id},
+              m_patch: BezierPatch{m_pointRowCount: 3, m_pointColumnCount: 3, m_bounds: { min: (0 0 0), max: (2 2 2) }, m_controlPoints: [0 0 0 0 0,1 0 1 0 0,2 0 0 0 0,0 1 1 0 0,1 1 2 0 0,2 1 1 0 0,0 2 0 0 0,1 2 1 0 0,2 2 0 0 0], m_textureName: texture},
+              m_linkId: patch_link_id,
               m_children: [],
             }
           ],

--- a/common/test/src/IO/tst_NodeWriter.cpp
+++ b/common/test/src/IO/tst_NodeWriter.cpp
@@ -922,7 +922,7 @@ TEST_CASE("NodeWriterTest.writeNodesWithLinkedGroup")
     *groupNodeClone, vm::translation_matrix(vm::vec3(0.0, 16.0, 0.0)), worldBounds);
 
   worldNode.defaultLayer()->addChild(groupNodeClone);
-  REQUIRE(groupNodeClone->group().linkId() == groupNode->group().linkId());
+  REQUIRE(groupNodeClone->linkId() == groupNode->linkId());
 
   auto str = std::stringstream{};
   auto writer = NodeWriter{worldNode, str};

--- a/common/test/src/IO/tst_WorldReader.cpp
+++ b/common/test/src/IO/tst_WorldReader.cpp
@@ -1600,8 +1600,8 @@ TEST_CASE("WorldReader.parseLinkedGroups")
   REQUIRE(groupNode1 != nullptr);
   REQUIRE(groupNode2 != nullptr);
 
-  CHECK(groupNode1->group().linkId() == "abcd");
-  CHECK(groupNode2->group().linkId() == "abcd");
+  CHECK(groupNode1->linkId() == "abcd");
+  CHECK(groupNode2->linkId() == "abcd");
 
   CHECK(
     groupNode1->group().transformation()
@@ -1640,7 +1640,7 @@ TEST_CASE("WorldReader.parseOrphanedLinkedGroups")
     dynamic_cast<Model::GroupNode*>(world->defaultLayer()->children().front());
 
   CHECK(groupNode != nullptr);
-  CHECK(groupNode->group().linkId() == "abcd");
+  CHECK(groupNode->linkId() == "abcd");
   CHECK(
     groupNode->group().transformation() == vm::translation_matrix(vm::vec3{32, 0, 0}));
 }
@@ -1696,9 +1696,9 @@ TEST_CASE("WorldReader.parseLinkedGroupsWithMissingTransformation")
   REQUIRE(groupNode2 != nullptr);
   REQUIRE(groupNode3 != nullptr);
 
-  CHECK(groupNode1->group().linkId() == "1");
-  CHECK(groupNode2->group().linkId() == "1");
-  CHECK(groupNode3->group().linkId() == "1");
+  CHECK(groupNode1->linkId() == "1");
+  CHECK(groupNode2->linkId() == "1");
+  CHECK(groupNode3->linkId() == "1");
 
   CHECK(groupNode1->group().transformation() == vm::mat4x4d::identity());
   CHECK(
@@ -1859,30 +1859,30 @@ TEST_CASE("WorldReader.parseRecursiveLinkedGroups")
   const auto* groupNode_4_1_1_fgh =
     dynamic_cast<Model::GroupNode*>(groupNode_4_1->children().front());
 
-  CHECK(groupNode_1_abcd->group().linkId() == "abcd");
+  CHECK(groupNode_1_abcd->linkId() == "abcd");
   CHECK(
     groupNode_1_abcd->group().transformation()
     == vm::translation_matrix(vm::vec3{32, 0, 0}));
-  CHECK(groupNode_1_2_abcd->group().linkId() != "abcd");
+  CHECK(groupNode_1_2_abcd->linkId() != "abcd");
   CHECK(groupNode_1_2_abcd->group().transformation() == vm::mat4x4::identity());
 
-  CHECK(groupNode_2_xyz->group().linkId() == "xyz");
+  CHECK(groupNode_2_xyz->linkId() == "xyz");
   CHECK(
     groupNode_2_xyz->group().transformation()
     == vm::translation_matrix(vm::vec3{32, 0, 0}));
-  CHECK(groupNode_2_1_xyz->group().linkId() != "xyz");
+  CHECK(groupNode_2_1_xyz->linkId() != "xyz");
   CHECK(groupNode_2_1_xyz->group().transformation() == vm::mat4x4::identity());
-  CHECK(groupNode_3_xyz->group().linkId() == "xyz");
+  CHECK(groupNode_3_xyz->linkId() == "xyz");
   CHECK(
     groupNode_3_xyz->group().transformation()
     == vm::translation_matrix(vm::vec3{32, 0, 0}));
 
-  CHECK(groupNode_4_fgh->group().linkId() == "fgh");
+  CHECK(groupNode_4_fgh->linkId() == "fgh");
   CHECK(
     groupNode_4_fgh->group().transformation()
     == vm::translation_matrix(vm::vec3{32, 0, 0}));
   CHECK(groupNode_4_1->group().transformation() == vm::mat4x4::identity());
-  CHECK(groupNode_4_1_1_fgh->group().linkId() != "fgh");
+  CHECK(groupNode_4_1_1_fgh->linkId() != "fgh");
   CHECK(groupNode_4_1_1_fgh->group().transformation() == vm::mat4x4::identity());
 }
 

--- a/common/test/src/Model/tst_GroupNode.cpp
+++ b/common/test/src/Model/tst_GroupNode.cpp
@@ -134,7 +134,7 @@ TEST_CASE("GroupNode.canAddChild")
   {
     auto linkedGroupNode = std::make_unique<GroupNode>(Group{"group"});
     setLinkId(groupNode, "linked_group_id");
-    setLinkId(*linkedGroupNode, groupNode.group().linkId());
+    setLinkId(*linkedGroupNode, groupNode.linkId());
     CHECK_FALSE(groupNode.canAddChild(linkedGroupNode.get()));
 
     auto outerGroupNode = GroupNode{Group{"outer_group"}};

--- a/common/test/src/Model/tst_LinkedGroupUtils.cpp
+++ b/common/test/src/Model/tst_LinkedGroupUtils.cpp
@@ -626,17 +626,15 @@ std::unordered_map<const Node*, std::string> getLinkIds(const Node& node)
       layerNode->visitChildren(thisLambda);
     },
     [&](auto&& thisLambda, const GroupNode* groupNode) {
-      result[groupNode] = groupNode->group().linkId();
+      result[groupNode] = groupNode->linkId();
       groupNode->visitChildren(thisLambda);
     },
     [&](auto&& thisLambda, const EntityNode* entityNode) {
-      result[entityNode] = entityNode->entity().linkId();
+      result[entityNode] = entityNode->linkId();
       entityNode->visitChildren(thisLambda);
     },
-    [&](const BrushNode* brushNode) { result[brushNode] = brushNode->brush().linkId(); },
-    [&](const PatchNode* patchNode) {
-      result[patchNode] = patchNode->patch().linkId();
-    }));
+    [&](const BrushNode* brushNode) { result[brushNode] = brushNode->linkId(); },
+    [&](const PatchNode* patchNode) { result[patchNode] = patchNode->linkId(); }));
   return result;
 }
 

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -385,32 +385,9 @@ void checkBrushTexCoordSystem(
 void setLinkId(Node& node, std::string linkId)
 {
   node.accept(kdl::overload(
-    [&](WorldNode* worldNode) {
-      auto entity = worldNode->entity();
-      entity.setLinkId(std::move(linkId));
-      worldNode->setEntity(std::move(entity));
-    },
+    [](const WorldNode*) {},
     [](const LayerNode*) {},
-    [&](GroupNode* groupNode) {
-      auto group = groupNode->group();
-      group.setLinkId(std::move(linkId));
-      groupNode->setGroup(std::move(group));
-    },
-    [&](EntityNode* entityNode) {
-      auto entity = entityNode->entity();
-      entity.setLinkId(std::move(linkId));
-      entityNode->setEntity(std::move(entity));
-    },
-    [&](BrushNode* brushNode) {
-      auto brush = brushNode->brush();
-      brush.setLinkId(std::move(linkId));
-      brushNode->setBrush(std::move(brush));
-    },
-    [&](PatchNode* patchNode) {
-      auto patch = patchNode->patch();
-      patch.setLinkId(std::move(linkId));
-      patchNode->setPatch(std::move(patch));
-    }));
+    [&](Object* object) { object->setLinkId(std::move(linkId)); }));
 }
 } // namespace Model
 

--- a/common/test/src/View/tst_ClipTool.cpp
+++ b/common/test/src/View/tst_ClipTool.cpp
@@ -1,0 +1,94 @@
+/*
+ Copyright (C) 2024 Kristian Duske
+ Copyright (C) 2019 Eric Wasylishen
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MapDocumentTest.h"
+#include "Model/BrushNode.h"
+#include "Model/LayerNode.h"
+#include "Model/WorldNode.h"
+#include "Renderer/PerspectiveCamera.h"
+#include "View/ClipTool.h"
+#include "View/ClipToolController.h"
+#include "View/Grid.h"
+#include "View/PasteType.h"
+#include "View/Tool.h"
+
+#include "Catch2.h"
+
+namespace TrenchBroom::View
+{
+
+TEST_CASE_METHOD(ValveMapDocumentTest, "ClipToolTest")
+{
+  // https://github.com/TrenchBroom/TrenchBroom/issues/4461
+  SECTION("Clipped brushes get new link IDs")
+  {
+    const auto data = R"(// entity 0
+{
+"mapversion" "220"
+"wad" ""
+"classname" "worldspawn"
+// brush 0
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) __TB_empty [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) __TB_empty [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
+}
+}
+)";
+    REQUIRE(document->paste(data) == PasteType::Node);
+
+    const auto* defaultLayer = document->world()->defaultLayer();
+
+    const auto* originalBrushNode =
+      dynamic_cast<const Model::BrushNode*>(defaultLayer->children().front());
+    REQUIRE(originalBrushNode);
+
+    const auto originalLinkId = originalBrushNode->linkId();
+
+    auto tool = ClipTool{document};
+    REQUIRE(tool.activate());
+
+    tool.addPoint(vm::vec3{0, 16, 16}, {});
+    tool.addPoint(vm::vec3{0, -16, 16}, {});
+    tool.addPoint(vm::vec3{0, -64, 0}, {});
+
+    REQUIRE(tool.canClip());
+    tool.toggleSide();
+    tool.performClip();
+
+    REQUIRE(defaultLayer->childCount() == 2);
+    const auto* clippedBrushNode1 =
+      dynamic_cast<const Model::BrushNode*>(defaultLayer->children().front());
+    const auto* clippedBrushNode2 =
+      dynamic_cast<const Model::BrushNode*>(defaultLayer->children().back());
+
+    REQUIRE(clippedBrushNode1);
+    REQUIRE(clippedBrushNode2);
+
+    CHECK(clippedBrushNode1->linkId() != originalLinkId);
+    CHECK(clippedBrushNode2->linkId() != originalLinkId);
+    CHECK(clippedBrushNode1->linkId() != clippedBrushNode2->linkId());
+  }
+}
+
+} // namespace TrenchBroom::View

--- a/common/test/src/View/tst_CopyPaste.cpp
+++ b/common/test/src/View/tst_CopyPaste.cpp
@@ -347,14 +347,14 @@ TEST_CASE_METHOD(
   document->selectNodes({groupNode});
   auto* linkedGroup = document->createLinkedDuplicate();
 
-  const auto originalGroupLinkId = linkedGroup->group().linkId();
-  REQUIRE(originalGroupLinkId == groupNode->group().linkId());
+  const auto originalGroupLinkId = linkedGroup->linkId();
+  REQUIRE(originalGroupLinkId == groupNode->linkId());
 
   auto* linkedBrush = dynamic_cast<Model::BrushNode*>(linkedGroup->children().front());
   REQUIRE(linkedBrush);
 
-  const auto originalBrushLinkId = linkedBrush->brush().linkId();
-  REQUIRE(originalBrushLinkId == brushNode->brush().linkId());
+  const auto originalBrushLinkId = linkedBrush->linkId();
+  REQUIRE(originalBrushLinkId == brushNode->linkId());
 
   document->deselectAll();
 
@@ -377,7 +377,7 @@ TEST_CASE_METHOD(
         document->world()->defaultLayer()->children().back());
       REQUIRE(pastedGroup);
 
-      CHECK(pastedGroup->group().linkId() == originalGroupLinkId);
+      CHECK(pastedGroup->linkId() == originalGroupLinkId);
     }
 
     SECTION("Pasting duplicate linked group ID")
@@ -389,13 +389,13 @@ TEST_CASE_METHOD(
         document->world()->defaultLayer()->children().back());
       REQUIRE(pastedGroup);
 
-      CHECK(pastedGroup->group().linkId() == originalGroupLinkId);
+      CHECK(pastedGroup->linkId() == originalGroupLinkId);
 
       const auto* pastedBrush =
         dynamic_cast<Model::BrushNode*>(pastedGroup->children().front());
       REQUIRE(pastedBrush);
 
-      CHECK(pastedBrush->brush().linkId() == originalBrushLinkId);
+      CHECK(pastedBrush->linkId() == originalBrushLinkId);
     }
 
     SECTION("Pasting recursive linked group")
@@ -409,25 +409,25 @@ TEST_CASE_METHOD(
       auto* pastedGroup = dynamic_cast<Model::GroupNode*>(groupNode->children().back());
       REQUIRE(pastedGroup);
 
-      CHECK(pastedGroup->group().linkId() != originalGroupLinkId);
+      CHECK(pastedGroup->linkId() != originalGroupLinkId);
 
       const auto* pastedBrush =
         dynamic_cast<Model::BrushNode*>(pastedGroup->children().front());
       REQUIRE(pastedBrush);
 
-      CHECK(pastedBrush->brush().linkId() != originalBrushLinkId);
+      CHECK(pastedBrush->linkId() != originalBrushLinkId);
 
       auto* linkedPastedGroup =
         dynamic_cast<Model::GroupNode*>(linkedGroup->children().back());
       REQUIRE(linkedPastedGroup);
 
-      CHECK(linkedPastedGroup->group().linkId() == pastedGroup->group().linkId());
+      CHECK(linkedPastedGroup->linkId() == pastedGroup->linkId());
 
       const auto* linkedPastedBrush =
         dynamic_cast<Model::BrushNode*>(linkedPastedGroup->children().front());
       REQUIRE(pastedBrush);
 
-      CHECK(linkedPastedBrush->brush().linkId() == pastedBrush->brush().linkId());
+      CHECK(linkedPastedBrush->linkId() == pastedBrush->linkId());
     }
   }
 
@@ -449,20 +449,20 @@ TEST_CASE_METHOD(
       dynamic_cast<Model::GroupNode*>(document->world()->defaultLayer()->children()[3]);
     REQUIRE(pastedGroup2);
 
-    CHECK(pastedGroup1->group().linkId() == originalGroupLinkId);
-    CHECK(pastedGroup2->group().linkId() == originalGroupLinkId);
+    CHECK(pastedGroup1->linkId() == originalGroupLinkId);
+    CHECK(pastedGroup2->linkId() == originalGroupLinkId);
 
     const auto* pastedBrush1 =
       dynamic_cast<Model::BrushNode*>(pastedGroup1->children().front());
     REQUIRE(pastedBrush1);
 
-    CHECK(pastedBrush1->brush().linkId() == originalBrushLinkId);
+    CHECK(pastedBrush1->linkId() == originalBrushLinkId);
 
     const auto* pastedBrush2 =
       dynamic_cast<Model::BrushNode*>(pastedGroup2->children().front());
     REQUIRE(pastedBrush2);
 
-    CHECK(pastedBrush2->brush().linkId() == originalBrushLinkId);
+    CHECK(pastedBrush2->linkId() == originalBrushLinkId);
   }
 }
 

--- a/common/test/src/View/tst_ExtrudeTool.cpp
+++ b/common/test/src/View/tst_ExtrudeTool.cpp
@@ -50,6 +50,8 @@
 #include <filesystem>
 #include <memory>
 
+#include "CatchUtils/Matchers.h"
+
 #include "Catch2.h"
 
 namespace TrenchBroom::View
@@ -358,6 +360,12 @@ TEST_CASE("ExtrudeToolTest.splitBrushes")
         {{-16, 176, 16}, {16, 192, 32}}, {{-16, 192, 16}, {16, 224, 32}}};
       CHECK_THAT(bounds, Catch::UnorderedEquals(expectedBounds));
     }
+
+    CHECK_THAT(
+      kdl::vec_transform(
+        document->selectedNodes().brushes(),
+        [](const auto* brushNode) { return brushNode->linkId(); }),
+      AllDifferent<std::vector<std::string>>());
   }
 
   SECTION("split brushes inwards 48 units towards -Y")
@@ -462,6 +470,12 @@ TEST_CASE("ExtrudeToolTest.splitBrushes")
       const auto expectedBounds = std::vector<vm::bbox3>{{{-16, 224, 16}, {16, 240, 32}}};
       CHECK_THAT(bounds, Catch::UnorderedEquals(expectedBounds));
     }
+
+    CHECK_THAT(
+      kdl::vec_transform(
+        document->selectedNodes().brushes(),
+        [](const auto* brushNode) { return brushNode->linkId(); }),
+      AllDifferent<std::vector<std::string>>());
   }
 }
 } // namespace TrenchBroom::View

--- a/common/test/src/View/tst_GroupNodes.cpp
+++ b/common/test/src/View/tst_GroupNodes.cpp
@@ -421,8 +421,8 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLinkedGroups")
   auto* groupNode = document->groupSelection("test");
   REQUIRE(groupNode != nullptr);
 
-  const auto originalGroupLinkId = groupNode->group().linkId();
-  const auto originalBrushLinkId = brushNode->brush().linkId();
+  const auto originalGroupLinkId = groupNode->linkId();
+  const auto originalBrushLinkId = brushNode->linkId();
 
   document->deselectAll();
   document->selectNodes({groupNode});
@@ -456,9 +456,9 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLinkedGroups")
       document->world()->defaultLayer()->children(),
       Catch::UnorderedEquals(
         std::vector<Model::Node*>{groupNode, linkedGroupNode, linkedBrushNode2}));
-    CHECK(groupNode->group().linkId() == linkedGroupNode->group().linkId());
-    CHECK(linkedGroupNode2->group().linkId() != groupNode->group().linkId());
-    CHECK(linkedBrushNode2->brush().linkId() != brushNode->brush().linkId());
+    CHECK(groupNode->linkId() == linkedGroupNode->linkId());
+    CHECK(linkedGroupNode2->linkId() != groupNode->linkId());
+    CHECK(linkedBrushNode2->linkId() != brushNode->linkId());
   }
 
   SECTION(
@@ -473,14 +473,14 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLinkedGroups")
       Catch::UnorderedEquals(
         std::vector<Model::Node*>{groupNode, linkedBrushNode, linkedBrushNode2}));
 
-    CHECK(groupNode->group().linkId() == originalGroupLinkId);
-    CHECK(linkedGroupNode->group().linkId() != originalGroupLinkId);
-    CHECK(linkedGroupNode2->group().linkId() != originalGroupLinkId);
-    CHECK(linkedGroupNode2->group().linkId() != linkedGroupNode->group().linkId());
+    CHECK(groupNode->linkId() == originalGroupLinkId);
+    CHECK(linkedGroupNode->linkId() != originalGroupLinkId);
+    CHECK(linkedGroupNode2->linkId() != originalGroupLinkId);
+    CHECK(linkedGroupNode2->linkId() != linkedGroupNode->linkId());
 
-    CHECK(linkedBrushNode->brush().linkId() != brushNode->brush().linkId());
-    CHECK(linkedBrushNode2->brush().linkId() != brushNode->brush().linkId());
-    CHECK(linkedBrushNode2->brush().linkId() != linkedBrushNode->brush().linkId());
+    CHECK(linkedBrushNode->linkId() != brushNode->linkId());
+    CHECK(linkedBrushNode2->linkId() != brushNode->linkId());
+    CHECK(linkedBrushNode2->linkId() != linkedBrushNode->linkId());
   }
 
   SECTION("Given three linked groups, we ungroup all of them")
@@ -495,13 +495,13 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLinkedGroups")
       Catch::UnorderedEquals(
         std::vector<Model::Node*>{brushNode, linkedBrushNode, linkedBrushNode2}));
 
-    CHECK(groupNode->group().linkId() != originalGroupLinkId);
-    CHECK(linkedGroupNode->group().linkId() != originalGroupLinkId);
-    CHECK(linkedGroupNode2->group().linkId() != originalGroupLinkId);
+    CHECK(groupNode->linkId() != originalGroupLinkId);
+    CHECK(linkedGroupNode->linkId() != originalGroupLinkId);
+    CHECK(linkedGroupNode2->linkId() != originalGroupLinkId);
 
-    CHECK(linkedGroupNode->group().linkId() != groupNode->group().linkId());
-    CHECK(linkedGroupNode2->group().linkId() != groupNode->group().linkId());
-    CHECK(linkedGroupNode2->group().linkId() != linkedGroupNode->group().linkId());
+    CHECK(linkedGroupNode->linkId() != groupNode->linkId());
+    CHECK(linkedGroupNode2->linkId() != groupNode->linkId());
+    CHECK(linkedGroupNode2->linkId() != linkedGroupNode->linkId());
   }
 
   document->undoCommand();
@@ -509,13 +509,13 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.ungroupLinkedGroups")
     document->world()->defaultLayer()->children(),
     Catch::UnorderedEquals(
       std::vector<Model::Node*>{groupNode, linkedGroupNode, linkedGroupNode2}));
-  CHECK(groupNode->group().linkId() == originalGroupLinkId);
-  CHECK(linkedGroupNode->group().linkId() == originalGroupLinkId);
-  CHECK(linkedGroupNode2->group().linkId() == originalGroupLinkId);
+  CHECK(groupNode->linkId() == originalGroupLinkId);
+  CHECK(linkedGroupNode->linkId() == originalGroupLinkId);
+  CHECK(linkedGroupNode2->linkId() == originalGroupLinkId);
 
-  CHECK(brushNode->brush().linkId() == originalBrushLinkId);
-  CHECK(linkedBrushNode->brush().linkId() == originalBrushLinkId);
-  CHECK(linkedBrushNode2->brush().linkId() == originalBrushLinkId);
+  CHECK(brushNode->linkId() == originalBrushLinkId);
+  CHECK(linkedBrushNode->linkId() == originalBrushLinkId);
+  CHECK(linkedBrushNode2->linkId() == originalBrushLinkId);
 }
 
 TEST_CASE_METHOD(MapDocumentTest, "GroupNodesTest.createLinkedDuplicate")
@@ -640,8 +640,8 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
   document->deselectAll();
   document->selectNodes({groupNode});
 
-  const auto originalGroupLinkId = groupNode->group().linkId();
-  const auto originalBrushLinkId = brushNode->brush().linkId();
+  const auto originalGroupLinkId = groupNode->linkId();
+  const auto originalBrushLinkId = brushNode->linkId();
 
   SECTION("Separating a group that isn't linked")
   {
@@ -671,16 +671,16 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
 
     CHECK(document->canSeparateLinkedGroups());
     document->separateLinkedGroups();
-    CHECK(groupNode->group().linkId() == originalGroupLinkId);
-    CHECK(brushNode->brush().linkId() == originalBrushLinkId);
-    CHECK(linkedGroupNode->group().linkId() != originalGroupLinkId);
-    CHECK(linkedBrushNode->brush().linkId() != originalBrushLinkId);
+    CHECK(groupNode->linkId() == originalGroupLinkId);
+    CHECK(brushNode->linkId() == originalBrushLinkId);
+    CHECK(linkedGroupNode->linkId() != originalGroupLinkId);
+    CHECK(linkedBrushNode->linkId() != originalBrushLinkId);
 
     document->undoCommand();
-    CHECK(groupNode->group().linkId() == originalGroupLinkId);
-    CHECK(linkedGroupNode->group().linkId() == originalGroupLinkId);
-    CHECK(brushNode->brush().linkId() == originalBrushLinkId);
-    CHECK(linkedBrushNode->brush().linkId() == originalBrushLinkId);
+    CHECK(groupNode->linkId() == originalGroupLinkId);
+    CHECK(linkedGroupNode->linkId() == originalGroupLinkId);
+    CHECK(brushNode->linkId() == originalBrushLinkId);
+    CHECK(linkedBrushNode->linkId() == originalBrushLinkId);
   }
 
   SECTION("Separating multiple groups from a link set with several members")
@@ -705,28 +705,28 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
     CHECK(document->canSeparateLinkedGroups());
 
     document->separateLinkedGroups();
-    CHECK(groupNode->group().linkId() == originalGroupLinkId);
-    CHECK(linkedGroupNode1->group().linkId() == originalGroupLinkId);
+    CHECK(groupNode->linkId() == originalGroupLinkId);
+    CHECK(linkedGroupNode1->linkId() == originalGroupLinkId);
 
-    CHECK(linkedGroupNode2->group().linkId() != originalGroupLinkId);
-    CHECK(linkedGroupNode3->group().linkId() == linkedGroupNode2->group().linkId());
+    CHECK(linkedGroupNode2->linkId() != originalGroupLinkId);
+    CHECK(linkedGroupNode3->linkId() == linkedGroupNode2->linkId());
 
-    CHECK(linkedBrushNode2->brush().linkId() != originalBrushLinkId);
-    CHECK(linkedBrushNode3->brush().linkId() == linkedBrushNode2->brush().linkId());
+    CHECK(linkedBrushNode2->linkId() != originalBrushLinkId);
+    CHECK(linkedBrushNode3->linkId() == linkedBrushNode2->linkId());
 
     CHECK(document->selectedNodes().groupCount() == 2u);
 
     document->undoCommand();
 
-    CHECK(groupNode->group().linkId() == originalGroupLinkId);
-    CHECK(linkedGroupNode1->group().linkId() == originalGroupLinkId);
-    CHECK(linkedGroupNode2->group().linkId() == originalGroupLinkId);
-    CHECK(linkedGroupNode3->group().linkId() == originalGroupLinkId);
+    CHECK(groupNode->linkId() == originalGroupLinkId);
+    CHECK(linkedGroupNode1->linkId() == originalGroupLinkId);
+    CHECK(linkedGroupNode2->linkId() == originalGroupLinkId);
+    CHECK(linkedGroupNode3->linkId() == originalGroupLinkId);
 
-    CHECK(brushNode->brush().linkId() == originalBrushLinkId);
-    CHECK(linkedBrushNode1->brush().linkId() == originalBrushLinkId);
-    CHECK(linkedBrushNode2->brush().linkId() == originalBrushLinkId);
-    CHECK(linkedBrushNode3->brush().linkId() == originalBrushLinkId);
+    CHECK(brushNode->linkId() == originalBrushLinkId);
+    CHECK(linkedBrushNode1->linkId() == originalBrushLinkId);
+    CHECK(linkedBrushNode2->linkId() == originalBrushLinkId);
+    CHECK(linkedBrushNode3->linkId() == originalBrushLinkId);
   }
 }
 

--- a/common/test/src/View/tst_UpdateLinkedGroupsHelper.cpp
+++ b/common/test/src/View/tst_UpdateLinkedGroupsHelper.cpp
@@ -289,22 +289,21 @@ TEST_CASE_METHOD(
   auto* linkedInnerGroupNode = static_cast<Model::GroupNode*>(
     innerGroupNode->cloneRecursively(document->worldBounds(), Model::SetLinkId::keep));
   setGroupName(*linkedInnerGroupNode, "linkedInnerGroupNode");
-  REQUIRE(linkedInnerGroupNode->group().linkId() == innerGroupNode->group().linkId());
+  REQUIRE(linkedInnerGroupNode->linkId() == innerGroupNode->linkId());
 
   document->addNodes({{document->parentForNodes(), {linkedInnerGroupNode}}});
 
   auto* linkedOuterGroupNode = static_cast<Model::GroupNode*>(
     outerGroupNode->cloneRecursively(document->worldBounds(), Model::SetLinkId::keep));
   setGroupName(*linkedOuterGroupNode, "linkedOuterGroupNode");
-  REQUIRE(linkedOuterGroupNode->group().linkId() == outerGroupNode->group().linkId());
+  REQUIRE(linkedOuterGroupNode->linkId() == outerGroupNode->linkId());
 
   document->addNodes({{document->parentForNodes(), {linkedOuterGroupNode}}});
 
   auto* nestedLinkedInnerGroupNode =
     static_cast<Model::GroupNode*>(linkedOuterGroupNode->children().front());
   setGroupName(*nestedLinkedInnerGroupNode, "nestedLinkedInnerGroupNode");
-  REQUIRE(
-    nestedLinkedInnerGroupNode->group().linkId() == innerGroupNode->group().linkId());
+  REQUIRE(nestedLinkedInnerGroupNode->linkId() == innerGroupNode->linkId());
 
   /*
   world

--- a/lib/kdl/include/kdl/transform_range.h
+++ b/lib/kdl/include/kdl/transform_range.h
@@ -119,6 +119,7 @@ public:
   using const_iterator = transform_iterator<typename C::const_iterator, Transform>;
   using const_reverse_iterator =
     transform_iterator<typename C::const_reverse_iterator, Transform>;
+  using value_type = typename const_iterator::value_type;
 
 private:
   const C& m_container;


### PR DESCRIPTION
Closes #4461. The current approach to storing link IDs in node contents is dangerous because we often copy node contents around when creating new nodes. For example, both `ClipTool` and `ExtrudeTool` do this, and it leads to them creating new nodes with existing link IDs, which leads to bugs.

In this PR, we change the approach and store link IDs in nodes instead. Nodes cannot be copied, only cloned, and `Node::clone` expects callers to pass an argument indicating whether the cloned node has a new link ID or whether it copies the link ID of the original node. This makes it much safer to create new nodes by cloning existing nodes.