### PR TITLE
969: Add trackpad mode preference, trackpad gesture support

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -136,7 +136,7 @@ Download Xcode from the App Store.
 Open a command prompt and execute this command to install required dependencies:
 
 ```bash
-brew install cmake qt pandoc python pkg-config
+brew install cmake qt@5 pandoc python pkg-config
 ```
 
 Finally, build the project:
@@ -144,7 +144,7 @@ Finally, build the project:
 ```bash
 mkdir build-xcode
 cd build-xcode
-cmake .. -GXcode -DCMAKE_PREFIX_PATH="$(brew --prefix qt)"
+cmake .. -GXcode -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
 open TrenchBroom.xcodeproj
 ```
 

--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -223,6 +223,7 @@ Preference<float> CameraPanSpeed("Controls/Camera/Pan speed", 0.5f);
 Preference<bool> CameraPanInvertH("Controls/Camera/Invert horizontal pan", false);
 Preference<bool> CameraPanInvertV("Controls/Camera/Invert vertical pan", false);
 Preference<bool> CameraMouseWheelInvert("Controls/Camera/Invert mouse wheel", false);
+Preference<bool> CameraTrackpadMode("Controls/Camera/Trackpad mode", false);
 Preference<float> CameraMoveSpeed("Controls/Camera/Move speed", 0.3f);
 Preference<bool> CameraEnableAltMove("Controls/Camera/Use alt to move", false);
 Preference<bool> CameraAltMoveInvert(
@@ -402,6 +403,7 @@ const std::vector<PreferenceBase*>& staticPreferences()
     &CameraPanInvertH,
     &CameraPanInvertV,
     &CameraMouseWheelInvert,
+    &CameraTrackpadMode,
     &CameraMoveSpeed,
     &CameraEnableAltMove,
     &CameraAltMoveInvert,

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -153,6 +153,7 @@ extern Preference<bool> CameraPanInvertH;
 extern Preference<bool> CameraPanInvertV;
 extern Preference<float> CameraMoveSpeed;
 extern Preference<bool> CameraMouseWheelInvert;
+extern Preference<bool> CameraTrackpadMode;
 extern Preference<bool> CameraEnableAltMove;
 extern Preference<bool> CameraAltMoveInvert;
 extern Preference<bool> CameraMoveInCursorDir;

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -90,10 +90,12 @@ void CameraTool2D::mouseScroll(const InputState& inputState)
   if (pref(Preferences::CameraTrackpadMode))
   {
     const auto factor = pref(Preferences::CameraMouseWheelInvert) ? -1.0f : 1.0f;
+    const auto shouldZoom = inputState.modifierKeysPressed(ModifierKeys::MKShift);
 
-    if (inputState.pinchAmount() != 0.0f)
+    if (inputState.pinchAmount() != 0.0f || shouldZoom)
     {
-      const auto zoomFactor = 1.0f + inputState.pinchAmount() * factor;
+      const auto zoomFactor =
+        1.0f + inputState.pinchAmount() * factor + inputState.scrollY() / 50.0f * factor;
       const auto mousePos = vm::vec2f{inputState.mouseX(), inputState.mouseY()};
 
       if (zoomFactor > 0.0f)

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -193,6 +193,12 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::WheelAxis& rhs)
   case MouseEvent::WheelAxis::Vertical:
     lhs << "Vertical";
     break;
+  case MouseEvent::WheelAxis::Pinch:
+    lhs << "Pinch";
+    break;
+  case MouseEvent::WheelAxis::Rotate:
+    lhs << "Rotate";
+    break;
   }
   return lhs;
 }
@@ -419,6 +425,34 @@ void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent)
       posX,
       posY,
       static_cast<float>(scrollDistance.y())));
