### PR TITLE
Update vcpkg and drop CMAKE_OSX_DEPLOYMENT_TARGET from CMakeLists

### DIFF
--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -15,6 +15,15 @@ brew --prefix qt@5
 BUILD_TYPE_VALUE="Release"
 TB_ENABLE_ASAN_VALUE="NO"
 
+# Note: When this variable is changed, vcpkg will need to recompile all dependencies.
+# However, vcpkg will not detect the change and will happily keep using any cached binaries (see
+# the lukka/run-vcpkg workflow step for details). This will cause a mismatch between the deployment
+# target under which the binaries were compiled and the new deployment target used here.
+# Therefore, when this variable is changed, the vcpkg binary cache must be invalidated. The easiest
+# way to do that is to update vcpkg to the latest version because the vcpkg commit ID is part of the
+# cache key for the binary cache.
+export MACOSX_DEPLOYMENT_TARGET=10.15
+
 if [[ $TB_DEBUG_BUILD == "true" ]] ; then
     BUILD_TYPE_VALUE="Debug"
     TB_ENABLE_ASAN_VALUE="YES"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,15 +16,6 @@ if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
 
-# Note: When this variable is changed, vcpkg will need to recompile all dependencies.
-# However, vcpkg will not detect the change and will happily keep using any cached
-# binaries (see the lukka/run-vcpkg workflow step for details). This will cause a mismatch
-# between the deployment target under which the binaries were compiled and the new
-# deployment target used here. Therefore, when this variable is changed, the vcpkg binary
-# cache must be invalidated. The easiest way to do that is to update vcpkg to the latest
-# version because the vcpkg commit ID is part of the cache key for the binary cache.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
-
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 set(VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/vcpkg-overlay-ports/freeimage;${CMAKE_SOURCE_DIR}/vcpkg-overlay-ports/openexr")
 


### PR DESCRIPTION
The macOS deployment target should be set for CI builds only. On developer machines, it's better to drop it so that it will be defaulted to whatever system version the machine is running. This will avoid lots of warnings about mismatching object files.