### PR TITLE
Add support for native gestures

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -322,7 +322,6 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/CurrentGroupCommand.cpp
         ${COMMON_SOURCE_DIR}/View/CyclingMapView.cpp
         ${COMMON_SOURCE_DIR}/View/DialogHeader.cpp
-        ${COMMON_SOURCE_DIR}/View/DragTracker.cpp
         ${COMMON_SOURCE_DIR}/View/DrawShapeTool.cpp
         ${COMMON_SOURCE_DIR}/View/DrawShapeToolController2D.cpp
         ${COMMON_SOURCE_DIR}/View/DrawShapeToolController3D.cpp
@@ -363,6 +362,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/GameEngineProfileManager.cpp
         ${COMMON_SOURCE_DIR}/View/GameListBox.cpp
         ${COMMON_SOURCE_DIR}/View/GamesPreferencePane.cpp
+        ${COMMON_SOURCE_DIR}/View/GestureTracker.cpp
         ${COMMON_SOURCE_DIR}/View/GetVersion.cpp
         ${COMMON_SOURCE_DIR}/View/GLContextManager.cpp
         ${COMMON_SOURCE_DIR}/View/Grid.cpp
@@ -857,7 +857,6 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/CurrentGroupCommand.h
         ${COMMON_SOURCE_DIR}/View/CyclingMapView.h
         ${COMMON_SOURCE_DIR}/View/DialogHeader.h
-        ${COMMON_SOURCE_DIR}/View/DragTracker.h
         ${COMMON_SOURCE_DIR}/View/DrawShapeTool.h
         ${COMMON_SOURCE_DIR}/View/DrawShapeToolController2D.h
         ${COMMON_SOURCE_DIR}/View/DrawShapeToolController3D.h
@@ -898,6 +897,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/GameEngineProfileManager.h
         ${COMMON_SOURCE_DIR}/View/GameListBox.h
         ${COMMON_SOURCE_DIR}/View/GamesPreferencePane.h
+        ${COMMON_SOURCE_DIR}/View/GestureTracker.h
         ${COMMON_SOURCE_DIR}/View/GetVersion.h
         ${COMMON_SOURCE_DIR}/View/GLContextManager.h
         ${COMMON_SOURCE_DIR}/View/Grid.h

--- a/common/src/View/AssembleBrushToolController3D.cpp
+++ b/common/src/View/AssembleBrushToolController3D.cpp
@@ -21,6 +21,7 @@
 
 #include "FloatType.h"
 #include "Model/BrushFace.h"
+#include "Model/BrushFaceHandle.h"
 #include "Model/BrushNode.h"
 #include "Model/Hit.h"
 #include "Model/HitAdapter.h"
@@ -36,7 +37,6 @@
 #include "View/Grid.h"
 #include "View/HandleDragTracker.h"
 #include "View/InputState.h"
-#include "View/MapDocument.h"
 
 #include "kdl/vector_utils.h"
 
@@ -160,7 +160,7 @@ private:
   {
     using namespace Model::HitFilters;
 
-    if (inputState.modifierKeysDown(ModifierKeys::MKShift))
+    if (inputState.modifierKeysDown(ModifierKeys::Shift))
     {
       return nullptr;
     }
@@ -255,7 +255,7 @@ private:
   {
     using namespace Model::HitFilters;
 
-    if (!inputState.modifierKeysDown(ModifierKeys::MKShift))
+    if (!inputState.modifierKeysDown(ModifierKeys::Shift))
     {
       return nullptr;
     }
@@ -305,8 +305,9 @@ const Tool& AssembleBrushToolController3D::tool() const
 bool AssembleBrushToolController3D::mouseClick(const InputState& inputState)
 {
   if (
-    !inputState.mouseButtonsDown(MouseButtons::MBLeft)
-    || !inputState.checkModifierKeys(MK_No, MK_No, MK_No))
+    !inputState.mouseButtonsDown(MouseButtons::Left)
+    || !inputState.checkModifierKeys(
+      ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::No))
   {
     return false;
   }
@@ -332,8 +333,9 @@ bool AssembleBrushToolController3D::mouseClick(const InputState& inputState)
 bool AssembleBrushToolController3D::mouseDoubleClick(const InputState& inputState)
 {
   if (
-    !inputState.mouseButtonsDown(MouseButtons::MBLeft)
-    || !inputState.checkModifierKeys(MK_No, MK_No, MK_No))
+    !inputState.mouseButtonsDown(MouseButtons::Left)
+    || !inputState.checkModifierKeys(
+      ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::No))
   {
     return false;
   }
@@ -356,8 +358,9 @@ bool AssembleBrushToolController3D::mouseDoubleClick(const InputState& inputStat
 bool AssembleBrushToolController3D::doShouldHandleMouseDrag(
   const InputState& inputState) const
 {
-  return inputState.mouseButtonsDown(MouseButtons::MBLeft)
-         && inputState.checkModifierKeys(MK_No, MK_No, MK_DontCare);
+  return inputState.mouseButtonsDown(MouseButtons::Left)
+         && inputState.checkModifierKeys(
+           ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::DontCare);
 }
 
 void AssembleBrushToolController3D::render(
@@ -386,7 +389,7 @@ void AssembleBrushToolController3D::render(
       renderService.renderHandle(vm::vec3f(vertex->position()));
     }
 
-    if (polyhedron.polygon() && inputState.modifierKeysDown(ModifierKeys::MKShift))
+    if (polyhedron.polygon() && inputState.modifierKeysDown(ModifierKeys::Shift))
     {
       if (polyhedron.pickFace(inputState.pickRay()))
       {

--- a/common/src/View/AssembleBrushToolController3D.cpp
+++ b/common/src/View/AssembleBrushToolController3D.cpp
@@ -97,7 +97,7 @@ public:
       makeIdentityHandleSnapper());
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override
@@ -212,7 +212,7 @@ public:
       makeRelativeLineHandleSnapper(m_tool.grid(), line));
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/AssembleBrushToolController3D.cpp
+++ b/common/src/View/AssembleBrushToolController3D.cpp
@@ -156,7 +156,7 @@ private:
   Tool& tool() override { return m_tool; }
   const Tool& tool() const override { return m_tool; }
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
   {
     using namespace Model::HitFilters;
 
@@ -251,7 +251,7 @@ private:
   Tool& tool() override { return m_tool; }
   const Tool& tool() const override { return m_tool; }
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
   {
     using namespace Model::HitFilters;
 

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -99,7 +99,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const auto currentMousePos = vm::vec2f{inputState.mouseX(), inputState.mouseY()};
     const auto lastWorldPos =
@@ -129,7 +129,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const auto speed = pref(Preferences::CameraAltMoveInvert) ? 1.0f : -1.0f;
     const auto factor = 1.0f + static_cast<float>(inputState.mouseDY()) / 100.0f * speed;

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -28,9 +28,7 @@
 #include "vm/forward.h"
 #include "vm/vec.h"
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 CameraTool2D::CameraTool2D(Renderer::OrthographicCamera& camera)
   : ToolController{}
@@ -52,8 +50,8 @@ const Tool& CameraTool2D::tool() const
 static bool shouldZoom(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBNone)
-    && inputState.modifierKeysPressed(ModifierKeys::MKNone));
+    inputState.mouseButtonsPressed(MouseButtons::None)
+    && inputState.modifierKeysPressed(ModifierKeys::None));
 }
 
 static void zoom(
@@ -147,15 +145,15 @@ public:
 static bool shouldPan(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBRight)
-    || (inputState.mouseButtonsPressed(MouseButtons::MBMiddle) && !pref(Preferences::CameraEnableAltMove)));
+    inputState.mouseButtonsPressed(MouseButtons::Right)
+    || (inputState.mouseButtonsPressed(MouseButtons::Middle) && !pref(Preferences::CameraEnableAltMove)));
 }
 
 static bool shouldDragZoom(const InputState& inputState)
 {
   return (
     pref(Preferences::CameraEnableAltMove)
-    && inputState.mouseButtonsPressed(MouseButtons::MBMiddle)
+    && inputState.mouseButtonsPressed(MouseButtons::Middle)
     && inputState.modifierKeysPressed(ModifierKeys::MKAlt));
 }
 
@@ -180,5 +178,4 @@ bool CameraTool2D::cancel()
 {
   return false;
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -22,7 +22,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/OrthographicCamera.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 
 #include "vm/forward.h"
@@ -86,7 +86,7 @@ void CameraTool2D::mouseScroll(const InputState& inputState)
 
 namespace
 {
-class PanDragTracker : public DragTracker
+class PanDragTracker : public GestureTracker
 {
 private:
   Renderer::OrthographicCamera& m_camera;
@@ -116,7 +116,7 @@ public:
   void cancel() override {}
 };
 
-class ZoomDragTracker : public DragTracker
+class ZoomDragTracker : public GestureTracker
 {
 private:
   Renderer::OrthographicCamera& m_camera;
@@ -157,7 +157,8 @@ static bool shouldDragZoom(const InputState& inputState)
     && inputState.modifierKeysPressed(ModifierKeys::MKAlt));
 }
 
-std::unique_ptr<DragTracker> CameraTool2D::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> CameraTool2D::acceptMouseDrag(
+  const InputState& inputState)
 {
   if (shouldPan(inputState))
   {

--- a/common/src/View/CameraTool2D.h
+++ b/common/src/View/CameraTool2D.h
@@ -23,16 +23,14 @@
 #include "View/ToolController.h"
 
 #include "vm/forward.h"
-#include "vm/vec.h"
+#include "vm/vec.h" // IWYU pragma: keep
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class OrthographicCamera;
 }
 
-namespace View
+namespace TrenchBroom::View
 {
 class DragTracker;
 
@@ -55,5 +53,5 @@ private:
 
   bool cancel() override;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/CameraTool2D.h
+++ b/common/src/View/CameraTool2D.h
@@ -32,7 +32,7 @@ class OrthographicCamera;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 
 class CameraTool2D : public ToolController, public Tool
 {
@@ -49,7 +49,7 @@ private:
 
   void mouseScroll(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -19,12 +19,9 @@
 
 #include "CameraTool3D.h"
 
-#include "Model/BrushNode.h"
-#include "Model/EntityNode.h"
 #include "Model/Hit.h"
 #include "Model/HitFilter.h"
 #include "Model/ModelUtils.h"
-#include "Model/PatchNode.h"
 #include "Model/PickResult.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
@@ -38,43 +35,43 @@
 #include "vm/scalar.h"
 #include "vm/vec.h"
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 static bool shouldMove(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBNone)
-    && inputState.checkModifierKeys(MK_No, MK_No, MK_DontCare));
+    inputState.mouseButtonsPressed(MouseButtons::None)
+    && inputState.checkModifierKeys(
+      ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::DontCare));
 }
 
 static bool shouldLook(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBRight)
-    && inputState.modifierKeysPressed(ModifierKeys::MKNone));
+    inputState.mouseButtonsPressed(MouseButtons::Right)
+    && inputState.modifierKeysPressed(ModifierKeys::None));
 }
 
 static bool shouldPan(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBMiddle)
-    && (inputState.modifierKeysPressed(ModifierKeys::MKNone) || inputState.modifierKeysPressed(ModifierKeys::MKAlt)));
+    inputState.mouseButtonsPressed(MouseButtons::Middle)
+    && (inputState.modifierKeysPressed(ModifierKeys::None) || inputState.modifierKeysPressed(ModifierKeys::MKAlt)));
 }
 
 static bool shouldOrbit(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBRight)
+    inputState.mouseButtonsPressed(MouseButtons::Right)
     && inputState.modifierKeysPressed(ModifierKeys::MKAlt));
 }
 
 static bool shouldAdjustFlySpeed(const InputState& inputState)
 {
   return (
-    inputState.mouseButtonsPressed(MouseButtons::MBRight)
-    && inputState.checkModifierKeys(MK_No, MK_No, MK_No));
+    inputState.mouseButtonsPressed(MouseButtons::Right)
+    && inputState.checkModifierKeys(
+      ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::No));
 }
 
 static float adjustSpeedToZoom(
@@ -153,11 +150,11 @@ const Tool& CameraTool3D::tool() const
 void CameraTool3D::mouseScroll(const InputState& inputState)
 {
   const float factor = pref(Preferences::CameraMouseWheelInvert) ? -1.0f : 1.0f;
-  const bool zoom = inputState.modifierKeysPressed(ModifierKeys::MKShift);
+  const bool zoom = inputState.modifierKeysPressed(ModifierKeys::Shift);
   const float scrollDist =
 #ifdef __APPLE__
-    inputState.modifierKeysPressed(ModifierKeys::MKShift) ? inputState.scrollX()
-                                                          : inputState.scrollY();
+    inputState.modifierKeysPressed(ModifierKeys::Shift) ? inputState.scrollX()
+                                                        : inputState.scrollY();
 #else
     inputState.scrollY();
 #endif
@@ -182,7 +179,7 @@ void CameraTool3D::mouseScroll(const InputState& inputState)
 
 void CameraTool3D::mouseUp(const InputState& inputState)
 {
-  if (inputState.mouseButtonsPressed(MouseButtons::MBRight))
+  if (inputState.mouseButtonsPressed(MouseButtons::Right))
   {
     auto& prefs = PreferenceManager::instance();
     if (!prefs.saveInstantly())
@@ -241,7 +238,7 @@ private:
   Renderer::PerspectiveCamera& m_camera;
 
 public:
-  LookDragTracker(Renderer::PerspectiveCamera& camera)
+  explicit LookDragTracker(Renderer::PerspectiveCamera& camera)
     : m_camera{camera}
   {
   }
@@ -285,7 +282,7 @@ private:
   Renderer::PerspectiveCamera& m_camera;
 
 public:
-  PanDragTracker(Renderer::PerspectiveCamera& camera)
+  explicit PanDragTracker(Renderer::PerspectiveCamera& camera)
     : m_camera{camera}
   {
   }
@@ -351,5 +348,4 @@ bool CameraTool3D::cancel()
 {
   return false;
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -220,7 +220,7 @@ public:
     }
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const float hAngle = static_cast<float>(inputState.mouseDX()) * lookSpeedH(m_camera);
     const float vAngle = static_cast<float>(inputState.mouseDY()) * lookSpeedV(m_camera);
@@ -264,7 +264,7 @@ public:
     }
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const float hAngle = static_cast<float>(inputState.mouseDX()) * lookSpeedH(m_camera);
     const float vAngle = static_cast<float>(inputState.mouseDY()) * lookSpeedV(m_camera);
@@ -287,7 +287,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const bool altMove = pref(Preferences::CameraEnableAltMove);
     auto delta = vm::vec3f{};

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -26,7 +26,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/PerspectiveCamera.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 
 #include "vm/forward.h"
@@ -191,7 +191,7 @@ void CameraTool3D::mouseUp(const InputState& inputState)
 
 namespace
 {
-class OrbitDragTracker : public DragTracker
+class OrbitDragTracker : public GestureTracker
 {
 private:
   Renderer::PerspectiveCamera& m_camera;
@@ -232,7 +232,7 @@ public:
   void cancel() override {}
 };
 
-class LookDragTracker : public DragTracker
+class LookDragTracker : public GestureTracker
 {
 private:
   Renderer::PerspectiveCamera& m_camera;
@@ -276,7 +276,7 @@ public:
   void cancel() override {}
 };
 
-class PanDragTracker : public DragTracker
+class PanDragTracker : public GestureTracker
 {
 private:
   Renderer::PerspectiveCamera& m_camera;
@@ -318,7 +318,8 @@ public:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> CameraTool3D::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> CameraTool3D::acceptMouseDrag(
+  const InputState& inputState)
 {
   using namespace Model::HitFilters;
 

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -22,19 +22,14 @@
 #include "View/Tool.h"
 #include "View/ToolController.h"
 
-#include "vm/forward.h"
-#include "vm/vec.h"
-
 #include <memory>
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class PerspectiveCamera;
 }
 
-namespace View
+namespace TrenchBroom::View
 {
 class DragTracker;
 
@@ -44,7 +39,7 @@ private:
   Renderer::PerspectiveCamera& m_camera;
 
 public:
-  CameraTool3D(Renderer::PerspectiveCamera& camera);
+  explicit CameraTool3D(Renderer::PerspectiveCamera& camera);
 
 private:
   Tool& tool() override;
@@ -57,5 +52,5 @@ private:
 
   bool cancel() override;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/CameraTool3D.h
+++ b/common/src/View/CameraTool3D.h
@@ -31,7 +31,7 @@ class PerspectiveCamera;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 
 class CameraTool3D : public ToolController, public Tool
 {
@@ -48,7 +48,7 @@ private:
   void mouseScroll(const InputState& inputState) override;
   void mouseUp(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -565,6 +565,7 @@ QString CellView::tooltip(const Cell&)
 
 void CellView::processEvent(const KeyEvent& /* event */) {}
 void CellView::processEvent(const MouseEvent& /* event */) {}
+void CellView::processEvent(const GestureEvent& /* event */) {}
 void CellView::processEvent(const CancelEvent& /* event */) {}
 
 } // namespace TrenchBroom::View

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -565,6 +565,7 @@ QString CellView::tooltip(const Cell&)
 
 void CellView::processEvent(const KeyEvent& /* event */) {}
 void CellView::processEvent(const MouseEvent& /* event */) {}
+void CellView::processEvent(const ScrollEvent& /* event */) {}
 void CellView::processEvent(const GestureEvent& /* event */) {}
 void CellView::processEvent(const CancelEvent& /* event */) {}
 

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -133,6 +133,7 @@ private:
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 };
 

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -133,6 +133,7 @@ private:
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const ScrollEvent& event) override;
   void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 };

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -333,7 +333,7 @@ public:
       inputState, initialHandlePosition, handleOffset);
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState& inputState,
     const DragState&,
     const vm::vec3& proposedHandlePosition) override
@@ -465,7 +465,7 @@ public:
       inputState, initialHandlePosition, handleOffset);
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState& inputState,
     const DragState&,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -36,7 +36,6 @@
 #include "View/ClipTool.h"
 #include "View/Grid.h"
 #include "View/HandleDragTracker.h"
-#include "View/MapDocument.h"
 
 #include "kdl/optional_utils.h"
 #include "kdl/vector_utils.h"
@@ -49,9 +48,7 @@
 #include <memory>
 #include <optional>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 namespace
 {
@@ -397,8 +394,8 @@ private:
   bool mouseClick(const InputState& inputState) override
   {
     if (
-      !inputState.mouseButtonsPressed(MouseButtons::MBLeft)
-      || !inputState.modifierKeysPressed(ModifierKeys::MKNone))
+      !inputState.mouseButtonsPressed(MouseButtons::Left)
+      || !inputState.modifierKeysPressed(ModifierKeys::None))
     {
       return false;
     }
@@ -409,8 +406,8 @@ private:
   bool mouseDoubleClick(const InputState& inputState) override
   {
     if (
-      !inputState.mouseButtonsPressed(MouseButtons::MBLeft)
-      || !inputState.modifierKeysPressed(ModifierKeys::MKNone))
+      !inputState.mouseButtonsPressed(MouseButtons::Left)
+      || !inputState.modifierKeysPressed(ModifierKeys::None))
     {
       return false;
     }
@@ -420,8 +417,8 @@ private:
   std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
   {
     if (
-      inputState.mouseButtons() != MouseButtons::MBLeft
-      || inputState.modifierKeys() != ModifierKeys::MKNone)
+      inputState.mouseButtons() != MouseButtons::Left
+      || inputState.modifierKeys() != ModifierKeys::None)
     {
       return nullptr;
     }
@@ -509,8 +506,8 @@ private:
   std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
   {
     if (
-      inputState.mouseButtons() != MouseButtons::MBLeft
-      || inputState.modifierKeys() != ModifierKeys::MKNone)
+      inputState.mouseButtons() != MouseButtons::Left
+      || inputState.modifierKeys() != ModifierKeys::None)
     {
       return nullptr;
     }
@@ -606,5 +603,4 @@ ClipToolController3D::ClipToolController3D(ClipTool& tool)
   addController(
     std::make_unique<AddClipPointPart>(std::make_unique<PartDelegate3D>(tool)));
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -414,7 +414,7 @@ private:
     return m_delegate->setClipFace(inputState);
   }
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
   {
     if (
       inputState.mouseButtons() != MouseButtons::Left
@@ -503,7 +503,7 @@ private:
 
   const Tool& tool() const override { return m_delegate->tool(); }
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
   {
     if (
       inputState.mouseButtons() != MouseButtons::Left

--- a/common/src/View/ClipToolController.h
+++ b/common/src/View/ClipToolController.h
@@ -19,30 +19,25 @@
 
 #pragma once
 
-#include "FloatType.h"
 #include "View/ToolController.h"
-
-#include "vm/forward.h"
 
 #include <memory>
 #include <vector>
 
-namespace TrenchBroom
-{
-namespace Model
+namespace TrenchBroom::Model
 {
 class BrushFace;
 class BrushNode;
 class PickResult;
-} // namespace Model
+} // namespace TrenchBroom::Model
 
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class ClipTool;
 
@@ -53,7 +48,7 @@ protected:
 
 protected:
   explicit ClipToolControllerBase(ClipTool& tool);
-  virtual ~ClipToolControllerBase() override;
+  ~ClipToolControllerBase() override;
 
 private:
   Tool& tool() override;
@@ -82,5 +77,5 @@ class ClipToolController3D : public ClipToolControllerBase
 public:
   explicit ClipToolController3D(ClipTool& tool);
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/DragTracker.cpp
+++ b/common/src/View/DragTracker.cpp
@@ -19,17 +19,13 @@
 
 #include "DragTracker.h"
 
-#include "FloatType.h"
 #include "View/InputState.h"
-
-#include "vm/vec.h"
 
 #include <cassert>
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 DragTracker::~DragTracker() = default;
 
 void DragTracker::modifierKeyChange(const InputState&) {}
@@ -42,5 +38,5 @@ void DragTracker::render(
   const InputState&, Renderer::RenderContext&, Renderer::RenderBatch&) const
 {
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/DragTracker.h
+++ b/common/src/View/DragTracker.h
@@ -52,7 +52,7 @@ public:
    * Called when a drag took place. This does not always have to correspond to a mouse
    * movement; sometimes these events are synthesized.
    */
-  virtual bool drag(const InputState& inputState) = 0;
+  virtual bool update(const InputState& inputState) = 0;
 
   /**
    * Called once at the end of a successful drag. Not called if the drag is cancelled.

--- a/common/src/View/DragTracker.h
+++ b/common/src/View/DragTracker.h
@@ -19,15 +19,13 @@
 
 #pragma once
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class InputState;
 
@@ -80,5 +78,6 @@ public:
     Renderer::RenderContext& renderContext,
     Renderer::RenderBatch& renderBatch) const;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+
+} // namespace TrenchBroom::View

--- a/common/src/View/DrawShapeToolController2D.cpp
+++ b/common/src/View/DrawShapeToolController2D.cpp
@@ -205,7 +205,7 @@ private:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> DrawShapeToolController2D::acceptMouseDrag(
+std::unique_ptr<GestureTracker> DrawShapeToolController2D::acceptMouseDrag(
   const InputState& inputState)
 {
   if (!inputState.mouseButtonsPressed(MouseButtons::Left))

--- a/common/src/View/DrawShapeToolController2D.cpp
+++ b/common/src/View/DrawShapeToolController2D.cpp
@@ -167,7 +167,7 @@ private:
       vm::merge(
         vm::bbox3{initialHandlePosition, initialHandlePosition}, currentHandlePosition));
 
-    if (inputState.modifierKeysDown(ModifierKeys::MKShift))
+    if (inputState.modifierKeysDown(ModifierKeys::Shift))
     {
       const auto viewAxis = vm::abs(vm::vec3{inputState.camera().direction()});
       const auto orthoAxes = vm::vec3::one() - viewAxis;
@@ -208,14 +208,12 @@ private:
 std::unique_ptr<DragTracker> DrawShapeToolController2D::acceptMouseDrag(
   const InputState& inputState)
 {
-  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }
   if (!inputState.checkModifierKeys(
-        ModifierKeyPressed::MK_No,
-        ModifierKeyPressed::MK_No,
-        ModifierKeyPressed::MK_DontCare))
+        ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::DontCare))
   {
     return nullptr;
   }

--- a/common/src/View/DrawShapeToolController2D.cpp
+++ b/common/src/View/DrawShapeToolController2D.cpp
@@ -89,7 +89,7 @@ public:
       makePlaneHandlePicker(plane, handleOffset), makeIdentityHandleSnapper());
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState& inputState,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/DrawShapeToolController2D.h
+++ b/common/src/View/DrawShapeToolController2D.h
@@ -30,7 +30,7 @@ namespace TrenchBroom::View
 {
 
 class DrawShapeTool;
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 
 class DrawShapeToolController2D : public ToolController
@@ -46,7 +46,7 @@ private:
   Tool& tool() override;
   const Tool& tool() const override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/DrawShapeToolController3D.cpp
+++ b/common/src/View/DrawShapeToolController3D.cpp
@@ -122,7 +122,7 @@ public:
       ResetInitialHandlePosition::Keep};
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState& inputState,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/DrawShapeToolController3D.cpp
+++ b/common/src/View/DrawShapeToolController3D.cpp
@@ -243,7 +243,7 @@ private:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> DrawShapeToolController3D::acceptMouseDrag(
+std::unique_ptr<GestureTracker> DrawShapeToolController3D::acceptMouseDrag(
   const InputState& inputState)
 {
   using namespace Model::HitFilters;

--- a/common/src/View/DrawShapeToolController3D.cpp
+++ b/common/src/View/DrawShapeToolController3D.cpp
@@ -91,7 +91,7 @@ public:
   std::optional<UpdateDragConfig> modifierKeyChange(
     const InputState& inputState, const DragState& dragState) override
   {
-    if (inputState.modifierKeys() == ModifierKeys::MKShift)
+    if (inputState.modifierKeys() == ModifierKeys::Shift)
     {
       const auto currentBounds = makeBounds(
         inputState, dragState.initialHandlePosition, dragState.currentHandlePosition);
@@ -184,7 +184,7 @@ private:
         vm::min(initialHandlePosition, currentHandlePosition),
         vm::max(initialHandlePosition, currentHandlePosition)});
 
-    if (inputState.modifierKeysDown(ModifierKeys::MKShift))
+    if (inputState.modifierKeysDown(ModifierKeys::Shift))
     {
       const auto includeZAxis = inputState.modifierKeysDown(ModifierKeys::MKAlt);
 
@@ -248,15 +248,13 @@ std::unique_ptr<DragTracker> DrawShapeToolController3D::acceptMouseDrag(
 {
   using namespace Model::HitFilters;
 
-  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }
 
   if (!inputState.checkModifierKeys(
-        ModifierKeyPressed::MK_No,
-        ModifierKeyPressed::MK_No,
-        ModifierKeyPressed::MK_DontCare))
+        ModifierKeyPressed::No, ModifierKeyPressed::No, ModifierKeyPressed::DontCare))
   {
     return nullptr;
   }

--- a/common/src/View/DrawShapeToolController3D.h
+++ b/common/src/View/DrawShapeToolController3D.h
@@ -30,7 +30,7 @@ namespace TrenchBroom::View
 {
 
 class DrawShapeTool;
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 
 class DrawShapeToolController3D : public ToolController
@@ -48,7 +48,7 @@ private:
   Tool& tool() override;
   const Tool& tool() const override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/DropTracker.cpp
+++ b/common/src/View/DropTracker.cpp
@@ -19,10 +19,9 @@
 
 #include "DropTracker.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 DropTracker::~DropTracker() = default;
-}
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/DropTracker.h
+++ b/common/src/View/DropTracker.h
@@ -19,9 +19,7 @@
 
 #pragma once
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 class InputState;
 
@@ -34,5 +32,5 @@ public:
   virtual bool drop(const InputState& inputState) = 0;
   virtual void leave(const InputState& inputState) = 0;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ExtrudeToolController.cpp
+++ b/common/src/View/ExtrudeToolController.cpp
@@ -235,7 +235,7 @@ struct ExtrudeDragDelegate : public HandleDragTrackerDelegate
     return makeHandlePositionProposer(std::move(picker), std::move(snapper));
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override
@@ -330,7 +330,7 @@ struct MoveDragDelegate : public HandleDragTrackerDelegate
     return makeHandlePositionProposer(std::move(picker), std::move(snapper));
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/ExtrudeToolController.cpp
+++ b/common/src/View/ExtrudeToolController.cpp
@@ -31,8 +31,8 @@
 #include "Renderer/PrimType.h"
 #include "Renderer/RenderContext.h"
 #include "Renderer/VertexArray.h"
-#include "View/DragTracker.h"
 #include "View/ExtrudeTool.h"
+#include "View/GestureTracker.h"
 #include "View/Grid.h"
 #include "View/HandleDragTracker.h"
 #include "View/InputState.h"
@@ -384,7 +384,7 @@ auto createMoveDragTracker(
 }
 } // namespace
 
-std::unique_ptr<DragTracker> ExtrudeToolController::acceptMouseDrag(
+std::unique_ptr<GestureTracker> ExtrudeToolController::acceptMouseDrag(
   const InputState& inputState)
 {
   using namespace Model::HitFilters;

--- a/common/src/View/ExtrudeToolController.cpp
+++ b/common/src/View/ExtrudeToolController.cpp
@@ -19,17 +19,14 @@
 
 #include "ExtrudeToolController.h"
 
-#include "Model/Brush.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceHandle.h"
-#include "Model/BrushGeometry.h"
-#include "Model/BrushNode.h"
-#include "Model/HitAdapter.h"
 #include "Model/PickResult.h"
 #include "Model/Polyhedron.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/Camera.h"
+#include "Renderer/EdgeRenderer.h"
 #include "Renderer/GLVertexType.h"
 #include "Renderer/PrimType.h"
 #include "Renderer/RenderContext.h"
@@ -41,8 +38,6 @@
 #include "View/InputState.h"
 
 #include "vm/distance.h"
-#include "vm/intersection.h"
-#include "vm/line.h"
 #include "vm/plane.h"
 #include "vm/scalar.h"
 
@@ -96,8 +91,7 @@ void ExtrudeToolController::mouseMove(const InputState& inputState)
 
 namespace
 {
-Renderer::DirectEdgeRenderer buildEdgeRenderer(
-  const std::vector<Model::BrushFaceHandle>& dragHandles)
+auto buildEdgeRenderer(const std::vector<Model::BrushFaceHandle>& dragHandles)
 {
   using Vertex = Renderer::GLVertexTypes::P3::Vertex;
   auto vertices = std::vector<Vertex>{};
@@ -116,8 +110,7 @@ Renderer::DirectEdgeRenderer buildEdgeRenderer(
     Renderer::VertexArray::move(std::move(vertices)), Renderer::PrimType::Lines};
 }
 
-Renderer::DirectEdgeRenderer buildEdgeRenderer(
-  const std::vector<ExtrudeDragHandle>& dragHandles)
+auto buildEdgeRenderer(const std::vector<ExtrudeDragHandle>& dragHandles)
 {
   return buildEdgeRenderer(
     kdl::vec_transform(dragHandles, [](const auto& h) { return h.faceHandle; }));
@@ -402,7 +395,7 @@ std::unique_ptr<DragTracker> ExtrudeToolController::acceptMouseDrag(
   }
   // NOTE: We check for MBLeft here rather than in handleInput because we want the
   // yellow highlight to render as a preview when Shift is down, before you press MBLeft.
-  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }
@@ -468,9 +461,9 @@ Model::Hit ExtrudeToolController2D::doPick(
 bool ExtrudeToolController2D::doHandleInput(const InputState& inputState) const
 {
   return (
-    inputState.modifierKeysPressed(ModifierKeys::MKShift)
-    || inputState.modifierKeysPressed(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd)
-    || inputState.modifierKeysPressed(ModifierKeys::MKShift | ModifierKeys::MKAlt));
+    inputState.modifierKeysPressed(ModifierKeys::Shift)
+    || inputState.modifierKeysPressed(ModifierKeys::Shift | ModifierKeys::MKCtrlCmd)
+    || inputState.modifierKeysPressed(ModifierKeys::Shift | ModifierKeys::MKAlt));
 }
 
 ExtrudeToolController3D::ExtrudeToolController3D(ExtrudeTool& tool)
@@ -487,7 +480,7 @@ Model::Hit ExtrudeToolController3D::doPick(
 bool ExtrudeToolController3D::doHandleInput(const InputState& inputState) const
 {
   return (
-    inputState.modifierKeysPressed(ModifierKeys::MKShift)
-    || inputState.modifierKeysPressed(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd));
+    inputState.modifierKeysPressed(ModifierKeys::Shift)
+    || inputState.modifierKeysPressed(ModifierKeys::Shift | ModifierKeys::MKCtrlCmd));
 }
 } // namespace TrenchBroom::View

--- a/common/src/View/ExtrudeToolController.h
+++ b/common/src/View/ExtrudeToolController.h
@@ -19,19 +19,15 @@
 
 #pragma once
 
-#include "Renderer/EdgeRenderer.h"
 #include "View/ToolController.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::Renderer
 {
-namespace Renderer
-{
-class DirectEdgeRenderer;
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class DragTracker;
 class ExtrudeTool;
@@ -95,5 +91,5 @@ private:
     const vm::ray3& pickRay, const Model::PickResult& pickResult) override;
   bool doHandleInput(const InputState& inputState) const override;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ExtrudeToolController.h
+++ b/common/src/View/ExtrudeToolController.h
@@ -29,7 +29,7 @@ class RenderContext;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class ExtrudeTool;
 
 class ExtrudeToolController : public ToolController
@@ -53,7 +53,7 @@ private:
 
   void mouseMove(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void render(
     const InputState& inputState,

--- a/common/src/View/GestureTracker.cpp
+++ b/common/src/View/GestureTracker.cpp
@@ -17,7 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "DragTracker.h"
+#include "GestureTracker.h"
 
 #include "View/InputState.h"
 
@@ -26,15 +26,17 @@
 namespace TrenchBroom::View
 {
 
-DragTracker::~DragTracker() = default;
+GestureTracker::~GestureTracker() = default;
 
-void DragTracker::modifierKeyChange(const InputState&) {}
+void GestureTracker::modifierKeyChange(const InputState&) {}
 
-void DragTracker::mouseScroll(const InputState&) {}
+void GestureTracker::mouseScroll(const InputState&) {}
 
-void DragTracker::setRenderOptions(const InputState&, Renderer::RenderContext&) const {}
+void GestureTracker::setRenderOptions(const InputState&, Renderer::RenderContext&) const
+{
+}
 
-void DragTracker::render(
+void GestureTracker::render(
   const InputState&, Renderer::RenderContext&, Renderer::RenderBatch&) const
 {
 }

--- a/common/src/View/GestureTracker.h
+++ b/common/src/View/GestureTracker.h
@@ -32,10 +32,10 @@ class InputState;
 /**
  * Defines the protocol for handling mouse dragging in the tool system.
  */
-class DragTracker
+class GestureTracker
 {
 public:
-  virtual ~DragTracker();
+  virtual ~GestureTracker();
 
   /**
    * Called when a modifier key is pressed or released. The given input state represents
@@ -49,18 +49,18 @@ public:
   virtual void mouseScroll(const InputState& inputState);
 
   /**
-   * Called when a drag took place. This does not always have to correspond to a mouse
-   * movement; sometimes these events are synthesized.
+   * Called when a gesture is updated. Sometimes these events are synthesized.
    */
   virtual bool update(const InputState& inputState) = 0;
 
   /**
-   * Called once at the end of a successful drag. Not called if the drag is cancelled.
+   * Called once at the end of a successful gesture. Not called if the gesture is
+   * cancelled.
    */
   virtual void end(const InputState& inputState) = 0;
 
   /**
-   * Called once at the end of a canceled drag.
+   * Called once at the end of a canceled gesture.
    */
   virtual void cancel() = 0;
 

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -22,7 +22,7 @@
 #include "FloatType.h"
 #include "Model/HitFilter.h"
 #include "Renderer/Camera.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 
 #include "kdl/reflection_decl.h"
@@ -242,7 +242,7 @@ struct HandleDragTrackerDelegate
  * horizontally and vertically.
  */
 template <typename Delegate>
-class HandleDragTracker : public DragTracker
+class HandleDragTracker : public GestureTracker
 {
 private:
   enum class IdenticalPositionPolicy

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -138,7 +138,7 @@ struct HandleDragTrackerDelegate
    * @return a value of DragStatus that instructs the drag tracker on how to continue with
    * the drag
    */
-  virtual DragStatus drag(
+  virtual DragStatus update(
     const InputState& inputState,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) = 0;
@@ -230,7 +230,7 @@ struct HandleDragTrackerDelegate
  * function that the tracker uses to compute a new handle position from the current input
  * state.
  *
- * The current handle position updates in response to calls to drag() or a modifier key
+ * The current handle position updates in response to calls to update() or a modifier key
  * change.
  *
  * The delegate's start function is called once when this drag tracker is constructed. It
@@ -287,7 +287,7 @@ public:
    * of the returned ResetInitialHandlePosition value.
    *
    * If a new proposer function is returned by the delegate, it is called with the current
-   * drag state and drag() is called with the new proposed handle position.
+   * drag state and update() is called with the new proposed handle position.
    */
   void modifierKeyChange(const InputState& inputState) override
   {
@@ -307,7 +307,7 @@ public:
 
       m_proposeHandlePosition = std::move(dragConfig->proposeHandlePosition);
 
-      assertResult(drag(inputState, IdenticalPositionPolicy::ForceDrag));
+      assertResult(update(inputState, IdenticalPositionPolicy::ForceDrag));
     }
   }
 
@@ -328,11 +328,11 @@ public:
    */
   bool update(const InputState& inputState) override
   {
-    return drag(inputState, IdenticalPositionPolicy::SkipDrag);
+    return update(inputState, IdenticalPositionPolicy::SkipDrag);
   }
 
   /**
-   * Called when the drag ends normally (e.g. by releasing a mouse button) or if drag()
+   * Called when the drag ends normally (e.g. by releasing a mouse button) or if update()
    * returns false. The delegate should commit any changes made in result of the drag.
    */
   void end(const InputState& inputState) override
@@ -367,7 +367,7 @@ public:
   }
 
 private:
-  bool drag(
+  bool update(
     const InputState& inputState, const IdenticalPositionPolicy identicalPositionPolicy)
   {
     const auto proposedHandlePosition = m_proposeHandlePosition(inputState, m_dragState);
@@ -379,7 +379,7 @@ private:
     }
 
     const auto dragResult =
-      m_delegate.drag(inputState, m_dragState, *proposedHandlePosition);
+      m_delegate.update(inputState, m_dragState, *proposedHandlePosition);
     if (dragResult == DragStatus::End)
     {
       return false;

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -326,7 +326,7 @@ public:
    * Returns true to indicate succes. If this function returns false, the drag ends and
    * end() is called.
    */
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     return drag(inputState, IdenticalPositionPolicy::SkipDrag);
   }

--- a/common/src/View/HandleDragTracker.h
+++ b/common/src/View/HandleDragTracker.h
@@ -35,9 +35,7 @@
 #include <optional>
 #include <type_traits>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 class Grid;
 
@@ -527,5 +525,4 @@ HandlePositionProposer makeBrushFaceHandleProposer(const Grid& grid);
  */
 HandlePositionProposer makeHandlePositionProposer(
   DragHandlePicker pickHandlePosition, DragHandleSnapper snapHandlePosition);
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -171,15 +171,16 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs)
   return lhs;
 }
 
-ScrollEvent::ScrollEvent(const Axis i_axis, const float i_distance)
-  : axis{i_axis}
+ScrollEvent::ScrollEvent(const Source i_source, const Axis i_axis, const float i_distance)
+  : source{i_source}
+  , axis{i_axis}
   , distance{i_distance}
 {
 }
 
 bool ScrollEvent::collateWith(const ScrollEvent& event)
 {
-  if (axis == event.axis)
+  if (source == event.source && axis == event.axis)
   {
     distance += event.distance;
     return true;
@@ -194,6 +195,20 @@ void ScrollEvent::processWith(InputEventProcessor& processor) const
 }
 
 kdl_reflect_impl(ScrollEvent);
+
+std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Source& rhs)
+{
+  switch (rhs)
+  {
+  case ScrollEvent::Source::Mouse:
+    lhs << "Mouse";
+    break;
+  case ScrollEvent::Source::Trackpad:
+    lhs << "Trackpad";
+    break;
+  }
+  return lhs;
+}
 
 std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Axis& rhs)
 {
@@ -412,6 +427,10 @@ QPointF InputEventRecorder::scrollLinesForEvent(const QWheelEvent& qtEvent)
 
 void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent)
 {
+  const auto source = qtEvent.source() == Qt::MouseEventNotSynthesized
+                        ? ScrollEvent::Source::Mouse
+                        : ScrollEvent::Source::Trackpad;
+
   // Number of "lines" to scroll
   auto scrollDistance = scrollLinesForEvent(qtEvent);
 
@@ -432,12 +451,12 @@ void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent)
   if (scrollDistance.x() != 0.0f)
   {
     m_queue.enqueueEvent(std::make_unique<ScrollEvent>(
-      ScrollEvent::Axis::Horizontal, static_cast<float>(scrollDistance.x())));
+      source, ScrollEvent::Axis::Horizontal, static_cast<float>(scrollDistance.x())));
   }
   if (scrollDistance.y() != 0.0f)
   {
     m_queue.enqueueEvent(std::make_unique<ScrollEvent>(
-      ScrollEvent::Axis::Vertical, static_cast<float>(scrollDistance.y())));
+      source, ScrollEvent::Axis::Vertical, static_cast<float>(scrollDistance.y())));
   }
 }
 

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -42,6 +42,11 @@ bool InputEvent::collateWith(const MouseEvent& /* event */)
   return false;
 }
 
