### PR TITLE
4595: Assign e1u1/trigger to trigger brushes in Quake 2

### DIFF
--- a/app/resources/games/Quake2/GameConfig.cfg
+++ b/app/resources/games/Quake2/GameConfig.cfg
@@ -26,7 +26,7 @@
                 "attribs": [ "transparent" ],
                 "match": "classname",
                 "pattern": "trigger*",
-                "material": "trigger"
+                "material": "e1u1/trigger"
             }
         ],
         "brushface": [


### PR DESCRIPTION
Closes #4595.