### PR TITLE
4308: Store user config files in a suitable location

### DIFF
--- a/common/src/IO/DiskFileSystem.cpp
+++ b/common/src/IO/DiskFileSystem.cpp
@@ -121,4 +121,11 @@ Result<void> WritableDiskFileSystem::doMoveFile(
   return makeAbsolute(sourcePath).join(makeAbsolute(destPath))
          | kdl::and_then(Disk::moveFile);
 }
+
+Result<void> WritableDiskFileSystem::doRenameDirectory(
+  const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
+{
+  return makeAbsolute(sourcePath).join(makeAbsolute(destPath))
+         | kdl::and_then(Disk::renameDirectory);
+}
 } // namespace TrenchBroom::IO

--- a/common/src/IO/DiskFileSystem.h
+++ b/common/src/IO/DiskFileSystem.h
@@ -73,6 +73,9 @@ private:
   Result<void> doMoveFile(
     const std::filesystem::path& sourcePath,
     const std::filesystem::path& destPath) override;
+  Result<void> doRenameDirectory(
+    const std::filesystem::path& sourcePath,
+    const std::filesystem::path& destPath) override;
 };
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/common/src/IO/DiskIO.cpp
+++ b/common/src/IO/DiskIO.cpp
@@ -251,6 +251,36 @@ Result<void> moveFile(
   return kdl::void_success;
 }
 
+Result<void> renameDirectory(
+  const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
+{
+  const auto fixedSourcePath = fixPath(sourcePath);
+  if (pathInfo(fixedSourcePath) == PathInfo::File)
+  {
+    return Error{
+      "Failed to rename '" + fixedSourcePath.string() + "': path denotes a file"};
+  }
+
+  auto fixedDestPath = fixPath(destPath);
+  if (pathInfo(fixedDestPath) != PathInfo::Unknown)
+  {
+    return Error{
+      "Failed to rename '" + fixedSourcePath.string() + "' to '" + fixedDestPath.string()
+      + "': target path already exists"};
+  }
+
+  auto error = std::error_code{};
+  std::filesystem::rename(fixedSourcePath, fixedDestPath, error);
+  if (error)
+  {
+    return Error{
+      "Failed to rename '" + fixedSourcePath.string() + "' to '" + fixedDestPath.string()
+      + "': " + error.message()};
+  }
+
+  return kdl::void_success;
+}
+
 std::filesystem::path resolvePath(
   const std::vector<std::filesystem::path>& searchPaths,
   const std::filesystem::path& path)

--- a/common/src/IO/DiskIO.h
+++ b/common/src/IO/DiskIO.h
@@ -132,6 +132,9 @@ Result<void> copyFile(
 Result<void> moveFile(
   const std::filesystem::path& sourcePath, const std::filesystem::path& destPath);
 
+Result<void> renameDirectory(
+  const std::filesystem::path& sourcePath, const std::filesystem::path& destPath);
+
 std::filesystem::path resolvePath(
   const std::vector<std::filesystem::path>& searchPaths,
   const std::filesystem::path& path);

--- a/common/src/IO/FileSystem.cpp
+++ b/common/src/IO/FileSystem.cpp
@@ -146,4 +146,19 @@ Result<void> WritableFileSystem::moveFile(
   }
   return doMoveFile(sourcePath, destPath);
 }
+
+Result<void> WritableFileSystem::renameDirectory(
+  const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
+{
+  if (sourcePath.is_absolute())
+  {
+    return Error{"'" + sourcePath.string() + "' is absolute"};
+  }
+  if (destPath.is_absolute())
+  {
+    return Error{"'" + destPath.string() + "' is absolute"};
+  }
+  return doRenameDirectory(sourcePath, destPath);
+}
+
 } // namespace TrenchBroom::IO

--- a/common/src/IO/FileSystem.h
+++ b/common/src/IO/FileSystem.h
@@ -89,6 +89,8 @@ public:
     const std::filesystem::path& sourcePath, const std::filesystem::path& destPath);
   Result<void> moveFile(
     const std::filesystem::path& sourcePath, const std::filesystem::path& destPath);
+  Result<void> renameDirectory(
+    const std::filesystem::path& sourcePath, const std::filesystem::path& destPath);
 
 private:
   virtual Result<void> doCreateFile(
@@ -98,6 +100,8 @@ private:
   virtual Result<void> doCopyFile(
     const std::filesystem::path& sourcePath, const std::filesystem::path& destPath) = 0;
   virtual Result<void> doMoveFile(
+    const std::filesystem::path& sourcePath, const std::filesystem::path& destPath) = 0;
+  virtual Result<void> doRenameDirectory(
     const std::filesystem::path& sourcePath, const std::filesystem::path& destPath) = 0;
 };
 

