### PR TITLE
Throw an exception when creating a TestEnvironment with an absolute path

### DIFF
--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -15,15 +15,6 @@ brew --prefix qt@5
 BUILD_TYPE_VALUE="Release"
 TB_ENABLE_ASAN_VALUE="NO"
 
-# Note: When this variable is changed, vcpkg will need to recompile all dependencies.
-# However, vcpkg will not detect the change and will happily keep using any cached binaries (see
-# the lukka/run-vcpkg workflow step for details). This will cause a mismatch between the deployment
-# target under which the binaries were compiled and the new deployment target used here.
-# Therefore, when this variable is changed, the vcpkg binary cache must be invalidated. The easiest
-# way to do that is to update vcpkg to the latest version because the vcpkg commit ID is part of the
-# cache key for the binary cache.
-export MACOSX_DEPLOYMENT_TARGET=10.15
-
 if [[ $TB_DEBUG_BUILD == "true" ]] ; then
     BUILD_TYPE_VALUE="Debug"
     TB_ENABLE_ASAN_VALUE="YES"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,15 @@ if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
 
+# Note: When this variable is changed, vcpkg will need to recompile all dependencies.
+# However, vcpkg will not detect the change and will happily keep using any cached
+# binaries (see the lukka/run-vcpkg workflow step for details). This will cause a mismatch
+# between the deployment target under which the binaries were compiled and the new
+# deployment target used here. Therefore, when this variable is changed, the vcpkg binary
+# cache must be invalidated. The easiest way to do that is to update vcpkg to the latest
+# version because the vcpkg commit ID is part of the cache key for the binary cache.
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 set(VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/vcpkg-overlay-ports/freeimage;${CMAKE_SOURCE_DIR}/vcpkg-overlay-ports/openexr")
 
@@ -32,8 +41,6 @@ set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT T
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-set (CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
 
 # Using C and CXX because GLEW is C
 project(TrenchBroom C CXX)

--- a/common/test/src/io/TestEnvironment.cpp
+++ b/common/test/src/io/TestEnvironment.cpp
@@ -21,6 +21,8 @@
 
 #include "Macros.h"
 
+#include <fmt/format.h>
+
 #include <fstream>
 #include <string>
 
@@ -34,6 +36,11 @@ TestEnvironment::TestEnvironment(
   : m_sandboxPath{std::filesystem::current_path() / generateUuid()}
   , m_dir{m_sandboxPath / dir}
 {
+  if (!dir.is_relative())
+  {
+    throw std::runtime_error{fmt::format("'{}' is not a relative path", dir.string())};
+  }
+
   createTestEnvironment(setup);
 }
 

--- a/common/test/src/io/TestEnvironment.cpp
+++ b/common/test/src/io/TestEnvironment.cpp
@@ -29,7 +29,8 @@
 namespace tb::io
 {
 
-TestEnvironment::TestEnvironment(const std::string& dir, const SetupFunction& setup)
+TestEnvironment::TestEnvironment(
+  const std::filesystem::path& dir, const SetupFunction& setup)
   : m_sandboxPath{std::filesystem::current_path() / generateUuid()}
   , m_dir{m_sandboxPath / dir}
 {

--- a/common/test/src/io/TestEnvironment.h
+++ b/common/test/src/io/TestEnvironment.h
@@ -40,7 +40,8 @@ private:
 
 public:
   explicit TestEnvironment(
-    const std::string& dir, const SetupFunction& setup = [](TestEnvironment&) {});
+    const std::filesystem::path& dir,
+    const SetupFunction& setup = [](TestEnvironment&) {});
   explicit TestEnvironment(const SetupFunction& setup = [](TestEnvironment&) {});
   ~TestEnvironment();
 


### PR DESCRIPTION
Otherwise, this throws hard to diagnose errors in the destructor that show up only when using ASAN (and might even end up deleting important files).