### PR TITLE
Hide hidden faces even in locked layers

### DIFF
--- a/common/src/render/MapRenderer.cpp
+++ b/common/src/render/MapRenderer.cpp
@@ -97,9 +97,17 @@ public:
     }
 
     const auto& brush = brushNode.brush();
+    bool hasMarkedFaces = false;
     for (const auto& face : brush.faces())
     {
-      face.setMarked(true);
+      const bool mark = visible(brushNode, face);
+      face.setMarked(mark);
+      hasMarkedFaces |= mark;
+    }
+
+    if (!hasMarkedFaces)
+    {
+      return renderNothing();
     }
 
     return {FaceRenderPolicy::RenderMarked, EdgeRenderPolicy::RenderAll};


### PR DESCRIPTION
Closes #4705.

Hidden faces are not hidden when they're in a locked layer. This PR fixes that.

Repro map with an unlocked brush encased in a locked brush, using a single SKIP face on each brush:
```
// Game: Half-Life
// Format: Valve
// entity 0
{
"mapversion" "220"
"classname" "worldspawn"
// brush 0
{
( -16 -16 -128 ) ( -16 -15 -128 ) ( -16 -16 -127 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
( 16 -16 -128 ) ( 16 -16 -127 ) ( 17 -16 -128 ) SKIP [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( 16 -16 -128 ) ( 17 -16 -128 ) ( 16 -15 -128 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 96 16 64 ) ( 96 17 64 ) ( 97 16 64 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 96 16 -112 ) ( 97 16 -112 ) ( 96 16 -111 ) __TB_empty [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( 96 16 -112 ) ( 96 16 -111 ) ( 96 17 -112 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
}
}
// entity 1
{
"classname" "func_group"
"_tb_type" "_tb_layer"
"_tb_name" "locked"
"_tb_id" "258"
"_tb_layer_sort_index" "4"
// brush 0
{
( -96 -96 -16 ) ( -96 -95 -16 ) ( -96 -96 -15 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
( -64 -96 -16 ) ( -64 -96 -15 ) ( -63 -96 -16 ) SKIP [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( -64 -96 -16 ) ( -63 -96 -16 ) ( -64 -95 -16 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 96 0 128 ) ( 96 1 128 ) ( 97 0 128 ) __TB_empty [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1
( 96 0 0 ) ( 97 0 0 ) ( 96 0 1 ) __TB_empty [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1
( 96 0 0 ) ( 96 0 1 ) ( 96 1 0 ) __TB_empty [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1
}
}
```

Before and after:
![00_before](https://github.com/user-attachments/assets/6bc021fb-597d-453f-8182-a45bcd92cc39)
![01_after](https://github.com/user-attachments/assets/37f426a5-5d6b-445f-8fb0-f43e5a51358a)
