### PR TITLE
4452: Always enable used texture collections and show paths instead of names

### DIFF
--- a/common/src/Assets/TextureCollection.cpp
+++ b/common/src/Assets/TextureCollection.cpp
@@ -73,11 +73,6 @@ const std::filesystem::path& TextureCollection::path() const
   return m_path;
 }
 
-std::string TextureCollection::name() const
-{
-  return !m_path.empty() ? m_path.filename().string() : "";
-}
-
 size_t TextureCollection::textureCount() const
 {
   return m_textures.size();

--- a/common/src/Assets/TextureCollection.h
+++ b/common/src/Assets/TextureCollection.h
@@ -62,7 +62,6 @@ public:
 
   bool loaded() const;
   const std::filesystem::path& path() const;
-  std::string name() const;
   size_t textureCount() const;
 
   const std::vector<Texture>& textures() const;

--- a/common/src/View/FaceInspector.h
+++ b/common/src/View/FaceInspector.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "NotifierConnection.h"
 #include "View/TabBook.h"
 
 #include <memory>
@@ -49,6 +50,9 @@ private:
   QSplitter* m_splitter{nullptr};
   FaceAttribsEditor* m_faceAttribsEditor{nullptr};
   TextureBrowser* m_textureBrowser{nullptr};
+  QWidget* m_textureBrowserInfo{nullptr};
+
+  NotifierConnection m_notifierConnection;
 
 public:
   FaceInspector(
@@ -61,17 +65,15 @@ public:
   void revealTexture(const Assets::Texture* texture);
 
 private:
-  void createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
-  QWidget* createFaceAttribsEditor(
-    QWidget* parent,
-    std::weak_ptr<MapDocument> document,
-    GLContextManager& contextManager);
-  QWidget* createTextureBrowser(
-    QWidget* parent,
-    std::weak_ptr<MapDocument> document,
-    GLContextManager& contextManager);
+  void createGui(GLContextManager& contextManager);
+  QWidget* createFaceAttribsEditor(GLContextManager& contextManager);
+  QWidget* createTextureBrowser(GLContextManager& contextManager);
+  QWidget* createTextureBrowserInfo();
 
   void textureSelected(const Assets::Texture* texture);
+
+  void connectObservers();
+  void documentWasNewedOrOpened(MapDocument* document);
 };
 } // namespace View
 } // namespace TrenchBroom

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -164,7 +164,7 @@ void TextureBrowserView::doReloadLayout(Layout& layout)
   {
     for (const auto* collection : getCollections())
     {
-      layout.addGroup(collection->name(), float(fontSize) + 2.0f);
+      layout.addGroup(collection->path().u8string(), float(fontSize) + 2.0f);
       addTexturesToLayout(layout, getTextures(*collection), font);
     }
   }

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -214,8 +214,7 @@ std::vector<const Assets::TextureCollection*> TextureBrowserView::getCollections
   auto result = std::vector<const Assets::TextureCollection*>{};
   for (const auto& collection : document->textureManager().collections())
   {
-    if (kdl::vec_contains(
-          enabledTextureCollections, std::filesystem::path{collection.name()}))
+    if (kdl::vec_contains(enabledTextureCollections, collection.path()))
     {
       result.push_back(&collection);
     }


### PR DESCRIPTION
Closes #4452 and #4491.

https://github.com/TrenchBroom/TrenchBroom/pull/4485 used the names of texture collections for filtering them, but the names are not unique. In this PR, we switch to using paths, which are unique.

Furthermore, we enable some texture collections by default. If the map has a `wad` property, then all texture collections are enabled by default. Otherwise, we enable only those texture collections that contain used textures by default.