### PR TITLE
4654: Don't unlink nested linked groups when separating linked groups

### DIFF
--- a/common/test/src/ui/tst_GroupNodes.cpp
+++ b/common/test/src/ui/tst_GroupNodes.cpp
@@ -962,7 +962,7 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
     CHECK(linkedBrushNode3->linkId() == originalBrushLinkId);
   }
 
-  SECTION("Separating linked groups nested inside a linked group")
+  SECTION("Nested linked groups")
   {
     /*
      * groupNode
@@ -998,18 +998,21 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
     auto* linkedGroupNode = document->createLinkedDuplicate();
     REQUIRE_THAT(*linkedGroupNode, mdl::MatchesNode(*groupNode));
 
-    document->openGroup(groupNode);
-    document->deselectAll();
-    document->selectNodes({nestedLinkedGroupNode});
-    document->separateLinkedGroups();
+    SECTION("Separating linked groups nested inside a linked group")
+    {
+      document->openGroup(groupNode);
+      document->deselectAll();
+      document->selectNodes({nestedLinkedGroupNode});
+      document->separateLinkedGroups();
 
-    REQUIRE(nestedGroupNode->linkId() != nestedLinkedGroupNode->linkId());
+      REQUIRE(nestedGroupNode->linkId() != nestedLinkedGroupNode->linkId());
 
-    document->deselectAll();
-    document->closeGroup();
+      document->deselectAll();
+      document->closeGroup();
 
-    // the change was propagated to linkedGroupNode:
-    CHECK_THAT(*linkedGroupNode, mdl::MatchesNode(*groupNode));
+      // the change was propagated to linkedGroupNode:
+      CHECK_THAT(*linkedGroupNode, mdl::MatchesNode(*groupNode));
+    }
   }
 }
 

--- a/common/test/src/ui/tst_GroupNodes.cpp
+++ b/common/test/src/ui/tst_GroupNodes.cpp
@@ -1013,12 +1013,8 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
       CHECK(brushNode->linkId() != linkedBrushNode->linkId());
 
       // But the nested group nodes are still all linked to each other
-      /* EXPECTED:
       CHECK(linkedNestedGroupNode->linkId() == nestedGroupNode->linkId());
       CHECK(nestedGroupNode->linkId() == nestedLinkedGroupNode->linkId());
-      ACTUAL: */
-      CHECK(linkedNestedGroupNode->linkId() != nestedGroupNode->linkId());
-      CHECK(nestedGroupNode->linkId() != nestedLinkedGroupNode->linkId());
       CHECK(linkedNestedGroupNode->linkId() == linkedNestedLinkedGroupNode->linkId());
     }
 

--- a/common/test/src/ui/tst_GroupNodes.cpp
+++ b/common/test/src/ui/tst_GroupNodes.cpp
@@ -998,10 +998,33 @@ TEST_CASE_METHOD(MapDocumentTest, "GroupNodestTest.separateGroups")
     auto* linkedGroupNode = document->createLinkedDuplicate();
     REQUIRE_THAT(*linkedGroupNode, mdl::MatchesNode(*groupNode));
 
+    const auto [linkedBrushNode, linkedNestedGroupNode, linkedNestedLinkedGroupNode] =
+      getChildrenAs<mdl::BrushNode, mdl::GroupNode, mdl::GroupNode>(*linkedGroupNode);
+
+    document->deselectAll();
+
+    SECTION("Separating linked groups with nested linked groups inside")
+    {
+      document->selectNodes({groupNode});
+      document->separateLinkedGroups();
+
+      // The outer groups where separated
+      CHECK(groupNode->linkId() != linkedGroupNode->linkId());
+      CHECK(brushNode->linkId() != linkedBrushNode->linkId());
+
+      // But the nested group nodes are still all linked to each other
+      /* EXPECTED:
+      CHECK(linkedNestedGroupNode->linkId() == nestedGroupNode->linkId());
+      CHECK(nestedGroupNode->linkId() == nestedLinkedGroupNode->linkId());
+      ACTUAL: */
+      CHECK(linkedNestedGroupNode->linkId() != nestedGroupNode->linkId());
+      CHECK(nestedGroupNode->linkId() != nestedLinkedGroupNode->linkId());
+      CHECK(linkedNestedGroupNode->linkId() == linkedNestedLinkedGroupNode->linkId());
+    }
+
     SECTION("Separating linked groups nested inside a linked group")
     {
       document->openGroup(groupNode);
-      document->deselectAll();
       document->selectNodes({nestedLinkedGroupNode});
       document->separateLinkedGroups();
 


### PR DESCRIPTION
Closes #4654.