### PR TITLE
Update WRATH GameConfig.cfg

### DIFF
--- a/app/resources/games/Wrath/GameConfig.cfg
+++ b/app/resources/games/Wrath/GameConfig.cfg
@@ -6,8 +6,8 @@
     "fileformats": [
 // brush primitives not yet implemented
 //      { "format": "Quake3" },
-        { "format": "Quake3 (legacy)" },
-        { "format": "Quake3 (Valve)" }
+        { "format": "Quake3 (Valve)" },
+        { "format": "Quake3 (legacy)" }
     ],
     "filesystem": {
         "searchpath": "kp1",
@@ -15,7 +15,7 @@
     },
     "materials": {
         "root": "textures",
-        "extensions": [ "" ],
+        "extensions": [ ".tga", ".png", ".jpg", ".jpeg" ],
         "shaderSearchPath": "scripts", // this will likely change when we get a material system
         "excludes": [ "*sky_bk", "*sky_dn", "*sky_ft", "*sky_lf", "*sky_rt", "*sky_up", "*_bump", "*_gloss", "*_glow", "_luma", "*_norm" ]
     },
@@ -127,5 +127,8 @@
             } // 134,217,728
         ]
     },
-    "softMapBounds":"-65536 -65536 -65536 65536 65536 65536"
+    "softMapBounds":"-65536 -65536 -65536 65536 65536 65536",
+    "compilationTools": [
+        { "name": "q3map2", "description": "Path to your q3map2 executable, which performs the main bsp/vis/light compilation phases" }
+    ]
 }


### PR DESCRIPTION
Add a tool option and missing textures extensions to bring in alignment with Q3A's texture/script support.