### PR TITLE
Better support for FGD property types #1048

### DIFF
--- a/common/src/Model/EntityNodeBase.cpp
+++ b/common/src/Model/EntityNodeBase.cpp
@@ -307,6 +307,20 @@ void EntityNodeBase::updatePropertyIndex(
   addToIndex(this, newKey, newValue);
 }
 
+void EntityNodeBase::getAllCustomTargetPropertyNames(std::vector<std::string>& result) const
+{
+  if (!entity().definition())
+    return;
+
+  for (const auto& property : entity().definition()->propertyDefinitions())
+  {
+    if (property->type() == Assets::PropertyDefinitionType::TargetDestinationProperty)
+    {
+      result.push_back(property->key());
+    }
+  }
+}
+
 const std::vector<EntityNodeBase*>& EntityNodeBase::linkSources() const
 {
   return m_linkSources;
@@ -405,19 +419,7 @@ void EntityNodeBase::findMissingTargets(
   }
 }
 
-void EntityNodeBase::getAllCustomTargetPropertyNames(std::vector<std::string>& result) const
-{
-   if (!entity().definition())
-    return;
 
-  for (const auto& property : entity().definition()->propertyDefinitions())
-  {
-    if (property->type() == Assets::PropertyDefinitionType::TargetDestinationProperty)
-    {
-      result.push_back(property->key());
-    }
-  }
-}
 
 void EntityNodeBase::addLinks(const std::string& name, const std::string& value)
 {

--- a/common/src/Model/EntityNodeBase.cpp
+++ b/common/src/Model/EntityNodeBase.cpp
@@ -121,11 +121,18 @@ void EntityNodeBase::setDefinition(Assets::EntityDefinition* definition)
   const auto notifyChange = NotifyPropertyChange{*this};
   m_entity.setDefinition(definition);
 
-  // Update custom targets/sources
-  std::vector<std::string> customTargetPropertyNames;
+  //
+  auto customTargetPropertyNames = std::vector<std::string>{};
   getAllCustomTargetPropertyNames(customTargetPropertyNames);
 
-  //removeAllCustomSources(); //TODO(jwf): hack - remove
+  auto customSourcePropertyNames = std::vector<std::string>{};
+  for (auto* customSource : customSources())
+  {
+    //TODO(jwf): don't do this - customSource needs to store which prop name it came from
+    customSource->getAllCustomTargetPropertyNames(customSourcePropertyNames);
+  }
+
+  removeAllCustomSources();
   removeAllCustomTargets();
 
   for (const auto& customTargetPropertyName : customTargetPropertyNames)
@@ -136,12 +143,9 @@ void EntityNodeBase::setDefinition(Assets::EntityDefinition* definition)
   const auto* targetname = m_entity.property(EntityPropertyKeys::Targetname);
   if (targetname && !targetname->empty())
   {
-    for (const auto& customTargetPropertyName : customTargetPropertyNames)
+    for (const auto& customSourcePropertyName : customSourcePropertyNames)
     {
-      //TODO(jwf): this is the bug - we're readding things that are targeting this node
-      // based on the prop names that THIS node uses to target things - we need to
-      // do it based on what the SOURCE nodes use to target things... somehow
-      addAllCustomSources(customTargetPropertyName, *targetname);
+      addAllCustomSources(customSourcePropertyName, *targetname);
     }
   }
 }

--- a/common/src/Model/EntityNodeBase.h
+++ b/common/src/Model/EntityNodeBase.h
@@ -55,10 +55,6 @@ protected:
 
   std::vector<EntityNodeBase*> m_linkSources;
   std::vector<EntityNodeBase*> m_linkTargets;
-  std::vector<EntityNodeBase*> m_customSources;
-  std::vector<EntityNodeBase*> m_customTargets;
-  std::vector<EntityNodeBase*> m_killSources;
-  std::vector<EntityNodeBase*> m_killTargets;
 
 public:
   ~EntityNodeBase() override;
@@ -112,18 +108,12 @@ public: // link management
 
   const std::vector<EntityNodeBase*>& linkSources() const;
   const std::vector<EntityNodeBase*>& linkTargets() const;
