### PR TITLE
Upgrade external GitHub Actions actions (Node 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       # Dependencies
-
       - name: Install common Linux dependencies
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         run: |
@@ -143,32 +142,42 @@ jobs:
       # These need to be separate, otherwise all of the artifacts are bundled into
       # one .zip file.
 
-      # win64
-      - name: Upload win64 artifact
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.os == 'windows-2019' && matrix.tb-arch == 'x64' }}
-        with:
-          name: win64
-          path: |
-            cmakebuild/*.7z
-            cmakebuild/*.7z.md5
-
-      # win32
+      # Windows 2019 x32
       - name: Upload win32 artifact
         uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'windows-2019' && matrix.tb-arch == 'Win32' }}
         with:
-          name: win32
+          name: windows-2019-x32
           path: |
             cmakebuild/*.7z
             cmakebuild/*.7z.md5
 
-      # Linux
+      # Windows 2019 x64
+      - name: Upload win64 artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.os == 'windows-2019' && matrix.tb-arch == 'x64' }}
+        with:
+          name: windows-2019-x64
+          path: |
+            cmakebuild/*.7z
+            cmakebuild/*.7z.md5
+
+      # Ubuntu 20.04
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         with:
-          name: linux
+          name: ubuntu-20.04
+          path: |
+            build/*.deb
+            build/*.md5
+
+      # Ubuntu 22.04
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        with:
+          name: ubuntu-22.04
           path: |
             build/*.deb
             build/*.md5
@@ -178,7 +187,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'macos-12' && matrix.tb-build-type != 'asan' }}
         with:
-          name: macos
+          name: macos-12
           path: |
             build/*.dmg
             build/*.md5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       # See: https://github.com/actions/checkout
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -53,9 +53,10 @@ jobs:
         run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
         shell: bash
 
-      # Set env vars needed for vcpkg to leverage the GitHub Action cache as a storage
+      # Set env vars needed for vcpkg to leverage the GitHub Actions cache as a storage
       # for Binary Caching.
-      - uses: actions/github-script@v6
+      - name: Set vcpkg environment variables
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -144,7 +145,7 @@ jobs:
 
       # win64
       - name: Upload win64 artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'windows-2019' && matrix.tb-arch == 'x64' }}
         with:
           name: win64
@@ -154,7 +155,7 @@ jobs:
 
       # win32
       - name: Upload win32 artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'windows-2019' && matrix.tb-arch == 'Win32' }}
         with:
           name: win32
@@ -164,7 +165,7 @@ jobs:
 
       # Linux
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         with:
           name: linux
@@ -174,7 +175,7 @@ jobs:
 
       # macOS
       - name: Upload macOS artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'macos-12' && matrix.tb-build-type != 'asan' }}
         with:
           name: macos

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,7 +13,8 @@ jobs:
           - 'lib/kdl'
           - 'lib/vecmath'
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:

--- a/.github/workflows/clean-commit.yml
+++ b/.github/workflows/clean-commit.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clean commit step
-        uses: TrenchBroom/clean-commit-action@v0.7.0
+        uses: TrenchBroom/clean-commit-action@v0.8.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clean-commit.yml
+++ b/.github/workflows/clean-commit.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clean commit step
-        uses: TrenchBroom/clean-commit-action@v0.8.1
+        uses: TrenchBroom/clean-commit-action@v0.8.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clean-commit.yml
+++ b/.github/workflows/clean-commit.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clean commit step
-        uses: TrenchBroom/clean-commit-action@v0.8.0
+        uses: TrenchBroom/clean-commit-action@v0.8.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -35,7 +35,6 @@ else
     echo "Skipping common-benmchark because this is a debug build"
 fi
 
-
 cd "$BUILD_DIR"
 
 cpack || exit 1


### PR DESCRIPTION
This PR aims to eliminate these warning messages in GitHub Actions as the entire infrastructure is migrating to Node 20:

![image](https://github.com/TrenchBroom/TrenchBroom/assets/14064112/4b4136d4-a7f0-46cd-8caa-cef16452a009)

The external actions must be upgraded to their newest available version.

**Reference**: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
