### PR TITLE
Run cpplinter checks on Ubuntu 22.04

### DIFF
--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   cpp-linter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
Ubuntu 24.04 uses a different version of the clang tools than what is in the dev-tools repo, causing issues with clang-format.