### PR TITLE
4631: Fix use of wrong base vector for rotation angle indicator

### DIFF
--- a/common/src/render/EntityRenderer.cpp
+++ b/common/src/render/EntityRenderer.cpp
@@ -332,7 +332,7 @@ void EntityRenderer::renderAngles(RenderContext& renderContext, RenderBatch& ren
       }
 
       const auto rotation = vm::mat4x4f{entityNode->entity().rotation()};
-      const auto direction = rotation * vm::vec3f{0, 0, 1};
+      const auto direction = rotation * vm::vec3f{1, 0, 0};
       const auto center = vm::vec3f{entityNode->logicalBounds().center()};
 
       const auto toCam = renderContext.camera().position() - center;


### PR DESCRIPTION
Closes #4631.