+bool InputEvent::collateWith(const ScrollEvent& /* event */)
+{
+  return false;
+}
+
 bool InputEvent::collateWith(const GestureEvent& /* event */)
 {
   return false;
@@ -79,18 +84,11 @@ std::ostream& operator<<(std::ostream& lhs, const KeyEvent::Type& rhs)
 }
 
 MouseEvent::MouseEvent(
-  const Type i_type,
-  const Button i_button,
-  const WheelAxis i_wheelAxis,
-  const float i_posX,
-  const float i_posY,
-  const float i_scrollDistance)
+  const Type i_type, const Button i_button, const float i_posX, const float i_posY)
   : type{i_type}
   , button{i_button}
-  , wheelAxis{i_wheelAxis}
   , posX{i_posX}
   , posY{i_posY}
-  , scrollDistance{i_scrollDistance}
 {
 }
 
@@ -103,15 +101,6 @@ bool MouseEvent::collateWith(const MouseEvent& event)
     posX = event.posX;
     posY = event.posY;
     return true;
-  }
-
-  if (type == Type::Scroll && event.type == Type::Scroll)
-  {
-    if (wheelAxis == event.wheelAxis)
-    {
-      scrollDistance += event.scrollDistance;
-      return true;
-    }
   }
 
   return false;
@@ -142,9 +131,6 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Type& rhs)
     break;
   case MouseEvent::Type::Motion:
     lhs << "Motion";
-    break;
-  case MouseEvent::Type::Scroll:
-    lhs << "Scroll";
     break;
   case MouseEvent::Type::DragStart:
     lhs << "DragStart";
@@ -185,17 +171,38 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs)
   return lhs;
 }
 
-std::ostream& operator<<(std::ostream& lhs, const MouseEvent::WheelAxis& rhs)
+ScrollEvent::ScrollEvent(const Axis i_axis, const float i_distance)
+  : axis{i_axis}
+  , distance{i_distance}
+{
+}
+
+bool ScrollEvent::collateWith(const ScrollEvent& event)
+{
+  if (axis == event.axis)
+  {
+    distance += event.distance;
+    return true;
+  }
+
+  return false;
+}
+
+void ScrollEvent::processWith(InputEventProcessor& processor) const
+{
+  processor.processEvent(*this);
+}
+
+kdl_reflect_impl(ScrollEvent);
+
+std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Axis& rhs)
 {
   switch (rhs)
   {
-  case MouseEvent::WheelAxis::None:
-    lhs << "None";
-    break;
-  case MouseEvent::WheelAxis::Horizontal:
+  case ScrollEvent::Axis::Horizontal:
     lhs << "Horizontal";
     break;
-  case MouseEvent::WheelAxis::Vertical:
+  case ScrollEvent::Axis::Vertical:
     lhs << "Vertical";
     break;
   }
@@ -288,9 +295,6 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
   const auto posX = static_cast<float>(qEvent.localPos().x());
   const auto posY = static_cast<float>(qEvent.localPos().y());
 
-  const auto wheelAxis = MouseEvent::WheelAxis::None;
-  const float scrollDistance = 0.0f;
-
   if (type == MouseEvent::Type::Down)
   {
     // macOS: apply Ctrl+click = right click emulation
@@ -306,8 +310,8 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
     m_lastClickY = posY;
     m_lastClickTime = std::chrono::high_resolution_clock::now();
     m_anyMouseButtonDown = true;
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-      MouseEvent::Type::Down, button, wheelAxis, posX, posY, scrollDistance));
+    m_queue.enqueueEvent(
+      std::make_unique<MouseEvent>(MouseEvent::Type::Down, button, posX, posY));
   }
   else if (type == MouseEvent::Type::Up)
   {
@@ -337,18 +341,13 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
         if (!isDrag(posX, posY))
         {
           m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-            MouseEvent::Type::Click,
-            button,
-            wheelAxis,
-            m_lastClickX,
-            m_lastClickY,
-            scrollDistance));
+            MouseEvent::Type::Click, button, m_lastClickX, m_lastClickY));
         }
       }
       else
       {
-        m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-          MouseEvent::Type::DragEnd, button, wheelAxis, posX, posY, scrollDistance));
+        m_queue.enqueueEvent(
+          std::make_unique<MouseEvent>(MouseEvent::Type::DragEnd, button, posX, posY));
         m_dragging = false;
       }
     }
@@ -356,17 +355,12 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
     {
       // Synthesize a click event
       m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-        MouseEvent::Type::Click,
-        button,
-        wheelAxis,
-        m_lastClickX,
-        m_lastClickY,
-        scrollDistance));
+        MouseEvent::Type::Click, button, m_lastClickX, m_lastClickY));
     }
     m_anyMouseButtonDown = false;
     m_nextMouseUpIsDblClick = false;
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-      MouseEvent::Type::Up, button, wheelAxis, posX, posY, scrollDistance));
+    m_queue.enqueueEvent(
+      std::make_unique<MouseEvent>(MouseEvent::Type::Up, button, posX, posY));
   }
   else if (type == MouseEvent::Type::Motion)
   {
@@ -375,38 +369,32 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
       if (isDrag(posX, posY))
       {
         m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-          MouseEvent::Type::DragStart,
-          button,
-          wheelAxis,
-          m_lastClickX,
-          m_lastClickY,
-          scrollDistance));
+          MouseEvent::Type::DragStart, button, m_lastClickX, m_lastClickY));
         m_dragging = true;
       }
     }
     if (m_dragging)
     {
-      m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-        MouseEvent::Type::Drag, button, wheelAxis, posX, posY, scrollDistance));
+      m_queue.enqueueEvent(
+        std::make_unique<MouseEvent>(MouseEvent::Type::Drag, button, posX, posY));
     }
     else
     {
-      m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-        MouseEvent::Type::Motion, button, wheelAxis, posX, posY, scrollDistance));
+      m_queue.enqueueEvent(
+        std::make_unique<MouseEvent>(MouseEvent::Type::Motion, button, posX, posY));
     }
   }
   else if (type == MouseEvent::Type::DoubleClick)
   {
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-      MouseEvent::Type::Down, button, wheelAxis, posX, posY, scrollDistance));
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-      MouseEvent::Type::DoubleClick, button, wheelAxis, posX, posY, scrollDistance));
+    m_queue.enqueueEvent(
+      std::make_unique<MouseEvent>(MouseEvent::Type::Down, button, posX, posY));
+    m_queue.enqueueEvent(
+      std::make_unique<MouseEvent>(MouseEvent::Type::DoubleClick, button, posX, posY));
     m_nextMouseUpIsDblClick = true;
   }
   else
   {
-    m_queue.enqueueEvent(
-      std::make_unique<MouseEvent>(type, button, wheelAxis, posX, posY, scrollDistance));
+    m_queue.enqueueEvent(std::make_unique<MouseEvent>(type, button, posX, posY));
   }
 }
 
@@ -424,11 +412,6 @@ QPointF InputEventRecorder::scrollLinesForEvent(const QWheelEvent& qtEvent)
 
 void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent)
 {
-  // These are the mouse X and Y position, not the wheel delta, in points relative to top
-  // left of widget.
-  const auto posX = static_cast<float>(qtEvent.x());
-  const auto posY = static_cast<float>(qtEvent.y());
-
   // Number of "lines" to scroll
   auto scrollDistance = scrollLinesForEvent(qtEvent);
 
@@ -448,23 +431,13 @@ void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent)
 
   if (scrollDistance.x() != 0.0f)
   {
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      posX,
-      posY,
-      static_cast<float>(scrollDistance.x())));
+    m_queue.enqueueEvent(std::make_unique<ScrollEvent>(
+      ScrollEvent::Axis::Horizontal, static_cast<float>(scrollDistance.x())));
   }
   if (scrollDistance.y() != 0.0f)
   {
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Vertical,
-      posX,
-      posY,
-      static_cast<float>(scrollDistance.y())));
+    m_queue.enqueueEvent(std::make_unique<ScrollEvent>(
+      ScrollEvent::Axis::Vertical, static_cast<float>(scrollDistance.y())));
   }
 }
 

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -23,6 +23,7 @@
 
 #include "Ensure.h"
 
+#include "kdl/overload.h"
 #include "kdl/reflection_impl.h"
 
 #include <iostream>
@@ -30,37 +31,6 @@
 
 namespace TrenchBroom::View
 {
-InputEvent::~InputEvent() = default;
-
-bool InputEvent::collateWith(const KeyEvent& /* event */)
-{
-  return false;
-}
-
-bool InputEvent::collateWith(const MouseEvent& /* event */)
-{
-  return false;
-}
-
-bool InputEvent::collateWith(const ScrollEvent& /* event */)
-{
-  return false;
-}
-
-bool InputEvent::collateWith(const GestureEvent& /* event */)
-{
-  return false;
-}
-
-bool InputEvent::collateWith(const CancelEvent& /* event */)
-{
-  return false;
-}
-
-KeyEvent::KeyEvent(const Type i_type)
-  : type{i_type}
-{
-}
 
 void KeyEvent::processWith(InputEventProcessor& processor) const
 {
@@ -81,15 +51,6 @@ std::ostream& operator<<(std::ostream& lhs, const KeyEvent::Type& rhs)
     break;
   }
   return lhs;
-}
-
-MouseEvent::MouseEvent(
-  const Type i_type, const Button i_button, const float i_posX, const float i_posY)
-  : type{i_type}
-  , button{i_button}
-  , posX{i_posX}
-  , posY{i_posY}
-{
 }
 
 bool MouseEvent::collateWith(const MouseEvent& event)
@@ -171,13 +132,6 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs)
   return lhs;
 }
 
-ScrollEvent::ScrollEvent(const Source i_source, const Axis i_axis, const float i_distance)
-  : source{i_source}
-  , axis{i_axis}
-  , distance{i_distance}
-{
-}
-
 bool ScrollEvent::collateWith(const ScrollEvent& event)
 {
   if (source == event.source && axis == event.axis)
@@ -222,15 +176,6 @@ std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Axis& rhs)
     break;
   }
   return lhs;
-}
-
-GestureEvent::GestureEvent(
-  const Type i_type, const float i_posX, const float i_posY, const float i_value)
-  : type{i_type}
-  , posX{i_posX}
-  , posY{i_posY}
-  , value{i_value}
-{
 }
 
 bool GestureEvent::collateWith(const GestureEvent& event)
@@ -286,21 +231,50 @@ void GestureEvent::processWith(InputEventProcessor& processor) const
 
 kdl_reflect_impl(CancelEvent);
 
+namespace
+{
+bool collateEvents(InputEvent& lhs, const InputEvent& rhs)
+{
+  return std::visit(
+    kdl::overload(
+      [](MouseEvent& lhsMouseEvent, const MouseEvent& rhsMouseEvent) {
+        return lhsMouseEvent.collateWith(rhsMouseEvent);
+      },
+      [](ScrollEvent& lhsScrollEvent, const ScrollEvent& rhsScrollEvent) {
+        return lhsScrollEvent.collateWith(rhsScrollEvent);
+      },
+      [](GestureEvent& lhsGestureEvent, const GestureEvent& rhsGestureEvent) {
+        return lhsGestureEvent.collateWith(rhsGestureEvent);
+      },
+      [](auto&, const auto&) { return false; }),
+    lhs,
+    rhs);
+}
+} // namespace
+
+void InputEventQueue::enqueueEvent(InputEvent event)
+{
+  if (m_eventQueue.empty() || !collateEvents(m_eventQueue.back(), event))
+  {
+    m_eventQueue.push_back(std::move(event));
+  }
+}
+
 void InputEventQueue::processEvents(InputEventProcessor& processor)
 {
   // Swap out the queue before processing it, because if processing an event blocks (e.g.
   // a popup menu), then stale events maybe processed again.
 
-  auto eventQueue = std::exchange(m_eventQueue, EventQueue{});
+  auto eventQueue = std::exchange(m_eventQueue, std::vector<InputEvent>{});
   for (const auto& event : eventQueue)
   {
-    event->processWith(processor);
+    std::visit([&processor](const auto& x) { x.processWith(processor); }, event);
   }
 }
 
 void InputEventRecorder::recordEvent(const QKeyEvent& qEvent)
 {
-  m_queue.enqueueEvent(std::make_unique<KeyEvent>(getEventType(qEvent)));
+  m_queue.enqueueEvent(KeyEvent{getEventType(qEvent)});
 }
 
 void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
@@ -325,8 +299,7 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
     m_lastClickY = posY;
     m_lastClickTime = std::chrono::high_resolution_clock::now();
     m_anyMouseButtonDown = true;
-    m_queue.enqueueEvent(
-      std::make_unique<MouseEvent>(MouseEvent::Type::Down, button, posX, posY));
+    m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::Down, button, posX, posY});
   }
   else if (type == MouseEvent::Type::Up)
   {
@@ -349,33 +322,31 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
       if (duration < minDuration)
       {
         // This was an accidental drag.
-        m_queue.enqueueEvent(std::make_unique<CancelEvent>());
+        m_queue.enqueueEvent(CancelEvent{});
         m_dragging = false;
 
         // Synthesize a click event
         if (!isDrag(posX, posY))
         {
-          m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-            MouseEvent::Type::Click, button, m_lastClickX, m_lastClickY));
+          m_queue.enqueueEvent(
+            MouseEvent{MouseEvent::Type::Click, button, m_lastClickX, m_lastClickY});
         }
       }
       else
       {
-        m_queue.enqueueEvent(
-          std::make_unique<MouseEvent>(MouseEvent::Type::DragEnd, button, posX, posY));
+        m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::DragEnd, button, posX, posY});
         m_dragging = false;
       }
     }
     else if (!m_nextMouseUpIsDblClick)
     {
       // Synthesize a click event
-      m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-        MouseEvent::Type::Click, button, m_lastClickX, m_lastClickY));
+      m_queue.enqueueEvent(
+        MouseEvent{MouseEvent::Type::Click, button, m_lastClickX, m_lastClickY});
     }
     m_anyMouseButtonDown = false;
     m_nextMouseUpIsDblClick = false;
-    m_queue.enqueueEvent(
-      std::make_unique<MouseEvent>(MouseEvent::Type::Up, button, posX, posY));
+    m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::Up, button, posX, posY});
   }
   else if (type == MouseEvent::Type::Motion)
   {
@@ -383,33 +354,29 @@ void InputEventRecorder::recordEvent(const QMouseEvent& qEvent)
     {
       if (isDrag(posX, posY))
       {
-        m_queue.enqueueEvent(std::make_unique<MouseEvent>(
-          MouseEvent::Type::DragStart, button, m_lastClickX, m_lastClickY));
+        m_queue.enqueueEvent(
+          MouseEvent{MouseEvent::Type::DragStart, button, m_lastClickX, m_lastClickY});
         m_dragging = true;
       }
     }
     if (m_dragging)
     {
-      m_queue.enqueueEvent(
-        std::make_unique<MouseEvent>(MouseEvent::Type::Drag, button, posX, posY));
+      m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::Drag, button, posX, posY});
     }
     else
     {
-      m_queue.enqueueEvent(
-        std::make_unique<MouseEvent>(MouseEvent::Type::Motion, button, posX, posY));
+      m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::Motion, button, posX, posY});
     }
   }
   else if (type == MouseEvent::Type::DoubleClick)
   {
-    m_queue.enqueueEvent(
-      std::make_unique<MouseEvent>(MouseEvent::Type::Down, button, posX, posY));
-    m_queue.enqueueEvent(
-      std::make_unique<MouseEvent>(MouseEvent::Type::DoubleClick, button, posX, posY));
+    m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::Down, button, posX, posY});
+    m_queue.enqueueEvent(MouseEvent{MouseEvent::Type::DoubleClick, button, posX, posY});
     m_nextMouseUpIsDblClick = true;
   }
   else
   {
-    m_queue.enqueueEvent(std::make_unique<MouseEvent>(type, button, posX, posY));
+    m_queue.enqueueEvent(MouseEvent{type, button, posX, posY});
   }
 }
 
