### PR TITLE
Allow selecting faces through hidden materials

### DIFF
--- a/common/src/ui/SelectionTool.cpp
+++ b/common/src/ui/SelectionTool.cpp
@@ -217,7 +217,9 @@ public:
     const auto& editorContext = m_document->editorContext();
     if (m_document->hasSelectedBrushFaces())
     {
-      const auto hit = firstHit(inputState, type(mdl::BrushNode::BrushHitType));
+      const auto hit = firstHit(
+        inputState,
+        type(mdl::BrushNode::BrushHitType) && isNodeSelectable(editorContext));
       if (const auto faceHandle = mdl::hitToFaceHandle(hit))
       {
         const auto* brush = faceHandle->node();
@@ -292,7 +294,8 @@ bool SelectionTool::mouseClick(const InputState& inputState)
 
   if (isFaceClick(inputState))
   {
-    const auto hit = firstHit(inputState, type(mdl::BrushNode::BrushHitType));
+    const auto hit = firstHit(
+      inputState, type(mdl::BrushNode::BrushHitType) && isNodeSelectable(editorContext));
     if (const auto faceHandle = mdl::hitToFaceHandle(hit))
     {
       const auto* brush = faceHandle->node();


### PR DESCRIPTION
When hiding a material (eg. `NULL` or `SKIP`) you can select brushes through faces that are hidden but you cannot select faces, shift-clicking through hidden materials is a no-op.

This fixes the issue and allows the user to select faces as well as brushes through hidden materials.