### PR TITLE
4519: Mount wads directly under /textures

### DIFF
--- a/app/resources/shader/TextureBrowser.fragsh
+++ b/app/resources/shader/TextureBrowser.fragsh
@@ -23,7 +23,6 @@ uniform float Brightness;
 uniform sampler2D Texture;
 uniform bool ApplyTinting;
 uniform vec4 TintColor;
-uniform bool GrayScale;
 
 void main() {
     gl_FragColor = texture2D(Texture, gl_TexCoord[0].st);
@@ -31,11 +30,6 @@ void main() {
     gl_FragColor = vec4(vec3(Brightness / 2.0 * gl_FragColor), gl_FragColor.a);
     gl_FragColor = clamp(2.0 * gl_FragColor, 0.0, 1.0);
 
-    if (GrayScale) {
-        float gray = dot(gl_FragColor.rgb, vec3(0.299, 0.587, 0.114));
-        gl_FragColor = vec4(gray, gray, gray, gl_FragColor.a);
-    }
-    
     if (ApplyTinting) {
         gl_FragColor = vec4(gl_FragColor.rgb * TintColor.rgb * TintColor.a, gl_FragColor.a);
         gl_FragColor = clamp(2.0 * gl_FragColor, 0.0, 1.0);

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -123,7 +123,6 @@ Texture::Texture(
   , m_height{height}
   , m_averageColor{averageColor}
   , m_usageCount{0u}
-  , m_overridden{false}
   , m_format{format}
   , m_type{type}
   , m_culling{TextureCulling::Default}
@@ -151,7 +150,6 @@ Texture::Texture(
   , m_height{height}
   , m_averageColor{averageColor}
   , m_usageCount{0u}
-  , m_overridden{false}
   , m_format{format}
   , m_type{type}
   , m_culling{TextureCulling::Default}
@@ -192,7 +190,6 @@ Texture::Texture(
   , m_height{height}
   , m_averageColor(Color(0.0f, 0.0f, 0.0f, 1.0f))
   , m_usageCount{0u}
-  , m_overridden{false}
   , m_format{format}
   , m_type{type}
   , m_culling{TextureCulling::Default}
@@ -212,7 +209,6 @@ Texture::Texture(Texture&& other)
   , m_height{std::move(other.m_height)}
   , m_averageColor{std::move(other.m_averageColor)}
   , m_usageCount{static_cast<size_t>(other.m_usageCount)}
-  , m_overridden{std::move(other.m_overridden)}
   , m_format{std::move(other.m_format)}
   , m_type{std::move(other.m_type)}
   , m_surfaceParms{std::move(other.m_surfaceParms)}
@@ -233,7 +229,6 @@ Texture& Texture::operator=(Texture&& other)
   m_height = std::move(other.m_height);
   m_averageColor = std::move(other.m_averageColor);
   m_usageCount = static_cast<size_t>(other.m_usageCount);
-  m_overridden = std::move(other.m_overridden);
   m_format = std::move(other.m_format);
   m_type = std::move(other.m_type);
   m_surfaceParms = std::move(other.m_surfaceParms);
@@ -352,16 +347,6 @@ void Texture::decUsageCount()
   const size_t previous = m_usageCount--;
   assert(previous > 0);
   unused(previous);
-}
-
-bool Texture::overridden() const
-{
-  return m_overridden;
-}
-
-void Texture::setOverridden(const bool overridden)
-{
-  m_overridden = overridden;
 }
 
 bool Texture::isPrepared() const

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -115,7 +115,6 @@ private:
   Color m_averageColor;
 
   std::atomic<size_t> m_usageCount;
-  bool m_overridden;
 
   GLenum m_format;
   TextureType m_type;
@@ -145,7 +144,6 @@ private:
     m_height,
     m_averageColor,
     m_usageCount,
-    m_overridden,
     m_format,
     m_type,
     m_surfaceParms,
@@ -225,8 +223,6 @@ public:
   size_t usageCount() const;
   void incUsageCount();
   void decUsageCount();
-  bool overridden() const;
-  void setOverridden(bool overridden);
 
   bool isPrepared() const;
   void prepare(GLuint textureId, int minFilter, int magFilter);

--- a/common/src/Assets/TextureManager.cpp
+++ b/common/src/Assets/TextureManager.cpp
@@ -213,12 +213,10 @@ void TextureManager::updateTextures()
     for (auto& texture : collection.textures())
     {
       const auto key = kdl::str_to_lower(texture.name());
-      texture.setOverridden(false);
 
       auto mIt = m_texturesByName.find(key);
       if (mIt != m_texturesByName.end())
       {
-        mIt->second->setOverridden(true);
         mIt->second = &texture;
       }
       else

--- a/common/src/IO/LoadTextureCollection.cpp
+++ b/common/src/IO/LoadTextureCollection.cpp
@@ -89,10 +89,10 @@ Result<Assets::Texture, ReadTextureError> readTexture(
   const size_t prefixLength,
   const std::optional<Assets::Palette>& palette)
 {
+  auto name = getTextureNameFromPathSuffix(path, prefixLength);
   const auto extension = kdl::str_to_lower(path.extension().string());
   if (extension == ".d")
   {
-    auto name = path.stem().string();
     if (!palette)
     {
       return ReadTextureError{std::move(name), "Could not load texture: missing palette"};
@@ -102,42 +102,35 @@ Result<Assets::Texture, ReadTextureError> readTexture(
   }
   else if (extension == ".c")
   {
-    auto name = path.stem().string();
     auto reader = file.reader().buffer();
     return readHlMipTexture(std::move(name), reader);
   }
   else if (extension == ".wal")
   {
-    auto name = getTextureNameFromPathSuffix(path, prefixLength);
     auto reader = file.reader().buffer();
     return readWalTexture(std::move(name), reader, palette);
   }
   else if (extension == ".m8")
   {
-    auto name = getTextureNameFromPathSuffix(path, prefixLength);
     auto reader = file.reader().buffer();
     return readM8Texture(std::move(name), reader);
   }
   else if (extension == ".dds")
   {
-    auto name = getTextureNameFromPathSuffix(path, prefixLength);
     auto reader = file.reader().buffer();
     return readDdsTexture(std::move(name), reader);
   }
   else if (extension.empty())
   {
-    auto name = getTextureNameFromPathSuffix(path, prefixLength);
     auto reader = file.reader().buffer();
     return readQuake3ShaderTexture(std::move(name), file, gameFS);
   }
   else if (isSupportedFreeImageExtension(extension))
   {
-    auto name = getTextureNameFromPathSuffix(path, prefixLength);
     auto reader = file.reader().buffer();
     return readFreeImageTexture(std::move(name), reader);
   }
 
-  auto name = getTextureNameFromPathSuffix(path, prefixLength);
   return ReadTextureError{
     std::move(name), "Unknown texture file extension: " + path.extension().string()};
 }

--- a/common/src/Model/GameFileSystem.cpp
+++ b/common/src/Model/GameFileSystem.cpp
@@ -220,14 +220,13 @@ void GameFileSystem::mountWads(
 {
   for (const auto& wadPath : wadPaths)
   {
-    const auto mountPath = rootPath / wadPath.filename();
     const auto resolvedWadPath = IO::Disk::resolvePath(wadSearchPaths, wadPath);
     IO::Disk::openFile(resolvedWadPath)
       .and_then([](auto file) {
         return IO::createImageFileSystem<IO::WadFileSystem>(std::move(file));
       })
       .transform(
-        [&](auto fs) { m_wadMountPoints.push_back(mount(mountPath, std::move(fs))); })
+        [&](auto fs) { m_wadMountPoints.push_back(mount(rootPath, std::move(fs))); })
       .transform_error([&](auto e) {
         logger.error() << "Could not load wad file at '" << wadPath << "': " << e.msg;
       });

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -237,10 +237,7 @@ std::vector<const Assets::Texture*> TextureBrowserView::getTextures() const
   {
     for (const auto& texture : collection->textures())
     {
-      if (!texture.overridden())
-      {
-        textures.push_back(&texture);
-      }
+      textures.push_back(&texture);
     }
   }
   return sortTextures(filterTextures(textures));
@@ -404,7 +401,6 @@ void TextureBrowserView::renderTextures(Layout& layout, const float y, const flo
               TextureVertex{{bounds.right(), height - (bounds.top() - y)}, {1, 0}},
             });
 
-            shader.set("GrayScale", texture.overridden());
             texture.activate();
 
             vertexArray.prepare(vboManager());
@@ -423,16 +419,13 @@ void TextureBrowserView::doLeftClick(Layout& layout, const float x, const float 
   if (const auto* cell = layout.cellAt(x, y))
   {
     const auto& texture = cellData(*cell);
-    if (!texture.overridden())
-    {
-      // NOTE: wx had the ability for the textureSelected event to veto the selection, but
-      // it wasn't used.
-      setSelectedTexture(&texture);
+    // NOTE: wx had the ability for the textureSelected event to veto the selection, but
+    // it wasn't used.
+    setSelectedTexture(&texture);
 
-      emit textureSelected(&texture);
+    emit textureSelected(&texture);
 
-      update();
-    }
+    update();
   }
 }
 
@@ -451,16 +444,12 @@ void TextureBrowserView::doContextMenu(
   if (const auto* cell = layout.cellAt(x, y))
   {
     const auto& texture = cellData(*cell);
-    if (!cellData(*cell).overridden())
-    {
-
-      auto menu = QMenu{this};
-      menu.addAction(tr("Select Faces"), this, [&, texture = &texture]() {
-        auto doc = kdl::mem_lock(m_document);
-        doc->selectFacesWithTexture(texture);
-      });
-      menu.exec(event->globalPos());
-    }
+    auto menu = QMenu{this};
+    menu.addAction(tr("Select Faces"), this, [&, texture = &texture]() {
+      auto doc = kdl::mem_lock(m_document);
+      doc->selectFacesWithTexture(texture);
+    });
+    menu.exec(event->globalPos());
   }
 }
 

--- a/common/test/src/IO/tst_LoadTextureCollection.cpp
+++ b/common/test/src/IO/tst_LoadTextureCollection.cpp
@@ -90,7 +90,7 @@ TEST_CASE("loadTextureCollection")
 
   const auto wadPath =
     std::filesystem::current_path() / "fixture/test/IO/Wad/cr8_czg.wad";
-  fs.mount("textures" / wadPath.filename(), openFS<WadFileSystem>(wadPath));
+  fs.mount("textures", openFS<WadFileSystem>(wadPath));
 
   auto logger = NullLogger{};
 
@@ -105,8 +105,7 @@ TEST_CASE("loadTextureCollection")
       {},
     };
 
-    CHECK(loadTextureCollection("textures/missing.wad", fs, textureConfig, logger)
-            .is_error());
+    CHECK(loadTextureCollection("some_other_path", fs, textureConfig, logger).is_error());
   }
 
   SECTION("missing palette")
@@ -121,9 +120,9 @@ TEST_CASE("loadTextureCollection")
     };
 
     CHECK(
-      makeInfo(loadTextureCollection("textures/cr8_czg.wad", fs, textureConfig, logger))
+      makeInfo(loadTextureCollection("textures", fs, textureConfig, logger))
       == TextureCollectionInfo{
-        "textures/cr8_czg.wad",
+        "textures",
         {
           {"cr8_czg_1", 32, 32},       {"cr8_czg_2", 32, 32},
           {"cr8_czg_3", 32, 32},       {"cr8_czg_4", 32, 32},
@@ -152,9 +151,9 @@ TEST_CASE("loadTextureCollection")
     };
 
     CHECK(
-      makeInfo(loadTextureCollection("textures/cr8_czg.wad", fs, textureConfig, logger))
+      makeInfo(loadTextureCollection("textures", fs, textureConfig, logger))
       == TextureCollectionInfo{
-        "textures/cr8_czg.wad",
+        "textures",
         {
           {"cr8_czg_1", 64, 64},
           {"cr8_czg_2", 64, 64},
@@ -193,9 +192,9 @@ TEST_CASE("loadTextureCollection")
     };
 
     CHECK(
-      makeInfo(loadTextureCollection("textures/cr8_czg.wad", fs, textureConfig, logger))
+      makeInfo(loadTextureCollection("textures", fs, textureConfig, logger))
       == TextureCollectionInfo{
-        "textures/cr8_czg.wad",
+        "textures",
         {
           {"cr8_czg_1", 64, 64},
           {"cr8_czg_2", 64, 64},

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -232,8 +232,7 @@ void TestGame::doReloadWads(
   for (const auto& wadPath : wadPaths)
   {
     const auto absoluteWadPath = std::filesystem::current_path() / wadPath;
-    m_fs->mount(
-      "textures" / wadPath.filename(), IO::openFS<IO::WadFileSystem>(absoluteWadPath));
+    m_fs->mount("textures", IO::openFS<IO::WadFileSystem>(absoluteWadPath));
   }
 }
 


### PR DESCRIPTION
Wad files used to be mounted under textures/<wadname>. This was useful
because it allows to filter the wad files in the texture browser
settings, and it also allowed us to show overridden textures in the
browser. At the same time, it complicates handling of texture names
because the texture names cannot be extracted from the file paths in a
uniform matter across different games.

We change this to simplify texture loading, in preparation for the new
material system.