### PR TITLE
4624: Don't crash when opening compilation task context menu

### DIFF
--- a/common/src/ui/CompilationTaskListBox.cpp
+++ b/common/src/ui/CompilationTaskListBox.cpp
@@ -600,7 +600,10 @@ ControlListBoxItemRenderer* CompilationTaskListBox::createItemRenderer(
     task);
 
   connect(
-    renderer, &QWidget::customContextMenuRequested, this, [&, index](const QPoint& pos) {
+    renderer,
+    &QWidget::customContextMenuRequested,
+    this,
+    [&, renderer, index](const QPoint& pos) {
       emit this->taskContextMenuRequested(
         renderer->mapToGlobal(pos), m_profile->tasks[index]);
     });


### PR DESCRIPTION
Closes #4624.