### PR TITLE
Apply default properties for worldspawn on new map

### DIFF
--- a/common/src/ui/MapDocument.cpp
+++ b/common/src/ui/MapDocument.cpp
@@ -584,6 +584,23 @@ void MapDocument::createEntityDefinitionActions()
     actionManager.createEntityDefinitionActions(m_entityDefinitionManager->definitions());
 }
 
+namespace
+{
+void setWorldDefaultProperties(
+  mdl::WorldNode& world, mdl::EntityDefinitionManager& entityDefinitionManager)
+{
+  const auto definition =
+    entityDefinitionManager.definition(mdl::EntityPropertyValues::WorldspawnClassname);
+
+  if (definition && world.entityPropertyConfig().setDefaultProperties)
+  {
+    auto entity = world.entity();
+    mdl::setDefaultProperties(*definition, entity, mdl::SetDefaultPropertyMode::SetAll);
+    world.setEntity(std::move(entity));
+  }
+}
+} // namespace
+
 Result<void> MapDocument::newDocument(
   const mdl::MapFormat mapFormat,
   const vm::bbox3d& worldBounds,
@@ -596,7 +613,7 @@ Result<void> MapDocument::newDocument(
   return game->newMap(mapFormat, m_worldBounds, logger())
          | kdl::transform([&](auto worldNode) {
              setWorld(worldBounds, std::move(worldNode), game, DefaultDocumentName);
-
+             setWorldDefaultProperties(*m_world, *m_entityDefinitionManager);
              clearModificationCount();
              documentWasNewedNotifier(this);
            });


### PR DESCRIPTION
This PR addresses the first item from #4552 where default properties are not applied to the `worldspawn` entity when creating a new map and `setDefaultProperties` is set. The second item should probably be tracked in a separate issue.

I was thinking in moving `setWorldDefaultProps()` to `setWorld()`, after the line `loadAssets()` but that would require an extra parameter to check if it's loading a map or creating a new one.

Thank you very much!