-  const std::vector<EntityNodeBase*>& customSources() const;
-  const std::vector<EntityNodeBase*>& customTargets() const;
-  const std::vector<EntityNodeBase*>& killSources() const;
-  const std::vector<EntityNodeBase*>& killTargets() const;
 
   vm::vec3 linkSourceAnchor() const;
   vm::vec3 linkTargetAnchor() const;
 
   bool hasMissingSources() const;
   std::vector<std::string> findMissingLinkTargets() const;
-  std::vector<std::string> findMissingCustomTargets() const;
-  std::vector<std::string> findMissingKillTargets() const;
 
 private: // link management internals
   void findMissingTargets(
@@ -139,51 +129,26 @@ private: // link management internals
 
   //jwf: does targetname only
   void addLinkTargets(const std::string& targetname);
-  void addCustomTargets(const std::string& targetname);
-  void addKillTargets(const std::string& targetname);
-
   void removeLinkTargets(const std::string& targetname);
-  void removeCustomTargets(const std::string& targetname);
-  void removeKillTargets(const std::string& targetname);
 
   //jwf: does targetname1,2,3 etc
-  void addAllLinkSources(const std::string& targetname);
-  void addAllLinkTargets();
-  void addAllCustomSources(const std::string& propertyName, const std::string& targetname);
-  void addAllCustomTargets(const std::string& propertyName);
-  void addAllKillSources(const std::string& targetname);
-  void addAllKillTargets();
+  void addLinkSourcesIncludingNumbered(const std::string& linkPropertyName, const std::string& targetname);
+  void addLinkTargetsIncludingNumbered(const std::string& linkPropertyName);
 
   void addLinkTargets(const std::vector<EntityNodeBase*>& targets);
-  void addCustomTargets(const std::vector<EntityNodeBase*>& targets);
-  void addKillTargets(const std::vector<EntityNodeBase*>& targets);
-  void addLinkSources(const std::vector<EntityNodeBase*>& sources);
   void addCustomSources(const std::vector<EntityNodeBase*>& sources);
-  void addKillSources(const std::vector<EntityNodeBase*>& sources);
 
   void removeAllLinkSources();
   void removeAllLinkTargets();
-  void removeAllCustomSources();
-  void removeAllCustomTargets();
-  void removeAllKillSources();
-  void removeAllKillTargets();
 
   void removeAllLinks();
   void addAllLinks();
 
   void addLinkSource(EntityNodeBase* node);
   void addLinkTarget(EntityNodeBase* node);
-  void addCustomSource(EntityNodeBase* node);
-  void addCustomTarget(EntityNodeBase* node);
-  void addKillSource(EntityNodeBase* node);
-  void addKillTarget(EntityNodeBase* node);
 
   void removeLinkSource(EntityNodeBase* node);
   void removeLinkTarget(EntityNodeBase* node);
-  void removeCustomSource(EntityNodeBase* node);
-  void removeCustomTarget(EntityNodeBase* node);
-  void removeKillSource(EntityNodeBase* node);
-  void removeKillTarget(EntityNodeBase* node);
 
 protected:
   EntityNodeBase();

--- a/common/src/Model/EntityNodeBase.h
+++ b/common/src/Model/EntityNodeBase.h
@@ -108,6 +108,8 @@ private: // search index management
     const std::string& newValue);
 
 public: // link management
+  void getAllCustomTargetPropertyNames(std::vector<std::string>& result) const;
+
   const std::vector<EntityNodeBase*>& linkSources() const;
   const std::vector<EntityNodeBase*>& linkTargets() const;
   const std::vector<EntityNodeBase*>& customSources() const;
@@ -126,8 +128,6 @@ public: // link management
 private: // link management internals
   void findMissingTargets(
     const std::string& prefix, std::vector<std::string>& result) const;
-
-  void getAllCustomTargetPropertyNames(std::vector<std::string>& result) const;
 
   void addLinks(const std::string& name, const std::string& value);
   void removeLinks(const std::string& name, const std::string& value);

