### PR TITLE
4528: Fix python install on macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
           brew unlink python@3.12
           brew uninstall --force azure-cli
           brew uninstall --force aws-sam-cli
+          brew uninstall --force cfn-lint
+          brew uninstall --force cookiecutter
           brew uninstall --force pipx
           brew uninstall --force python@3.11
           brew uninstall --force python@3.12


### PR DESCRIPTION
This reverts commit db71fb6ebe1850983ae65c6c603fe2eb613e9934.

Apparently this issue is now fixed or different in a new runner image that is being deployed.