### PR TITLE
4715: Remove `-` from `-ldd` command (`CI-linux.sh`)

### DIFF
--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -46,7 +46,7 @@ fi
 
 cd "$BUILD_DIR"
 
--ldd --verbose ./app/trenchbroom
+ldd --verbose ./app/trenchbroom
 
 make install DESTDIR=AppDir | exit 1
 


### PR DESCRIPTION
Resolves #4715.