### PR TITLE
Update GameConfig.cfg fixes & additions for DDAY

### DIFF
--- a/app/resources/games/DDayNormandy/GameConfig.cfg
+++ b/app/resources/games/DDayNormandy/GameConfig.cfg
@@ -22,31 +22,26 @@
     "tags": {
         "brush": [
             {
+                "name": "Areaportal",
+                "attribs": [ "transparent" ],
+                "match": "classname",
+                "pattern": "*_areaportal",
+                "material": "e1u1/trigger"
+            },
+            {
                 "name": "Trigger",
                 "attribs": [ "transparent" ],
                 "match": "classname",
                 "pattern": "trigger*",
-                "material": "trigger"
+                "material": "e1u1/trigger"
             }
         ],
         "brushface": [
             {
                 "name": "Clip",
                 "attribs": [ "transparent" ],
-                "match": "material",
-                "pattern": "clip"
-            },
-            {
-                "name": "Skip",
-                "attribs": [ "transparent" ],
-                "match": "material",
-                "pattern": "skip"
-            },
-            {
-                "name": "Hint",
-                "attribs": [ "transparent" ],
-                "match": "material",
-                "pattern": "hint*"
+                "match": "contentflag",
+                "flags": [ "clip"]
             },
             {
                 "name": "Detail",
@@ -54,13 +49,58 @@
                 "flags": [ "detail" ]
             },
             {
+                "name": "Hint",
+                "attribs": [ "transparent" ],
+                "match": "surfaceflag",
+                "flags": ["hint"]
+            },
+            {
                 "name": "Liquid",
                 "match": "contentflag",
                 "flags": [ "lava", "slime", "water" ]
+            },
+            {
+                "name": "Nodraw",
+                "attribs": [ "transparent" ],
+                "match": "surfaceflag",
+                "flags": [ "nodraw" ]
+            },
+            {
+                "name": "Origin",
+                "attribs": [ "transparent" ],
+                "match": "contentflag",
+                "flags": [ "origin" ]
+            },
+            {
+                "name": "Skip",
+                "attribs": [ "transparent" ],
+                "match": "surfaceflag",
+                "flags": ["skip"]
+            },
+            {
+                "name": "Sky",
+                "attribs": [],
+                "match": "surfaceflag",
+                "flags": ["sky"]
+            },
+            {
+                "name": "Slick",
+                "attribs": [],
+                "match": "surfaceflag",
+                "flags": ["slick"]
+            },
+            {
+                "name": "Transparent",
+                "attribs": [ "transparent" ],
+                "match": "surfaceflag",
+                "flags": [ "trans33", "trans66" ]
             }
         ]
     },
     "faceattribs": {
+        "defaults": {
+            "scale": [1.0, 1.0]
+        },
         "surfaceflags": [
             {
                 "name": "light",
@@ -132,15 +172,15 @@
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 1 << 6
-            { "name": "true" }, // 1 << 7
-            { "name": "true" }, // 1 << 8
-            { "name": "true" }, // 1 << 9
-            { "name": "true" }, // 1 << 10
-            { "name": "true" }, // 1 << 11
-            { "name": "true" }, // 1 << 12
-            { "name": "true" }, // 1 << 13
-            { "name": "true" }, // 1 << 14
-            { "name": "true" }, // 1 << 15
+            { "unused": true }, // 1 << 7
+            { "unused": true }, // 1 << 8
+            { "unused": true }, // 1 << 9
+            { "unused": true }, // 1 << 10
+            { "unused": true }, // 1 << 11
+            { "unused": true }, // 1 << 12
+            { "unused": true }, // 1 << 13
+            { "unused": true }, // 1 << 14
+            { "unused": true }, // 1 << 15
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"
@@ -198,5 +238,11 @@
                 "description": "Brushes with this flag allow a player to move up and down a vertical surface"
             } // 1 << 29
         ]
-    }
+    },
+    "softMapBounds":"-16384 -16384 -16384 16384 16384 16384",
+    "compilationTools": [
+        { "name": "bsp", "description": "Path to your directory containing your bsp compiler. ${bsp}." },
+        { "name": "vis", "description": "Path to your directory containing your vis compiler. ${vis}" },
+        { "name": "light", "description": "Path to your directory containing your light compiler. ${light}" }
+    ]
 }


### PR DESCRIPTION
The main changes are as follows :

- Added map compiler tool path options under preferences.
- Add brush/face options in line with TB's Quake 2 cfg (being based on same engine/map format).
- Fixed unused contentflags being shown in TB, now hidden.