+  }
+}
+
+void InputEventRecorder::recordEvent(const QNativeGestureEvent& qtEvent)
+{
+  const auto pos = qtEvent.pos();
+  const auto posX = static_cast<float>(pos.x());
+  const auto posY = static_cast<float>(pos.y());
+
+  if (qtEvent.gestureType() == Qt::NativeGestureType::ZoomNativeGesture)
+  {
+    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
+      MouseEvent::Type::Scroll,
+      MouseEvent::Button::None,
+      MouseEvent::WheelAxis::Pinch,
+      posX,
+      posY,
+      static_cast<float>(qtEvent.value())));
+  }
+  else if (qtEvent.gestureType() == Qt::NativeGestureType::RotateNativeGesture)
+  {
+    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
+      MouseEvent::Type::Scroll,
+      MouseEvent::Button::None,
+      MouseEvent::WheelAxis::Rotate,
+      posX,
+      posY,
+      static_cast<float>(qtEvent.value())));
   }
 }
 

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <QKeyEvent>
+#include <QNativeGestureEvent>
 
 #include "kdl/reflection_decl.h"
 
@@ -180,7 +181,9 @@ public:
   {
     None,
     Vertical,
-    Horizontal
+    Horizontal,
+    Pinch,
+    Rotate
   };
 
 public:
@@ -361,6 +364,13 @@ public:
   static QPointF scrollLinesForEvent(const QWheelEvent& event);
 
   void recordEvent(const QWheelEvent& event);
+
+  /**
+   * Records the given native gesture event
+   *
+   * @param event the event to record
+   */
+  void recordEvent(const QNativeGestureEvent& event);
 
   /**
    * Processes all recorded events using the given event processor.

--- a/common/src/View/InputState.cpp
+++ b/common/src/View/InputState.cpp
@@ -41,6 +41,8 @@ InputState::InputState()
   , m_mouseDY(0.0f)
   , m_scrollX(0.0f)
   , m_scrollY(0.0f)
+  , m_pinchAmount(0.0f)
+  , m_rotateAmount(0.0f)
   , m_anyToolDragging(false)
 {
   const QPoint mouseState = QCursor::pos();
@@ -166,6 +168,16 @@ float InputState::scrollY() const
   return m_scrollY;
 }
 
+float InputState::pinchAmount() const
+{
+  return m_pinchAmount;
+}
+
+float InputState::rotateAmount() const
+{
+  return m_rotateAmount;
+}
+
 void InputState::setModifierKeys(const ModifierKeyState keys)
 {
   m_modifierKeys = keys;
@@ -204,6 +216,16 @@ void InputState::scroll(const float scrollX, const float scrollY)
 {
   m_scrollX = scrollX;
   m_scrollY = scrollY;
+}
+
+void InputState::pinch(const float pinchAmount)
+{
+  m_pinchAmount = pinchAmount;
+}
+
+void InputState::rotate(const float rotateAmount)
+{
+  m_rotateAmount = rotateAmount;
 }
 
 bool InputState::anyToolDragging() const

--- a/common/src/View/InputState.h
+++ b/common/src/View/InputState.h
@@ -70,6 +70,8 @@ private:
   float m_mouseDY;
   float m_scrollX;
   float m_scrollY;
+  float m_pinchAmount;
+  float m_rotateAmount;
 
   bool m_anyToolDragging;
   PickRequest m_pickRequest;
@@ -111,6 +113,14 @@ public:
    * Number of "lines" to scroll vertically.
    */
   float scrollY() const;
+  /**
+   * Pinch gesture change amount.
+   */
+  float pinchAmount() const;
+  /**
+   * Rotate gesture change amount. (In degrees)
+   */
+  float rotateAmount() const;
 
   void setModifierKeys(const ModifierKeyState keys);
   void clearModifierKeys();
@@ -120,6 +130,8 @@ public:
   void mouseMove(
     const float mouseX, const float mouseY, const float mouseDX, const float mouseDY);
   void scroll(const float scrollX, const float scrollY);
+  void pinch(const float pinchAmount);
+  void rotate(const float rotateAmount);
 
   bool anyToolDragging() const;
   void setAnyToolDragging(bool anyToolDragging);