--- a/common/src/Model/EntityNodeBase.h
+++ b/common/src/Model/EntityNodeBase.h
@@ -53,8 +53,8 @@ protected:
 
   Entity m_entity;
 
-  std::vector<EntityNodeBase*> m_linkSources;
-  std::vector<EntityNodeBase*> m_linkTargets;
+  std::vector<std::tuple<EntityNodeBase*, int>> m_linkSources;
+  std::vector<std::tuple<EntityNodeBase*, int>> m_linkTargets;
 
 public:
   ~EntityNodeBase() override;
@@ -107,8 +107,8 @@ public: // link management
   void getAllTargetSourcePropertyNames(std::vector<std::string>& result) const;
   void getAllTargetDestinationPropertyNames(std::vector<std::string>& result) const;
 
-  const std::vector<EntityNodeBase*>& linkSources() const;
-  const std::vector<EntityNodeBase*>& linkTargets() const;
+  std::vector<EntityNodeBase*> linkSources() const;
+  std::vector<EntityNodeBase*> linkTargets() const;
 
   vm::vec3 linkSourceAnchor() const;
   vm::vec3 linkTargetAnchor() const;

--- a/common/src/Model/EntityNodeBase.h
+++ b/common/src/Model/EntityNodeBase.h
@@ -104,7 +104,8 @@ private: // search index management
     const std::string& newValue);
 
 public: // link management
-  void getAllCustomTargetPropertyNames(std::vector<std::string>& result) const;
+  void getAllTargetSourcePropertyNames(std::vector<std::string>& result) const;
+  void getAllTargetDestinationPropertyNames(std::vector<std::string>& result) const;
 
   const std::vector<EntityNodeBase*>& linkSources() const;
   const std::vector<EntityNodeBase*>& linkTargets() const;
@@ -132,11 +133,11 @@ private: // link management internals
   void removeLinkTargets(const std::string& targetname);
 
   //jwf: does targetname1,2,3 etc
-  void addLinkSourcesIncludingNumbered(const std::string& linkPropertyName, const std::string& targetname);
+  void addLinkSourcesIncludingNumbered(const std::string& targetname);
   void addLinkTargetsIncludingNumbered(const std::string& linkPropertyName);
 
   void addLinkTargets(const std::vector<EntityNodeBase*>& targets);
-  void addCustomSources(const std::vector<EntityNodeBase*>& sources);
+  void addLinkSources(const std::vector<EntityNodeBase*>& sources);
 
   void removeAllLinkSources();
   void removeAllLinkTargets();

--- a/common/src/Model/EntityNodeBase.h
+++ b/common/src/Model/EntityNodeBase.h
@@ -55,6 +55,8 @@ protected:
 
   std::vector<EntityNodeBase*> m_linkSources;
   std::vector<EntityNodeBase*> m_linkTargets;
+  std::vector<EntityNodeBase*> m_customSources;
+  std::vector<EntityNodeBase*> m_customTargets;
   std::vector<EntityNodeBase*> m_killSources;
   std::vector<EntityNodeBase*> m_killTargets;
 
@@ -108,6 +110,8 @@ private: // search index management
 public: // link management
   const std::vector<EntityNodeBase*>& linkSources() const;
   const std::vector<EntityNodeBase*>& linkTargets() const;
+  const std::vector<EntityNodeBase*>& customSources() const;
+  const std::vector<EntityNodeBase*>& customTargets() const;
   const std::vector<EntityNodeBase*>& killSources() const;
   const std::vector<EntityNodeBase*>& killTargets() const;
 
@@ -116,11 +120,14 @@ public: // link management
 
   bool hasMissingSources() const;
   std::vector<std::string> findMissingLinkTargets() const;
+  std::vector<std::string> findMissingCustomTargets() const;
   std::vector<std::string> findMissingKillTargets() const;
 
 private: // link management internals
   void findMissingTargets(
     const std::string& prefix, std::vector<std::string>& result) const;
+
+  void getAllCustomTargetPropertyNames(std::vector<std::string>& result) const;
 
   void addLinks(const std::string& name, const std::string& value);
   void removeLinks(const std::string& name, const std::string& value);
