### PR TITLE
Fix uniform name mixups.

### DIFF
--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -526,7 +526,7 @@ void CellView::renderTitleStrings(float y, float height)
 
   auto shader =
     Renderer::ActiveShader{shaderManager(), Renderer::Shaders::ColoredTextShader};
-  shader.set("Material", 0);
+  shader.set("Texture", 0);
 
   for (auto& [descriptor, vertexArray] : stringRenderers)
   {

--- a/common/src/View/MaterialBrowserView.cpp
+++ b/common/src/View/MaterialBrowserView.cpp
@@ -374,7 +374,7 @@ void MaterialBrowserView::renderMaterials(
   auto shader =
     Renderer::ActiveShader{shaderManager(), Renderer::Shaders::MaterialBrowserShader};
   shader.set("ApplyTinting", false);
-  shader.set("Texture", 0);
+  shader.set("Material", 0);
   shader.set("Brightness", pref(Preferences::Brightness));
 
   for (const auto& group : layout.groups())


### PR DESCRIPTION
Would otherwise crash when going to entity browser, or material browser respectively.