--- a/common/src/View/MousePreferencePane.cpp
+++ b/common/src/View/MousePreferencePane.cpp
@@ -60,6 +60,7 @@ void MousePreferencePane::createGui()
   m_moveSpeedSlider = new SliderWithLabel{1, 100};
   m_moveSpeedSlider->setMaximumWidth(400);
   m_invertMouseWheelCheckBox = new QCheckBox{"Invert mouse wheel"};
+  m_trackpadModeCheckBox = new QCheckBox{"Optimize for trackpad input"};
   m_enableAltMoveCheckBox = new QCheckBox{"Alt + middle mouse drag to move camera"};
   m_invertAltMoveAxisCheckBox = new QCheckBox{"Invert Z axis in Alt + middle mouse drag"};
   m_moveInCursorDirCheckBox = new QCheckBox{"Move camera towards cursor"};
@@ -119,6 +120,7 @@ void MousePreferencePane::createGui()
   layout->addSection("Mouse Move");
   layout->addRow("Sensitivity", m_moveSpeedSlider);
   layout->addRow("", m_invertMouseWheelCheckBox);
+  layout->addRow("", m_trackpadModeCheckBox);
   layout->addRow("", m_enableAltMoveCheckBox);
   layout->addRow("", m_invertAltMoveAxisCheckBox);
   layout->addRow("", m_moveInCursorDirCheckBox);
@@ -195,6 +197,11 @@ void MousePreferencePane::bindEvents()
     this,
     &MousePreferencePane::invertMouseWheelChanged);
   connect(
+    m_trackpadModeCheckBox,
+    &QCheckBox::stateChanged,
+    this,
+    &MousePreferencePane::trackpadModeChanged);
+  connect(
     m_enableAltMoveCheckBox,
     &QCheckBox::stateChanged,
     this,
@@ -266,6 +273,7 @@ void MousePreferencePane::doResetToDefaults()
 
   prefs.resetToDefault(Preferences::CameraMoveSpeed);
   prefs.resetToDefault(Preferences::CameraMouseWheelInvert);
+  prefs.resetToDefault(Preferences::CameraTrackpadMode);
   prefs.resetToDefault(Preferences::CameraEnableAltMove);
   prefs.resetToDefault(Preferences::CameraAltMoveInvert);
   prefs.resetToDefault(Preferences::CameraMoveInCursorDir);
@@ -292,6 +300,7 @@ void MousePreferencePane::doUpdateControls()
 
   m_moveSpeedSlider->setRatio(pref(Preferences::CameraMoveSpeed));
   m_invertMouseWheelCheckBox->setChecked(pref(Preferences::CameraMouseWheelInvert));
+  m_trackpadModeCheckBox->setChecked(pref(Preferences::CameraTrackpadMode));
   m_enableAltMoveCheckBox->setChecked(pref(Preferences::CameraEnableAltMove));
   m_invertAltMoveAxisCheckBox->setChecked(pref(Preferences::CameraAltMoveInvert));
   m_moveInCursorDirCheckBox->setChecked(pref(Preferences::CameraMoveInCursorDir));
@@ -368,6 +377,13 @@ void MousePreferencePane::invertMouseWheelChanged(const int state)
   const auto value = (state == Qt::Checked);
   auto& prefs = PreferenceManager::instance();
   prefs.set(Preferences::CameraMouseWheelInvert, value);
+}
+
+void MousePreferencePane::trackpadModeChanged(const int state)
+{
+  const auto value = (state == Qt::Checked);
+  auto& prefs = PreferenceManager::instance();
+  prefs.set(Preferences::CameraTrackpadMode, value);
 }
 
 void MousePreferencePane::enableAltMoveChanged(const int state)