@@ -450,13 +417,13 @@ void InputEventRecorder::recordEvent(const QWheelEvent& qtEvent)
 
   if (scrollDistance.x() != 0.0f)
   {
-    m_queue.enqueueEvent(std::make_unique<ScrollEvent>(
-      source, ScrollEvent::Axis::Horizontal, static_cast<float>(scrollDistance.x())));
+    m_queue.enqueueEvent(
+      ScrollEvent{source, ScrollEvent::Axis::Horizontal, float(scrollDistance.x())});
   }
   if (scrollDistance.y() != 0.0f)
   {
-    m_queue.enqueueEvent(std::make_unique<ScrollEvent>(
-      source, ScrollEvent::Axis::Vertical, static_cast<float>(scrollDistance.y())));
+    m_queue.enqueueEvent(
+      ScrollEvent{source, ScrollEvent::Axis::Vertical, float(scrollDistance.y())});
   }
 }
 
@@ -509,7 +476,7 @@ void InputEventRecorder::recordEvent(const QNativeGestureEvent& qEvent)
     const auto posX = float(qEvent.localPos().x());
     const auto posY = float(qEvent.localPos().y());
     const auto value = float(qEvent.value());
-    m_queue.enqueueEvent(std::make_unique<GestureEvent>(*type, posX, posY, value));
+    m_queue.enqueueEvent(GestureEvent{*type, posX, posY, value});
   }
 }
 

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -33,6 +33,7 @@
 namespace TrenchBroom::View
 {
 class CancelEvent;
+class GestureEvent;
 class InputEventProcessor;
 class KeyEvent;
 class MouseEvent;
@@ -60,6 +61,14 @@ public:
    * @return true if this event was collated with the given event and false otherwise
    */
   virtual bool collateWith(const MouseEvent& event);
+
+  /**
+   * Collate this event with the given gesture event.
+   *
+   * @param event the event to collate with
+   * @return true if this event was collated with the given event and false otherwise
+   */
+  virtual bool collateWith(const GestureEvent& event);
 
   /**
    * Collate this event with the given cancellation event.
@@ -236,6 +245,70 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs);
 std::ostream& operator<<(std::ostream& lhs, const MouseEvent::WheelAxis& rhs);
 
 /**
+ * A gesture event. Supports several gesture types such as pan, zoom, and rotate.
+ */
+class GestureEvent : public InputEvent
+{
+public:
+  enum class Type
+  {
+    /**
+     * A gesture was started.
+     */
+    Start,
+    /**
+     * A gesture has ended.
+     */
+    End,
+    /**
+     * A panning gesture update.
+     */
+    Pan,
+    /**
+     * A zoom gesture update.
+     */
+    Zoom,
+    /**
+     * A rotate gesture update.
+     */
+    Rotate,
+  };
+
+  Type type;
+
+  /** Cursor position in Points, relative to top left of widget. */
+  float posX;
+  float posY;
+  float value;
+
+  /**
+   * Creates a new gesture event with the given parameters.
+   */
+  GestureEvent(Type type, float posX, float posY, float value);
+
+  /**
+   * Collates this gesture event with the given gesture event. Only successive Pan,
+   * Zoom and Rotate events are collated.
+   *
+   * @param event the gesture event to collate with
+   * @return true if this event was collated with the given gesture event and false
+   * otherwise
+   */
+  bool collateWith(const GestureEvent& event) override;
+
+  /**
+   * Process this gesture event using the given event processor.
+   *
+   * @param processor the event processor
+   */
+  void processWith(InputEventProcessor& processor) const override;
+
+  kdl_reflect_decl(GestureEvent, type, posX, posY, value);
+};
+
+std::ostream& operator<<(std::ostream& lhs, const GestureEvent::Type& rhs);
+
+/**
  * Event to signal that a mouse drag was cancelled by the windowing system, e.g. when the
  * window lost focus.
  */
@@ -336,6 +409,11 @@ private:
    * Used to suppress a click event for the mouse up event that follows a double click.
    */
   bool m_nextMouseUpIsDblClick = false;
+  /**
+   * The number of active gestures. Used to send start / end events when the first gesture
+   * starts and the last gesture ends.
+   */
+  size_t m_activeGestures = 0;
 
 public:
   /**
@@ -355,6 +433,13 @@ public:
   static QPointF scrollLinesForEvent(const QWheelEvent& event);
 
   void recordEvent(const QWheelEvent& event);
+
+  /**
+   * Records the given native gesture event.
+   *
+   * @param event the event to record
+   */
+  void recordEvent(const QNativeGestureEvent& event);
 
   /**
    * Processes all recorded events using the given event processor.
@@ -421,6 +506,13 @@ public:
    * @param event the event to process
    */
   virtual void processEvent(const MouseEvent& event) = 0;
+
+  /**
+   * Process a gesture event.
+   *
+   * @param event the event to process
+   */
+  virtual void processEvent(const GestureEvent& event) = 0;
 
   /**
    * Process a cancellation event.

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -30,9 +30,7 @@
 // Undefine this symbol since it interferes somehow with our enums.
 #undef None
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 class CancelEvent;
 class InputEventProcessor;
@@ -312,38 +310,34 @@ private:
   /**
    * Indicates whether or not a mouse drag is taking place.
    */
-  bool m_dragging;
+  bool m_dragging = false;
   /**
    Indicates that we received a mouse down event, cleared on mouse up.
    */
-  bool m_anyMouseButtonDown;
+  bool m_anyMouseButtonDown = false;
   /**
    * The X position of the last mouse down event.
    */
-  float m_lastClickX;
+  float m_lastClickX = 0.0f;
   /**
    * The Y position of the last mouse down event.
    */
-  float m_lastClickY;
+  float m_lastClickY = 0.0f;
   /**
    * The time at which the last mouse down event was recorded.
    */
-  std::chrono::time_point<std::chrono::high_resolution_clock> m_lastClickTime;
+  std::chrono::time_point<std::chrono::high_resolution_clock> m_lastClickTime =
+    std::chrono::high_resolution_clock::now();
   /**
    * Used in implementing the macOS behaviour where Ctrl+Click is RMB.
    */
-  bool m_nextMouseUpIsRMB;
+  bool m_nextMouseUpIsRMB = false;
   /**
    * Used to suppress a click event for the mouse up event that follows a double click.
    */
-  bool m_nextMouseUpIsDblClick;
+  bool m_nextMouseUpIsDblClick = false;
 
 public:
-  /**
-   * Creates a new event handler.
-   */
-  InputEventRecorder();
-
   /**
    * Records the given key event.
    *
@@ -435,5 +429,4 @@ public:
    */
   virtual void processEvent(const CancelEvent& event) = 0;
 };
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -236,16 +236,23 @@ std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs);
 class ScrollEvent : public InputEvent
 {
 public:
+  enum class Source
+  {
+    Mouse,
+    Trackpad,
+  };
+
   enum class Axis
   {
     Vertical,
     Horizontal,
   };
 
+  Source source;
   Axis axis;
   float distance;
 
-  ScrollEvent(Axis axis, float distance);
+  ScrollEvent(Source source, Axis axis, float distance);
 
   /**
    * Collates this scroll event with the given scroll event. Only successive Pan,
@@ -264,9 +271,10 @@ public:
    */
   void processWith(InputEventProcessor& processor) const override;
 
-  kdl_reflect_decl(ScrollEvent, axis, distance);
+  kdl_reflect_decl(ScrollEvent, source, axis, distance);
 };
 
+std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Source& rhs);
 std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Axis& rhs);
 
 /**

--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -37,6 +37,7 @@ class GestureEvent;
 class InputEventProcessor;
 class KeyEvent;
 class MouseEvent;
+class ScrollEvent;
 
 /**
  * Superclass for all input events. Provides protocols for event collation and processing.
@@ -61,6 +62,14 @@ public:
    * @return true if this event was collated with the given event and false otherwise
    */
   virtual bool collateWith(const MouseEvent& event);
+
+  /**
+   * Collate this event with the given scroll event.
+   *
+   * @param event the event to collate with
+   * @return true if this event was collated with the given event and false otherwise
+   */
+  virtual bool collateWith(const ScrollEvent& event);
 
   /**
    * Collate this event with the given gesture event.
@@ -158,10 +167,6 @@ public:
      */
     Motion,
     /**
-     * The mouse wheel was scrolled.
-     */
-    Scroll,
-    /**
      * A mouse drag was started.
      */
     DragStart,
@@ -183,22 +188,14 @@ public:
     Aux1,
     Aux2
   };
-  enum class WheelAxis
-  {
-    None,
-    Vertical,
-    Horizontal
-  };
 
 public:
   Type type;
   Button button;
-  WheelAxis wheelAxis;
 
   /** Cursor position in Points, relative to top left of widget. */
   float posX;
   float posY;
-  float scrollDistance;
 
 public:
   /**
@@ -209,15 +206,8 @@ public:
    * @param wheelAxis the wheel axies that was scrolled, if any
    * @param posX the current X position of the mouse pointer
    * @param posY the current Y position of the mouse pointer
-   * @param scrollDistance the distance by which the mouse wheel was scrolled, in lines
    */
-  MouseEvent(
-    Type type,
-    Button button,
-    WheelAxis wheelAxis,
-    float posX,
-    float posY,
-    float scrollDistance);
+  MouseEvent(Type type, Button button, float posX, float posY);
 
 public:
   /**
@@ -237,12 +227,47 @@ public:
    */
   void processWith(InputEventProcessor& processor) const override;
 
-  kdl_reflect_decl(MouseEvent, type, button, wheelAxis, posX, posY, scrollDistance);
+  kdl_reflect_decl(MouseEvent, type, button, posX, posY);
 };
 
 std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Type& rhs);
 std::ostream& operator<<(std::ostream& lhs, const MouseEvent::Button& rhs);
-std::ostream& operator<<(std::ostream& lhs, const MouseEvent::WheelAxis& rhs);
+
+class ScrollEvent : public InputEvent
+{
+public:
+  enum class Axis
+  {
+    Vertical,
+    Horizontal,
+  };
+
+  Axis axis;
+  float distance;
+
+  ScrollEvent(Axis axis, float distance);
+
+  /**
+   * Collates this scroll event with the given scroll event. Only successive Pan,
+   * Zoom and Rotate events are collated.
+   *
+   * @param event the scroll event to collate with
+   * @return true if this event was collated with the given scroll event and false
+   * otherwise
+   */
+  bool collateWith(const ScrollEvent& event) override;
+
+  /**
+   * Process this scroll event using the given event processor.
+   *
+   * @param processor the event processor
+   */
+  void processWith(InputEventProcessor& processor) const override;
+
+  kdl_reflect_decl(ScrollEvent, axis, distance);
+};
+
+std::ostream& operator<<(std::ostream& lhs, const ScrollEvent::Axis& rhs);
 
 /**
  * A gesture event. Supports several gesture types such as pan, zoom, and rotate.
@@ -513,6 +538,13 @@ public:
    * @param event the event to process
    */
   virtual void processEvent(const GestureEvent& event) = 0;
+
+  /**
+   * Process a scroll event.
+   *
+   * @param event the event to process
+   */
+  virtual void processEvent(const ScrollEvent& event) = 0;
 
   /**
    * Process a cancellation event.

--- a/common/src/View/InputState.cpp
+++ b/common/src/View/InputState.cpp
@@ -146,6 +146,11 @@ float InputState::mouseDY() const
   return m_mouseDY;
 }
 
+ScrollSource InputState::scrollSource() const
+{
+  return m_scrollSource;
+}
+
 float InputState::scrollX() const
 {
   return m_scrollX;
@@ -224,8 +229,10 @@ void InputState::mouseMove(
   m_mouseDY = mouseDY;
 }
 
-void InputState::scroll(const float scrollX, const float scrollY)
+void InputState::scroll(
+  const ScrollSource scrollSource, const float scrollX, const float scrollY)
 {
+  m_scrollSource = scrollSource;
   m_scrollX = scrollX;
   m_scrollY = scrollY;
 }

--- a/common/src/View/InputState.cpp
+++ b/common/src/View/InputState.cpp
@@ -23,41 +23,23 @@
 
 #include "FloatType.h"
 #include "Macros.h"
-#include "Model/CompareHits.h"
 #include "Renderer/Camera.h"
 
 #include "vm/vec.h"
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 InputState::InputState()
-  : m_modifierKeys(ModifierKeys::MKNone)
-  , m_mouseButtons(MouseButtons::MBNone)
-  , m_mouseX(0.0f)
-  , m_mouseY(0.0f)
-  , m_mouseDX(0.0f)
-  , m_mouseDY(0.0f)
-  , m_scrollX(0.0f)
-  , m_scrollY(0.0f)
-  , m_anyToolDragging(false)
 {
-  const QPoint mouseState = QCursor::pos();
-  m_mouseX = static_cast<float>(mouseState.x());
-  m_mouseY = static_cast<float>(mouseState.y());
+  const auto mouseState = QCursor::pos();
+  m_mouseX = float(mouseState.x());
+  m_mouseY = float(mouseState.y());
 }
 
 InputState::InputState(const float mouseX, const float mouseY)
-  : m_modifierKeys(ModifierKeys::MKNone)
-  , m_mouseButtons(MouseButtons::MBNone)
-  , m_mouseX(mouseX)
-  , m_mouseY(mouseY)
-  , m_mouseDX(0.0f)
-  , m_mouseDY(0.0f)
-  , m_scrollX(0.0f)
-  , m_scrollY(0.0f)
-  , m_anyToolDragging(false)
+  : m_mouseX{mouseX}
+  , m_mouseY{mouseY}
 {
 }
 
@@ -84,15 +66,23 @@ bool InputState::checkModifierKeys(
   const ModifierKeyState key3,
   const ModifierKeyState key4) const
 {
-  assert(key1 != ModifierKeys::MKDontCare);
+  assert(key1 != ModifierKeys::DontCare);
   if (modifierKeysPressed(key1))
+  {
     return true;
-  if (key2 != ModifierKeys::MKDontCare && modifierKeysPressed(key2))
+  }
+  if (key2 != ModifierKeys::DontCare && modifierKeysPressed(key2))
+  {
     return true;
-  if (key3 != ModifierKeys::MKDontCare && modifierKeysPressed(key3))
+  }
+  if (key3 != ModifierKeys::DontCare && modifierKeysPressed(key3))
+  {
     return true;
-  if (key4 != ModifierKeys::MKDontCare && modifierKeysPressed(key4))
+  }
+  if (key4 != ModifierKeys::DontCare && modifierKeysPressed(key4))
+  {
     return true;
+  }
   return false;
 }
 
@@ -104,18 +94,18 @@ bool InputState::checkModifierKeys(
   return (
     checkModifierKey(ctrl, ModifierKeys::MKCtrlCmd)
     && checkModifierKey(alt, ModifierKeys::MKAlt)
-    && checkModifierKey(shift, ModifierKeys::MKShift));
+    && checkModifierKey(shift, ModifierKeys::Shift));
 }
 
 bool InputState::checkModifierKey(ModifierKeyPressed state, ModifierKeyState key) const
 {
   switch (state)
   {
-  case MK_Yes:
+  case ModifierKeyPressed::Yes:
     return modifierKeysDown(key);
-  case MK_No:
+  case ModifierKeyPressed::No:
     return !modifierKeysDown(key);
-  case MK_DontCare:
+  case ModifierKeyPressed::DontCare:
     return true;
     switchDefault();
   }
@@ -173,7 +163,7 @@ void InputState::setModifierKeys(const ModifierKeyState keys)
 
 void InputState::clearModifierKeys()
 {
-  m_modifierKeys = ModifierKeys::MKNone;
+  m_modifierKeys = ModifierKeys::None;
 }
 
 void InputState::mouseDown(const MouseButtonState button)
@@ -188,7 +178,7 @@ void InputState::mouseUp(const MouseButtonState button)
 
 void InputState::clearMouseButtons()
 {
-  m_mouseButtons = MouseButtons::MBNone;
+  m_mouseButtons = MouseButtons::None;
 }
 
 void InputState::mouseMove(
@@ -223,12 +213,12 @@ const vm::ray3& InputState::pickRay() const
 
 const vm::vec3 InputState::defaultPoint() const
 {
-  return vm::vec3(camera().defaultPoint());
+  return vm::vec3{camera().defaultPoint()};
 }
 
 const vm::vec3 InputState::defaultPointUnderMouse() const
 {
-  return vm::vec3(camera().defaultPoint(pickRay()));
+  return vm::vec3{camera().defaultPoint(pickRay())};
 }
 
 const Renderer::Camera& InputState::camera() const
@@ -246,9 +236,8 @@ const Model::PickResult& InputState::pickResult() const
   return m_pickResult;
 }
 
-void InputState::setPickResult(Model::PickResult&& pickResult)
+void InputState::setPickResult(Model::PickResult pickResult)
 {
   m_pickResult = std::move(pickResult);
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/InputState.cpp
+++ b/common/src/View/InputState.cpp
@@ -156,6 +156,40 @@ float InputState::scrollY() const
   return m_scrollY;
 }
 
+bool InputState::gestureActive() const
+{
+  return m_gestureActive;
+}
+
+float InputState::gesturePanX() const
+{
+  return m_gesturePanX;
+}
+
+float InputState::gesturePanY() const
+{
+  return m_gesturePanY;
+}
+
+float InputState::gesturePanDX() const
+{
+  return m_gesturePanDX;
+}
+float InputState::gesturePanDY() const
+{
+  return m_gesturePanDY;
+}
+
+float InputState::gestureZoomValue() const
+{
+  return m_gestureZoomValue;
+}
+
+float InputState::gestureRotateValue() const
+{
+  return m_gestureRotateValue;
+}
+
 void InputState::setModifierKeys(const ModifierKeyState keys)
 {
   m_modifierKeys = keys;
@@ -194,6 +228,38 @@ void InputState::scroll(const float scrollX, const float scrollY)
 {
   m_scrollX = scrollX;
   m_scrollY = scrollY;
+}
+
+void InputState::startGesture()
+{
+  m_gestureActive = true;
+}
+
+void InputState::gesturePan(const float x, const float y, const float dx, const float dy)
+{
+  m_gesturePanX = x;
+  m_gesturePanY = y;
+  m_gesturePanDX = dx;
+  m_gesturePanDY = dy;
+}
+
+void InputState::gestureZoom(const float value)
+{
+  m_gestureZoomValue = value;
+}
+
+void InputState::gestureRotate(const float value)
+{
+  m_gestureRotateValue = value;
+}
+
+void InputState::endGesture()
+{
+  m_gestureActive = false;
+  m_gesturePanX = 0.0f;
+  m_gesturePanY = 0.0f;
+  m_gestureZoomValue = 0.0f;
+  m_gestureRotateValue = 0.0f;
 }
 
 bool InputState::anyToolDragging() const

--- a/common/src/View/InputState.h
+++ b/common/src/View/InputState.h
@@ -56,6 +56,13 @@ static const MouseButtonState Right = 1 << 1;
 static const MouseButtonState Middle = 1 << 2;
 } // namespace MouseButtons
 
+enum class GestureType
+{
+  Pan,
+  Zoom,
+  Rotate,
+};
+
 class InputState
 {
 private:
@@ -68,6 +75,14 @@ private:
   float m_mouseDY = 0.0f;
   float m_scrollX = 0.0f;
   float m_scrollY = 0.0f;
+
+  bool m_gestureActive = false;
+  float m_gesturePanX = 0.0;
+  float m_gesturePanY = 0.0;
+  float m_gesturePanDX = 0.0;
+  float m_gesturePanDY = 0.0;
+  float m_gestureZoomValue = 0.0f;
+  float m_gestureRotateValue = 0.0f;
 
   bool m_anyToolDragging = false;
   PickRequest m_pickRequest;
@@ -110,6 +125,14 @@ public:
    */
   float scrollY() const;
 
+  bool gestureActive() const;
+  float gesturePanX() const;
+  float gesturePanY() const;
+  float gesturePanDX() const;
+  float gesturePanDY() const;
+  float gestureZoomValue() const;
+  float gestureRotateValue() const;
+
   void setModifierKeys(ModifierKeyState keys);
   void clearModifierKeys();
   void mouseDown(MouseButtonState button);
@@ -117,6 +140,12 @@ public:
   void clearMouseButtons();
   void mouseMove(float mouseX, float mouseY, float mouseDX, float mouseDY);
   void scroll(float scrollX, float scrollY);
+
+  void startGesture();
+  void gesturePan(float x, float y, float dx, float dy);
+  void gestureZoom(float value);
+  void gestureRotate(float value);
+  void endGesture();
 
   bool anyToolDragging() const;
   void setAnyToolDragging(bool anyToolDragging);

--- a/common/src/View/InputState.h
+++ b/common/src/View/InputState.h
@@ -23,61 +23,59 @@
 #include "Model/PickResult.h"
 #include "View/PickRequest.h"
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class Camera;
 }
 
-namespace View
+namespace TrenchBroom::View
 {
 using ModifierKeyState = unsigned int;
 namespace ModifierKeys
 {
-static const ModifierKeyState MKNone = 0;
-static const ModifierKeyState MKShift = 1 << 0;
+static const ModifierKeyState None = 0;
+static const ModifierKeyState Shift = 1 << 0;
 static const ModifierKeyState MKCtrlCmd = 1 << 1; // Cmd on Mac, Ctrl on other systems
 static const ModifierKeyState MKAlt = 1 << 2;
-static const ModifierKeyState MKDontCare = 1 << 3;
+static const ModifierKeyState DontCare = 1 << 3;
 } // namespace ModifierKeys
 
-typedef enum
+enum class ModifierKeyPressed
 {
-  MK_Yes,
-  MK_No,
-  MK_DontCare
-} ModifierKeyPressed;
+  Yes,
+  No,
+  DontCare
+};
 
 using MouseButtonState = unsigned int;
 namespace MouseButtons
 {
-static const MouseButtonState MBNone = 0;
-static const MouseButtonState MBLeft = 1 << 0;
-static const MouseButtonState MBRight = 1 << 1;
-static const MouseButtonState MBMiddle = 1 << 2;
+static const MouseButtonState None = 0;
+static const MouseButtonState Left = 1 << 0;
+static const MouseButtonState Right = 1 << 1;
+static const MouseButtonState Middle = 1 << 2;
 } // namespace MouseButtons
 
 class InputState
 {
 private:
-  ModifierKeyState m_modifierKeys;
-  MouseButtonState m_mouseButtons;
+  ModifierKeyState m_modifierKeys = ModifierKeys::None;
+  MouseButtonState m_mouseButtons = MouseButtons::None;
   /** Mouse position in units of points, relative to top left of widget */
-  float m_mouseX;
-  float m_mouseY;
-  float m_mouseDX;
-  float m_mouseDY;
-  float m_scrollX;
-  float m_scrollY;
+  float m_mouseX = 0.0f;
+  float m_mouseY = 0.0f;
+  float m_mouseDX = 0.0f;
+  float m_mouseDY = 0.0f;
+  float m_scrollX = 0.0f;
+  float m_scrollY = 0.0f;
 
-  bool m_anyToolDragging;
+  bool m_anyToolDragging = false;
   PickRequest m_pickRequest;
   Model::PickResult m_pickResult;
 
 public:
   InputState();
-  InputState(const float mouseX, const float mouseY);
+  InputState(float mouseX, float mouseY);
   virtual ~InputState();
 
   virtual ModifierKeyState modifierKeys() const;
@@ -85,9 +83,9 @@ public:
   bool modifierKeysPressed(ModifierKeyState keys) const;
   bool checkModifierKeys(
     ModifierKeyState key1,
-    ModifierKeyState key2 = ModifierKeys::MKDontCare,
-    ModifierKeyState key3 = ModifierKeys::MKDontCare,
-    ModifierKeyState key4 = ModifierKeys::MKDontCare) const;
+    ModifierKeyState key2 = ModifierKeys::DontCare,
+    ModifierKeyState key3 = ModifierKeys::DontCare,
+    ModifierKeyState key4 = ModifierKeys::DontCare) const;
   bool checkModifierKeys(
     ModifierKeyPressed ctrl, ModifierKeyPressed alt, ModifierKeyPressed shift) const;
   bool checkModifierKey(ModifierKeyPressed state, ModifierKeyState key) const;
@@ -97,7 +95,7 @@ public:
   /**
    * Checks whether only the given buttons are down (and no others).
    */
-  bool mouseButtonsPressed(const MouseButtonState buttons) const;
+  bool mouseButtonsPressed(MouseButtonState buttons) const;
   float mouseX() const;
   float mouseY() const;
   float mouseDX() const;
@@ -112,14 +110,13 @@ public:
    */
   float scrollY() const;
 
-  void setModifierKeys(const ModifierKeyState keys);
+  void setModifierKeys(ModifierKeyState keys);
   void clearModifierKeys();
-  void mouseDown(const MouseButtonState button);
-  void mouseUp(const MouseButtonState button);
+  void mouseDown(MouseButtonState button);
+  void mouseUp(MouseButtonState button);
   void clearMouseButtons();
-  void mouseMove(
-    const float mouseX, const float mouseY, const float mouseDX, const float mouseDY);
-  void scroll(const float scrollX, const float scrollY);
+  void mouseMove(float mouseX, float mouseY, float mouseDX, float mouseDY);
+  void scroll(float scrollX, float scrollY);
 
   bool anyToolDragging() const;
   void setAnyToolDragging(bool anyToolDragging);
@@ -131,7 +128,7 @@ public:
   void setPickRequest(const PickRequest& pickRequest);
 
   const Model::PickResult& pickResult() const;
-  void setPickResult(Model::PickResult&& pickResult);
+  void setPickResult(Model::PickResult pickResult);
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/InputState.h
+++ b/common/src/View/InputState.h
@@ -56,6 +56,12 @@ static const MouseButtonState Right = 1 << 1;
 static const MouseButtonState Middle = 1 << 2;
 } // namespace MouseButtons
 
+enum class ScrollSource
+{
+  Mouse,
+  Trackpad,
+};
+
 enum class GestureType
 {
   Pan,
@@ -73,6 +79,8 @@ private:
   float m_mouseY = 0.0f;
   float m_mouseDX = 0.0f;
   float m_mouseDY = 0.0f;
+
+  ScrollSource m_scrollSource = ScrollSource::Mouse;
   float m_scrollX = 0.0f;
   float m_scrollY = 0.0f;
 
@@ -116,6 +124,8 @@ public:
   float mouseDX() const;
   float mouseDY() const;
 
+  ScrollSource scrollSource() const;
+
   /**
    * Number of "lines" to scroll horizontally.
    */
@@ -139,7 +149,7 @@ public:
   void mouseUp(MouseButtonState button);
   void clearMouseButtons();
   void mouseMove(float mouseX, float mouseY, float mouseDX, float mouseDY);
-  void scroll(float scrollX, float scrollY);
+  void scroll(ScrollSource scrollSource, float scrollX, float scrollY);
 
   void startGesture();
   void gesturePan(float x, float y, float dx, float dy);

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1176,6 +1176,11 @@ void MapViewBase::processEvent(const MouseEvent& event)
   ToolBoxConnector::processEvent(event);
 }
 
+void MapViewBase::processEvent(const ScrollEvent& event)
+{
+  ToolBoxConnector::processEvent(event);
+}
+
 void MapViewBase::processEvent(const GestureEvent& event)
 {
   ToolBoxConnector::processEvent(event);

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1176,6 +1176,11 @@ void MapViewBase::processEvent(const MouseEvent& event)
   ToolBoxConnector::processEvent(event);
 }
 
+void MapViewBase::processEvent(const GestureEvent& event)
+{
+  ToolBoxConnector::processEvent(event);
+}
+
 void MapViewBase::processEvent(const CancelEvent& event)
 {
   ToolBoxConnector::processEvent(event);

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -347,6 +347,7 @@ private: // implement RenderView interface
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 
 private: // implement ToolBoxConnector

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -347,6 +347,7 @@ private: // implement RenderView interface
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const ScrollEvent& event) override;
   void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 

