### PR TITLE
4657: Set default face attributes when resetting UV in UV editor

### DIFF
--- a/common/src/ui/UVEditor.cpp
+++ b/common/src/ui/UVEditor.cpp
@@ -157,6 +157,7 @@ void UVEditor::resetUVClicked()
   auto request = mdl::ChangeBrushFaceAttributesRequest{};
 
   auto document = kdl::mem_lock(m_document);
+  request.resetAll(document->game()->config().faceAttribsConfig.defaults);
   document->setFaceAttributes(request);
 }
 


### PR DESCRIPTION
Closes #4657.