@@ -130,24 +137,34 @@ private: // link management internals
     const std::string& newName,
     const std::string& newValue);
 
+  //jwf: does targetname only
   void addLinkTargets(const std::string& targetname);
+  void addCustomTargets(const std::string& targetname);
   void addKillTargets(const std::string& targetname);
 
   void removeLinkTargets(const std::string& targetname);
+  void removeCustomTargets(const std::string& targetname);
   void removeKillTargets(const std::string& targetname);
 
+  //jwf: does targetname1,2,3 etc
   void addAllLinkSources(const std::string& targetname);
   void addAllLinkTargets();
+  void addAllCustomSources(const std::string& propertyName, const std::string& targetname);
+  void addAllCustomTargets(const std::string& propertyName);
   void addAllKillSources(const std::string& targetname);
   void addAllKillTargets();
 
   void addLinkTargets(const std::vector<EntityNodeBase*>& targets);
+  void addCustomTargets(const std::vector<EntityNodeBase*>& targets);
   void addKillTargets(const std::vector<EntityNodeBase*>& targets);
   void addLinkSources(const std::vector<EntityNodeBase*>& sources);
+  void addCustomSources(const std::vector<EntityNodeBase*>& sources);
   void addKillSources(const std::vector<EntityNodeBase*>& sources);
 
   void removeAllLinkSources();
   void removeAllLinkTargets();
+  void removeAllCustomSources();
+  void removeAllCustomTargets();
   void removeAllKillSources();
   void removeAllKillTargets();
 
@@ -156,11 +173,15 @@ private: // link management internals
 
   void addLinkSource(EntityNodeBase* node);
   void addLinkTarget(EntityNodeBase* node);
+  void addCustomSource(EntityNodeBase* node);
+  void addCustomTarget(EntityNodeBase* node);
   void addKillSource(EntityNodeBase* node);
   void addKillTarget(EntityNodeBase* node);
 
   void removeLinkSource(EntityNodeBase* node);
   void removeLinkTarget(EntityNodeBase* node);
+  void removeCustomSource(EntityNodeBase* node);
+  void removeCustomTarget(EntityNodeBase* node);
   void removeKillSource(EntityNodeBase* node);
   void removeKillTarget(EntityNodeBase* node);
 

--- a/common/src/Model/EntityNodeIndex.cpp
+++ b/common/src/Model/EntityNodeIndex.cpp
@@ -180,6 +180,96 @@ std::vector<EntityNodeBase*> EntityNodeIndex::findEntityNodes(
   return result;
 }
 
