### PR TITLE
Ignore error on Wayland linux systems

### DIFF
--- a/common/src/View/GLContextManager.cpp
+++ b/common/src/View/GLContextManager.cpp
@@ -63,7 +63,9 @@ static void initializeGlew()
 {
   glewExperimental = GL_TRUE;
   const GLenum glewState = glewInit();
-  if (glewState != GLEW_OK)
+  /* The GLEW_ERROR_NO_GLX_DISPLAY error is thrown on Wayland systems */
+  /*   that otherwise function just fine. */
+  if (glewState != GLEW_OK && glewState != GLEW_ERROR_NO_GLX_DISPLAY)
   {
     auto str = std::stringstream();
     str << "Error initializing glew: " << glewGetErrorString(glewState);


### PR DESCRIPTION
`GLEW` throws an error with code `GLEW_ERROR_NO_GLX_DISPLAY` when it cannot initialize a GLX display, but GLX is not used in Wayland.

There should probably be an additional check to see if the user is running on XOrg or Wayland.

fixes https://github.com/TrenchBroom/TrenchBroom/issues/3326