### PR TITLE
Function to select similar entities by classname

### DIFF
--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -95,6 +95,7 @@ public: // selection
 
   virtual void selectAllNodes() = 0;
   virtual void selectSiblings() = 0;
+  virtual void selectEntitiesWithSameClassname() = 0;
   virtual void selectTouching(bool del) = 0;
   virtual void selectInside(bool del) = 0;
   virtual void selectInverse() = 0;

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -1286,6 +1286,17 @@ void ActionManager::createEditMenu()
       return context.hasDocument() && context.frame()->canSelectSiblings();
     }));
   editMenu.addItem(createMenuAction(
+    std::filesystem::path{"Menu/Edit/Select With Same Classname"},
+    QObject::tr("Select With Same Classname"),
+    0,
+    [](ActionExecutionContext& context) {
+      context.frame()->selectEntitiesWithSameClassname();
+    },
+    [](ActionExecutionContext& context) {
+      return context.hasDocument()
+             && context.frame()->canSelectEntitiesWithSameClassname();
+    }));
+  editMenu.addItem(createMenuAction(
     std::filesystem::path{"Menu/Edit/Select Touching"},
     QObject::tr("Select Touching"),
     +Qt::CTRL + Qt::Key_T,

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -395,6 +395,7 @@ public: // selection
 
   void selectAllNodes() override;
   void selectSiblings() override;
+  void selectEntitiesWithSameClassname() override;
   void selectTouching(bool del) override;
   void selectInside(bool del) override;
   void selectInverse() override;

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -256,6 +256,7 @@ public:
 
   void selectAll();
   void selectSiblings();
+  void selectEntitiesWithSameClassname();
   void selectTouching();
   void selectInside();
   void selectTall();
@@ -265,6 +266,7 @@ public:
 
   bool canSelect() const;
   bool canSelectSiblings() const;
+  bool canSelectEntitiesWithSameClassname() const;
   bool canSelectByBrush() const;
   bool canSelectTall() const;
   bool canDeselect() const;


### PR DESCRIPTION
In my fork I was needing a function to select other entities like the current selection according to their classname, so wrote a new command to do this and thought it might be useful for upstream.

The comand `Edit > Select With Same Classname` takes the current selection, records the classnames of any point or brush entities in the selection, and then sets the selection to all point or brush entities (within the current selectable context) whose classnames match any of those that were previously selected. For example, if you had a `func_wall` brush and a `light` entity selected and then executed this function, all `func_wall` and `light` entities in that map that are allowed to be selected would become selected.

World brushes are excluded from this command. Although they are entities (part of `worldspawn`) as far as the editor is concerned, it doesn't really make sense from a user point of view to be able to select them in this way, because they are generally considered structural rather than real in-game entities with specific classnames. If any world brushes are already selected when this command is invoked, they are deselected as part of the command; I wasn't sure whether to leave them in or out of the resulting selection, but given the above I think leaving them out makes more sense.

I haven't assigned a keyboard shortcut for this command because it's quite specialist, and I don't think many people would use it regularly enough to justify taking up a key combination that would be better used for something else.

I've also included a simple test to verify the expected functionality, but for some reason a different test was crashing when I tried to run the test suite, so I wasn't able to properly verify that it all works.

I tried to base the implementation off the style of surrounding code, but if there's a better way to do any of it, do let me know.