--- a/common/src/View/MoveHandleDragTracker.h
+++ b/common/src/View/MoveHandleDragTracker.h
@@ -37,9 +37,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 enum class SnapMode
 {
@@ -216,7 +214,7 @@ public:
    * MoveHandleDragTrackerDelegate and is used to implement the actual effects and refine
    * the behavior of this delegate.
    */
-  MoveHandleDragDelegate(Delegate delegate)
+  explicit MoveHandleDragDelegate(Delegate delegate)
     : m_delegate{std::move(delegate)}
   {
   }
@@ -418,12 +416,12 @@ private:
   {
     const Renderer::Camera& camera = inputState.camera();
     return camera.perspectiveProjection()
-           && inputState.checkModifierKey(MK_Yes, ModifierKeys::MKAlt);
+           && inputState.checkModifierKey(ModifierKeyPressed::Yes, ModifierKeys::MKAlt);
   }
 
   static bool isConstrictedMove(const InputState& inputState, const DragState& dragState)
   {
-    if (inputState.checkModifierKey(MK_Yes, ModifierKeys::MKShift))
+    if (inputState.checkModifierKey(ModifierKeyPressed::Yes, ModifierKeys::Shift))
     {
       const auto delta =
         dragState.currentHandlePosition - dragState.initialHandlePosition;
@@ -435,7 +433,7 @@ private:
 
   static SnapMode snapMode(const InputState& inputState)
   {
-    return inputState.checkModifierKey(MK_Yes, ModifierKeys::MKCtrlCmd)
+    return inputState.checkModifierKey(ModifierKeyPressed::Yes, ModifierKeys::MKCtrlCmd)
              ? SnapMode::Absolute
              : SnapMode::Relative;
   }
@@ -510,5 +508,4 @@ createMoveHandleDragTracker(
  * Returns a relative or an absolute handle snapper according to the given snap mode.
  */
 DragHandleSnapper makeDragHandleSnapperFromSnapMode(const Grid& grid, SnapMode snapMode);
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/MoveHandleDragTracker.h
+++ b/common/src/View/MoveHandleDragTracker.h
@@ -244,9 +244,9 @@ public:
   }
 
   /**
-   * Forwards to the delegate's drag() function.
+   * Forwards to the delegate's move() function.
    */
-  DragStatus drag(
+  DragStatus update(
     const InputState& inputState,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -23,7 +23,7 @@
 #include "Model/HitFilter.h"
 #include "Model/ModelUtils.h"
 #include "Renderer/RenderContext.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/MoveHandleDragTracker.h"
 #include "View/MoveObjectsTool.h"
 
@@ -102,7 +102,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> MoveObjectsToolController::acceptMouseDrag(
+std::unique_ptr<GestureTracker> MoveObjectsToolController::acceptMouseDrag(
   const InputState& inputState)
 {
   using namespace Model::HitFilters;

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -108,7 +108,7 @@ std::unique_ptr<DragTracker> MoveObjectsToolController::acceptMouseDrag(
   using namespace Model::HitFilters;
 
   if (
-    !inputState.modifierKeysPressed(ModifierKeys::MKNone)
+    !inputState.modifierKeysPressed(ModifierKeys::None)
     && !inputState.modifierKeysPressed(ModifierKeys::MKAlt)
     && !inputState.modifierKeysPressed(ModifierKeys::MKCtrlCmd)
     && !inputState.modifierKeysPressed(ModifierKeys::MKCtrlCmd | ModifierKeys::MKAlt))

--- a/common/src/View/MoveObjectsToolController.h
+++ b/common/src/View/MoveObjectsToolController.h
@@ -25,7 +25,7 @@ namespace TrenchBroom
 {
 namespace View
 {
-class DragTracker;
+class GestureTracker;
 class MoveObjectsTool;
 
 class MoveObjectsToolController : public ToolController
@@ -41,7 +41,7 @@ private:
   Tool& tool() override;
   const Tool& tool() const override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -24,7 +24,6 @@
 #include "Renderer/GLVertexType.h"
 #include "Renderer/PrimType.h"
 #include "Renderer/Transformation.h"
-#include "Renderer/Vbo.h"
 #include "Renderer/VboManager.h"
 #include "Renderer/VertexArray.h"
 #include "TrenchBroomApp.h"
@@ -78,38 +77,34 @@
 
 #include <iostream>
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 RenderView::RenderView(GLContextManager& contextManager, QWidget* parent)
-  : QOpenGLWidget(parent)
-  , m_glContext(&contextManager)
-  , m_framesRendered(0)
-  , m_maxFrameTimeMsecs(0)
-  , m_lastFPSCounterUpdate(0)
+  : QOpenGLWidget{parent}
+  , m_glContext{&contextManager}
 {
-  QPalette pal;
-  const QColor color = pal.color(QPalette::Highlight);
+  auto pal = QPalette{};
+  const auto color = pal.color(QPalette::Highlight);
   m_focusColor = fromQColor(color);
 
   // FPS counter
-  QTimer* fpsCounter = new QTimer(this);
+  auto* fpsCounter = new QTimer{this};
 
   connect(fpsCounter, &QTimer::timeout, [&]() {
     const int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
     const int framesRenderedInPeriod = m_framesRendered;
     const int maxFrameTime = m_maxFrameTimeMsecs;
     const int64_t fpsCounterPeriod = currentTime - m_lastFPSCounterUpdate;
-    const double avgFps = static_cast<double>(framesRenderedInPeriod)
-                          / (static_cast<double>(fpsCounterPeriod) / 1000.0);
+    const double avgFps =
+      double(framesRenderedInPeriod) / (double(fpsCounterPeriod) / 1000.0);
 
     m_framesRendered = 0;
     m_maxFrameTimeMsecs = 0;
     m_lastFPSCounterUpdate = currentTime;
 
     m_currentFPS =
-      std::string("Avg FPS: ") + std::to_string(avgFps)
+      std::string{"Avg FPS: "} + std::to_string(avgFps)
       + " Max time between frames: " + std::to_string(maxFrameTime) + "ms. "
       + std::to_string(m_glContext->vboManager().currentVboCount()) + " current VBOs ("
       + std::to_string(m_glContext->vboManager().peakVboCount()) + " peak) totalling "
@@ -144,7 +139,7 @@ static auto mouseEventWithFullPrecisionLocalPos(
   // mapTo takes QPoint, so we just map the origin and subtract that.
   const auto localPos =
     event->windowPos() - QPointF(widget->mapTo(widget->window(), QPoint(0, 0)));
-  return QMouseEvent(
+  return QMouseEvent{
     event->type(),
     localPos,
     event->windowPos(),
@@ -152,7 +147,7 @@ static auto mouseEventWithFullPrecisionLocalPos(
     event->button(),
     event->buttons(),
     event->modifiers(),
-    event->source());
+    event->source()};
 }
 
 void RenderView::mouseDoubleClickEvent(QMouseEvent* event)
@@ -188,7 +183,9 @@ void RenderView::wheelEvent(QWheelEvent* event)
 void RenderView::paintGL()
 {
   if (TrenchBroom::View::isReportingCrash())
+  {
     return;
+  }
 
   render();
 
@@ -196,7 +193,7 @@ void RenderView::paintGL()
   m_framesRendered++;
   if (m_timeSinceLastFrame.isValid())
   {
-    int frameTime = static_cast<int>(m_timeSinceLastFrame.restart());
+    auto frameTime = int(m_timeSinceLastFrame.restart());
     if (frameTime > m_maxFrameTimeMsecs)
     {
       m_maxFrameTimeMsecs = frameTime;
@@ -276,49 +273,51 @@ const Color& RenderView::getBackgroundColor()
 void RenderView::renderFocusIndicator()
 {
   if (!doShouldRenderFocusIndicator() || !hasFocus())
+  {
     return;
+  }
 
-  const Color& outer = m_focusColor;
-  const Color& inner = m_focusColor;
+  const auto& outer = m_focusColor;
+  const auto& inner = m_focusColor;
 
-  const qreal r = devicePixelRatioF();
-  const auto w = static_cast<float>(width() * r);
-  const auto h = static_cast<float>(height() * r);
-  glAssert(glViewport(0, 0, static_cast<int>(w), static_cast<int>(h)));
+  const auto r = devicePixelRatioF();
+  const auto w = float(width() * r);
+  const auto h = float(height() * r);
+  glAssert(glViewport(0, 0, int(w), int(h)));
 
   const auto t = 1.0f;
 
-  const auto projection = vm::ortho_matrix(
-    -1.0f, 1.0f, 0.0f, 0.0f, static_cast<float>(w), static_cast<float>(h));
-  Renderer::Transformation transformation(projection, vm::mat4x4f::identity());
+  const auto projection = vm::ortho_matrix(-1.0f, 1.0f, 0.0f, 0.0f, float(w), float(h));
+  auto transformation = Renderer::Transformation{projection, vm::mat4x4f::identity()};
 
   glAssert(glDisable(GL_DEPTH_TEST));
 
   using Vertex = Renderer::GLVertexTypes::P3C4::Vertex;
-  auto array = Renderer::VertexArray::move(
-    std::vector<Vertex>({// top
-                         Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
-                         Vertex(vm::vec3f(w, 0.0f, 0.0f), outer),
-                         Vertex(vm::vec3f(w - t, t, 0.0f), inner),
-                         Vertex(vm::vec3f(t, t, 0.0f), inner),
+  auto array = Renderer::VertexArray::move(std::vector{
+    // top
+    Vertex{{0.0f, 0.0f, 0.0f}, outer},
+    Vertex{{w, 0.0f, 0.0f}, outer},
+    Vertex{{w - t, t, 0.0f}, inner},
+    Vertex{{t, t, 0.0f}, inner},
 
-                         // right
-                         Vertex(vm::vec3f(w, 0.0f, 0.0f), outer),
-                         Vertex(vm::vec3f(w, h, 0.0f), outer),
-                         Vertex(vm::vec3f(w - t, h - t, 0.0f), inner),
-                         Vertex(vm::vec3f(w - t, t, 0.0f), inner),
+    // right
+    Vertex{{w, 0.0f, 0.0f}, outer},
+    Vertex{{w, h, 0.0f}, outer},
+    Vertex{{w - t, h - t, 0.0f}, inner},
+    Vertex{{w - t, t, 0.0f}, inner},
 
-                         // bottom
-                         Vertex(vm::vec3f(w, h, 0.0f), outer),
-                         Vertex(vm::vec3f(0.0f, h, 0.0f), outer),
-                         Vertex(vm::vec3f(t, h - t, 0.0f), inner),
-                         Vertex(vm::vec3f(w - t, h - t, 0.0f), inner),
+    // bottom
+    Vertex{{w, h, 0.0f}, outer},
+    Vertex{{0.0f, h, 0.0f}, outer},
+    Vertex{{t, h - t, 0.0f}, inner},
+    Vertex{{w - t, h - t, 0.0f}, inner},
 
-                         // left
-                         Vertex(vm::vec3f(0.0f, h, 0.0f), outer),
-                         Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
-                         Vertex(vm::vec3f(t, t, 0.0f), inner),
-                         Vertex(vm::vec3f(t, h - t, 0.0f), inner)}));
+    // left
+    Vertex{{0.0f, h, 0.0f}, outer},
+    Vertex{{0.0f, 0.0f, 0.0f}, outer},
+    Vertex{{t, t, 0.0f}, inner},
+    Vertex{{t, h - t, 0.0f}, inner},
+  });
 
   array.prepare(vboManager());
   array.render(Renderer::PrimType::Quads);
@@ -334,5 +333,5 @@ void RenderView::doUpdateViewport(
   const int /* x */, const int /* y */, const int /* width */, const int /* height */)
 {
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -180,6 +180,22 @@ void RenderView::wheelEvent(QWheelEvent* event)
   update();
 }
 
+bool RenderView::event(QEvent* event)
+{
+  // Unfortunately, QWidget doesn't define a specialized handler for QNativeGestureEvent,
+  // so we must override the main event handler to handle it.
+  if (event->type() == QEvent::NativeGesture)
+  {
+    const auto gestureEvent = static_cast<QNativeGestureEvent*>(event);
+    m_eventRecorder.recordEvent(*gestureEvent);
+    update();
+    return true;
+  }
+
+  // Let the base class handle all other events normally
+  return QOpenGLWidget::event(event);
+}
+
 void RenderView::paintGL()
 {
   if (TrenchBroom::View::isReportingCrash())

--- a/common/src/View/RenderView.h
+++ b/common/src/View/RenderView.h
@@ -77,6 +77,7 @@ protected: // QWindow overrides
   void mousePressEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;
+  bool event(QEvent* event) override;
 
 protected:
   Renderer::VboManager& vboManager();

--- a/common/src/View/RenderView.h
+++ b/common/src/View/RenderView.h
@@ -25,7 +25,6 @@
 #include <QOpenGLWidget>
 
 #include "Color.h"
-#include "Renderer/GL.h"
 #include "View/InputEvent.h"
 
 #include <string>
@@ -34,16 +33,14 @@
 #undef Status
 #undef CursorShape
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class FontManager;
 class ShaderManager;
 class VboManager;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class GLContextManager;
 
@@ -57,10 +54,10 @@ private:
 
 private: // FPS counter
   // stats since the last counter update
-  int m_framesRendered;
-  int m_maxFrameTimeMsecs;
+  int m_framesRendered = 0;
+  int m_maxFrameTimeMsecs = 0;
   // other
-  int64_t m_lastFPSCounterUpdate;
+  int64_t m_lastFPSCounterUpdate = 0;
   QElapsedTimer m_timeSinceLastFrame;
 
 protected:
@@ -110,5 +107,5 @@ private:
   virtual bool doShouldRenderFocusIndicator() const = 0;
   virtual void doRender() = 0;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -255,7 +255,7 @@ private:
     return true;
   }
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
   {
     using namespace Model::HitFilters;
 
@@ -405,7 +405,7 @@ protected:
 
   const Tool& tool() const override { return m_tool; }
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
   {
     using namespace Model::HitFilters;
 

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -137,7 +137,7 @@ public:
       makeCircleHandleSnapper(m_tool.grid(), m_tool.angle(), center, axis, radius));
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -35,6 +35,7 @@
 #include "View/HandleDragTracker.h"
 #include "View/InputState.h"
 #include "View/MoveHandleDragTracker.h"
+#include "View/RotateObjectsHandle.h"
 #include "View/RotateObjectsTool.h"
 #include "View/ToolController.h"
 
@@ -48,12 +49,11 @@
 #include <memory>
 #include <sstream>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 namespace
 {
+
 class AngleIndicatorRenderer : public Renderer::DirectRenderable
 {
 private:
@@ -110,7 +110,7 @@ private:
   RotateObjectsTool& m_tool;
   RotateObjectsHandle::HitArea m_area;
   RenderHighlight m_renderHighlight;
-  FloatType m_angle{0.0};
+  FloatType m_angle = 0.0;
 
 public:
   RotateObjectsDragDelegate(
@@ -144,8 +144,8 @@ public:
   {
     const auto center = m_tool.rotationCenter();
     const auto axis = m_tool.rotationAxis(m_area);
-    const vm::vec3 ref = vm::normalize(dragState.initialHandlePosition - center);
-    const vm::vec3 vec = vm::normalize(proposedHandlePosition - center);
+    const auto ref = vm::normalize(dragState.initialHandlePosition - center);
+    const auto vec = vm::normalize(proposedHandlePosition - center);
     m_angle = vm::measure_angle(vec, ref, axis);
     m_tool.applyRotation(center, axis, m_angle);
 
@@ -233,19 +233,19 @@ private:
   {
     using namespace Model::HitFilters;
 
-    if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+    if (!inputState.mouseButtonsPressed(MouseButtons::Left))
     {
       return false;
     }
 
-    const Model::Hit& hit =
+    const auto& hit =
       inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));
     if (!hit.isMatch())
     {
       return false;
     }
 
-    const RotateObjectsHandle::HitArea area = hit.target<RotateObjectsHandle::HitArea>();
+    const auto area = hit.target<RotateObjectsHandle::HitArea>();
     if (area == RotateObjectsHandle::HitArea::Center)
     {
       return false;
@@ -260,20 +260,20 @@ private:
     using namespace Model::HitFilters;
 
     if (
-      inputState.mouseButtons() != MouseButtons::MBLeft
-      || inputState.modifierKeys() != ModifierKeys::MKNone)
+      inputState.mouseButtons() != MouseButtons::Left
+      || inputState.modifierKeys() != ModifierKeys::None)
     {
       return nullptr;
     }
 
-    const Model::Hit& hit =
+    const auto& hit =
       inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));
     if (!hit.isMatch())
     {
       return nullptr;
     }
 
-    const RotateObjectsHandle::HitArea area = hit.target<RotateObjectsHandle::HitArea>();
+    const auto area = hit.target<RotateObjectsHandle::HitArea>();
     if (area == RotateObjectsHandle::HitArea::Center)
     {
       return nullptr;
@@ -319,12 +319,11 @@ private:
 
     if (!inputState.anyToolDragging())
     {
-      const Model::Hit& hit =
+      const auto& hit =
         inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));
       if (hit.isMatch())
       {
-        const RotateObjectsHandle::HitArea area =
-          hit.target<RotateObjectsHandle::HitArea>();
+        const auto area = hit.target<RotateObjectsHandle::HitArea>();
         if (area != RotateObjectsHandle::HitArea::Center)
         {
           doRenderHighlight(
@@ -398,7 +397,7 @@ protected:
 
 protected:
   explicit MoveCenterBase(RotateObjectsTool& tool)
-    : m_tool(tool)
+    : m_tool{tool}
   {
   }
 
@@ -411,16 +410,14 @@ protected:
     using namespace Model::HitFilters;
 
     if (
-      !inputState.mouseButtonsPressed(MouseButtons::MBLeft)
+      !inputState.mouseButtonsPressed(MouseButtons::Left)
       || !inputState.checkModifierKeys(
-        ModifierKeyPressed::MK_No,
-        ModifierKeyPressed::MK_DontCare,
-        ModifierKeyPressed::MK_No))
+        ModifierKeyPressed::No, ModifierKeyPressed::DontCare, ModifierKeyPressed::No))
     {
       return nullptr;
     }
 
-    const Model::Hit& hit =
+    const auto& hit =
       inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));
     if (!hit.isMatch())
     {
@@ -457,7 +454,7 @@ protected:
 
     if (!inputState.anyToolDragging())
     {
-      const Model::Hit& hit =
+      const auto& hit =
         inputState.pickResult().first(type(RotateObjectsHandle::HandleHitType));
       if (
         hit.isMatch()
@@ -484,7 +481,7 @@ class MoveCenterPart2D : public MoveCenterBase
 {
 public:
   explicit MoveCenterPart2D(RotateObjectsTool& tool)
-    : MoveCenterBase(tool)
+    : MoveCenterBase{tool}
   {
   }
 
@@ -503,7 +500,7 @@ class RotateObjectsPart2D : public RotateObjectsBase
 {
 public:
   explicit RotateObjectsPart2D(RotateObjectsTool& tool)
-    : RotateObjectsBase(tool)
+    : RotateObjectsBase{tool}
   {
   }
 
@@ -522,7 +519,7 @@ class MoveCenterPart3D : public MoveCenterBase
 {
 public:
   explicit MoveCenterPart3D(RotateObjectsTool& tool)
-    : MoveCenterBase(tool)
+    : MoveCenterBase{tool}
   {
   }
 
@@ -541,7 +538,7 @@ class RotateObjectsPart3D : public RotateObjectsBase
 {
 public:
   explicit RotateObjectsPart3D(RotateObjectsTool& tool)
-    : RotateObjectsBase(tool)
+    : RotateObjectsBase{tool}
   {
   }
 
@@ -555,10 +552,11 @@ private:
     m_tool.renderHighlight3D(renderContext, renderBatch, area);
   }
 };
+
 } // namespace
 
 RotateObjectsToolController::RotateObjectsToolController(RotateObjectsTool& tool)
-  : m_tool(tool)
+  : m_tool{tool}
 {
 }
 
@@ -577,7 +575,7 @@ const Tool& RotateObjectsToolController::tool() const
 void RotateObjectsToolController::pick(
   const InputState& inputState, Model::PickResult& pickResult)
 {
-  const Model::Hit hit = doPick(inputState);
+  const auto hit = doPick(inputState);
   if (hit.isMatch())
   {
     pickResult.addHit(hit);
@@ -609,7 +607,7 @@ bool RotateObjectsToolController::cancel()
 }
 
 RotateObjectsToolController2D::RotateObjectsToolController2D(RotateObjectsTool& tool)
-  : RotateObjectsToolController(tool)
+  : RotateObjectsToolController{tool}
 {
   addController(std::make_unique<MoveCenterPart2D>(tool));
   addController(std::make_unique<RotateObjectsPart2D>(tool));
@@ -627,7 +625,7 @@ void RotateObjectsToolController2D::doRenderHandle(
 }
 
 RotateObjectsToolController3D::RotateObjectsToolController3D(RotateObjectsTool& tool)
-  : RotateObjectsToolController(tool)
+  : RotateObjectsToolController{tool}
 {
   addController(std::make_unique<MoveCenterPart3D>(tool));
   addController(std::make_unique<RotateObjectsPart3D>(tool));
@@ -643,5 +641,5 @@ void RotateObjectsToolController3D::doRenderHandle(
 {
   m_tool.renderHandle3D(renderContext, renderBatch);
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/RotateObjectsToolController.h
+++ b/common/src/View/RotateObjectsToolController.h
@@ -19,18 +19,15 @@
 
 #pragma once
 
-#include "View/RotateObjectsHandle.h"
 #include "View/ToolController.h"
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class RotateObjectsTool;
 
@@ -87,5 +84,5 @@ private:
   void doRenderHandle(
     Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -228,7 +228,7 @@ static std::tuple<vm::vec3, vm::vec3> getInitialHandlePositionAndHitPoint(
   return {handleLine.get_origin(), dragStartHit.hitPoint()};
 }
 
-std::unique_ptr<DragTracker> ScaleObjectsToolController::acceptMouseDrag(
+std::unique_ptr<GestureTracker> ScaleObjectsToolController::acceptMouseDrag(
   const InputState& inputState)
 {
   using namespace Model::HitFilters;

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -36,19 +36,20 @@
 #include "kdl/memory_utils.h"
 #include "kdl/vector_utils.h"
 
+#include "vm/line.h"
+#include "vm/plane.h"
 #include "vm/polygon.h"
 #include "vm/segment.h"
 
 #include <cassert>
+#include <utility>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 ScaleObjectsToolController::ScaleObjectsToolController(
   ScaleObjectsTool& tool, std::weak_ptr<MapDocument> document)
   : m_tool{tool}
-  , m_document{document}
+  , m_document{std::move(document)}
 {
 }
 
@@ -80,7 +81,7 @@ static HandlePositionProposer makeHandlePositionProposer(
   const vm::bbox3& bboxAtDragStart,
   const vm::vec3& handleOffset)
 {
-  const bool scaleAllAxes = inputState.modifierKeysDown(ModifierKeys::MKShift);
+  const bool scaleAllAxes = inputState.modifierKeysDown(ModifierKeys::Shift);
 
   if (
     dragStartHit.type() == ScaleObjectsTool::ScaleToolEdgeHitType
@@ -115,7 +116,7 @@ static std::pair<AnchorPos, ProportionalAxes> modifierSettingsForInputState(
                               : AnchorPos::Opposite;
 
   ProportionalAxes scaleAllAxes = ProportionalAxes::None();
-  if (inputState.modifierKeysDown(ModifierKeys::MKShift))
+  if (inputState.modifierKeysDown(ModifierKeys::Shift))
   {
     scaleAllAxes = ProportionalAxes::All();
 
@@ -162,7 +163,7 @@ private:
   ScaleObjectsTool& m_tool;
 
 public:
-  ScaleObjectsDragDelegate(ScaleObjectsTool& tool)
+  explicit ScaleObjectsDragDelegate(ScaleObjectsTool& tool)
     : m_tool{tool}
   {
   }
@@ -223,7 +224,7 @@ public:
 static std::tuple<vm::vec3, vm::vec3> getInitialHandlePositionAndHitPoint(
   const vm::bbox3& bboxAtDragStart, const Model::Hit& dragStartHit)
 {
-  const vm::line3 handleLine = handleLineForHit(bboxAtDragStart, dragStartHit);
+  const auto handleLine = handleLineForHit(bboxAtDragStart, dragStartHit);
   return {handleLine.get_origin(), dragStartHit.hitPoint()};
 }
 
@@ -232,7 +233,7 @@ std::unique_ptr<DragTracker> ScaleObjectsToolController::acceptMouseDrag(
 {
   using namespace Model::HitFilters;
 
-  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }
@@ -243,7 +244,7 @@ std::unique_ptr<DragTracker> ScaleObjectsToolController::acceptMouseDrag(
   }
   auto document = kdl::mem_lock(m_document);
 
-  const Model::Hit& hit = inputState.pickResult().first(type(
+  const auto& hit = inputState.pickResult().first(type(
     ScaleObjectsTool::ScaleToolSideHitType | ScaleObjectsTool::ScaleToolEdgeHitType
     | ScaleObjectsTool::ScaleToolCornerHitType));
   if (!hit.isMatch())
@@ -285,7 +286,7 @@ static void renderCornerHandles(
 
   for (const auto& corner : corners)
   {
-    renderService.renderHandle(vm::vec3f(corner));
+    renderService.renderHandle(vm::vec3f{corner});
   }
 }
 
@@ -311,8 +312,8 @@ static void renderDragSideHighlights(
     {
       auto renderService = Renderer::RenderService{renderContext, renderBatch};
       renderService.setLineWidth(2.0);
-      renderService.setForegroundColor(Color(
-        pref(Preferences::ScaleOutlineColor), pref(Preferences::ScaleOutlineDimAlpha)));
+      renderService.setForegroundColor(Color{
+        pref(Preferences::ScaleOutlineColor), pref(Preferences::ScaleOutlineDimAlpha)});
       renderService.renderPolygonOutline(side.vertices());
     }
   }
@@ -468,5 +469,4 @@ void ScaleObjectsToolController3D::doPick(
 {
   m_tool.pick3D(pickRay, camera, pickResult);
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -199,7 +199,7 @@ public:
       ResetInitialHandlePosition::Keep};
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -22,20 +22,16 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 #include "View/ToolController.h"
 
-#include "vm/forward.h"
-
 #include <memory>
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class Camera;
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class MapDocument;
 class ScaleObjectsTool;
@@ -106,5 +102,5 @@ private:
     const Renderer::Camera& camera,
     Model::PickResult& pickResult) const override;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ScaleObjectsToolController.h
+++ b/common/src/View/ScaleObjectsToolController.h
@@ -59,7 +59,7 @@ private:
 
   void mouseMove(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void setRenderOptions(
     const InputState& inputState, Renderer::RenderContext& renderContext) const override;

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -43,10 +43,9 @@
 #include <unordered_set>
 #include <vector>
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
-{
+
 /**
  * Implements the Group picking logic: if `node` is inside a (possibly nested chain of)
  * closed group(s), the outermost closed group is returned. Otherwise, `node` itself is
@@ -120,7 +119,7 @@ std::vector<Model::Node*> hitsToNodesWithGroupPicking(const std::vector<Model::H
 
 static bool isFaceClick(const InputState& inputState)
 {
-  return inputState.modifierKeysDown(ModifierKeys::MKShift);
+  return inputState.modifierKeysDown(ModifierKeys::Shift);
 }
 
 static bool isMultiClick(const InputState& inputState)
@@ -143,11 +142,14 @@ static std::vector<Model::Node*> collectSelectableChildren(
 static bool handleClick(
   const InputState& inputState, const Model::EditorContext& editorContext)
 {
-  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return false;
   }
-  if (!inputState.checkModifierKeys(MK_DontCare, MK_No, MK_DontCare))
+  if (!inputState.checkModifierKeys(
+        ModifierKeyPressed::DontCare,
+        ModifierKeyPressed::No,
+        ModifierKeyPressed::DontCare))
   {
     return false;
   }
@@ -451,11 +453,13 @@ void SelectionTool::mouseScroll(const InputState& inputState)
 {
   const auto document = kdl::mem_lock(m_document);
 
-  if (inputState.checkModifierKeys(MK_Yes, MK_Yes, MK_No))
+  if (inputState.checkModifierKeys(
+        ModifierKeyPressed::Yes, ModifierKeyPressed::Yes, ModifierKeyPressed::No))
   {
     adjustGrid(inputState, document->grid());
   }
-  else if (inputState.checkModifierKeys(MK_Yes, MK_No, MK_No))
+  else if (inputState.checkModifierKeys(
+             ModifierKeyPressed::Yes, ModifierKeyPressed::No, ModifierKeyPressed::No))
   {
     drillSelection(inputState, *document);
   }
@@ -469,7 +473,7 @@ private:
   std::shared_ptr<MapDocument> m_document;
 
 public:
-  PaintSelectionDragTracker(std::shared_ptr<MapDocument> document)
+  explicit PaintSelectionDragTracker(std::shared_ptr<MapDocument> document)
     : m_document{std::move(document)}
   {
   }
@@ -603,5 +607,5 @@ bool SelectionTool::cancel()
   // closing the current group is handled in MapViewBase
   return false;
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -31,7 +31,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/RenderContext.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/Grid.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
@@ -467,7 +467,7 @@ void SelectionTool::mouseScroll(const InputState& inputState)
 
 namespace
 {
-class PaintSelectionDragTracker : public DragTracker
+class PaintSelectionDragTracker : public GestureTracker
 {
 private:
   std::shared_ptr<MapDocument> m_document;
@@ -519,7 +519,8 @@ public:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> SelectionTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> SelectionTool::acceptMouseDrag(
+  const InputState& inputState)
 {
   using namespace Model::HitFilters;
 

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -478,7 +478,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     using namespace Model::HitFilters;
 

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -40,7 +40,7 @@ class RenderContext;
 
 namespace View
 {
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 
 /**
@@ -66,7 +66,7 @@ public:
   bool mouseDoubleClick(const InputState& inputState) override;
   void mouseScroll(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void setRenderOptions(
     const InputState& inputState, Renderer::RenderContext& renderContext) const override;

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -312,7 +312,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     using namespace Model::HitFilters;
 

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -31,7 +31,7 @@
 #include "Model/LinkedGroupUtils.h"
 #include "Model/ModelUtils.h"
 #include "Model/UVCoordSystem.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
 #include "View/TransactionScope.h"
@@ -296,7 +296,7 @@ void transferFaceAttributes(
   transaction.commit();
 }
 
-class SetBrushFaceAttributesDragTracker : public DragTracker
+class SetBrushFaceAttributesDragTracker : public GestureTracker
 {
 private:
   MapDocument& m_document;
@@ -359,7 +359,7 @@ public:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> SetBrushFaceAttributesTool::acceptMouseDrag(
+std::unique_ptr<GestureTracker> SetBrushFaceAttributesTool::acceptMouseDrag(
   const InputState& inputState)
 {
   if (!applies(inputState))

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -119,7 +119,7 @@ bool copyMaterialAttribsProjectionModifiersDown(const InputState& inputState)
 
 bool copyMaterialAttribsRotationModifiersDown(const InputState& inputState)
 {
-  return inputState.modifierKeys() == (ModifierKeys::MKAlt | ModifierKeys::MKShift);
+  return inputState.modifierKeys() == (ModifierKeys::MKAlt | ModifierKeys::Shift);
 }
 
 /**
@@ -132,7 +132,7 @@ bool applies(const InputState& inputState)
   const auto projection = copyMaterialAttribsProjectionModifiersDown(inputState);
   const auto rotation = copyMaterialAttribsRotationModifiersDown(inputState);
 
-  return inputState.mouseButtonsPressed(MouseButtons::MBLeft)
+  return inputState.mouseButtonsPressed(MouseButtons::Left)
          && (materialOnly || projection || rotation);
 }
 

--- a/common/src/View/SetBrushFaceAttributesTool.h
+++ b/common/src/View/SetBrushFaceAttributesTool.h
@@ -28,7 +28,7 @@
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 
 /**
@@ -61,7 +61,7 @@ private:
 
   bool cancel() override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void copyAttributesFromSelection(const InputState& inputState, bool applyToBrush);
   bool canCopyAttributesFromSelection(const InputState& inputState) const;

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -36,13 +36,13 @@
 
 #include "kdl/memory_utils.h"
 
+#include "vm/line.h"
+#include "vm/plane.h"
 #include "vm/polygon.h"
 
 #include <cassert>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 ShearObjectsToolController::ShearObjectsToolController(
   ShearObjectsTool& tool, std::weak_ptr<MapDocument> document)
@@ -80,11 +80,11 @@ static HandlePositionProposer makeHandlePositionProposer(
   const vm::bbox3& bboxAtDragStart,
   const vm::vec3& handleOffset)
 {
-  const bool vertical = inputState.modifierKeysDown(ModifierKeys::MKAlt);
+  const auto vertical = inputState.modifierKeysDown(ModifierKeys::MKAlt);
   const auto& camera = inputState.camera();
 
-  const BBoxSide side = dragStartHit.target<BBoxSide>();
-  const vm::vec3 sideCenter = centerForBBoxSide(bboxAtDragStart, side);
+  const auto side = dragStartHit.target<BBoxSide>();
+  const auto sideCenter = centerForBBoxSide(bboxAtDragStart, side);
 
   if (camera.perspectiveProjection())
   {
@@ -131,7 +131,7 @@ private:
   ShearObjectsTool& m_tool;
 
 public:
-  ShearObjectsDragDelegate(ShearObjectsTool& tool)
+  explicit ShearObjectsDragDelegate(ShearObjectsTool& tool)
     : m_tool{tool}
   {
   }
@@ -165,7 +165,7 @@ public:
     }
 
     // Can't do vertical restraint on these
-    const BBoxSide side = m_tool.dragStartHit().target<BBoxSide>();
+    const auto side = m_tool.dragStartHit().target<BBoxSide>();
     if (side.normal == vm::vec3::pos_z() || side.normal == vm::vec3::neg_z())
     {
       return std::nullopt;
@@ -208,12 +208,12 @@ public:
 } // namespace
 
 static std::tuple<vm::vec3, vm::vec3> getInitialHandlePositionAndHitPoint(
-  const vm::bbox3& bounds, const Model::Hit& hit)
+  const vm::bbox3& bounds, const auto& hit)
 {
   assert(hit.isMatch());
   assert(hit.hasType(ShearObjectsTool::ShearToolSideHitType));
 
-  const BBoxSide side = hit.target<BBoxSide>();
+  const auto side = hit.template target<BBoxSide>();
   return {centerForBBoxSide(bounds, side), hit.hitPoint()};
 }
 
@@ -224,11 +224,11 @@ std::unique_ptr<DragTracker> ShearObjectsToolController::acceptMouseDrag(
 
   const bool vertical = inputState.modifierKeysDown(ModifierKeys::MKAlt);
 
-  if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }
-  if (!(inputState.modifierKeysPressed(ModifierKeys::MKNone) || vertical))
+  if (!(inputState.modifierKeysPressed(ModifierKeys::None) || vertical))
   {
     return nullptr;
   }
@@ -239,7 +239,7 @@ std::unique_ptr<DragTracker> ShearObjectsToolController::acceptMouseDrag(
 
   auto document = kdl::mem_lock(m_document);
 
-  const Model::Hit& hit =
+  const auto& hit =
     inputState.pickResult().first(type(ShearObjectsTool::ShearToolSideHitType));
   if (!hit.isMatch())
   {
@@ -333,5 +333,4 @@ void ShearObjectsToolController3D::doPick(
 {
   m_tool.pick3D(pickRay, camera, pickResult);
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -185,7 +185,7 @@ public:
       ResetInitialHandlePosition::Keep};
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -217,7 +217,7 @@ static std::tuple<vm::vec3, vm::vec3> getInitialHandlePositionAndHitPoint(
   return {centerForBBoxSide(bounds, side), hit.hitPoint()};
 }
 
-std::unique_ptr<DragTracker> ShearObjectsToolController::acceptMouseDrag(
+std::unique_ptr<GestureTracker> ShearObjectsToolController::acceptMouseDrag(
   const InputState& inputState)
 {
   using namespace Model::HitFilters;

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -24,16 +24,14 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 #include <memory>
 
-namespace TrenchBroom
-{
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class Camera;
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class DragTracker;
 class MapDocument;
@@ -102,5 +100,5 @@ private:
     const Renderer::Camera& camera,
     Model::PickResult& pickResult) override;
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ShearObjectsToolController.h
+++ b/common/src/View/ShearObjectsToolController.h
@@ -33,7 +33,7 @@ class RenderContext;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 class ShearObjectsTool;
 
@@ -62,7 +62,7 @@ private:
 
   void mouseMove(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void setRenderOptions(
     const InputState& inputState, Renderer::RenderContext& renderContext) const override;

--- a/common/src/View/Tool.cpp
+++ b/common/src/View/Tool.cpp
@@ -22,22 +22,16 @@
 #include <QStackedLayout>
 #include <QWidget>
 
-#include "IO/ResourceUtils.h"
-
 #include <cassert>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 Tool::Tool(const bool initiallyActive)
-  : m_active(initiallyActive)
-  , m_book(nullptr)
-  , m_pageIndex(0)
+  : m_active{initiallyActive}
 {
 }
 
-Tool::~Tool() {}
+Tool::~Tool() = default;
 
 bool Tool::active() const
 {
@@ -78,7 +72,7 @@ void Tool::notifyToolHandleSelectionChanged()
 
 void Tool::createPage(QStackedLayout* book)
 {
-  assert(m_book == nullptr);
+  assert(!m_book);
 
   m_book = book;
   m_pageIndex = m_book->count();
@@ -102,7 +96,7 @@ bool Tool::doDeactivate()
 
 QWidget* Tool::doCreatePage(QWidget* parent)
 {
-  return new QWidget(parent);
+  return new QWidget{parent};
 }
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/Tool.h
+++ b/common/src/View/Tool.h
@@ -24,17 +24,15 @@
 class QWidget;
 class QStackedLayout;
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 class Tool
 {
 private:
-  bool m_active;
+  bool m_active = false;
 
-  QStackedLayout* m_book;
-  int m_pageIndex;
+  QStackedLayout* m_book = nullptr;
+  int m_pageIndex = 0;
 
 public:
   Notifier<Tool&> toolActivatedNotifier;
@@ -64,5 +62,5 @@ private:
 
   virtual QWidget* doCreatePage(QWidget* parent);
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -22,8 +22,8 @@
 #include <QDateTime>
 #include <QDebug>
 
-#include "View/DragTracker.h"
 #include "View/DropTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/Tool.h"
 #include "View/ToolChain.h"
@@ -110,9 +110,9 @@ void ToolBox::modifierKeyChange(ToolChain& chain, const InputState& inputState)
   if (m_enabled)
   {
     chain.modifierKeyChange(inputState);
-    if (m_dragTracker)
+    if (m_gestureTracker)
     {
-      m_dragTracker->modifierKeyChange(inputState);
+      m_gestureTracker->modifierKeyChange(inputState);
     }
   }
 }
@@ -161,44 +161,44 @@ void ToolBox::mouseMove(ToolChain& chain, const InputState& inputState) const
 
 bool ToolBox::dragging() const
 {
-  return m_dragTracker != nullptr;
+  return m_gestureTracker != nullptr;
 }
 
 void ToolBox::startMouseDrag(ToolChain& chain, const InputState& inputState)
 {
   if (m_enabled)
   {
-    m_dragTracker = chain.acceptMouseDrag(inputState);
+    m_gestureTracker = chain.acceptMouseDrag(inputState);
   }
 }
 
 bool ToolBox::mouseDrag(const InputState& inputState)
 {
   assert(enabled() && dragging());
-  return m_dragTracker->update(inputState);
+  return m_gestureTracker->update(inputState);
 }
 
 void ToolBox::endMouseDrag(const InputState& inputState)
 {
   assert(enabled() && dragging());
-  m_dragTracker->end(inputState);
-  m_dragTracker = nullptr;
+  m_gestureTracker->end(inputState);
+  m_gestureTracker = nullptr;
 }
 
 void ToolBox::cancelMouseDrag()
 {
   assert(dragging());
-  m_dragTracker->cancel();
-  m_dragTracker = nullptr;
+  m_gestureTracker->cancel();
+  m_gestureTracker = nullptr;
 }
 
 void ToolBox::mouseScroll(ToolChain& chain, const InputState& inputState)
 {
   if (m_enabled)
   {
-    if (m_dragTracker)
+    if (m_gestureTracker)
     {
-      m_dragTracker->mouseScroll(inputState);
+      m_gestureTracker->mouseScroll(inputState);
     }
     else
     {
@@ -289,9 +289,9 @@ void ToolBox::setRenderOptions(
   ToolChain& chain, const InputState& inputState, Renderer::RenderContext& renderContext)
 {
   chain.setRenderOptions(inputState, renderContext);
-  if (m_dragTracker)
+  if (m_gestureTracker)
   {
-    m_dragTracker->setRenderOptions(inputState, renderContext);
+    m_gestureTracker->setRenderOptions(inputState, renderContext);
   }
 }
 
@@ -302,9 +302,9 @@ void ToolBox::renderTools(
   Renderer::RenderBatch& renderBatch)
 {
   chain.render(inputState, renderContext, renderBatch);
-  if (m_dragTracker)
+  if (m_gestureTracker)
   {
-    m_dragTracker->render(inputState, renderContext, renderBatch);
+    m_gestureTracker->render(inputState, renderContext, renderBatch);
   }
 }
 

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -207,6 +207,53 @@ void ToolBox::mouseScroll(ToolChain& chain, const InputState& inputState)
   }
 }
 
+void ToolBox::startGesture(ToolChain& chain, const InputState& inputState)
+{
+  assert(!m_gestureTracker);
+
+  if (m_enabled)
+  {
+    m_gestureTracker = chain.acceptGesture(inputState);
+  }
+}
+
+void ToolBox::gesturePan(const InputState& inputState)
+{
+  assert(enabled());
+  if (m_gestureTracker)
+  {
+    m_gestureTracker->update(inputState);
+  }
+}
+
+void ToolBox::gestureZoom(const InputState& inputState)
+{
+  assert(enabled());
+  if (m_gestureTracker)
+  {
+    m_gestureTracker->update(inputState);
+  }
+}
+
+void ToolBox::gestureRotate(const InputState& inputState)
+{
+  assert(enabled());
+  if (m_gestureTracker)
+  {
+    m_gestureTracker->update(inputState);
+  }
+}
+
+void ToolBox::endGesture(const InputState& inputState)
+{
+  assert(enabled());
+  if (m_gestureTracker)
+  {
+    m_gestureTracker->end(inputState);
+    m_gestureTracker = nullptr;
+  }
+}
+
 bool ToolBox::cancel(ToolChain& chain)
 {
   if (dragging())

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -46,15 +46,15 @@ void ToolBox::addTool(Tool& tool)
 }
 
 void ToolBox::pick(
-  ToolChain* chain, const InputState& inputState, Model::PickResult& pickResult)
+  ToolChain& chain, const InputState& inputState, Model::PickResult& pickResult)
 {
-  chain->pick(inputState, pickResult);
+  chain.pick(inputState, pickResult);
 }
 
 bool ToolBox::dragEnter(
-  ToolChain* chain, const InputState& inputState, const std::string& text)
+  ToolChain& chain, const InputState& inputState, const std::string& text)
 {
-  if (!m_enabled || !chain->shouldAcceptDrop(inputState, text))
+  if (!m_enabled || !chain.shouldAcceptDrop(inputState, text))
   {
     return false;
   }
@@ -65,12 +65,12 @@ bool ToolBox::dragEnter(
   }
 
   deactivateAllTools();
-  m_dropTracker = chain->dragEnter(inputState, text);
+  m_dropTracker = chain.dragEnter(inputState, text);
   return m_dropTracker != nullptr;
 }
 
 bool ToolBox::dragMove(
-  ToolChain* /* chain */, const InputState& inputState, const std::string& /* text */)
+  ToolChain& /* chain */, const InputState& inputState, const std::string& /* text */)
 {
   if (!m_enabled || !m_dropTracker)
   {
@@ -81,7 +81,7 @@ bool ToolBox::dragMove(
   return true;
 }
 
-void ToolBox::dragLeave(ToolChain* /* chain */, const InputState& inputState)
+void ToolBox::dragLeave(ToolChain& /* chain */, const InputState& inputState)
 {
   if (!m_enabled || !m_dropTracker)
   {
@@ -93,7 +93,7 @@ void ToolBox::dragLeave(ToolChain* /* chain */, const InputState& inputState)
 }
 
 bool ToolBox::dragDrop(
-  ToolChain* /* chain */, const InputState& inputState, const std::string& /* text */)
+  ToolChain& /* chain */, const InputState& inputState, const std::string& /* text */)
 {
   if (!m_enabled || !m_dropTracker)
   {
@@ -105,11 +105,11 @@ bool ToolBox::dragDrop(
   return result;
 }
 
-void ToolBox::modifierKeyChange(ToolChain* chain, const InputState& inputState)
+void ToolBox::modifierKeyChange(ToolChain& chain, const InputState& inputState)
 {
   if (m_enabled)
   {
-    chain->modifierKeyChange(inputState);
+    chain.modifierKeyChange(inputState);
     if (m_dragTracker)
     {
       m_dragTracker->modifierKeyChange(inputState);
@@ -117,45 +117,45 @@ void ToolBox::modifierKeyChange(ToolChain* chain, const InputState& inputState)
   }
 }
 
-void ToolBox::mouseDown(ToolChain* chain, const InputState& inputState) const
+void ToolBox::mouseDown(ToolChain& chain, const InputState& inputState) const
 {
   if (m_enabled)
   {
-    chain->mouseDown(inputState);
+    chain.mouseDown(inputState);
   }
 }
 
-void ToolBox::mouseUp(ToolChain* chain, const InputState& inputState) const
+void ToolBox::mouseUp(ToolChain& chain, const InputState& inputState) const
 {
   if (m_enabled)
   {
-    chain->mouseUp(inputState);
+    chain.mouseUp(inputState);
   }
 }
 
-bool ToolBox::mouseClick(ToolChain* chain, const InputState& inputState) const
+bool ToolBox::mouseClick(ToolChain& chain, const InputState& inputState) const
 {
   if (m_enabled)
   {
-    return chain->mouseClick(inputState);
+    return chain.mouseClick(inputState);
   }
 
   return false;
 }
 
-void ToolBox::mouseDoubleClick(ToolChain* chain, const InputState& inputState) const
+void ToolBox::mouseDoubleClick(ToolChain& chain, const InputState& inputState) const
 {
   if (m_enabled)
   {
-    chain->mouseDoubleClick(inputState);
+    chain.mouseDoubleClick(inputState);
   }
 }
 
-void ToolBox::mouseMove(ToolChain* chain, const InputState& inputState) const
+void ToolBox::mouseMove(ToolChain& chain, const InputState& inputState) const
 {
   if (m_enabled)
   {
-    chain->mouseMove(inputState);
+    chain.mouseMove(inputState);
   }
 }
 
@@ -164,11 +164,11 @@ bool ToolBox::dragging() const
   return m_dragTracker != nullptr;
 }
 
-void ToolBox::startMouseDrag(ToolChain* chain, const InputState& inputState)
+void ToolBox::startMouseDrag(ToolChain& chain, const InputState& inputState)
 {
   if (m_enabled)
   {
-    m_dragTracker = chain->startMouseDrag(inputState);
+    m_dragTracker = chain.acceptMouseDrag(inputState);
   }
 }
 
@@ -192,7 +192,7 @@ void ToolBox::cancelMouseDrag()
   m_dragTracker = nullptr;
 }
 
-void ToolBox::mouseScroll(ToolChain* chain, const InputState& inputState)
+void ToolBox::mouseScroll(ToolChain& chain, const InputState& inputState)
 {
   if (m_enabled)
   {
@@ -202,12 +202,12 @@ void ToolBox::mouseScroll(ToolChain* chain, const InputState& inputState)
     }
     else
     {
-      chain->mouseScroll(inputState);
+      chain.mouseScroll(inputState);
     }
   }
 }
 
-bool ToolBox::cancel(ToolChain* chain)
+bool ToolBox::cancel(ToolChain& chain)
 {
   if (dragging())
   {
@@ -215,7 +215,7 @@ bool ToolBox::cancel(ToolChain* chain)
     return true;
   }
 
-  if (chain->cancel())
+  if (chain.cancel())
   {
     return true;
   }
@@ -286,9 +286,9 @@ void ToolBox::disable()
 }
 
 void ToolBox::setRenderOptions(
-  ToolChain* chain, const InputState& inputState, Renderer::RenderContext& renderContext)
+  ToolChain& chain, const InputState& inputState, Renderer::RenderContext& renderContext)
 {
-  chain->setRenderOptions(inputState, renderContext);
+  chain.setRenderOptions(inputState, renderContext);
   if (m_dragTracker)
   {
     m_dragTracker->setRenderOptions(inputState, renderContext);
@@ -296,12 +296,12 @@ void ToolBox::setRenderOptions(
 }
 
 void ToolBox::renderTools(
-  ToolChain* chain,
+  ToolChain& chain,
   const InputState& inputState,
   Renderer::RenderContext& renderContext,
   Renderer::RenderBatch& renderBatch)
 {
-  chain->render(inputState, renderContext, renderBatch);
+  chain.render(inputState, renderContext, renderBatch);
   if (m_dragTracker)
   {
     m_dragTracker->render(inputState, renderContext, renderBatch);

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -175,7 +175,7 @@ void ToolBox::startMouseDrag(ToolChain& chain, const InputState& inputState)
 bool ToolBox::mouseDrag(const InputState& inputState)
 {
   assert(enabled() && dragging());
-  return m_dragTracker->drag(inputState);
+  return m_dragTracker->update(inputState);
 }
 
 void ToolBox::endMouseDrag(const InputState& inputState)

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -106,6 +106,12 @@ public: // event handling
 
   void mouseScroll(ToolChain& chain, const InputState& inputState);
 
+  void startGesture(ToolChain& chain, const InputState& inputState);
+  void gesturePan(const InputState& inputState);
+  void gestureZoom(const InputState& inputState);
+  void gestureRotate(const InputState& inputState);
+  void endGesture(const InputState& inputState);
+
   bool cancel(ToolChain& chain);
 
 public: // tool management

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -47,7 +47,7 @@ class RenderContext;
 namespace TrenchBroom::View
 {
 
-class DragTracker;
+class GestureTracker;
 class DropTracker;
 class InputState;
 class Tool;
@@ -58,7 +58,7 @@ class ToolBox : public QObject
 {
   Q_OBJECT
 private:
-  std::unique_ptr<DragTracker> m_dragTracker;
+  std::unique_ptr<GestureTracker> m_gestureTracker;
   std::unique_ptr<DropTracker> m_dropTracker;
   Tool* m_modalTool = nullptr;
 

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -83,30 +83,30 @@ protected:
 
 public: // picking
   void pick(
-    ToolChain* chain, const InputState& inputState, Model::PickResult& pickResult);
+    ToolChain& chain, const InputState& inputState, Model::PickResult& pickResult);
 
 public: // event handling
-  bool dragEnter(ToolChain* chain, const InputState& inputState, const std::string& text);
-  bool dragMove(ToolChain* chain, const InputState& inputState, const std::string& text);
-  void dragLeave(ToolChain* chain, const InputState& inputState);
-  bool dragDrop(ToolChain* chain, const InputState& inputState, const std::string& text);
+  bool dragEnter(ToolChain& chain, const InputState& inputState, const std::string& text);
+  bool dragMove(ToolChain& chain, const InputState& inputState, const std::string& text);
+  void dragLeave(ToolChain& chain, const InputState& inputState);
+  bool dragDrop(ToolChain& chain, const InputState& inputState, const std::string& text);
 
-  void modifierKeyChange(ToolChain* chain, const InputState& inputState);
-  void mouseDown(ToolChain* chain, const InputState& inputState) const;
-  void mouseUp(ToolChain* chain, const InputState& inputState) const;
-  bool mouseClick(ToolChain* chain, const InputState& inputState) const;
-  void mouseDoubleClick(ToolChain* chain, const InputState& inputState) const;
-  void mouseMove(ToolChain* chain, const InputState& inputState) const;
+  void modifierKeyChange(ToolChain& chain, const InputState& inputState);
+  void mouseDown(ToolChain& chain, const InputState& inputState) const;
+  void mouseUp(ToolChain& chain, const InputState& inputState) const;
+  bool mouseClick(ToolChain& chain, const InputState& inputState) const;
+  void mouseDoubleClick(ToolChain& chain, const InputState& inputState) const;
+  void mouseMove(ToolChain& chain, const InputState& inputState) const;
 
   bool dragging() const;
-  void startMouseDrag(ToolChain* chain, const InputState& inputState);
+  void startMouseDrag(ToolChain& chain, const InputState& inputState);
   bool mouseDrag(const InputState& inputState);
   void endMouseDrag(const InputState& inputState);
   void cancelMouseDrag();
 
-  void mouseScroll(ToolChain* chain, const InputState& inputState);
+  void mouseScroll(ToolChain& chain, const InputState& inputState);
 
-  bool cancel(ToolChain* chain);
+  bool cancel(ToolChain& chain);
 
 public: // tool management
   /**
@@ -129,11 +129,11 @@ public: // tool management
 
 public: // rendering
   void setRenderOptions(
-    ToolChain* chain,
+    ToolChain& chain,
     const InputState& inputState,
     Renderer::RenderContext& renderContext);
   void renderTools(
-    ToolChain* chain,
+    ToolChain& chain,
     const InputState& inputState,
     Renderer::RenderContext& renderContext,
     Renderer::RenderBatch& renderBatch);

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -223,9 +223,6 @@ void ToolBoxConnector::processEvent(const MouseEvent& event)
   case MouseEvent::Type::Motion:
     processMouseMotion(event);
     break;
-  case MouseEvent::Type::Scroll:
-    processScroll(event);
-    break;
   case MouseEvent::Type::DragStart:
     processDragStart(event);
     break;
@@ -238,6 +235,22 @@ void ToolBoxConnector::processEvent(const MouseEvent& event)
     switchDefault();
   }
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
+}
+
+void ToolBoxConnector::processEvent(const ScrollEvent& event)
+{
+  updateModifierKeys();
+  if (event.axis == ScrollEvent::Axis::Horizontal)
+  {
+    m_inputState.scroll(event.distance, 0.0f);
+  }
+  else if (event.axis == ScrollEvent::Axis::Vertical)
+  {
+    m_inputState.scroll(0.0f, event.distance);
+  }
+  m_toolBox->mouseScroll(*m_toolChain, m_inputState);
+
+  updatePickResult();
 }
 
 void ToolBoxConnector::processEvent(const GestureEvent& event)
@@ -315,22 +328,6 @@ void ToolBoxConnector::processMouseMotion(const MouseEvent& event)
   mouseMoved(event.posX, event.posY);
   updatePickResult();
   m_toolBox->mouseMove(*m_toolChain, m_inputState);
-}
-
-void ToolBoxConnector::processScroll(const MouseEvent& event)
-{
-  updateModifierKeys();
-  if (event.wheelAxis == MouseEvent::WheelAxis::Horizontal)
-  {
-    m_inputState.scroll(event.scrollDistance, 0.0f);
-  }
-  else if (event.wheelAxis == MouseEvent::WheelAxis::Vertical)
-  {
-    m_inputState.scroll(0.0f, event.scrollDistance);
-  }
-  m_toolBox->mouseScroll(*m_toolChain, m_inputState);
-
-  updatePickResult();
 }
 
 void ToolBoxConnector::processDragStart(const MouseEvent& event)

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -237,16 +237,34 @@ void ToolBoxConnector::processEvent(const MouseEvent& event)
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
 }
 
+namespace
+{
+
+auto getScrollSource(const ScrollEvent& event)
+{
+  switch (event.source)
+  {
+  case ScrollEvent::Source::Mouse:
+    return ScrollSource::Mouse;
+  case ScrollEvent::Source::Trackpad:
+    return ScrollSource::Trackpad;
+    switchDefault();
+  }
+}
+
+} // namespace
+
 void ToolBoxConnector::processEvent(const ScrollEvent& event)
 {
   updateModifierKeys();
+  const auto scrollSource = getScrollSource(event);
   if (event.axis == ScrollEvent::Axis::Horizontal)
   {
-    m_inputState.scroll(event.distance, 0.0f);
+    m_inputState.scroll(scrollSource, event.distance, 0.0f);
   }
   else if (event.axis == ScrollEvent::Axis::Vertical)
   {
-    m_inputState.scroll(0.0f, event.distance);
+    m_inputState.scroll(scrollSource, 0.0f, event.distance);
   }
   m_toolBox->mouseScroll(*m_toolChain, m_inputState);
 

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -30,23 +30,14 @@
 
 #include <string>
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 ToolBoxConnector::ToolBoxConnector()
-  : m_toolBox(nullptr)
-  , m_toolChain(new ToolChain())
-  , m_lastMouseX(0.0f)
-  , m_lastMouseY(0.0f)
-  , m_ignoreNextDrag(false)
+  : m_toolChain{std::make_unique<ToolChain>()}
 {
 }
 
-ToolBoxConnector::~ToolBoxConnector()
-{
-  delete m_toolChain;
-}
+ToolBoxConnector::~ToolBoxConnector() = default;
 
 const vm::ray3& ToolBoxConnector::pickRay() const
 {
@@ -60,18 +51,18 @@ const Model::PickResult& ToolBoxConnector::pickResult() const
 
 void ToolBoxConnector::updatePickResult()
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
 
   m_inputState.setPickRequest(
     doGetPickRequest(m_inputState.mouseX(), m_inputState.mouseY()));
-  Model::PickResult pickResult = doPick(m_inputState.pickRay());
-  m_toolBox->pick(m_toolChain, m_inputState, pickResult);
+  auto pickResult = doPick(m_inputState.pickRay());
+  m_toolBox->pick(*m_toolChain, m_inputState, pickResult);
   m_inputState.setPickResult(std::move(pickResult));
 }
 
 void ToolBoxConnector::setToolBox(ToolBox& toolBox)
 {
-  assert(m_toolBox == nullptr);
+  assert(!m_toolBox);
   m_toolBox = &toolBox;
 }
 
@@ -82,61 +73,61 @@ void ToolBoxConnector::addTool(std::unique_ptr<ToolController> tool)
 
 bool ToolBoxConnector::dragEnter(const float x, const float y, const std::string& text)
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
 
   mouseMoved(x, y);
   updatePickResult();
 
-  return m_toolBox->dragEnter(m_toolChain, m_inputState, text);
+  return m_toolBox->dragEnter(*m_toolChain, m_inputState, text);
 }
 
 bool ToolBoxConnector::dragMove(const float x, const float y, const std::string& text)
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
 
   mouseMoved(x, y);
   updatePickResult();
 
-  return m_toolBox->dragMove(m_toolChain, m_inputState, text);
+  return m_toolBox->dragMove(*m_toolChain, m_inputState, text);
 }
 
 void ToolBoxConnector::dragLeave()
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
 
-  m_toolBox->dragLeave(m_toolChain, m_inputState);
+  m_toolBox->dragLeave(*m_toolChain, m_inputState);
 }
 
 bool ToolBoxConnector::dragDrop(
   const float /* x */, const float /* y */, const std::string& text)
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
 
   updatePickResult();
 
-  return m_toolBox->dragDrop(m_toolChain, m_inputState, text);
+  return m_toolBox->dragDrop(*m_toolChain, m_inputState, text);
 }
 
 bool ToolBoxConnector::cancel()
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
-  return m_toolBox->cancel(m_toolChain);
+  return m_toolBox->cancel(*m_toolChain);
 }
 
 void ToolBoxConnector::setRenderOptions(Renderer::RenderContext& renderContext)
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
-  m_toolBox->setRenderOptions(m_toolChain, m_inputState, renderContext);
+  m_toolBox->setRenderOptions(*m_toolChain, m_inputState, renderContext);
 }
 
 void ToolBoxConnector::renderTools(
   Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch)
 {
-  ensure(m_toolBox != nullptr, "toolBox is null");
+  ensure(m_toolBox, "toolBox is set");
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
-  m_toolBox->renderTools(m_toolChain, m_inputState, renderContext, renderBatch);
+  m_toolBox->renderTools(*m_toolChain, m_inputState, renderContext, renderBatch);
 }
 
 ModifierKeyState ToolBoxConnector::modifierKeys()
@@ -144,16 +135,16 @@ ModifierKeyState ToolBoxConnector::modifierKeys()
   // QGuiApplication::queryKeyboardModifiers() is needed instead of
   // QGuiApplication::keyboardModifiers(), because when a modifier (e.g. Shift) is
   // pressed, QGuiApplication::keyboardModifiers() isn't updated soon enough.
-  const Qt::KeyboardModifiers mouseState = QGuiApplication::queryKeyboardModifiers();
+  const auto mouseState = QGuiApplication::queryKeyboardModifiers();
 
-  ModifierKeyState state = ModifierKeys::MKNone;
+  auto state = ModifierKeys::None;
   if (mouseState & Qt::ControlModifier)
   {
     state |= ModifierKeys::MKCtrlCmd;
   }
   if (mouseState & Qt::ShiftModifier)
   {
-    state |= ModifierKeys::MKShift;
+    state |= ModifierKeys::Shift;
   }
   if (mouseState & Qt::AltModifier)
   {
@@ -170,33 +161,27 @@ bool ToolBoxConnector::setModifierKeys()
 {
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
 
-  const ModifierKeyState keys = modifierKeys();
+  const auto keys = modifierKeys();
   if (keys != m_inputState.modifierKeys())
   {
     m_inputState.setModifierKeys(keys);
     return true;
   }
-  else
-  {
-    return false;
-  }
+  return false;
 }
 
 bool ToolBoxConnector::clearModifierKeys()
 {
   m_inputState.setAnyToolDragging(m_toolBox->dragging());
 
-  if (m_inputState.modifierKeys() != ModifierKeys::MKNone)
+  if (m_inputState.modifierKeys() != ModifierKeys::None)
   {
-    m_inputState.setModifierKeys(ModifierKeys::MKNone);
+    m_inputState.setModifierKeys(ModifierKeys::None);
     updatePickResult();
-    m_toolBox->modifierKeyChange(m_toolChain, m_inputState);
+    m_toolBox->modifierKeyChange(*m_toolChain, m_inputState);
     return true;
   }
-  else
-  {
-    return false;
-  }
+  return false;
 }
 
 void ToolBoxConnector::updateModifierKeys()
@@ -204,7 +189,7 @@ void ToolBoxConnector::updateModifierKeys()
   if (setModifierKeys())
   {
     updatePickResult();
-    m_toolBox->modifierKeyChange(m_toolChain, m_inputState);
+    m_toolBox->modifierKeyChange(*m_toolChain, m_inputState);
   }
 }
 
@@ -264,7 +249,7 @@ void ToolBoxConnector::processMouseButtonDown(const MouseEvent& event)
 {
   updateModifierKeys();
   m_inputState.mouseDown(mouseButton(event));
-  m_toolBox->mouseDown(m_toolChain, m_inputState);
+  m_toolBox->mouseDown(*m_toolChain, m_inputState);
 
   updatePickResult();
   m_ignoreNextDrag = false;
@@ -273,7 +258,7 @@ void ToolBoxConnector::processMouseButtonDown(const MouseEvent& event)
 void ToolBoxConnector::processMouseButtonUp(const MouseEvent& event)
 {
   updateModifierKeys();
-  m_toolBox->mouseUp(m_toolChain, m_inputState);
+  m_toolBox->mouseUp(*m_toolChain, m_inputState);
   m_inputState.mouseUp(mouseButton(event));
 
   updatePickResult();
@@ -282,7 +267,7 @@ void ToolBoxConnector::processMouseButtonUp(const MouseEvent& event)
 
 void ToolBoxConnector::processMouseClick(const MouseEvent& event)
 {
-  const auto handled = m_toolBox->mouseClick(m_toolChain, m_inputState);
+  const auto handled = m_toolBox->mouseClick(*m_toolChain, m_inputState);
   if (event.button == MouseEvent::Button::Right && !handled)
   {
     // We miss mouse events when a popup menu is already open, so we must make sure that
@@ -297,7 +282,7 @@ void ToolBoxConnector::processMouseDoubleClick(const MouseEvent& event)
 {
   updateModifierKeys();
   m_inputState.mouseDown(mouseButton(event));
-  m_toolBox->mouseDoubleClick(m_toolChain, m_inputState);
+  m_toolBox->mouseDoubleClick(*m_toolChain, m_inputState);
   m_inputState.mouseUp(mouseButton(event));
   updatePickResult();
 }
@@ -306,7 +291,7 @@ void ToolBoxConnector::processMouseMotion(const MouseEvent& event)
 {
   mouseMoved(event.posX, event.posY);
   updatePickResult();
-  m_toolBox->mouseMove(m_toolChain, m_inputState);
+  m_toolBox->mouseMove(*m_toolChain, m_inputState);
 }
 
 void ToolBoxConnector::processScroll(const MouseEvent& event)
@@ -320,7 +305,7 @@ void ToolBoxConnector::processScroll(const MouseEvent& event)
   {
     m_inputState.scroll(0.0f, event.scrollDistance);
   }
-  m_toolBox->mouseScroll(m_toolChain, m_inputState);
+  m_toolBox->mouseScroll(*m_toolChain, m_inputState);
 
   updatePickResult();
 }
@@ -334,19 +319,16 @@ void ToolBoxConnector::processDragStart(const MouseEvent& event)
   mouseMoved(event.posX, event.posY);
   updatePickResult();
 
-  m_toolBox->startMouseDrag(m_toolChain, m_inputState);
+  m_toolBox->startMouseDrag(*m_toolChain, m_inputState);
 }
 
 void ToolBoxConnector::processDrag(const MouseEvent& event)
 {
   mouseMoved(event.posX, event.posY);
   updatePickResult();
-  if (m_toolBox->dragging())
+  if (m_toolBox->dragging() && !m_toolBox->mouseDrag(m_inputState))
   {
-    if (!m_toolBox->mouseDrag(m_inputState))
-    {
-      processDragEnd(event);
-    }
+    processDragEnd(event);
   }
 }
 
@@ -363,15 +345,15 @@ MouseButtonState ToolBoxConnector::mouseButton(const MouseEvent& event)
   switch (event.button)
   {
   case MouseEvent::Button::Left:
-    return MouseButtons::MBLeft;
+    return MouseButtons::Left;
   case MouseEvent::Button::Middle:
-    return MouseButtons::MBMiddle;
+    return MouseButtons::Middle;
   case MouseEvent::Button::Right:
-    return MouseButtons::MBRight;
+    return MouseButtons::Right;
   case MouseEvent::Button::Aux1:
   case MouseEvent::Button::Aux2:
   case MouseEvent::Button::None:
-    return MouseButtons::MBNone;
+    return MouseButtons::None;
     switchDefault();
   }
 }
@@ -392,12 +374,9 @@ bool ToolBoxConnector::cancelDrag()
     m_toolBox->cancelMouseDrag();
     return true;
   }
-  else
-  {
-    return false;
-  }
+  return false;
 }
 
 void ToolBoxConnector::doShowPopupMenu() {}
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ToolBoxConnector.h
+++ b/common/src/View/ToolBoxConnector.h
@@ -26,21 +26,19 @@
 #include <memory>
 #include <string>
 
-namespace TrenchBroom
-{
-namespace Model
+namespace TrenchBroom::Model
 {
 class PickResult;
 }
 
-namespace Renderer
+namespace TrenchBroom::Renderer
 {
 class Camera;
 class RenderBatch;
 class RenderContext;
-} // namespace Renderer
+} // namespace TrenchBroom::Renderer
 
-namespace View
+namespace TrenchBroom::View
 {
 class PickRequest;
 class ToolController;
@@ -50,14 +48,14 @@ class ToolChain;
 class ToolBoxConnector : public InputEventProcessor
 {
 private:
-  ToolBox* m_toolBox;
-  ToolChain* m_toolChain;
+  ToolBox* m_toolBox = nullptr;
+  std::unique_ptr<ToolChain> m_toolChain;
 
   InputState m_inputState;
 
-  float m_lastMouseX;
-  float m_lastMouseY;
-  bool m_ignoreNextDrag;
+  float m_lastMouseX = 0.0f;
+  float m_lastMouseY = 0.0f;
+  bool m_ignoreNextDrag = false;
 
 public:
   ToolBoxConnector();
@@ -127,5 +125,5 @@ private:
 
   deleteCopyAndMove(ToolBoxConnector);
 };
-} // namespace View
-} // namespace TrenchBroom
+
+} // namespace TrenchBroom::View

--- a/common/src/View/ToolBoxConnector.h
+++ b/common/src/View/ToolBoxConnector.h
@@ -23,7 +23,10 @@
 #include "View/InputEvent.h"
 #include "View/InputState.h"
 
+#include <vm/vec.h>
+
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace TrenchBroom::Model
@@ -53,9 +56,10 @@ private:
 
   InputState m_inputState;
 
-  float m_lastMouseX = 0.0f;
-  float m_lastMouseY = 0.0f;
+  vm::vec2f m_lastMousePos = {0.0f, 0.0f};
   bool m_ignoreNextDrag = false;
+
+  std::optional<vm::vec2f> m_lastGesturePanPos;
 
 public:
   ToolBoxConnector();
@@ -99,6 +103,7 @@ private:
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 
 private:
@@ -114,6 +119,12 @@ private:
 
   MouseButtonState mouseButton(const MouseEvent& event);
   void mouseMoved(float x, float y);
+
+  void processGestureStart(const GestureEvent& event);
+  void processGestureEnd(const GestureEvent& event);
+  void processGesturePan(const GestureEvent& event);
+  void processGestureZoom(const GestureEvent& event);
+  void processGestureRotate(const GestureEvent& event);
 
 public:
   bool cancelDrag();

--- a/common/src/View/ToolBoxConnector.h
+++ b/common/src/View/ToolBoxConnector.h
@@ -103,6 +103,7 @@ private:
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const ScrollEvent& event) override;
   void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 
@@ -112,7 +113,6 @@ private:
   void processMouseClick(const MouseEvent& event);
   void processMouseDoubleClick(const MouseEvent& event);
   void processMouseMotion(const MouseEvent& event);
-  void processScroll(const MouseEvent& event);
   void processDragStart(const MouseEvent& event);
   void processDrag(const MouseEvent& event);
   void processDragEnd(const MouseEvent& event);

--- a/common/src/View/ToolChain.cpp
+++ b/common/src/View/ToolChain.cpp
@@ -156,7 +156,7 @@ void ToolChain::mouseMove(const InputState& inputState)
   }
 }
 
-std::unique_ptr<DragTracker> ToolChain::startMouseDrag(const InputState& inputState)
+std::unique_ptr<DragTracker> ToolChain::acceptMouseDrag(const InputState& inputState)
 {
   assert(checkInvariant());
   if (chainEndsHere())
@@ -170,7 +170,7 @@ std::unique_ptr<DragTracker> ToolChain::startMouseDrag(const InputState& inputSt
       return dragTracker;
     }
   }
-  return m_suffix->startMouseDrag(inputState);
+  return m_suffix->acceptMouseDrag(inputState);
 }
 
 bool ToolChain::shouldAcceptDrop(

--- a/common/src/View/ToolChain.cpp
+++ b/common/src/View/ToolChain.cpp
@@ -20,8 +20,8 @@
 #include "ToolChain.h"
 
 #include "Ensure.h"
-#include "View/DragTracker.h"
 #include "View/DropTracker.h"
+#include "View/GestureTracker.h"
 #include "View/ToolController.h"
 
 #include <cassert>
@@ -156,7 +156,7 @@ void ToolChain::mouseMove(const InputState& inputState)
   }
 }
 
-std::unique_ptr<DragTracker> ToolChain::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> ToolChain::acceptMouseDrag(const InputState& inputState)
 {
   assert(checkInvariant());
   if (chainEndsHere())
@@ -165,9 +165,9 @@ std::unique_ptr<DragTracker> ToolChain::acceptMouseDrag(const InputState& inputS
   }
   if (m_tool->toolActive())
   {
-    if (auto dragTracker = m_tool->acceptMouseDrag(inputState))
+    if (auto gestureTracker = m_tool->acceptMouseDrag(inputState))
     {
-      return dragTracker;
+      return gestureTracker;
     }
   }
   return m_suffix->acceptMouseDrag(inputState);

--- a/common/src/View/ToolChain.cpp
+++ b/common/src/View/ToolChain.cpp
@@ -173,6 +173,23 @@ std::unique_ptr<GestureTracker> ToolChain::acceptMouseDrag(const InputState& inp
   return m_suffix->acceptMouseDrag(inputState);
 }
 
+std::unique_ptr<GestureTracker> ToolChain::acceptGesture(const InputState& inputState)
+{
+  assert(checkInvariant());
+  if (chainEndsHere())
+  {
+    return nullptr;
+  }
+  if (m_tool->toolActive())
+  {
+    if (auto gestureTracker = m_tool->acceptGesture(inputState))
+    {
+      return gestureTracker;
+    }
+  }
+  return m_suffix->acceptGesture(inputState);
+}
+
 bool ToolChain::shouldAcceptDrop(
   const InputState& inputState, const std::string& payload) const
 {

--- a/common/src/View/ToolChain.h
+++ b/common/src/View/ToolChain.h
@@ -35,7 +35,7 @@ class RenderContext;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class DropTracker;
 class InputState;
 class ToolController;
@@ -63,7 +63,7 @@ public:
   void mouseScroll(const InputState& inputState);
   void mouseMove(const InputState& inputState);
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState);
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState);
 
   bool shouldAcceptDrop(const InputState& inputState, const std::string& payload) const;
   std::unique_ptr<DropTracker> dragEnter(

--- a/common/src/View/ToolChain.h
+++ b/common/src/View/ToolChain.h
@@ -63,7 +63,7 @@ public:
   void mouseScroll(const InputState& inputState);
   void mouseMove(const InputState& inputState);
 
-  std::unique_ptr<DragTracker> startMouseDrag(const InputState& inputState);
+  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState);
 
   bool shouldAcceptDrop(const InputState& inputState, const std::string& payload) const;
   std::unique_ptr<DropTracker> dragEnter(

--- a/common/src/View/ToolChain.h
+++ b/common/src/View/ToolChain.h
@@ -64,6 +64,7 @@ public:
   void mouseMove(const InputState& inputState);
 
   std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState);
+  std::unique_ptr<GestureTracker> acceptGesture(const InputState& inputState);
 
   bool shouldAcceptDrop(const InputState& inputState, const std::string& payload) const;
   std::unique_ptr<DropTracker> dragEnter(

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -20,8 +20,8 @@
 #include "ToolController.h"
 
 #include "Ensure.h"
-#include "View/DragTracker.h"
 #include "View/DropTracker.h"
+#include "View/GestureTracker.h"
 #include "View/Tool.h"
 
 namespace TrenchBroom::View
@@ -50,7 +50,7 @@ bool ToolController::mouseDoubleClick(const InputState&)
 void ToolController::mouseMove(const InputState&) {}
 void ToolController::mouseScroll(const InputState&) {}
 
-std::unique_ptr<DragTracker> ToolController::acceptMouseDrag(const InputState&)
+std::unique_ptr<GestureTracker> ToolController::acceptMouseDrag(const InputState&)
 {
   return nullptr;
 }
@@ -135,7 +135,7 @@ void ToolControllerGroup::mouseScroll(const InputState& inputState)
   m_chain.mouseScroll(inputState);
 }
 
-std::unique_ptr<DragTracker> ToolControllerGroup::acceptMouseDrag(
+std::unique_ptr<GestureTracker> ToolControllerGroup::acceptMouseDrag(
   const InputState& inputState)
 {
   if (!doShouldHandleMouseDrag(inputState))

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -55,6 +55,11 @@ std::unique_ptr<GestureTracker> ToolController::acceptMouseDrag(const InputState
   return nullptr;
 }
 
+std::unique_ptr<GestureTracker> ToolController::acceptGesture(const InputState&)
+{
+  return nullptr;
+}
+
 bool ToolController::shouldAcceptDrop(const InputState&, const std::string&) const
 {
   return false;

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -20,17 +20,9 @@
 #include "ToolController.h"
 
 #include "Ensure.h"
-#include "FloatType.h"
-#include "Model/HitType.h"
 #include "View/DragTracker.h"
 #include "View/DropTracker.h"
-#include "View/Grid.h"
 #include "View/Tool.h"
-
-#include "vm/distance.h"
-#include "vm/intersection.h"
-#include "vm/line.h"
-#include "vm/vec.h"
 
 namespace TrenchBroom::View
 {
@@ -151,7 +143,7 @@ std::unique_ptr<DragTracker> ToolControllerGroup::acceptMouseDrag(
     return nullptr;
   }
 
-  return m_chain.startMouseDrag(inputState);
+  return m_chain.acceptMouseDrag(inputState);
 }
 
 std::unique_ptr<DropTracker> ToolControllerGroup::acceptDrop(

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -67,6 +67,7 @@ public:
   virtual void mouseScroll(const InputState& inputState);
 
   virtual std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState);
+  virtual std::unique_ptr<GestureTracker> acceptGesture(const InputState& inputState);
 
   virtual bool shouldAcceptDrop(
     const InputState& inputState, const std::string& payload) const;

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -41,7 +41,7 @@ class RenderContext;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class DropTracker;
 class InputState;
 class Tool;
@@ -66,7 +66,7 @@ public:
   virtual void mouseMove(const InputState& inputState);
   virtual void mouseScroll(const InputState& inputState);
 
-  virtual std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState);
+  virtual std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState);
 
   virtual bool shouldAcceptDrop(
     const InputState& inputState, const std::string& payload) const;
@@ -110,7 +110,7 @@ public:
   void mouseMove(const InputState& inputState) override;
   void mouseScroll(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
   std::unique_ptr<DropTracker> acceptDrop(
     const InputState& inputState, const std::string& payload) override;
 

--- a/common/src/View/ToolController.h
+++ b/common/src/View/ToolController.h
@@ -19,15 +19,8 @@
 
 #pragma once
 
-#include "FloatType.h"
-#include "Model/HitFilter.h"
-#include "Model/HitType.h"
 #include "ToolChain.h"
 #include "View/InputState.h"
-
-#include "vm/line.h"
-#include "vm/plane.h"
-#include "vm/vec.h"
 
 #include <memory>
 #include <string>

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -89,7 +89,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState)
+  bool update(const InputState& inputState)
   {
     const auto oldX = inputState.mouseX() - inputState.mouseDX();
     const auto oldY = inputState.mouseY() - inputState.mouseDY();

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -110,8 +110,8 @@ public:
 std::unique_ptr<DragTracker> UVCameraTool::acceptMouseDrag(const InputState& inputState)
 {
   if (
-    !inputState.mouseButtonsPressed(MouseButtons::MBRight)
-    && !inputState.mouseButtonsPressed(MouseButtons::MBMiddle))
+    !inputState.mouseButtonsPressed(MouseButtons::Right)
+    && !inputState.mouseButtonsPressed(MouseButtons::Middle))
   {
     return nullptr;
   }

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -20,7 +20,7 @@
 #include "UVCameraTool.h"
 
 #include "Renderer/OrthographicCamera.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 
 #include "vm/vec.h"
@@ -78,7 +78,7 @@ void UVCameraTool::mouseScroll(const InputState& inputState)
 
 namespace
 {
-class UVCameraToolDragTracker : public DragTracker
+class UVCameraToolDragTracker : public GestureTracker
 {
 private:
   Renderer::Camera& m_camera;
@@ -107,7 +107,8 @@ public:
 };
 } // namespace
 
-std::unique_ptr<DragTracker> UVCameraTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> UVCameraTool::acceptMouseDrag(
+  const InputState& inputState)
 {
   if (
     !inputState.mouseButtonsPressed(MouseButtons::Right)

--- a/common/src/View/UVCameraTool.h
+++ b/common/src/View/UVCameraTool.h
@@ -33,7 +33,7 @@ class OrthographicCamera;
 
 namespace View
 {
-class DragTracker;
+class GestureTracker;
 
 class UVCameraTool : public ToolController, public Tool
 {
@@ -49,7 +49,7 @@ private:
 
   void mouseScroll(const InputState& inputState) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -155,8 +155,8 @@ std::unique_ptr<DragTracker> UVOffsetTool::acceptMouseDrag(const InputState& inp
   assert(m_helper.valid());
 
   if (
-    !inputState.modifierKeysPressed(ModifierKeys::MKNone)
-    || !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+    !inputState.modifierKeysPressed(ModifierKeys::None)
+    || !inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -24,7 +24,7 @@
 #include "Model/BrushGeometry.h"
 #include "Model/ChangeBrushFaceAttributesRequest.h"
 #include "Model/Polyhedron.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
 #include "View/TransactionScope.h"
@@ -82,7 +82,7 @@ vm::vec2f snapDelta(const UVViewHelper& helper, const vm::vec2f& delta)
   return vm::round(delta);
 }
 
-class UVOffsetDragTracker : public DragTracker
+class UVOffsetDragTracker : public GestureTracker
 {
 private:
   MapDocument& m_document;
@@ -150,7 +150,8 @@ const Tool& UVOffsetTool::tool() const
   return *this;
 }
 
-std::unique_ptr<DragTracker> UVOffsetTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> UVOffsetTool::acceptMouseDrag(
+  const InputState& inputState)
 {
   assert(m_helper.valid());
 

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -99,7 +99,7 @@ public:
     m_document.startTransaction("Move UV", TransactionScope::LongRunning);
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     assert(m_helper.valid());
 

--- a/common/src/View/UVOffsetTool.h
+++ b/common/src/View/UVOffsetTool.h
@@ -27,7 +27,7 @@
 namespace TrenchBroom::View
 {
 
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 class UVViewHelper;
 
@@ -44,7 +44,7 @@ private:
   Tool& tool() override;
   const Tool& tool() const override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -38,7 +38,7 @@
 #include "Renderer/ShaderManager.h"
 #include "Renderer/Shaders.h"
 #include "Renderer/Transformation.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/UVViewHelper.h"
 
@@ -258,7 +258,7 @@ void renderOriginHandle(
     new RenderOrigin{helper, UVOriginTool::OriginHandleRadius, highlight});
 }
 
-class UVOriginDragTracker : public DragTracker
+class UVOriginDragTracker : public GestureTracker
 {
 private:
   UVViewHelper& m_helper;
@@ -381,7 +381,8 @@ void UVOriginTool::pick(const InputState& inputState, Model::PickResult& pickRes
   }
 }
 
-std::unique_ptr<DragTracker> UVOriginTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> UVOriginTool::acceptMouseDrag(
+  const InputState& inputState)
 {
   using namespace Model::HitFilters;
 

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -388,8 +388,8 @@ std::unique_ptr<DragTracker> UVOriginTool::acceptMouseDrag(const InputState& inp
   assert(m_helper.valid());
 
   if (
-    !inputState.modifierKeysPressed(ModifierKeys::MKNone)
-    || !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+    !inputState.modifierKeysPressed(ModifierKeys::None)
+    || !inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -273,7 +273,7 @@ public:
   {
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const auto curPoint = computeHitPoint(m_helper, inputState.pickRay());
 

--- a/common/src/View/UVOriginTool.h
+++ b/common/src/View/UVOriginTool.h
@@ -37,7 +37,7 @@ class RenderContext;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class UVViewHelper;
 
 class UVOriginTool : public ToolController, public Tool
@@ -61,7 +61,7 @@ private:
 
   void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void render(
     const InputState& inputState,

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -202,7 +202,7 @@ public:
     document.startTransaction("Rotate UV", TransactionScope::LongRunning);
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     assert(m_helper.valid());
 

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -37,7 +37,7 @@
 #include "Renderer/Shaders.h"
 #include "Renderer/Transformation.h"
 #include "Renderer/VboManager.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
 #include "View/TransactionScope.h"
@@ -185,7 +185,7 @@ private:
   }
 };
 
-class UVRotateDragTracker : public DragTracker
+class UVRotateDragTracker : public GestureTracker
 {
 private:
   MapDocument& m_document;
@@ -354,7 +354,8 @@ void UVRotateTool::pick(const InputState& inputState, Model::PickResult& pickRes
   }
 }
 
-std::unique_ptr<DragTracker> UVRotateTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> UVRotateTool::acceptMouseDrag(
+  const InputState& inputState)
 {
   assert(m_helper.valid());
 

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -359,9 +359,9 @@ std::unique_ptr<DragTracker> UVRotateTool::acceptMouseDrag(const InputState& inp
   assert(m_helper.valid());
 
   if (
-    !(inputState.modifierKeysPressed(ModifierKeys::MKNone)
+    !(inputState.modifierKeysPressed(ModifierKeys::None)
       || inputState.modifierKeysPressed(ModifierKeys::MKCtrlCmd))
-    || !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+    || !inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }

--- a/common/src/View/UVRotateTool.h
+++ b/common/src/View/UVRotateTool.h
@@ -38,7 +38,7 @@ class RenderContext;
 
 namespace TrenchBroom::View
 {
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 class UVViewHelper;
 
@@ -60,7 +60,7 @@ private:
 
   void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void render(
     const InputState& inputState,

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -32,7 +32,7 @@
 #include "Renderer/PrimType.h"
 #include "Renderer/RenderBatch.h"
 #include "Renderer/RenderContext.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
 #include "View/TransactionScope.h"
@@ -169,7 +169,7 @@ void renderHighlight(
   handleRenderer.render(renderBatch, color, 1.0f);
 }
 
-class UVScaleDragTracker : public DragTracker
+class UVScaleDragTracker : public GestureTracker
 {
 private:
   MapDocument& m_document;
@@ -290,7 +290,7 @@ void UVScaleTool::pick(const InputState& inputState, Model::PickResult& pickResu
   }
 }
 
-std::unique_ptr<DragTracker> UVScaleTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> UVScaleTool::acceptMouseDrag(const InputState& inputState)
 {
   using namespace Model::HitFilters;
 

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -193,7 +193,7 @@ public:
     document.startTransaction("Scale UV", TransactionScope::LongRunning);
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const auto curPoint = getHitPoint(m_helper, inputState.pickRay());
     if (!curPoint)

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -297,8 +297,8 @@ std::unique_ptr<DragTracker> UVScaleTool::acceptMouseDrag(const InputState& inpu
   assert(m_helper.valid());
 
   if (
-    !inputState.modifierKeysPressed(ModifierKeys::MKNone)
-    || !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+    !inputState.modifierKeysPressed(ModifierKeys::None)
+    || !inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }

--- a/common/src/View/UVScaleTool.h
+++ b/common/src/View/UVScaleTool.h
@@ -40,7 +40,7 @@ class RenderContext;
 namespace TrenchBroom::View
 {
 
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 class UVViewHelper;
 
@@ -63,7 +63,7 @@ private:
 
   void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   void render(
     const InputState& inputState,

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -179,7 +179,7 @@ std::unique_ptr<DragTracker> UVShearTool::acceptMouseDrag(const InputState& inpu
 
   if (
     !inputState.modifierKeysPressed(ModifierKeys::MKAlt)
-    || !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+    || !inputState.mouseButtonsPressed(MouseButtons::Left))
   {
     return nullptr;
   }

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -87,7 +87,7 @@ public:
     m_document.startTransaction("Shear UV", TransactionScope::LongRunning);
   }
 
-  bool drag(const InputState& inputState) override
+  bool update(const InputState& inputState) override
   {
     const auto currentHit = getHit(m_helper, m_xAxis, m_yAxis, inputState.pickRay());
     if (!currentHit)

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -24,7 +24,7 @@
 #include "Model/Hit.h"
 #include "Model/HitFilter.h"
 #include "Model/PickResult.h"
-#include "View/DragTracker.h"
+#include "View/GestureTracker.h"
 #include "View/InputState.h"
 #include "View/MapDocument.h"
 #include "View/TransactionScope.h"
@@ -57,7 +57,7 @@ std::optional<vm::vec2f> getHit(
     });
 }
 
-class UVShearDragTracker : public DragTracker
+class UVShearDragTracker : public GestureTracker
 {
 private:
   MapDocument& m_document;
@@ -171,7 +171,7 @@ void UVShearTool::pick(const InputState& inputState, Model::PickResult& pickResu
   }
 }
 
-std::unique_ptr<DragTracker> UVShearTool::acceptMouseDrag(const InputState& inputState)
+std::unique_ptr<GestureTracker> UVShearTool::acceptMouseDrag(const InputState& inputState)
 {
   using namespace Model::HitFilters;
 

--- a/common/src/View/UVShearTool.h
+++ b/common/src/View/UVShearTool.h
@@ -28,7 +28,7 @@
 namespace TrenchBroom::View
 {
 
-class DragTracker;
+class GestureTracker;
 class MapDocument;
 class UVViewHelper;
 
@@ -51,7 +51,7 @@ private:
 
   void pick(const InputState& inputState, Model::PickResult& pickResult) override;
 
-  std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override;
+  std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override;
 
   bool cancel() override;
 };

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -398,6 +398,11 @@ void UVView::processEvent(const MouseEvent& event)
   ToolBoxConnector::processEvent(event);
 }
 
+void UVView::processEvent(const GestureEvent& event)
+{
+  ToolBoxConnector::processEvent(event);
+}
+
 void UVView::processEvent(const CancelEvent& event)
 {
   ToolBoxConnector::processEvent(event);

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -398,6 +398,11 @@ void UVView::processEvent(const MouseEvent& event)
   ToolBoxConnector::processEvent(event);
 }
 
+void UVView::processEvent(const ScrollEvent& event)
+{
+  ToolBoxConnector::processEvent(event);
+}
+
 void UVView::processEvent(const GestureEvent& event)
 {
   ToolBoxConnector::processEvent(event);

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -120,6 +120,7 @@ private:
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 
 private:

--- a/common/src/View/UVView.h
+++ b/common/src/View/UVView.h
@@ -120,6 +120,7 @@ private:
 public: // implement InputEventProcessor interface
   void processEvent(const KeyEvent& event) override;
   void processEvent(const MouseEvent& event) override;
+  void processEvent(const ScrollEvent& event) override;
   void processEvent(const GestureEvent& event) override;
   void processEvent(const CancelEvent& event) override;
 

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -48,8 +48,7 @@ Model::Hit VertexToolController::findHandleHit(
   if (vertexHit.isMatch())
     return vertexHit;
   if (
-    inputState.modifierKeysDown(ModifierKeys::MKShift)
-    && !inputState.pickResult().empty())
+    inputState.modifierKeysDown(ModifierKeys::Shift) && !inputState.pickResult().empty())
   {
     const auto& anyHit = inputState.pickResult().all().front();
     if (anyHit.hasType(
@@ -69,8 +68,7 @@ std::vector<Model::Hit> VertexToolController::findHandleHits(
   if (!vertexHits.empty())
     return vertexHits;
   if (
-    inputState.modifierKeysDown(ModifierKeys::MKShift)
-    && !inputState.pickResult().empty())
+    inputState.modifierKeysDown(ModifierKeys::Shift) && !inputState.pickResult().empty())
   {
     const auto& anyHit = inputState.pickResult().all().front();
     if (anyHit.hasType(EdgeHandleManager::HandleHitType))
@@ -129,8 +127,8 @@ private:
   bool mouseClick(const InputState& inputState) override
   {
     if (
-      inputState.mouseButtonsPressed(MouseButtons::MBLeft)
-      && inputState.modifierKeysPressed(ModifierKeys::MKAlt | ModifierKeys::MKShift)
+      inputState.mouseButtonsPressed(MouseButtons::Left)
+      && inputState.modifierKeysPressed(ModifierKeys::MKAlt | ModifierKeys::Shift)
       && m_tool.handleManager().selectedHandleCount() == 1)
     {
 
@@ -151,21 +149,21 @@ private:
   bool shouldStartMove(const InputState& inputState) const override
   {
     return (
-      inputState.mouseButtonsPressed(MouseButtons::MBLeft) &&
-      (inputState.modifierKeysPressed(ModifierKeys::MKNone) ||    // horizontal movement
+      inputState.mouseButtonsPressed(MouseButtons::Left) &&
+      (inputState.modifierKeysPressed(ModifierKeys::None) ||    // horizontal movement
        inputState.modifierKeysPressed(ModifierKeys::MKAlt) ||     // vertical movement
        inputState.modifierKeysPressed(ModifierKeys::MKCtrlCmd) || // horizontal absolute snap
        inputState.modifierKeysPressed(
          ModifierKeys::MKCtrlCmd | ModifierKeys::MKAlt) || // vertical absolute snap
        inputState.modifierKeysPressed(
-         ModifierKeys::MKShift) || // add new vertex and horizontal movement
+         ModifierKeys::Shift) || // add new vertex and horizontal movement
        inputState.modifierKeysPressed(
-         ModifierKeys::MKShift | ModifierKeys::MKAlt) || // add new vertex and vertical movement
+         ModifierKeys::Shift | ModifierKeys::MKAlt) || // add new vertex and vertical movement
        inputState.modifierKeysPressed(
-         ModifierKeys::MKShift |
+         ModifierKeys::Shift |
          ModifierKeys::MKCtrlCmd) || // add new vertex and horizontal movement with absolute snap
        inputState.modifierKeysPressed(
-         ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd |
+         ModifierKeys::Shift | ModifierKeys::MKCtrlCmd |
          ModifierKeys::MKAlt) // add new vertex and vertical movement with absolute snap
        ));
   }
@@ -184,7 +182,7 @@ private:
             EdgeHandleManager::HandleHitType | FaceHandleManager::HandleHitType))
       {
         const vm::vec3 handle = m_tool.getHandlePosition(hit);
-        if (inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+        if (inputState.mouseButtonsPressed(MouseButtons::Left))
           m_tool.renderHandle(
             renderContext, renderBatch, handle, pref(Preferences::SelectedHandleColor));
         else

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -214,7 +214,7 @@ protected:
       return m_tool.select(hits, inputState.modifierKeysPressed(ModifierKeys::MKCtrlCmd));
     }
 
-    std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+    std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
     {
       if (
         !inputState.mouseButtonsPressed(MouseButtons::Left)
@@ -402,7 +402,7 @@ protected:
 
     const Tool& tool() const override { return m_tool; }
 
-    std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
+    std::unique_ptr<GestureTracker> acceptMouseDrag(const InputState& inputState) override
     {
       if (!shouldStartMove(inputState))
       {

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -198,8 +198,9 @@ protected:
     bool mouseClick(const InputState& inputState) override
     {
       if (
-        !inputState.mouseButtonsPressed(MouseButtons::MBLeft)
-        || !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No))
+        !inputState.mouseButtonsPressed(MouseButtons::Left)
+        || !inputState.checkModifierKeys(
+          ModifierKeyPressed::DontCare, ModifierKeyPressed::No, ModifierKeyPressed::No))
       {
         return false;
       }
@@ -216,8 +217,9 @@ protected:
     std::unique_ptr<DragTracker> acceptMouseDrag(const InputState& inputState) override
     {
       if (
-        !inputState.mouseButtonsPressed(MouseButtons::MBLeft)
-        || !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No))
+        !inputState.mouseButtonsPressed(MouseButtons::Left)
+        || !inputState.checkModifierKeys(
+          ModifierKeyPressed::DontCare, ModifierKeyPressed::No, ModifierKeyPressed::No))
       {
         return nullptr;
       }
@@ -267,7 +269,7 @@ protected:
           const auto handle = m_tool.getHandlePosition(hit);
           m_tool.renderHighlight(renderContext, renderBatch, handle);
 
-          if (inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+          if (inputState.mouseButtonsPressed(MouseButtons::Left))
           {
             m_tool.renderGuide(renderContext, renderBatch, handle);
           }
@@ -430,8 +432,8 @@ protected:
     // Overridden in vertex tool controller to handle special cases for vertex moving.
     virtual bool shouldStartMove(const InputState& inputState) const
     {
-      return inputState.mouseButtonsPressed(MouseButtons::MBLeft) &&
-             (inputState.modifierKeysPressed(ModifierKeys::MKNone)     // horizontal movement
+      return inputState.mouseButtonsPressed(MouseButtons::Left) &&
+             (inputState.modifierKeysPressed(ModifierKeys::None)     // horizontal movement
               || inputState.modifierKeysPressed(ModifierKeys::MKAlt)); // vertical movement
     }
   };

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -145,7 +145,7 @@ protected:
         makePlaneHandlePicker(plane, handleOffset), makeIdentityHandleSnapper());
     }
 
-    DragStatus drag(
+    DragStatus update(
       const InputState&,
       const DragState&,
       const vm::vec3& proposedHandlePosition) override

--- a/common/test/src/View/tst_ClipToolController.cpp
+++ b/common/test/src/View/tst_ClipToolController.cpp
@@ -114,9 +114,9 @@ TEST_CASE_METHOD(
   updatePickState(inputState, camera, *document);
   REQUIRE(inputState.pickResult().size() == 1u);
 
-  inputState.mouseDown(MouseButtons::MBLeft);
+  inputState.mouseDown(MouseButtons::Left);
   CHECK(controller.mouseClick(inputState));
-  inputState.mouseUp(MouseButtons::MBLeft);
+  inputState.mouseUp(MouseButtons::Left);
 
   CHECK_FALSE(tool.canClip());
   CHECK(tool.canAddPoint(clipPoint2));
@@ -127,9 +127,9 @@ TEST_CASE_METHOD(
   updatePickState(inputState, camera, *document);
   REQUIRE(inputState.pickResult().size() == 1u);
 
-  inputState.mouseDown(MouseButtons::MBLeft);
+  inputState.mouseDown(MouseButtons::Left);
   CHECK(controller.mouseClick(inputState));
-  inputState.mouseUp(MouseButtons::MBLeft);
+  inputState.mouseUp(MouseButtons::Left);
 
   CHECK(tool.canClip());
 

--- a/common/test/src/View/tst_HandleDragTracker.cpp
+++ b/common/test/src/View/tst_HandleDragTracker.cpp
@@ -26,23 +26,21 @@
 
 #include "vm/approx.h"
 #include "vm/line.h"
-#include "vm/line_io.h"
+#include "vm/line_io.h" // IWYU pragma: keep
 #include "vm/plane.h"
-#include "vm/plane_io.h"
+#include "vm/plane_io.h" // IWYU pragma: keep
 #include "vm/ray.h"
-#include "vm/ray_io.h"
+#include "vm/ray_io.h" // IWYU pragma: keep
 #include "vm/scalar.h"
 #include "vm/vec.h"
-#include "vm/vec_io.h"
+#include "vm/vec_io.h" // IWYU pragma: keep
 
 #include <tuple>
 #include <vector>
 
-#include "Catch2.h"
+#include "Catch2.h" // IWYU pragma: keep
 
-namespace TrenchBroom
-{
-namespace View
+namespace TrenchBroom::View
 {
 struct TestDelegateData
 {
@@ -60,7 +58,7 @@ struct TestDelegateData
 
   std::vector<DragState> mouseScrollArguments;
 
-  TestDelegateData(HandlePositionProposer i_initialGetHandlePositionToReturn)
+  explicit TestDelegateData(HandlePositionProposer i_initialGetHandlePositionToReturn)
     : initialGetHandlePositionToReturn{std::move(i_initialGetHandlePositionToReturn)}
   {
   }
@@ -70,7 +68,7 @@ struct TestDelegate : public HandleDragTrackerDelegate
 {
   TestDelegateData& data;
 
-  TestDelegate(TestDelegateData& i_data)
+  explicit TestDelegate(TestDelegateData& i_data)
     : data{i_data}
   {
   }
@@ -78,37 +76,39 @@ struct TestDelegate : public HandleDragTrackerDelegate
   HandlePositionProposer start(
     const InputState&,
     const vm::vec3& initialHandlePosition,
-    const vm::vec3& handleOffset)
+    const vm::vec3& handleOffset) override
   {
     data.initializeArguments.emplace_back(initialHandlePosition, handleOffset);
     return data.initialGetHandlePositionToReturn;
   }
 
   DragStatus drag(
-    const InputState&, const DragState& dragState, const vm::vec3& proposedHandlePosition)
+    const InputState&,
+    const DragState& dragState,
+    const vm::vec3& proposedHandlePosition) override
   {
     data.dragArguments.emplace_back(dragState, proposedHandlePosition);
     return data.dragStatusToReturn;
   }
 
-  void end(const InputState&, const DragState& dragState)
+  void end(const InputState&, const DragState& dragState) override
   {
     data.endArguments.emplace_back(dragState);
   }
 
-  void cancel(const DragState& dragState)
+  void cancel(const DragState& dragState) override
   {
     data.cancelArguments.emplace_back(dragState);
   }
 
   std::optional<UpdateDragConfig> modifierKeyChange(
-    const InputState&, const DragState& dragState)
+    const InputState&, const DragState& dragState) override
   {
     data.modifierKeyChangeArguments.emplace_back(dragState);
     return data.updateDragConfigToReturn;
   }
 
-  void mouseScroll(const InputState&, const DragState& dragState)
+  void mouseScroll(const InputState&, const DragState& dragState) override
   {
     data.mouseScrollArguments.emplace_back(dragState);
   }
@@ -741,5 +741,4 @@ TEST_CASE("makeCircleHandleSnapper")
       proposedHandlePosition)
     == vm::approx{radius * expectedHandlePosition});
 }
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/test/src/View/tst_HandleDragTracker.cpp
+++ b/common/test/src/View/tst_HandleDragTracker.cpp
@@ -152,7 +152,7 @@ TEST_CASE("RestrictedDragTracker.constructor")
         "handle "
         "position")
       {
-        tracker.drag(InputState{});
+        tracker.update(InputState{});
 
         CHECK(
           data.dragArguments
@@ -183,7 +183,7 @@ TEST_CASE("RestrictedDragTracker.drag")
     WHEN("drag is called for the first time after the drag started")
     {
       handlePositionToReturn = vm::vec3{2, 2, 2};
-      REQUIRE(tracker.drag(InputState{}));
+      REQUIRE(tracker.update(InputState{}));
 
       THEN("drag got the initial and the next handle positions")
       {
@@ -197,7 +197,7 @@ TEST_CASE("RestrictedDragTracker.drag")
         AND_WHEN("drag is called again")
         {
           handlePositionToReturn = vm::vec3{3, 3, 3};
-          REQUIRE(tracker.drag(InputState{}));
+          REQUIRE(tracker.update(InputState{}));
 
           THEN("drag got the last and the next handle positions")
           {
@@ -218,7 +218,7 @@ TEST_CASE("RestrictedDragTracker.drag")
     {
       handlePositionToReturn = vm::vec3{2, 2, 2};
       data.dragStatusToReturn = DragStatus::Deny;
-      REQUIRE(tracker.drag(InputState{}));
+      REQUIRE(tracker.update(InputState{}));
 
       THEN("drag got the initial and the next handle positions")
       {
@@ -232,7 +232,7 @@ TEST_CASE("RestrictedDragTracker.drag")
         AND_WHEN("drag is called again")
         {
           handlePositionToReturn = vm::vec3{3, 3, 3};
-          REQUIRE(tracker.drag(InputState{}));
+          REQUIRE(tracker.update(InputState{}));
 
           THEN("drag got the initial handle position for the last handle position again")
           {
@@ -253,7 +253,7 @@ TEST_CASE("RestrictedDragTracker.drag")
     {
       handlePositionToReturn = vm::vec3{2, 2, 2};
       data.dragStatusToReturn = DragStatus::End;
-      const auto dragResult = tracker.drag(InputState{});
+      const auto dragResult = tracker.update(InputState{});
 
       THEN("the drag tracker returns false")
       {
@@ -287,7 +287,7 @@ TEST_CASE("RestrictedDragTracker.handlePositionComputations")
     WHEN("drag is called for the first time")
     {
       handlePositionToReturn = vm::vec3{2, 2, 2};
-      REQUIRE(tracker.drag(InputState{}));
+      REQUIRE(tracker.update(InputState{}));
 
       THEN("getHandlePosition is called with the expected arguments")
       {
@@ -312,7 +312,7 @@ TEST_CASE("RestrictedDragTracker.handlePositionComputations")
       AND_WHEN("drag is called again")
       {
         handlePositionToReturn = vm::vec3{3, 3, 3};
-        REQUIRE(tracker.drag(InputState{}));
+        REQUIRE(tracker.update(InputState{}));
 
         THEN("getHandlePosition is called with the expected arguments")
         {
@@ -364,7 +364,7 @@ TEST_CASE("RestrictedDragTracker.modifierKeyChange")
 
     auto tracker = makeHandleTracker(data, initialHandlePosition, initialHitPoint);
 
-    tracker.drag(InputState{});
+    tracker.update(InputState{});
     REQUIRE(initialGetHandlePositionArguments.size() == 1);
 
     WHEN("A modifier key change is notified")
@@ -380,7 +380,7 @@ TEST_CASE("RestrictedDragTracker.modifierKeyChange")
 
         AND_THEN("The next call to drag uses the initial drag config")
         {
-          tracker.drag(InputState{});
+          tracker.update(InputState{});
           CHECK(initialGetHandlePositionArguments.size() == 2);
         }
       }
@@ -416,7 +416,7 @@ TEST_CASE("RestrictedDragTracker.modifierKeyChange")
 
     auto tracker = makeHandleTracker(data, initialHandlePosition, initialHitPoint);
 
-    tracker.drag(InputState{});
+    tracker.update(InputState{});
     REQUIRE(initialGetHandlePositionArguments.size() == 1);
     REQUIRE(
       data.dragArguments
@@ -456,7 +456,7 @@ TEST_CASE("RestrictedDragTracker.modifierKeyChange")
         AND_WHEN("drag is called again")
         {
           otherHitPositionToReturn = vm::vec3{4, 4, 4};
-          tracker.drag(InputState{});
+          tracker.update(InputState{});
 
           AND_THEN("The other handle position is passed")
           {

--- a/common/test/src/View/tst_HandleDragTracker.cpp
+++ b/common/test/src/View/tst_HandleDragTracker.cpp
@@ -82,7 +82,7 @@ struct TestDelegate : public HandleDragTrackerDelegate
     return data.initialGetHandlePositionToReturn;
   }
 
-  DragStatus drag(
+  DragStatus update(
     const InputState&,
     const DragState& dragState,
     const vm::vec3& proposedHandlePosition) override

--- a/common/test/src/View/tst_InputEvent.cpp
+++ b/common/test/src/View/tst_InputEvent.cpp
@@ -115,23 +115,19 @@ TEST_CASE("ScrollEvent")
 {
   SECTION("collateWith")
   {
+    using Source = ScrollEvent::Source;
+    const auto lhsSource = GENERATE(Source::Mouse, Source::Trackpad);
+    const auto rhsSource = GENERATE(Source::Mouse, Source::Trackpad);
+
     using Axis = ScrollEvent::Axis;
     const auto lhsWheelAxis = GENERATE(Axis::Horizontal, Axis::Vertical);
     const auto rhsWheelAxis = GENERATE(Axis::Horizontal, Axis::Vertical);
 
-    // clang-format off
-      const auto expectedScrollDistances = std::array<std::array<std::optional<float>, 2>, 2>{{
-        // H           V
-        {-2.0f,        std::nullopt}, // H
-        {std::nullopt, -2.0f},        // V
-      }};
-    // clang-format on
+    const auto canCollate = lhsSource == rhsSource && lhsWheelAxis == rhsWheelAxis;
+    const auto expectedScrollDistance = canCollate ? std::optional{-2.0f} : std::nullopt;
 
-    const auto expectedScrollDistance =
-      expectedScrollDistances[size_t(lhsWheelAxis)][size_t(rhsWheelAxis)];
-
-    auto lhs = ScrollEvent{lhsWheelAxis, 3.0f};
-    const auto rhs = ScrollEvent{rhsWheelAxis, -5.0f};
+    auto lhs = ScrollEvent{lhsSource, lhsWheelAxis, 3.0f};
+    const auto rhs = ScrollEvent{rhsSource, rhsWheelAxis, -5.0f};
 
     CHECK(lhs.collateWith(rhs) == expectedScrollDistance.has_value());
     if (expectedScrollDistance)
@@ -404,7 +400,11 @@ TEST_CASE("InputEventRecorder")
     CHECK(
       getEvents(r)
       == std::vector<Event>{
-        ScrollEvent{ScrollEvent::Axis::Horizontal, expectedScrollLines},
+        ScrollEvent{
+          ScrollEvent::Source::Mouse,
+          ScrollEvent::Axis::Horizontal,
+          expectedScrollLines,
+        },
       });
   }
 
@@ -426,7 +426,11 @@ TEST_CASE("InputEventRecorder")
     CHECK(
       getEvents(r)
       == std::vector<Event>{
-        ScrollEvent{ScrollEvent::Axis::Vertical, expectedScrollLines},
+        ScrollEvent{
+          ScrollEvent::Source::Mouse,
+          ScrollEvent::Axis::Vertical,
+          expectedScrollLines,
+        },
       });
   }
 
@@ -450,9 +454,21 @@ TEST_CASE("InputEventRecorder")
     CHECK(
       getEvents(r)
       == std::vector<Event>{
-        ScrollEvent{ScrollEvent::Axis::Horizontal, float(expectedScrollLines1.x())},
-        ScrollEvent{ScrollEvent::Axis::Vertical, float(expectedScrollLines1.y())},
-        ScrollEvent{ScrollEvent::Axis::Horizontal, float(expectedScrollLines2.x())},
+        ScrollEvent{
+          ScrollEvent::Source::Mouse,
+          ScrollEvent::Axis::Horizontal,
+          float(expectedScrollLines1.x()),
+        },
+        ScrollEvent{
+          ScrollEvent::Source::Mouse,
+          ScrollEvent::Axis::Vertical,
+          float(expectedScrollLines1.y()),
+        },
+        ScrollEvent{
+          ScrollEvent::Source::Mouse,
+          ScrollEvent::Axis::Horizontal,
+          float(expectedScrollLines2.x()),
+        },
       });
   }
 

--- a/common/test/src/View/tst_InputEvent.cpp
+++ b/common/test/src/View/tst_InputEvent.cpp
@@ -33,19 +33,6 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 namespace TrenchBroom::View
 {
 
-TEST_CASE("KeyEvent")
-{
-  SECTION("collateWith")
-  {
-    const auto lhsType = GENERATE(KeyEvent::Type::Down, KeyEvent::Type::Up);
-    const auto rhsType = GENERATE(KeyEvent::Type::Down, KeyEvent::Type::Up);
-
-    auto lhs = KeyEvent{lhsType};
-    const auto rhs = KeyEvent{rhsType};
-    CHECK_FALSE(lhs.collateWith(rhs));
-  }
-}
-
 TEST_CASE("MouseEvent")
 {
   SECTION("collateWith")

--- a/common/test/src/View/tst_InputEvent.cpp
+++ b/common/test/src/View/tst_InputEvent.cpp
@@ -30,169 +30,148 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include <thread>
 #include <variant>
 
-#include "Catch2.h"
+#include "Catch2.h" // IWYU pragma: keep
 
-namespace TrenchBroom
+namespace TrenchBroom::View
 {
-namespace View
+
+TEST_CASE("KeyEvent")
 {
-TEST_CASE("KeyEventTest.collateWith")
-{
-  static const std::array<KeyEvent::Type, 2> eventTypes = {
-    KeyEvent::Type::Down, KeyEvent::Type::Up};
-
-  for (std::size_t i = 0; i < 2; ++i)
+  SECTION("collateWith")
   {
-    for (std::size_t j = 0; j < 2; ++j)
-    {
-      auto lhs = KeyEvent(eventTypes[i]);
-      const auto rhs = KeyEvent(eventTypes[j]);
-      CHECK_FALSE(lhs.collateWith(rhs));
-    }
-  }
-}
+    const auto lhsType = GENERATE(KeyEvent::Type::Down, KeyEvent::Type::Up);
+    const auto rhsType = GENERATE(KeyEvent::Type::Down, KeyEvent::Type::Up);
 
-TEST_CASE("MouseEventTest.collateWith")
-{
-  static const std::array<MouseEvent::Type, 9> eventTypes = {
-    MouseEvent::Type::Down,
-    MouseEvent::Type::Up,
-    MouseEvent::Type::Click,
-    MouseEvent::Type::DoubleClick,
-    MouseEvent::Type::Motion,
-    MouseEvent::Type::Scroll,
-    MouseEvent::Type::DragStart,
-    MouseEvent::Type::Drag,
-    MouseEvent::Type::DragEnd};
-  static const std::array<std::array<bool, 9>, 9> collationMatrix = {{
-    // Down   Up     Click  DClick Motion Scroll DragSt Drag   DragEnd
-    {false, false, false, false, false, false, false, false, false}, // Down
-    {false, false, false, false, false, false, false, false, false}, // Up
-    {false, false, false, false, false, false, false, false, false}, // Click
-    {false, false, false, false, false, false, false, false, false}, // DClick
-    {false, false, false, false, true, false, false, false, false},  // Motion
-    {false, false, false, false, false, true, false, false, false},  // Scroll
-    {false, false, false, false, false, false, false, false, false}, // DragStart
-    {false, false, false, false, false, false, false, true, false},  // Drag
-    {false, false, false, false, false, false, false, false, false}, // DragEnd
-  }};
-
-  for (std::size_t i = 0; i < 9; ++i)
-  {
-    for (std::size_t j = 0; j < 9; ++j)
-    {
-      auto lhs = MouseEvent(
-        eventTypes[i], MouseEvent::Button::None, MouseEvent::WheelAxis::None, 0, 0, 0.0f);
-      const auto rhs = MouseEvent(
-        eventTypes[j], MouseEvent::Button::None, MouseEvent::WheelAxis::None, 0, 0, 0.0f);
-
-      CHECK(lhs.collateWith(rhs) == collationMatrix[i][j]);
-    }
-  }
-
-  {
-    // motion collation
-    auto lhs = MouseEvent(
-      MouseEvent::Type::Motion,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::None,
-      2,
-      3,
-      0.0f);
-    const auto rhs = MouseEvent(
-      MouseEvent::Type::Motion,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::None,
-      5,
-      5,
-      0.0f);
-    CHECK(lhs.collateWith(rhs));
-    CHECK(lhs.posX == 5);
-    CHECK(lhs.posY == 5);
-  }
-
-  {
-    // drag collation
-    auto lhs = MouseEvent(
-      MouseEvent::Type::Drag,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::None,
-      2,
-      3,
-      0.0f);
-    const auto rhs = MouseEvent(
-      MouseEvent::Type::Drag,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::None,
-      5,
-      5,
-      0.0f);
-    CHECK(lhs.collateWith(rhs));
-    CHECK(lhs.posX == 5);
-    CHECK(lhs.posY == 5);
-  }
-
-  {
-    // horizontal wheel collation
-    auto lhs = MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      0,
-      0,
-      3.0f);
-    const auto rhs = MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      0,
-      0,
-      -5.0f);
-    CHECK(lhs.collateWith(rhs));
-    CHECK(lhs.scrollDistance == -2.0f);
-  }
-
-  {
-    // vertical wheel collation
-    auto lhs = MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Vertical,
-      0,
-      0,
-      3.0f);
-    const auto rhs = MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Vertical,
-      0,
-      0,
-      -5.0f);
-    CHECK(lhs.collateWith(rhs));
-    CHECK(lhs.scrollDistance == -2.0f);
-  }
-
-  {
-    // unmatched axis wheel collation
-    auto lhs = MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      0,
-      0,
-      3.0f);
-    const auto rhs = MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Vertical,
-      0,
-      0,
-      -5.0f);
+    auto lhs = KeyEvent{lhsType};
+    const auto rhs = KeyEvent{rhsType};
     CHECK_FALSE(lhs.collateWith(rhs));
-    CHECK(lhs.scrollDistance == 3.0f);
   }
 }
 
+TEST_CASE("MouseEvent")
+{
+  SECTION("collateWith")
+  {
+    SECTION("can collate")
+    {
+      constexpr std::array<std::array<bool, 9>, 9> expectedResult = {{
+        // Down   Up     Click  DClick Motion Scroll DragSt Drag   DragEnd
+        {false, false, false, false, false, false, false, false, false}, // Down
+        {false, false, false, false, false, false, false, false, false}, // Up
+        {false, false, false, false, false, false, false, false, false}, // Click
+        {false, false, false, false, false, false, false, false, false}, // DClick
+        {false, false, false, false, true, false, false, false, false},  // Motion
+        {false, false, false, false, false, true, false, false, false},  // Scroll
+        {false, false, false, false, false, false, false, false, false}, // DragStart
+        {false, false, false, false, false, false, false, true, false},  // Drag
+        {false, false, false, false, false, false, false, false, false}, // DragEnd
+      }};
+
+      using Type = MouseEvent::Type;
+      const auto lhsType = GENERATE(
+        Type::Down,
+        Type::Up,
+        Type::Click,
+        Type::DoubleClick,
+        Type::Motion,
+        Type::Scroll,
+        Type::DragStart,
+        Type::Drag,
+        Type::DragEnd);
+      const auto rhsType = GENERATE(
+        Type::Down,
+        Type::Up,
+        Type::Click,
+        Type::DoubleClick,
+        Type::Motion,
+        Type::Scroll,
+        Type::DragStart,
+        Type::Drag,
+        Type::DragEnd);
+
+      auto lhs = MouseEvent{
+        lhsType, MouseEvent::Button::None, MouseEvent::WheelAxis::None, 0, 0, 0.0f};
+      const auto rhs = MouseEvent{
+        rhsType, MouseEvent::Button::None, MouseEvent::WheelAxis::None, 0, 0, 0.0f};
+
+      CHECK(lhs.collateWith(rhs) == expectedResult[size_t(lhsType)][size_t(rhsType)]);
+    }
+
+    SECTION("motion collation")
+    {
+      auto lhs = MouseEvent{
+        MouseEvent::Type::Motion,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::None,
+        2,
+        3,
+        0.0f};
+      const auto rhs = MouseEvent{
+        MouseEvent::Type::Motion,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::None,
+        5,
+        5,
+        0.0f};
+      CHECK(lhs.collateWith(rhs));
+      CHECK(lhs.posX == 5);
+      CHECK(lhs.posY == 5);
+    }
+
+    SECTION("drag collation")
+    {
+      auto lhs = MouseEvent{
+        MouseEvent::Type::Drag,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::None,
+        2,
+        3,
+        0.0f};
+      const auto rhs = MouseEvent{
+        MouseEvent::Type::Drag,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::None,
+        5,
+        5,
+        0.0f};
+      CHECK(lhs.collateWith(rhs));
+      CHECK(lhs.posX == 5);
+      CHECK(lhs.posY == 5);
+    }
+
+    SECTION("horizontal wheel collation")
+    {
+      using Axis = MouseEvent::WheelAxis;
+      const auto lhsWheelAxis = GENERATE(Axis::Horizontal, Axis::Vertical);
+      const auto rhsWheelAxis = GENERATE(Axis::Horizontal, Axis::Vertical);
+
+      // clang-format off
+      const auto expectedScrollDistances = std::array<std::array<std::optional<float>, 2>, 2>{{
+        // H           V
+        {-2.0f,        std::nullopt}, // H
+        {std::nullopt, -2.0f},        // V
+      }};
+      // clang-format on
+
+      const auto expectedScrollDistance =
+        expectedScrollDistances[size_t(lhsWheelAxis) - 1][size_t(rhsWheelAxis) - 1];
+
+      auto lhs = MouseEvent{
+        MouseEvent::Type::Scroll, MouseEvent::Button::None, lhsWheelAxis, 0, 0, 3.0f};
+      const auto rhs = MouseEvent{
+        MouseEvent::Type::Scroll, MouseEvent::Button::None, rhsWheelAxis, 0, 0, -5.0f};
+
+      CHECK(lhs.collateWith(rhs) == expectedScrollDistance.has_value());
+      if (expectedScrollDistance)
+      {
+        CHECK(lhs.scrollDistance == expectedScrollDistance);
+      }
+    }
+  }
+}
+
+namespace
+{
 class TestEventProcessor : public InputEventProcessor
 {
 private:
@@ -201,7 +180,7 @@ private:
 
 public:
   template <typename... Args>
-  TestEventProcessor(Args&&... args)
+  explicit TestEventProcessor(Args&&... args)
   {
     (m_expectedEvents.emplace_back(std::forward<Args>(args)), ...);
   }
@@ -252,572 +231,650 @@ public:
 template <typename... Args>
 void checkEventQueue(InputEventRecorder& r, Args&&... args)
 {
-  TestEventProcessor p(std::forward<Args>(args)...);
+  auto p = TestEventProcessor{std::forward<Args>(args)...};
   r.processEvents(p);
   CHECK(p.allConsumed());
 }
 
-inline QWheelEvent makeWheelEvent(const QPoint& angleDelta)
+QWheelEvent makeWheelEvent(const QPoint& angleDelta)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
-  return QWheelEvent({}, {}, {}, angleDelta, Qt::NoButton, 0, Qt::ScrollUpdate, false);
+  return {{}, {}, {}, angleDelta, Qt::NoButton, nullptr, Qt::ScrollUpdate, false};
 #else
-  return QWheelEvent(
-    {}, {}, {}, angleDelta, 0, Qt::Orientation::Horizontal, Qt::NoButton, 0);
+  return {{}, {}, {}, angleDelta, 0, Qt::Orientation::Horizontal, Qt::NoButton, 0};
 #endif
 }
 
-TEST_CASE("InputEventRecorderTest.recordKeyEvents")
+} // namespace
+
+TEST_CASE("InputEventRecorder")
 {
-  InputEventRecorder r;
+  auto r = InputEventRecorder{};
 
-  r.recordEvent(QKeyEvent(QEvent::KeyPress, 0, 0, 0, 0));
-  r.recordEvent(QKeyEvent(QEvent::KeyRelease, 0, 0, 0, 0));
+  SECTION("recordKeyEvents")
+  {
+    r.recordEvent(QKeyEvent{QEvent::KeyPress, 0, nullptr, nullptr, 0});
+    r.recordEvent(QKeyEvent{QEvent::KeyRelease, 0, nullptr, nullptr, 0});
 
-  checkEventQueue(r, KeyEvent(KeyEvent::Type::Down), KeyEvent(KeyEvent::Type::Up));
+    checkEventQueue(r, KeyEvent{KeyEvent::Type::Down}, KeyEvent{KeyEvent::Type::Up});
+  }
+
+  SECTION("recordLeftClick")
+  {
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Click,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f});
+  }
+
+  SECTION("recordLeftDoubleClick")
+  {
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonDblClick,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Click,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::DoubleClick,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f});
+  }
+
+  SECTION("recordCtrlLeftClick")
+  {
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      Qt::MetaModifier});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Right,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Click,
+        MouseEvent::Button::Right,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Right,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f});
+  }
+
+  SECTION("recordRightClick")
+  {
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::RightButton,
+      Qt::RightButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::RightButton,
+      Qt::RightButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Right,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Click,
+        MouseEvent::Button::Right,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Right,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f});
+  }
+
+  SECTION("recordMotionWithCollation")
+  {
+    using namespace std::chrono_literals;
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::NoButton, Qt::NoButton, nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {12.0f, 8.0f}, {}, {}, Qt::NoButton, Qt::NoButton, nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Motion,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::None,
+        12,
+        8,
+        0.0f});
+  }
+
+  SECTION("recordHScrollWithCollation")
+  {
+    const auto qWheel1 = makeWheelEvent({2, 0});
+    const auto qWheel2 = makeWheelEvent({3, 0});
+
+    const auto expectedScrollLines =
+      float((InputEventRecorder::scrollLinesForEvent(qWheel1)
+             + InputEventRecorder::scrollLinesForEvent(qWheel2))
+              .x());
+    REQUIRE(expectedScrollLines > 0.0f);
+
+    using namespace std::chrono_literals;
+    r.recordEvent(qWheel1);
+    r.recordEvent(qWheel2);
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Scroll,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::Horizontal,
+        0,
+        0,
+        expectedScrollLines});
+  }
+
+  SECTION("recordVScrollWithCollation")
+  {
+    const auto qWheel1 = makeWheelEvent({0, 3});
+    const auto qWheel2 = makeWheelEvent({0, 4});
+
+    const auto expectedScrollLines =
+      float((InputEventRecorder::scrollLinesForEvent(qWheel1)
+             + InputEventRecorder::scrollLinesForEvent(qWheel2))
+              .y());
+    REQUIRE(expectedScrollLines > 0.0f);
+
+    using namespace std::chrono_literals;
+    r.recordEvent(qWheel1);
+    r.recordEvent(qWheel2);
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Scroll,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::Vertical,
+        0,
+        0,
+        expectedScrollLines});
+  }
+
+  SECTION("recordDiagonalScroll")
+  {
+    const auto qWheel1 = makeWheelEvent({1, 3});
+    const auto qWheel2 = makeWheelEvent({3, 0});
+
+    const auto expectedScrollLines1 = InputEventRecorder::scrollLinesForEvent(qWheel1);
+    REQUIRE(expectedScrollLines1.x() > 0.0f);
+    REQUIRE(expectedScrollLines1.y() > 0.0f);
+
+    const auto expectedScrollLines2 = InputEventRecorder::scrollLinesForEvent(qWheel2);
+    REQUIRE(expectedScrollLines2.x() > 0.0f);
+    REQUIRE(0.0f == expectedScrollLines2.y());
+
+    using namespace std::chrono_literals;
+    r.recordEvent(qWheel1);
+    r.recordEvent(qWheel2);
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Scroll,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::Horizontal,
+        0,
+        0,
+        float(expectedScrollLines1.x())},
+      MouseEvent{
+        MouseEvent::Type::Scroll,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::Vertical,
+        0,
+        0,
+        float(expectedScrollLines1.y())},
+      MouseEvent{
+        MouseEvent::Type::Scroll,
+        MouseEvent::Button::None,
+        MouseEvent::WheelAxis::Horizontal,
+        0,
+        0,
+        float(expectedScrollLines2.x())});
+  }
+
+  SECTION("recordLeftClickWithQuickSmallMotion")
+  {
+    using namespace std::chrono_literals;
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {4.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {4.0f, 3.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Motion,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        4,
+        3,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Click,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        4,
+        3,
+        0.0f});
+  }
+
+  SECTION("recordLeftClickWithSlowSmallMotion")
+  {
+    using namespace std::chrono_literals;
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {4.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, nullptr});
+    std::this_thread::sleep_for(200ms);
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {4.0f, 3.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Motion,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        4,
+        3,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Click,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        4,
+        3,
+        0.0f});
+  }
+
+  SECTION("recordLeftClickWithAccidentalDrag")
+  {
+    using namespace std::chrono_literals;
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {6.0f, 3.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::DragStart,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Drag,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        6,
+        3,
+        0.0f},
+      CancelEvent(),
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        6,
+        3,
+        0.0f});
+  }
+
+  SECTION("recordLeftDrag")
+  {
+    using namespace std::chrono_literals;
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, nullptr});
+    std::this_thread::sleep_for(200ms);
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {6.0f, 3.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::DragStart,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Drag,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        6,
+        3,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::DragEnd,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        6,
+        3,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        6,
+        3,
+        0.0f});
+  }
+
+  SECTION("recordLeftDragWithCollation")
+  {
+    using namespace std::chrono_literals;
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonPress,
+      {2.0f, 5.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, nullptr});
+    std::this_thread::sleep_for(200ms);
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseMove, {12.0f, 8.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, nullptr});
+    r.recordEvent(QMouseEvent{
+      QEvent::MouseButtonRelease,
+      {12.0f, 8.0f},
+      {},
+      {},
+      Qt::LeftButton,
+      Qt::LeftButton,
+      nullptr});
+
+    checkEventQueue(
+      r,
+      MouseEvent{
+        MouseEvent::Type::Down,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::DragStart,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        2,
+        5,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Drag,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        12,
+        8,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::DragEnd,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        12,
+        8,
+        0.0f},
+      MouseEvent{
+        MouseEvent::Type::Up,
+        MouseEvent::Button::Left,
+        MouseEvent::WheelAxis::None,
+        12,
+        8,
+        0.0f});
+  }
 }
 
-TEST_CASE("InputEventRecorderTest.recordLeftClick")
-{
-  InputEventRecorder r;
 
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Click,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordLeftDoubleClick")
-{
-  InputEventRecorder r;
-
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonDblClick,
-    {2.0f, 5.0f},
-    {},
-    {},
-    Qt::LeftButton,
-    Qt::LeftButton,
-    0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Click,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::DoubleClick,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordCtrlLeftClick")
-{
-  InputEventRecorder r;
-
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress,
-    {2.0f, 5.0f},
-    {},
-    {},
-    Qt::LeftButton,
-    Qt::LeftButton,
-    Qt::MetaModifier));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Right,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Click,
-      MouseEvent::Button::Right,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Right,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordRightClick")
-{
-  InputEventRecorder r;
-
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::RightButton, Qt::RightButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease,
-    {2.0f, 5.0f},
-    {},
-    {},
-    Qt::RightButton,
-    Qt::RightButton,
-    0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Right,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Click,
-      MouseEvent::Button::Right,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Right,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordMotionWithCollation")
-{
-  InputEventRecorder r;
-
-  using namespace std::chrono_literals;
-  r.recordEvent(
-    QMouseEvent(QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::NoButton, Qt::NoButton, 0));
-  r.recordEvent(
-    QMouseEvent(QEvent::MouseMove, {12.0f, 8.0f}, {}, {}, Qt::NoButton, Qt::NoButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Motion,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::None,
-      12,
-      8,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordHScrollWithCollation")
-{
-  InputEventRecorder r;
-  const auto qWheel1 = makeWheelEvent({2, 0});
-  const auto qWheel2 = makeWheelEvent({3, 0});
-
-  const float expectedScrollLines =
-    static_cast<float>((InputEventRecorder::scrollLinesForEvent(qWheel1)
-                        + InputEventRecorder::scrollLinesForEvent(qWheel2))
-                         .x());
-  REQUIRE(expectedScrollLines > 0.0f);
-
-  using namespace std::chrono_literals;
-  r.recordEvent(qWheel1);
-  r.recordEvent(qWheel2);
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      0,
-      0,
-      expectedScrollLines));
-}
-
-TEST_CASE("InputEventRecorderTest.recordVScrollWithCollation")
-{
-  InputEventRecorder r;
-  const auto qWheel1 = makeWheelEvent({0, 3});
-  const auto qWheel2 = makeWheelEvent({0, 4});
-
-  const float expectedScrollLines =
-    static_cast<float>((InputEventRecorder::scrollLinesForEvent(qWheel1)
-                        + InputEventRecorder::scrollLinesForEvent(qWheel2))
-                         .y());
-  REQUIRE(expectedScrollLines > 0.0f);
-
-  using namespace std::chrono_literals;
-  r.recordEvent(qWheel1);
-  r.recordEvent(qWheel2);
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Vertical,
-      0,
-      0,
-      expectedScrollLines));
-}
-
-TEST_CASE("InputEventRecorderTest.recordDiagonalScroll")
-{
-  InputEventRecorder r;
-  const auto qWheel1 = makeWheelEvent({1, 3});
-  const auto qWheel2 = makeWheelEvent({3, 0});
-
-  const QPointF expectedScrollLines1 = InputEventRecorder::scrollLinesForEvent(qWheel1);
-  REQUIRE(expectedScrollLines1.x() > 0.0f);
-  REQUIRE(expectedScrollLines1.y() > 0.0f);
-
-  const QPointF expectedScrollLines2 = InputEventRecorder::scrollLinesForEvent(qWheel2);
-  REQUIRE(expectedScrollLines2.x() > 0.0f);
-  REQUIRE(0.0f == expectedScrollLines2.y());
-
-  using namespace std::chrono_literals;
-  r.recordEvent(qWheel1);
-  r.recordEvent(qWheel2);
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      0,
-      0,
-      static_cast<float>(expectedScrollLines1.x())),
-    MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Vertical,
-      0,
-      0,
-      static_cast<float>(expectedScrollLines1.y())),
-    MouseEvent(
-      MouseEvent::Type::Scroll,
-      MouseEvent::Button::None,
-      MouseEvent::WheelAxis::Horizontal,
-      0,
-      0,
-      static_cast<float>(expectedScrollLines2.x())));
-}
-
-TEST_CASE("InputEventRecorderTest.recordLeftClickWithQuickSmallMotion")
-{
-  InputEventRecorder r;
-
-  using namespace std::chrono_literals;
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseMove, {4.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {4.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Motion,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      4,
-      3,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Click,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      4,
-      3,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordLeftClickWithSlowSmallMotion")
-{
-  InputEventRecorder r;
-
-  using namespace std::chrono_literals;
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseMove, {4.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  std::this_thread::sleep_for(200ms);
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {4.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Motion,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      4,
-      3,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Click,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      4,
-      3,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordLeftClickWithAccidentalDrag")
-{
-  InputEventRecorder r;
-
-  using namespace std::chrono_literals;
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::DragStart,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Drag,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      6,
-      3,
-      0.0f),
-    CancelEvent(),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      6,
-      3,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordLeftDrag")
-{
-  InputEventRecorder r;
-
-  using namespace std::chrono_literals;
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  std::this_thread::sleep_for(200ms);
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::DragStart,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Drag,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      6,
-      3,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::DragEnd,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      6,
-      3,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      6,
-      3,
-      0.0f));
-}
-
-TEST_CASE("InputEventRecorderTest.recordLeftDragWithCollation")
-{
-  InputEventRecorder r;
-
-  using namespace std::chrono_literals;
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonPress, {2.0f, 5.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseMove, {6.0f, 3.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  std::this_thread::sleep_for(200ms);
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseMove, {12.0f, 8.0f}, {}, {}, Qt::LeftButton, Qt::LeftButton, 0));
-  r.recordEvent(QMouseEvent(
-    QEvent::MouseButtonRelease,
-    {12.0f, 8.0f},
-    {},
-    {},
-    Qt::LeftButton,
-    Qt::LeftButton,
-    0));
-
-  checkEventQueue(
-    r,
-    MouseEvent(
-      MouseEvent::Type::Down,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::DragStart,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      2,
-      5,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Drag,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      12,
-      8,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::DragEnd,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      12,
-      8,
-      0.0f),
-    MouseEvent(
-      MouseEvent::Type::Up,
-      MouseEvent::Button::Left,
-      MouseEvent::WheelAxis::None,
-      12,
-      8,
-      0.0f));
-}
-} // namespace View
-} // namespace TrenchBroom
+} // namespace TrenchBroom::View

--- a/common/test/src/View/tst_MoveHandleDragTracker.cpp
+++ b/common/test/src/View/tst_MoveHandleDragTracker.cpp
@@ -230,7 +230,7 @@ TEST_CASE("MoveDragTracker.constructor")
         {
           // we check this indirectly by observing how the move handle position changes
           // when dragging
-          REQUIRE(tracker.drag(
+          REQUIRE(tracker.update(
             makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
           CHECK(
             tracker.dragState()
@@ -251,7 +251,7 @@ TEST_CASE("MoveDragTracker.constructor")
       {
         // we check this indirectly by observing how the move handle position changes when
         // dragging
-        REQUIRE(tracker.drag(
+        REQUIRE(tracker.update(
           makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
         CHECK(
           tracker.dragState()
@@ -284,7 +284,7 @@ TEST_CASE("MoveDragTracker.constructor")
         {
           // we check this indirectly by observing how the move handle position changes
           // when dragging
-          REQUIRE(tracker.drag(
+          REQUIRE(tracker.update(
             makeInputState(vm::vec3{16, 80, 64}, vm::vec3{0, 0, -1}, camera2d)));
           CHECK(
             tracker.dragState()
@@ -305,7 +305,7 @@ TEST_CASE("MoveDragTracker.constructor")
       {
         // we check this indirectly by observing how the move handle position changes when
         // dragging
-        REQUIRE(tracker.drag(
+        REQUIRE(tracker.update(
           makeInputState(vm::vec3{16, 80, 64}, vm::vec3{0, 0, -1}, camera2d)));
         CHECK(
           tracker.dragState()
@@ -341,7 +341,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
       {
         // we check this indirectly by observing how the move handle position changes when
         // dragging
-        REQUIRE(tracker.drag(
+        REQUIRE(tracker.update(
           makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
         CHECK(
           tracker.dragState()
@@ -358,7 +358,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
         {
           // we check this indirectly by observing how the move handle position changes
           // when dragging
-          REQUIRE(tracker.drag(
+          REQUIRE(tracker.update(
             makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
           CHECK(
             tracker.dragState()
@@ -376,7 +376,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
       {
         // we check this indirectly by observing how the move handle position changes when
         // dragging
-        REQUIRE(tracker.drag(
+        REQUIRE(tracker.update(
           makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
         CHECK(
           tracker.dragState()
@@ -386,8 +386,8 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
 
     WHEN("The shift modifier is pressed after the handle is moved diagonally")
     {
-      REQUIRE(
-        tracker.drag(makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
+      REQUIRE(tracker.update(
+        makeInputState(vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d)));
       REQUIRE(
         tracker.dragState()
         == DragState{initialHandlePosition, vm::vec3{16, 80, 0}, handleOffset});
@@ -407,8 +407,8 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
 
     WHEN("The shift modifier is pressed after the handle is moved non-diagonally")
     {
-      REQUIRE(
-        tracker.drag(makeInputState(vm::vec3{16, 32, 64}, vm::vec3{0, 1, -1}, camera3d)));
+      REQUIRE(tracker.update(
+        makeInputState(vm::vec3{16, 32, 64}, vm::vec3{0, 1, -1}, camera3d)));
       REQUIRE(
         tracker.dragState()
         == DragState{initialHandlePosition, vm::vec3{16, 96, 0}, handleOffset});
@@ -465,7 +465,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
       {
         // we check this indirectly by observing how the move handle position changes when
         // dragging
-        REQUIRE(tracker.drag(
+        REQUIRE(tracker.update(
           makeInputState(vm::vec3{16, 80, 64}, vm::vec3{0, 0, -1}, camera2d)));
         CHECK(
           tracker.dragState()

--- a/common/test/src/View/tst_MoveHandleDragTracker.cpp
+++ b/common/test/src/View/tst_MoveHandleDragTracker.cpp
@@ -194,7 +194,7 @@ static auto makeInputState(
   const vm::vec3& rayOrigin,
   const vm::vec3& rayDirection,
   Renderer::Camera& camera,
-  ModifierKeyState modifierKeys = ModifierKeys::MKNone)
+  ModifierKeyState modifierKeys = ModifierKeys::None)
 {
   auto inputState = InputState{};
   inputState.setPickRequest(
@@ -370,7 +370,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
     WHEN("The shift modifier is pressed before the handle is moved")
     {
       tracker.modifierKeyChange(makeInputState(
-        vm::vec3{0, 0, 64}, vm::vec3{0, 1, -1}, camera3d, ModifierKeys::MKShift));
+        vm::vec3{0, 0, 64}, vm::vec3{0, 1, -1}, camera3d, ModifierKeys::Shift));
 
       THEN("The tracker still has a default hit finder")
       {
@@ -393,7 +393,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
         == DragState{initialHandlePosition, vm::vec3{16, 80, 0}, handleOffset});
 
       tracker.modifierKeyChange(makeInputState(
-        vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d, ModifierKeys::MKShift));
+        vm::vec3{16, 16, 64}, vm::vec3{0, 1, -1}, camera3d, ModifierKeys::Shift));
 
       THEN("The tracker still has a default hit finder")
       {
@@ -414,7 +414,7 @@ TEST_CASE("MoveDragTracker.modifierKeyChange")
         == DragState{initialHandlePosition, vm::vec3{16, 96, 0}, handleOffset});
 
       tracker.modifierKeyChange(makeInputState(
-        vm::vec3{16, 32, 64}, vm::vec3{0, 1, -1}, camera3d, ModifierKeys::MKShift));
+        vm::vec3{16, 32, 64}, vm::vec3{0, 1, -1}, camera3d, ModifierKeys::Shift));
 
       THEN("The tracker has a constricted hit finder")
       {

--- a/common/test/src/View/tst_SelectionTool.cpp
+++ b/common/test/src/View/tst_SelectionTool.cpp
@@ -88,9 +88,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
       WHEN("I click once")
       {
-        inputState.mouseDown(MouseButtons::MBLeft);
+        inputState.mouseDown(MouseButtons::Left);
         tool.mouseClick(inputState);
-        inputState.mouseUp(MouseButtons::MBLeft);
+        inputState.mouseUp(MouseButtons::Left);
 
         THEN("The group gets selected")
         {
@@ -101,9 +101,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
       WHEN("I double click")
       {
-        inputState.mouseDown(MouseButtons::MBLeft);
+        inputState.mouseDown(MouseButtons::Left);
         tool.mouseDoubleClick(inputState);
-        inputState.mouseUp(MouseButtons::MBLeft);
+        inputState.mouseUp(MouseButtons::Left);
 
         THEN("The group is opened")
         {
@@ -156,10 +156,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
       WHEN("I shift click once")
       {
-        inputState.setModifierKeys(ModifierKeys::MKShift);
-        inputState.mouseDown(MouseButtons::MBLeft);
+        inputState.setModifierKeys(ModifierKeys::Shift);
+        inputState.mouseDown(MouseButtons::Left);
         tool.mouseClick(inputState);
-        inputState.mouseUp(MouseButtons::MBLeft);
+        inputState.mouseUp(MouseButtons::Left);
 
         THEN("The top face get selected")
         {
@@ -171,10 +171,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         AND_WHEN("I shift click on the selected face again")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The top face remains selected")
           {
@@ -187,10 +187,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         AND_WHEN("I shift+ctrl click on the selected face again")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift | ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The top face gets deselected")
           {
@@ -202,9 +202,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
       WHEN("I click once")
       {
-        inputState.mouseDown(MouseButtons::MBLeft);
+        inputState.mouseDown(MouseButtons::Left);
         tool.mouseClick(inputState);
-        inputState.mouseUp(MouseButtons::MBLeft);
+        inputState.mouseUp(MouseButtons::Left);
 
         THEN("The brush gets selected")
         {
@@ -214,9 +214,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         AND_WHEN("I click on the selected brushagain")
         {
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The brush remains selected")
           {
@@ -228,9 +228,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
         AND_WHEN("I ctrl click on the selected brush again")
         {
           inputState.setModifierKeys(ModifierKeys::MKCtrlCmd);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The brush gets deselected")
           {
@@ -242,10 +242,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
       WHEN("I shift double click")
       {
-        inputState.setModifierKeys(ModifierKeys::MKShift);
-        inputState.mouseDown(MouseButtons::MBLeft);
+        inputState.setModifierKeys(ModifierKeys::Shift);
+        inputState.mouseDown(MouseButtons::Left);
         tool.mouseDoubleClick(inputState);
-        inputState.mouseUp(MouseButtons::MBLeft);
+        inputState.mouseUp(MouseButtons::Left);
 
         THEN("All brush faces are selected")
         {
@@ -256,9 +256,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
       WHEN("I double click")
       {
-        inputState.mouseDown(MouseButtons::MBLeft);
+        inputState.mouseDown(MouseButtons::Left);
         tool.mouseDoubleClick(inputState);
-        inputState.mouseUp(MouseButtons::MBLeft);
+        inputState.mouseUp(MouseButtons::Left);
 
         THEN("All nodes are selected")
         {
@@ -274,10 +274,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I shift click once")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The top face get selected")
           {
@@ -290,10 +290,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I shift+ctrl click once")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift | ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("Both the front and the top faces are selected")
           {
@@ -307,9 +307,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I click once")
         {
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The brush gets selected")
           {
@@ -321,9 +321,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
         WHEN("I ctrl click once")
         {
           inputState.setModifierKeys(ModifierKeys::MKCtrlCmd);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The brush gets selected")
           {
@@ -339,10 +339,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I shift click once")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The top face get selected")
           {
@@ -355,10 +355,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I shift+ctrl click once")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift | ModifierKeys::MKCtrlCmd);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift | ModifierKeys::MKCtrlCmd);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The top face get selected")
           {
@@ -371,9 +371,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I click once")
         {
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The brush gets selected")
           {
@@ -385,9 +385,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
         WHEN("I ctrl click once")
         {
           inputState.setModifierKeys(ModifierKeys::MKCtrlCmd);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("The brush and entity both get selected")
           {
@@ -417,10 +417,10 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I shift click once")
         {
-          inputState.setModifierKeys(ModifierKeys::MKShift);
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.setModifierKeys(ModifierKeys::Shift);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("Nothing happens")
           {
@@ -431,9 +431,9 @@ TEST_CASE_METHOD(MapDocumentTest, "SelectionToolTest.clicking")
 
         WHEN("I click once")
         {
-          inputState.mouseDown(MouseButtons::MBLeft);
+          inputState.mouseDown(MouseButtons::Left);
           tool.mouseClick(inputState);
-          inputState.mouseUp(MouseButtons::MBLeft);
+          inputState.mouseUp(MouseButtons::Left);
 
           THEN("Nothing happens")
           {


### PR DESCRIPTION
This PR adds support for native trackpad gestures such as panning, zooming and rotating. Similar to how mouse dragging is implemented, when a new gesture is detected, every tool controller in the tool chain is asked to accept the gesture. If a tool controller accepts a gesture, it returns an instance of `GestureTracker` which handles all events related to it.

See also https://github.com/TrenchBroom/TrenchBroom/pull/4590