### PR TITLE
Fix Vertex Tool Crash

### DIFF
--- a/common/src/View/VertexHandleManager.cpp
+++ b/common/src/View/VertexHandleManager.cpp
@@ -104,13 +104,15 @@ void EdgeHandleManager::pickGridHandle(
     {
       const auto pointHandle =
         grid.snap(vm::point_at_distance(pickRay, *edgeDist), position);
-      if (
-        const auto pointDist = camera.pickPointHandle(
-          pickRay, pointHandle, FloatType(pref(Preferences::HandleRadius))))
-      {
-        const auto hitPoint = vm::point_at_distance(pickRay, *pointDist);
-        pickResult.addHit(Model::Hit(
-          HandleHitType, *pointDist, hitPoint, HitType(position, pointHandle)));
+      if (!vm::is_nan(pointHandle)){
+        if (
+            const auto pointDist = camera.pickPointHandle(
+                                                          pickRay, pointHandle, FloatType(pref(Preferences::HandleRadius))))
+          {
+            const auto hitPoint = vm::point_at_distance(pickRay, *pointDist);
+            pickResult.addHit(Model::Hit(
+                                         HandleHitType, *pointDist, hitPoint, HitType(position, pointHandle)));
+          }
       }
     }
   }


### PR DESCRIPTION
There's a crash related to the `vm::is_nan()` checks being removed in some places. This PR puts them back in one place, but I'd like to discuss replacing all of them.

https://github.com/TrenchBroom/TrenchBroom/issues/4599