--- a/common/src/IO/VirtualFileSystem.cpp
+++ b/common/src/IO/VirtualFileSystem.cpp
@@ -355,4 +355,10 @@ Result<void> WritableVirtualFileSystem::doMoveFile(
   return m_writableFs.moveFile(sourcePath, destPath);
 }
 
+Result<void> WritableVirtualFileSystem::doRenameDirectory(
+  const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
+{
+  return m_writableFs.renameDirectory(sourcePath, destPath);
+}
+
 } // namespace TrenchBroom::IO

--- a/common/src/IO/VirtualFileSystem.h
+++ b/common/src/IO/VirtualFileSystem.h
@@ -104,6 +104,9 @@ private:
   Result<void> doMoveFile(
     const std::filesystem::path& sourcePath,
     const std::filesystem::path& destPath) override;
+  Result<void> doRenameDirectory(
+    const std::filesystem::path& sourcePath,
+    const std::filesystem::path& destPath) override;
 };
 
 } // namespace TrenchBroom::IO

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -95,6 +95,11 @@ kdl_reflect_impl(CompilationTool);
 
 kdl_reflect_impl(GameConfig);
 
+std::filesystem::path GameConfig::configFileFolder() const
+{
+  return path.parent_path().filename();
+}
+
 std::filesystem::path GameConfig::findInitialMap(const std::string& formatName) const
 {
   for (const auto& format : fileFormats)

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -168,6 +168,9 @@ struct GameConfig
     gameEngineConfigParseFailed,
     maxPropertyLength);
 
+  /** Returns a folder name to use for user configuration files. */
+  std::filesystem::path configFileFolder() const;
+
   std::filesystem::path findInitialMap(const std::string& formatName) const;
   std::filesystem::path findConfigFile(const std::filesystem::path& filePath) const;
 };

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -162,8 +162,9 @@ public:
 private:
   GameFactory();
   Result<void> initializeFileSystem(const GamePathConfig& gamePathConfig);
-  Result<std::vector<std::string>> loadGameConfigs();
-  Result<void> loadGameConfig(const std::filesystem::path& path);
+  Result<std::vector<std::string>> loadGameConfigs(const GamePathConfig& gamePathConfig);
+  Result<void> loadGameConfig(
+    const GamePathConfig& gamePathConfig, const std::filesystem::path& path);
   void loadCompilationConfig(GameConfig& gameConfig);
   void loadGameEngineConfig(GameConfig& gameConfig);
 

--- a/common/test/src/IO/tst_DiskFileSystem.cpp
+++ b/common/test/src/IO/tst_DiskFileSystem.cpp
@@ -363,6 +363,32 @@ TEST_CASE("WritableDiskFileSystemTest")
     CHECK(fs.pathInfo("dir1/test2.map") == PathInfo::File);
   }
 
+  SECTION("renameDirectory")
+  {
+    const auto env = makeTestEnvironment();
+    auto fs = WritableDiskFileSystem{env.dir()};
+
+#if defined _WIN32
+    CHECK(
+      fs.renameDirectory("c:\\hopefully_nothing_here", "dest")
+      == Result<void>{Error{"'c:\\hopefully_nothing_here' is absolute"}});
+    CHECK(
+      fs.renameDirectory("test", "C:\\dest")
+      == Result<void>{Error{"'C:\\dest' is absolute"}});
+#else
+    CHECK(
+      fs.renameDirectory("/hopefully_nothing_here", "dir1/newDir")
+      == Result<void>{Error{"'/hopefully_nothing_here' is absolute"}});
+    CHECK(
+      fs.renameDirectory("anotherDir", "/dir1/newDir")
+      == Result<void>{Error{"'/dir1/newDir' is absolute"}});
+#endif
+
+    CHECK(fs.renameDirectory("anotherDir", "dir1/newDir") == Result<void>{});
+    CHECK(fs.pathInfo("anotherDir") == PathInfo::Unknown);
+    CHECK(fs.pathInfo("dir1/newDir") == PathInfo::Directory);
+  }
+
   SECTION("copyFile")
   {
     const auto env = makeTestEnvironment();


### PR DESCRIPTION
Closes #4308.

The user config files were stored in a path derived from the game's display name as configured in the game config. This name could contain invalid characters which would crash TB when saving user config files.

This commit changes this behavior to store these files in a directory named after the directory that contains the game config - which must be a valid name. Existing config files are migrated automatically.

As a consequence, users switching between this version of TB and older versions might have to manually undo the migration to keep their user ocnfigurations intact.