### PR TITLE
4647: Keep textures aligned after CSG convex merge

### DIFF
--- a/common/src/mdl/BrushFace.cpp
+++ b/common/src/mdl/BrushFace.cpp
@@ -289,10 +289,13 @@ void BrushFace::copyUVCoordSystemFromFace(
 
   // Adjust the offset on this face so that the UV coordinates at the refPoint stay
   // the same
-  const auto currentCoords =
-    m_uvCoordSystem->uvCoords(refPoint, m_attributes, vm::vec2f{1, 1});
-  const auto offsetChange = desriedCoords - currentCoords;
-  m_attributes.setOffset(correct(modOffset(m_attributes.offset() + offsetChange), 4));
+  if (!vm::is_zero(seam.direction, vm::Cd::almost_zero()))
+  {
+    const auto currentCoords =
+      m_uvCoordSystem->uvCoords(refPoint, m_attributes, vm::vec2f::one());
+    const auto offsetChange = desriedCoords - currentCoords;
+    m_attributes.setOffset(correct(modOffset(m_attributes.offset() + offsetChange), 4));
+  }
 }
 
 const BrushFace::Points& BrushFace::points() const

--- a/common/test/src/mdl/tst_Brush.cpp
+++ b/common/test/src/mdl/tst_Brush.cpp
@@ -242,6 +242,31 @@ TEST_CASE("BrushTest.constructBrushWithRedundantFaces")
           .is_error());
 }
 
+TEST_CASE("BrushTest.cloneFaceAttributesFrom")
+{
+  const auto worldBounds = vm::bbox3d{4096.0};
+
+  const auto brushBuilder = BrushBuilder{MapFormat::Valve, worldBounds};
+  auto brush =
+    brushBuilder.createCube(64.0, "left", "right", "front", "back", "top", "bottom")
+    | kdl::value();
+
+  const auto topFaceIndex = brush.findFace(vm::vec3d{0, 0, 1});
+  REQUIRE(topFaceIndex != std::nullopt);
+
+  auto& topFace = brush.face(*topFaceIndex);
+
+  auto attributes = topFace.attributes();
+  attributes.setXOffset(64.0f);
+  attributes.setYOffset(-48.0f);
+  topFace.setAttributes(attributes);
+
+  auto newBrush = brush;
+  newBrush.cloneFaceAttributesFrom(brush);
+
+  CHECK(newBrush == brush);
+}
+
 TEST_CASE("BrushTest.clip")
 {
   const auto worldBounds = vm::bbox3d{4096.0};


### PR DESCRIPTION
Closes #4647.

This broke in f24ba9427d02f97336221db738c0ced5e6dab091.