+std::vector<EntityNodeBase*> EntityNodeIndex::findEntityNodesWithTargetSource(
+  const std::string& value, bool allowNumberedProperties) const
+{
+  // first, find Nodes which have `value` as the value for any key
+  std::vector<EntityNodeBase*> result;
+  m_valueIndex->find_matches(value, std::back_inserter(result));
+  if (result.empty())
+  {
+    return {};
+  }
+
+  result = kdl::vec_sort_and_remove_duplicates(std::move(result));
+
+  // next, remove results from the result set that don't match `keyQuery`
+  auto it = std::begin(result);
+  while (it != std::end(result))
+  {
+    const EntityNodeBase* node = *it;
+
+    auto targetSourceProperties = std::vector<std::string>();
+    node->getAllTargetSourcePropertyNames(targetSourceProperties);
+
+    bool matches = false;
+    for (const auto& targetSourceProperty : targetSourceProperties)
+    {
+      auto keyQuery = allowNumberedProperties
+        ? EntityNodeIndexQuery::numbered(targetSourceProperty)
+        : EntityNodeIndexQuery::exact(targetSourceProperty);
+
+      if (keyQuery.execute(node, value))
+      {
+        matches = true;
+        break;
+      }
+    }
+
+    if (!matches)
+      it = result.erase(it);
+    else
+      ++it;
+  }
+
+  return result;
+}
+
+std::vector<EntityNodeBase*> EntityNodeIndex::findEntityNodesWithTargetDestination(
+  const std::string& value, bool allowNumberedProperties) const
+{
+  // first, find Nodes which have `value` as the value for any key
+  std::vector<EntityNodeBase*> result;
+  m_valueIndex->find_matches(value, std::back_inserter(result));
+  if (result.empty())
+  {
+    return {};
+  }
+
+  result = kdl::vec_sort_and_remove_duplicates(std::move(result));
+
+  // next, remove results from the result set that don't match `keyQuery`
+  auto it = std::begin(result);
+  while (it != std::end(result))
+  {
+    const EntityNodeBase* node = *it;
+
+    auto targetDestinationProperties = std::vector<std::string>();
+    node->getAllTargetDestinationPropertyNames(targetDestinationProperties);
+
+    bool matches = false;
+    for (const auto& targetDestinationProperty : targetDestinationProperties)
+    {
+      auto keyQuery = allowNumberedProperties
+        ? EntityNodeIndexQuery::numbered(targetDestinationProperty)
+        : EntityNodeIndexQuery::exact(targetDestinationProperty);
+
+      if (keyQuery.execute(node, value))
+      {
+        matches = true;
+        break;
+      }
+    }
+
+    if (!matches)
+      it = result.erase(it);
+    else
+      ++it;
+  }
+
+  return result;
+}
+
 std::vector<std::string> EntityNodeIndex::allKeys() const
 {
   std::vector<std::string> result;

--- a/common/src/Model/EntityNodeIndex.h
+++ b/common/src/Model/EntityNodeIndex.h
@@ -84,6 +84,10 @@ public:
 
   std::vector<EntityNodeBase*> findEntityNodes(
     const EntityNodeIndexQuery& keyQuery, const std::string& value) const;
+  std::vector<EntityNodeBase*> findEntityNodesWithTargetSource(
+    const std::string& value, bool allowNumberedProperties) const;
+  std::vector<EntityNodeBase*> findEntityNodesWithTargetDestination(
+    const std::string& value, bool allowNumberedProperties) const;
   std::vector<std::string> allKeys() const;
   std::vector<std::string> allValuesForKeys(const EntityNodeIndexQuery& keyQuery) const;
 };

--- a/common/src/Model/LinkTargetValidator.cpp
+++ b/common/src/Model/LinkTargetValidator.cpp
@@ -65,7 +65,6 @@ void LinkTargetValidator::doValidate(
   EntityNodeBase& entityNode, std::vector<std::unique_ptr<Issue>>& issues) const
 {
   validateInternal(entityNode, entityNode.findMissingLinkTargets(), issues);
-  validateInternal(entityNode, entityNode.findMissingKillTargets(), issues);
 }
 
 } // namespace Model

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -869,6 +869,32 @@ void Node::findEntityNodesWithNumberedProperty(
   return doFindEntityNodesWithNumberedProperty(prefix, value, result);
 }
 
+void Node::findEntityNodesWithTargetSourceProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  return doFindEntityNodesWithTargetSourceProperty(value, result);
+}
+void Node::findEntityNodesWithNumberedTargetSourceProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  return doFindEntityNodesWithNumberedTargetSourceProperty(value, result);
+}
+
+void Node::findEntityNodesWithTargetDestinationProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const
+{
+  return doFindEntityNodesWithTargetDestinationProperty(value, result);
+}
+void Node::findEntityNodesWithNumberedTargetDestinationProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  return doFindEntityNodesWithNumberedTargetDestinationProperty(value, result);
+}
+
 void Node::addToIndex(
   EntityNodeBase* node, const std::string& key, const std::string& value)
 {
@@ -948,6 +974,47 @@ void Node::doFindEntityNodesWithNumberedProperty(
   if (m_parent)
   {
     m_parent->findEntityNodesWithNumberedProperty(prefix, value, result);
+  }
+}
+
+void Node::doFindEntityNodesWithTargetSourceProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  if (m_parent)
+  {
+    m_parent->findEntityNodesWithTargetSourceProperty(value, result);
+  }
+}
+
+void Node::doFindEntityNodesWithNumberedTargetSourceProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  if (m_parent)
+  {
+    m_parent->findEntityNodesWithNumberedTargetSourceProperty(value, result);
+  }
+}
+
+
+void Node::doFindEntityNodesWithTargetDestinationProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  if (m_parent)
+  {
+    m_parent->findEntityNodesWithNumberedTargetDestinationProperty(value, result);
+  }
+}
+
+void Node::doFindEntityNodesWithNumberedTargetDestinationProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  if (m_parent)
+  {
+    m_parent->findEntityNodesWithNumberedTargetDestinationProperty(value, result);
   }
 }
 

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -497,6 +497,18 @@ protected: // index management
     const std::string& prefix,
     const std::string& value,
     std::vector<EntityNodeBase*>& result) const;
+  void findEntityNodesWithTargetSourceProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  void findEntityNodesWithNumberedTargetSourceProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  void findEntityNodesWithTargetDestinationProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  void findEntityNodesWithNumberedTargetDestinationProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
 
   void addToIndex(EntityNodeBase* node, const std::string& key, const std::string& value);
   void removeFromIndex(
@@ -560,6 +572,18 @@ private: // subclassing interface
     std::vector<EntityNodeBase*>& result) const;
   virtual void doFindEntityNodesWithNumberedProperty(
     const std::string& prefix,
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  virtual void doFindEntityNodesWithTargetSourceProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  virtual void doFindEntityNodesWithNumberedTargetSourceProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  virtual void doFindEntityNodesWithTargetDestinationProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const;
+  virtual void doFindEntityNodesWithNumberedTargetDestinationProperty(
     const std::string& value,
     std::vector<EntityNodeBase*>& result) const;
 

--- a/common/src/Model/WorldNode.cpp
+++ b/common/src/Model/WorldNode.cpp
@@ -492,6 +492,48 @@ void WorldNode::doFindEntityNodesWithNumberedProperty(
     m_entityNodeIndex->findEntityNodes(EntityNodeIndexQuery::numbered(prefix), value));
 }
 
+void WorldNode::doFindEntityNodesWithTargetSourceProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  constexpr bool allowNumberedProperties = false;
+
+  result = kdl::vec_concat(
+    std::move(result),
+    m_entityNodeIndex->findEntityNodesWithTargetSource(value, allowNumberedProperties));
+}
+void WorldNode::doFindEntityNodesWithNumberedTargetSourceProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  constexpr bool allowNumberedProperties = true;
+
+  result = kdl::vec_concat(
+    std::move(result),
+    m_entityNodeIndex->findEntityNodesWithTargetSource(value, allowNumberedProperties));
+}
+
+void WorldNode::doFindEntityNodesWithTargetDestinationProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  constexpr bool allowNumberedProperties = false;
+
+  result = kdl::vec_concat(
+    std::move(result),
+    m_entityNodeIndex->findEntityNodesWithTargetDestination(value, allowNumberedProperties));
+}
+void WorldNode::doFindEntityNodesWithNumberedTargetDestinationProperty(
+  const std::string& value,
+  std::vector<EntityNodeBase*>& result) const
+{
+  constexpr bool allowNumberedProperties = true;
+
+  result = kdl::vec_concat(
+    std::move(result),
+    m_entityNodeIndex->findEntityNodesWithTargetDestination(value, allowNumberedProperties));
+}
+
 void WorldNode::doAddToIndex(
   EntityNodeBase* node, const std::string& key, const std::string& value)
 {

--- a/common/src/Model/WorldNode.h
+++ b/common/src/Model/WorldNode.h
@@ -177,6 +177,18 @@ private: // implement Node interface
     const std::string& prefix,
     const std::string& value,
     std::vector<EntityNodeBase*>& result) const override;
+  void doFindEntityNodesWithTargetSourceProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const override;
+  void doFindEntityNodesWithNumberedTargetSourceProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const override;
+  void doFindEntityNodesWithTargetDestinationProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const override;
+  void doFindEntityNodesWithNumberedTargetDestinationProperty(
+    const std::string& value,
+    std::vector<EntityNodeBase*>& result) const override;
   void doAddToIndex(
     EntityNodeBase* node, const std::string& key, const std::string& value) override;
   void doRemoveFromIndex(

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -96,8 +96,6 @@ struct CollectAllLinksVisitor
     if (editorContext.visible(&node))
     {
       addTargets(node, node.linkTargets(), links);
-      addTargets(node, node.customTargets(), links);
-      addTargets(node, node.killTargets(), links);
     }
   }
 