--- a/common/src/View/MousePreferencePane.h
+++ b/common/src/View/MousePreferencePane.h
@@ -47,6 +47,7 @@ private:
   QCheckBox* m_invertPanVAxisCheckBox = nullptr;
   SliderWithLabel* m_moveSpeedSlider = nullptr;
   QCheckBox* m_invertMouseWheelCheckBox = nullptr;
+  QCheckBox* m_trackpadModeCheckBox = nullptr;
   QCheckBox* m_enableAltMoveCheckBox = nullptr;
   QCheckBox* m_invertAltMoveAxisCheckBox = nullptr;
   QCheckBox* m_moveInCursorDirCheckBox = nullptr;
@@ -89,6 +90,7 @@ private slots:
 
   void moveSpeedChanged(int value);
   void invertMouseWheelChanged(int state);
+  void trackpadModeChanged(int state);
   void enableAltMoveChanged(int state);
   void invertAltMoveAxisChanged(int state);
   void moveInCursorDirChanged(int state);

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -185,6 +185,22 @@ void RenderView::wheelEvent(QWheelEvent* event)
   update();
 }
 
+bool RenderView::event(QEvent* event)
+{
+  // Unfortunately, QWidget doesn't define a specialized handler for QNativeGestureEvent,
+  // so we must override the main event handler to handle it.
+  if (event->type() == QEvent::NativeGesture)
+  {
+    const auto gestureEvent = static_cast<QNativeGestureEvent*>(event);
+    m_eventRecorder.recordEvent(*gestureEvent);
+    update();
+    return true;
+  }
+
+  // Let the base class handle all other events normally
+  return QOpenGLWidget::event(event);
+}
+
 void RenderView::paintGL()
 {
   if (TrenchBroom::View::isReportingCrash())

--- a/common/src/View/RenderView.h
+++ b/common/src/View/RenderView.h
@@ -80,6 +80,7 @@ protected: // QWindow overrides
   void mousePressEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;
+  bool event(QEvent* event) override;
 
 protected:
   Renderer::VboManager& vboManager();

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -315,10 +315,26 @@ void ToolBoxConnector::processScroll(const MouseEvent& event)
   if (event.wheelAxis == MouseEvent::WheelAxis::Horizontal)
   {
     m_inputState.scroll(event.scrollDistance, 0.0f);
+    m_inputState.pinch(0.0f);
+    m_inputState.rotate(0.0f);
   }
   else if (event.wheelAxis == MouseEvent::WheelAxis::Vertical)
   {
     m_inputState.scroll(0.0f, event.scrollDistance);
+    m_inputState.pinch(0.0f);
+    m_inputState.rotate(0.0f);
+  }
+  else if (event.wheelAxis == MouseEvent::WheelAxis::Pinch)
+  {
+    m_inputState.scroll(0.0f, 0.0f);
+    m_inputState.pinch(event.scrollDistance);
+    m_inputState.rotate(0.0f);
+  }
+  else if (event.wheelAxis == MouseEvent::WheelAxis::Rotate)
+  {
+    m_inputState.scroll(0.0f, 0.0f);
+    m_inputState.pinch(0.0f);
+    m_inputState.rotate(event.scrollDistance);
   }
   m_toolBox->mouseScroll(m_toolChain, m_inputState);
 

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -84,10 +84,12 @@ void UVCameraTool::mouseScroll(const InputState& inputState)
   if (pref(Preferences::CameraTrackpadMode))
   {
     const auto factor = pref(Preferences::CameraMouseWheelInvert) ? -1.0f : 1.0f;
+    const auto shouldZoom = inputState.modifierKeysPressed(ModifierKeys::MKShift);
 
-    if (inputState.pinchAmount() != 0.0f)
+    if (inputState.pinchAmount() != 0.0f || shouldZoom)
     {
-      const auto zoomFactor = 1.0f + inputState.pinchAmount() * factor;
+      const auto zoomFactor =
+        1.0f + inputState.pinchAmount() * factor + inputState.scrollY() / 50.0f * factor;
 
       if (zoomFactor > 0.0f)
       {

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -29,6 +29,19 @@ namespace TrenchBroom
 {
 namespace View
 {
+
+static void zoom(
+  Renderer::OrthographicCamera& camera, const vm::vec2f& mousePos, const float factor)
+{
+  const auto oldWorldPos = camera.unproject(mousePos.x(), mousePos.y(), 0.0f);
+
+  camera.zoom(factor);
+
+  const auto newWorldPos = camera.unproject(mousePos.x(), mousePos.y(), 0.0f);
+  const auto delta = newWorldPos - oldWorldPos;
+  camera.moveBy(-delta);
+}
+
 UVCameraTool::UVCameraTool(Renderer::OrthographicCamera& camera)
   : ToolController{}
   , Tool{true}
@@ -48,8 +61,7 @@ const Tool& UVCameraTool::tool() const
 
 void UVCameraTool::mouseScroll(const InputState& inputState)
 {
-  const auto oldWorldPos =
-    m_camera.unproject(float(inputState.mouseX()), float(inputState.mouseY()), 0.0f);
+  const auto mousePos = vm::vec2f{inputState.mouseX(), inputState.mouseY()};
 
   // NOTE: some events will have scrollY() == 0, and have horizontal scorlling. We only
   // care about scrollY().
@@ -58,7 +70,7 @@ void UVCameraTool::mouseScroll(const InputState& inputState)
   {
     if (m_camera.zoom() < 10.0f)
     {
-      m_camera.zoom(1.1f);
+      zoom(m_camera, mousePos, 1.1f);
     }
   }
 
@@ -66,14 +78,9 @@ void UVCameraTool::mouseScroll(const InputState& inputState)
   {
     if (m_camera.zoom() > 0.1f)
     {
-      m_camera.zoom(1.0f / 1.1f);
+      zoom(m_camera, mousePos, 1.0f / 1.1f);
     }
   }
-
-  const auto newWorldPos =
-    m_camera.unproject(float(inputState.mouseX()), float(inputState.mouseY()), 0.0f);
-  const auto delta = oldWorldPos - newWorldPos;
-  m_camera.moveBy(delta);
 }
 
 namespace


### PR DESCRIPTION
Fixes #969, #2966.

👋 This PR aims to improve the usability of TrenchBroom for trackpad users:

- Introduces a new “Trackpad Mode” preference, for tailoring the input for trackpads (_particularly useful_ on macOS, but also a usability enhancement for Windows and Linux)
- Adds support for Pinch and Rotate gestures in the trackpad, by extending the existing support for scrolling:
  - Adds new `WheelAxis::Pinch` and `WheelAxis::Rotate` variants
  - Adds new `scrollZ()` and `scrollW()` axes on `InputState`
  - Based on [`QNativeGestureEvent`](https://doc.qt.io/qt-5/qnativegestureevent.html)(As of Qt 5, this is only fired on macOS, but Qt 6 also supports it under Wayland.)
- Adds special trackpad logic for the three camera tools (2D, 3D and UV)
  - Zoom level is honored
  - Inverse scroll direction preference is honored
  - Sensitivity preference is honored
- Fixes macOS build instructions by explicitly referencing Qt5 (6 is now the default in Homebrew)

## Control Scheme

### 3D Viewport

Input | Action
-|-
Two Finger Scroll (either direction) | Pan
Alt + Two Finger Scroll (either direction) | Orbit
Two Finger Pinch | Pan (backward/forward)
Shift + Two Finger Pinch | Zoom
Two Finger Rotate | Orbit
Shift + Two Finger Scroll (up/down) | Pan (backward/forward)

### 2D and UV Viewport

Input | Action
-|-
Two Finger Scroll (either direction) | Pan
Two Finger Pinch | Zoom
Shift + Two Finger Scroll (up/down) | Zoom

## Screenshot

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/c70e86db-1678-4f5e-a384-08446d0cf0e2">
