### PR TITLE
Convert windows paths in ASE files

### DIFF
--- a/common/src/io/AseLoader.cpp
+++ b/common/src/io/AseLoader.cpp
@@ -261,7 +261,7 @@ void AseLoader::parseMaterialListMaterialMapDiffuseBitmap(
 {
   expectDirective("BITMAP");
   const auto token = expect(AseToken::String, m_tokenizer.nextToken());
-  path = std::filesystem::path(token.data());
+  path = std::filesystem::path{token.data()};
 }
 
 void AseLoader::parseGeomObject(

--- a/common/src/io/AseLoader.cpp
+++ b/common/src/io/AseLoader.cpp
@@ -28,6 +28,7 @@
 #include "render/MaterialIndexRangeMapBuilder.h"
 #include "render/PrimType.h"
 
+#include "kdl/k.h"
 #include "kdl/path_utils.h"
 #include "kdl/string_format.h"
 
@@ -261,7 +262,7 @@ void AseLoader::parseMaterialListMaterialMapDiffuseBitmap(
 {
   expectDirective("BITMAP");
   const auto token = expect(AseToken::String, m_tokenizer.nextToken());
-  path = std::filesystem::path{token.data()};
+  path = kdl::parse_path(token.data(), K(replace_backslashes));
 }
 
 void AseLoader::parseGeomObject(

--- a/common/test/src/io/tst_AseLoader.cpp
+++ b/common/test/src/io/tst_AseLoader.cpp
@@ -58,7 +58,7 @@ TEST_CASE("AseLoaderTest")
 
   auto taskManager = kdl::task_manager{};
 
-  SECTION("loadWithoutException")
+  SECTION("Models load without exception")
   {
     const auto basePath =
       std::filesystem::current_path() / "fixture/test/io/Ase/wedge_with_shader";
@@ -86,7 +86,7 @@ TEST_CASE("AseLoaderTest")
     CHECK(model.is_success());
   }
 
-  SECTION("fallbackToMaterialName")
+  SECTION("Fall back to material name if bitmap directive is missing")
   {
     const auto basePath =
       std::filesystem::current_path() / "fixture/test/io/Ase/fallback_to_materialname";
@@ -117,7 +117,7 @@ TEST_CASE("AseLoaderTest")
     CHECK(modelData.value().surface(0).skin(0)->name() == "textures/bigtile");
   }
 
-  SECTION("loadDefaultMaterial")
+  SECTION("Fall back to default material if texture cannot be loaded")
   {
     const auto basePath =
       std::filesystem::current_path() / "fixture/test/io/Ase/load_default_material";

--- a/lib/kdl/include/kdl/path_utils.h
+++ b/lib/kdl/include/kdl/path_utils.h
@@ -25,9 +25,20 @@
 #include <algorithm>
 #include <filesystem>
 #include <numeric>
+#include <string>
 
 namespace kdl
 {
+
+inline std::filesystem::path parse_path(
+  std::string str, const bool replace_backslashes = true)
+{
+  if (replace_backslashes)
+  {
+    std::ranges::replace_if(str, [](char c) { return c == '\\'; }, '/');
+  }
+  return std::filesystem::path{std::move(str)};
+}
 
 inline size_t path_length(const std::filesystem::path& path)
 {

--- a/lib/kdl/test/src/tst_path_utils.cpp
+++ b/lib/kdl/test/src/tst_path_utils.cpp
@@ -18,6 +18,7 @@
  DEALINGS IN THE SOFTWARE.
 */
 
+#include "kdl/k.h"
 #include "kdl/path_utils.h"
 
 #include "catch2.h"
@@ -25,6 +26,17 @@
 namespace kdl
 {
 using std::filesystem::path;
+
+TEST_CASE("parse_path")
+{
+  CHECK(parse_path(R"()") == path{R"()"});
+  CHECK(parse_path(R"(/)") == path{R"(/)"});
+  CHECK(parse_path(R"(\)") == path{R"(/)"});
+  CHECK(parse_path(R"(\)", !K(replace_backslashes)) == path{R"(\)"});
+  CHECK(parse_path(R"(a/b/c)") == path{R"(a/b/c)"});
+  CHECK(parse_path(R"(a\b\c)") == path{R"(a/b/c)"});
+  CHECK(parse_path(R"(a\b\c)", !K(replace_backslashes)) == path{R"(a\b\c)"});
+}
 
 TEST_CASE("path_length")
 {


### PR DESCRIPTION
Closes #4763.

ASE files often contain material paths with backlashes as directory separators. Since a backslash is a valid path character on POSIX systems, such paths are not parse correctly. We convert the backslashes to forward slashes on such systems.