@@ -132,11 +130,7 @@ struct CollectTransitiveSelectedLinksVisitor
       if (visited.insert(&node).second)
       {
         addSources(node.linkSources(), node, links);
-        addSources(node.customSources(), node, links);
-        addSources(node.killSources(), node, links);
         addTargets(node, node.linkTargets(), links);
-        addTargets(node, node.customTargets(), links);
-        addTargets(node, node.killTargets(), links);
       }
     }
   }
@@ -184,11 +178,7 @@ struct CollectDirectSelectedLinksVisitor
     if (node.selected() || node.descendantSelected())
     {
       addSources(node.linkSources(), node, links);
-      addSources(node.customSources(), node, links);
-      addSources(node.killSources(), node, links);
       addTargets(node, node.linkTargets(), links);
-      addTargets(node, node.customTargets(), links);
-      addTargets(node, node.killTargets(), links);
     }
   }
 

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -96,6 +96,7 @@ struct CollectAllLinksVisitor
     if (editorContext.visible(&node))
     {
       addTargets(node, node.linkTargets(), links);
+      addTargets(node, node.customTargets(), links);
       addTargets(node, node.killTargets(), links);
     }
   }
@@ -131,8 +132,10 @@ struct CollectTransitiveSelectedLinksVisitor
       if (visited.insert(&node).second)
       {
         addSources(node.linkSources(), node, links);
+        addSources(node.customSources(), node, links);
         addSources(node.killSources(), node, links);
         addTargets(node, node.linkTargets(), links);
+        addTargets(node, node.customTargets(), links);
         addTargets(node, node.killTargets(), links);
       }
     }
@@ -181,8 +184,10 @@ struct CollectDirectSelectedLinksVisitor
     if (node.selected() || node.descendantSelected())
     {
       addSources(node.linkSources(), node, links);
+      addSources(node.customSources(), node, links);
       addSources(node.killSources(), node, links);
       addTargets(node, node.linkTargets(), links);
+      addTargets(node, node.customTargets(), links);
       addTargets(node, node.killTargets(), links);
     }
   }

--- a/common/src/View/EntityPropertyModel.cpp
+++ b/common/src/View/EntityPropertyModel.cpp
@@ -629,6 +629,24 @@ QStringList EntityPropertyModel::getCompletions(const QModelIndex& index) const
     {
       result = getAllClassnames();
     }
+    else
+    {
+      std::vector<std::string> customTargetPropertyNames;
+      auto document = kdl::mem_lock(m_document);
+      for (const auto& entity : document->allSelectedEntityNodes())
+      {
+        entity->getAllCustomTargetPropertyNames(customTargetPropertyNames);
+      }
+
+      for (const auto& customTargetPropertyName : customTargetPropertyNames)
+      {
+        if (key == customTargetPropertyName)
+        {
+          result = getAllValuesForPropertyKeys({Model::EntityPropertyKeys::Targetname});
+          break;
+        }
+      }
+    }
   }
 
   return toQStringList(std::begin(result), std::end(result));


### PR DESCRIPTION
This pull request adds support for non-standard "target" and "targetname" properties, by looking for "target_source" and "target_destination" names in the game's FGD.

This now appears to be working, and works in my project (which uses "id" for targetnames) as well as Quake (using the default "targetname").

Note that this PR removes the reliance on the hardcoded "target" and "targetname" properties (or rather, adds reliance on those being set up in the FGD). Since all the games that ship with TB have these properties configured in their FGDs, I think this is fine.

This PR is careful to refcount the number of target/source links per node, such that entities targeted multiple times from the same node are only counted as a single link.

The code style might need a bit of work; I've not submitted a PR to TB before so I just tried to match the code style as best as I could.