### PR TITLE
Improve Qt path conversion and add tests

### DIFF
--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -100,7 +100,7 @@ void AppPreferenceManager::initialize()
   loadCacheFromDisk();
 
   m_fileSystemWatcher = new QFileSystemWatcher{this};
-  if (m_fileSystemWatcher->addPath(io::pathAsQString(m_preferencesFilePath)))
+  if (m_fileSystemWatcher->addPath(io::pathAsQPath(m_preferencesFilePath)))
   {
     connect(
       m_fileSystemWatcher,
@@ -397,7 +397,7 @@ namespace
 QLockFile getLockFile(const std::filesystem::path& preferenceFilePath)
 {
   const auto lockFilePath = kdl::path_add_extension(preferenceFilePath, ".lck");
-  return QLockFile{io::pathAsQString(lockFilePath)};
+  return QLockFile{io::pathAsQPath(lockFilePath)};
 }
 } // namespace
 
@@ -445,7 +445,7 @@ WritePreferencesResult writePreferencesToFile(
     return PreferenceErrors::LockFileError{};
   }
 
-  auto saveFile = QSaveFile{io::pathAsQString(path)};
+  auto saveFile = QSaveFile{io::pathAsQPath(path)};
   if (!saveFile.open(QIODevice::WriteOnly))
   {
     return PreferenceErrors::FileAccessError{};

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -32,8 +32,10 @@
 #include "Preference.h"
 #include "Result.h"
 
-#include "kdl/result.h"
 #include "kdl/vector_set.h"
+
+#include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <filesystem>
 #include <map>
@@ -94,7 +96,7 @@ public:
     auto* pref = dynamic_cast<Preference<T>*>(prefBase);
     ensure(
       pref != nullptr,
-      ("Preference " + path.string() + " must be of the expected type").c_str());
+      fmt::format("Preference {} must be of the expected type", path).c_str());
     return *pref;
   }
 

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -303,7 +303,7 @@ QPalette TrenchBroomApp::darkPalette()
 bool TrenchBroomApp::loadStyleSheets()
 {
   const auto path = io::SystemPaths::findResourceFile("stylesheets/base.qss");
-  if (auto file = QFile{io::pathAsQString(path)}; file.exists())
+  if (auto file = QFile{io::pathAsQPath(path)}; file.exists())
   {
     // closed automatically by destructor
     file.open(QFile::ReadOnly | QFile::Text);
@@ -777,8 +777,8 @@ void reportCrashAndExit(const std::string& stacktrace, const std::string& reason
     }
 
     // Copy the log file
-    if (!QFile::copy(
-          io::pathAsQString(io::SystemPaths::logFilePath()), io::pathAsQString(logPath)))
+    auto ec = std::error_code{};
+    if (!std::filesystem::copy_file(io::SystemPaths::logFilePath(), logPath, ec) || ec)
     {
       logPath = std::filesystem::path{};
     }

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -70,6 +70,7 @@
 #include "kdl/string_utils.h"
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <chrono>
 #include <clocale>
@@ -392,7 +393,7 @@ bool TrenchBroomApp::openDocument(const std::filesystem::path& path)
   const auto checkFileExists = [&]() {
     return io::Disk::pathInfo(absPath) == io::PathInfo::File
              ? Result<void>{}
-             : Result<void>{Error{"'" + path.string() + "' not found"}};
+             : Result<void>{Error{fmt::format("{} not found", path)}};
   };
 
   auto* frame = static_cast<MapFrame*>(nullptr);
@@ -543,9 +544,7 @@ void TrenchBroomApp::openDocument()
 void TrenchBroomApp::showManual()
 {
   const auto manualPath = io::SystemPaths::findResourceFile("manual/index.html");
-  const auto manualPathString = manualPath.string();
-  const auto manualPathUrl =
-    QUrl::fromLocalFile(QString::fromStdString(manualPathString));
+  const auto manualPathUrl = QUrl::fromLocalFile(io::pathAsQString(manualPath));
   QDesktopServices::openUrl(manualPathUrl);
 }
 
@@ -570,8 +569,8 @@ void TrenchBroomApp::debugShowCrashReportDialog()
 }
 
 /**
- * If we catch exceptions in main() that are otherwise uncaught, Qt prints a warning to
- * override QCoreApplication::notify() and catch exceptions there instead.
+ * If we catch exceptions in main() that are otherwise uncaught, Qt prints a warning
+ * to override QCoreApplication::notify() and catch exceptions there instead.
  */
 bool TrenchBroomApp::notify(QObject* receiver, QEvent* event)
 {
@@ -717,8 +716,7 @@ std::filesystem::path crashReportBasePath()
   {
     ++index;
 
-    const auto testCrashLogName =
-      fmt::format("{}-{}.txt", crashLogPath.stem().string(), index);
+    const auto testCrashLogName = fmt::format("{}-{}.txt", crashLogPath.stem(), index);
     testCrashLogPath = crashLogPath.parent_path() / testCrashLogName;
   }
 
@@ -818,5 +816,4 @@ static void CrashHandler(int /* signum */)
   tb::ui::reportCrashAndExit(tb::TrenchBroomStackWalker::getStackTrace(), "SIGSEGV");
 }
 #endif
-
 } // namespace tb::ui

--- a/common/src/io/AseLoader.cpp
+++ b/common/src/io/AseLoader.cpp
@@ -262,7 +262,7 @@ void AseLoader::parseMaterialListMaterialMapDiffuseBitmap(
 {
   expectDirective("BITMAP");
   const auto token = expect(AseToken::String, m_tokenizer.nextToken());
-  path = kdl::parse_path(token.data(), K(replace_backslashes));
+  path = kdl::parse_path(token.data(), K(convert_separators));
 }
 
 void AseLoader::parseGeomObject(

--- a/common/src/io/AseLoader.cpp
+++ b/common/src/io/AseLoader.cpp
@@ -130,7 +130,7 @@ AseLoader::AseLoader(
 
 bool AseLoader::canParse(const std::filesystem::path& path)
 {
-  return kdl::str_to_lower(path.extension().string()) == ".ase";
+  return kdl::path_has_extension(kdl::path_to_lower(path), ".ase");
 }
 
 Result<mdl::EntityModelData> AseLoader::load(Logger& logger)

--- a/common/src/io/AssimpLoader.cpp
+++ b/common/src/io/AssimpLoader.cpp
@@ -794,7 +794,7 @@ AssimpLoader::AssimpLoader(std::filesystem::path path, const FileSystem& fs)
 bool AssimpLoader::canParse(const std::filesystem::path& path)
 {
   // clang-format off
-  static const auto supportedExtensions = std::vector<std::string>{
+  static const auto supportedExtensions = std::vector<std::filesystem::path>{
     // Quake model formats have been omitted since Trenchbroom's got its own parsers
     // already.
     ".3mf",  ".dae",      ".xml",          ".blend",    ".bvh",       ".3ds",  ".ase",
@@ -809,8 +809,7 @@ bool AssimpLoader::canParse(const std::filesystem::path& path)
     ".csm",  ".ply",      ".cob",          ".scn",      ".xgl"};
   // clang-format on
 
-  return kdl::vec_contains(
-    supportedExtensions, kdl::str_to_lower(path.extension().string()));
+  return kdl::vec_contains(supportedExtensions, kdl::path_to_lower(path.extension()));
 }
 
 Result<mdl::EntityModelData> AssimpLoader::load(tb::Logger& logger)

--- a/common/src/io/AssimpLoader.cpp
+++ b/common/src/io/AssimpLoader.cpp
@@ -49,11 +49,13 @@
 #include <assimp/scene.h>
 #include <assimp/types.h>
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <optional>
 #include <ranges>
 #include <string_view>
 #include <utility>
+
 
 namespace tb::io
 {
@@ -281,7 +283,7 @@ std::vector<mdl::Texture> loadTexturesForMaterial(
     logger.error(fmt::format(
       "No diffuse textures found for material {} of model '{}', loading fallback texture",
       materialIndex,
-      modelPath.string()));
+      modelPath));
 
     textures.push_back(loadFallbackOrDefaultTexture(fs, logger));
   }
@@ -829,9 +831,7 @@ Result<mdl::EntityModelData> AssimpLoader::load(tb::Logger& logger)
     if (!scene)
     {
       return Error{fmt::format(
-        "Assimp couldn't import model from '{}': {}",
-        m_path.string(),
-        importer.GetErrorString())};
+        "Assimp couldn't import model from '{}': {}", m_path, importer.GetErrorString())};
     }
 
     // Create model data.

--- a/common/src/io/BspLoader.cpp
+++ b/common/src/io/BspLoader.cpp
@@ -32,6 +32,7 @@
 #include "render/MaterialIndexRangeMapBuilder.h"
 #include "render/PrimType.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/result.h"
 #include "kdl/string_format.h"
 
@@ -295,7 +296,7 @@ BspLoader::BspLoader(
 
 bool BspLoader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::str_to_lower(path.extension().string()) != ".bsp")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".bsp"))
   {
     return false;
   }

--- a/common/src/io/DiskFileSystem.cpp
+++ b/common/src/io/DiskFileSystem.cpp
@@ -51,7 +51,7 @@ Result<std::filesystem::path> DiskFileSystem::makeAbsolute(
   const std::filesystem::path& path) const
 {
   const auto canonicalPath = path.lexically_normal();
-  if (!canonicalPath.empty() && kdl::path_front(canonicalPath).string() == "..")
+  if (!canonicalPath.empty() && kdl::path_front(canonicalPath) == "..")
   {
     return Error{fmt::format("Failed to make absolute path of {}", path)};
   }

--- a/common/src/io/DkmLoader.cpp
+++ b/common/src/io/DkmLoader.cpp
@@ -401,7 +401,7 @@ Result<std::filesystem::path> findSkin(const std::string& skin, const FileSystem
   }
 
   // try "wal" extension instead
-  if (kdl::str_to_lower(skinPath.extension().string()) == ".bmp")
+  if (kdl::path_has_extension(kdl::path_to_lower(skinPath), ".bmp"))
   {
     const auto walPath = kdl::path_replace_extension(skinPath, ".wal");
     if (fs.pathInfo(walPath) == PathInfo::File)
@@ -499,7 +499,7 @@ DkmLoader::DkmLoader(std::string name, const Reader& reader, const FileSystem& f
 
 bool DkmLoader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::path_to_lower(path.extension()) != ".dkm")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".dkm"))
   {
     return false;
   }

--- a/common/src/io/FgdParser.cpp
+++ b/common/src/io/FgdParser.cpp
@@ -36,6 +36,7 @@
 #include "kdl/vector_utils.h"
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <algorithm>
 #include <memory>
@@ -1069,23 +1070,20 @@ std::vector<EntityDefinitionClassInfo> FgdParser::handleInclude(
       m_tokenizer.restoreStateAndSource(snapshot);
     }};
 
-  status.debug(
-    m_tokenizer.location(), fmt::format("Parsing included file '{}'", path.string()));
+  status.debug(m_tokenizer.location(), fmt::format("Parsing included file '{}'", path));
 
   const auto filePath = currentRoot() / path;
   return m_fs->openFile(filePath) | kdl::transform([&](auto file) {
            status.debug(
              m_tokenizer.location(),
-             fmt::format("Resolved '{}' to '{}'", path.string(), filePath.string()));
+             fmt::format("Resolved '{}' to '{}'", path, filePath));
 
            if (isRecursiveInclude(filePath))
            {
              status.error(
                m_tokenizer.location(),
                fmt::format(
-                 "Skipping recursively included file: {} ({})",
-                 path.string(),
-                 filePath.string()));
+                 "Skipping recursively included file: {} ({})", path, filePath));
              return std::vector<EntityDefinitionClassInfo>{};
            }
 

--- a/common/src/io/File.cpp
+++ b/common/src/io/File.cpp
@@ -22,6 +22,7 @@
 #include "kdl/result.h"
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <cstdio>
 #include <cstring>
@@ -69,8 +70,7 @@ Result<kdl::resource<std::FILE*>> openPathAsFILE(
 
   if (!file)
   {
-    return Error{
-      fmt::format("Failed to open '{}': {}", path.string(), std::strerror(errno))};
+    return Error{fmt::format("Failed to open '{}': {}", path, std::strerror(errno))};
   }
 
   return kdl::resource{file, std::fclose};

--- a/common/src/io/ImageFileSystem.cpp
+++ b/common/src/io/ImageFileSystem.cpp
@@ -26,6 +26,9 @@
 #include "kdl/overload.h"
 #include "kdl/path_utils.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <cassert>
 #include <memory>
 
@@ -292,12 +295,12 @@ Result<std::shared_ptr<File>> ImageFileSystemBase::doOpenFile(
         kdl::overload(
           [&](const ImageDirectoryEntry&) {
             return Result<std::shared_ptr<File>>{
-              Error{"Cannot open directory entry at '" + path.string() + "'"}};
+              Error{fmt::format("Cannot open directory entry at {}", path)}};
           },
           [](const ImageFileEntry& fileEntry) { return fileEntry.getFile(); }),
         entry);
     },
-    Result<std::shared_ptr<File>>{Error{"'" + path.string() + "' not found"}});
+    Result<std::shared_ptr<File>>{Error{fmt::format("{} not found", path)}});
 }
 
 std::unordered_map<std::string, FileSystemMetadata> makeImageFileSystemMetadata(

--- a/common/src/io/ImageSpriteLoader.cpp
+++ b/common/src/io/ImageSpriteLoader.cpp
@@ -103,7 +103,7 @@ ImageSpriteLoader::ImageSpriteLoader(
 
 bool ImageSpriteLoader::canParse(const std::filesystem::path& path)
 {
-  return isSupportedFreeImageExtension(path.extension().string());
+  return isSupportedFreeImageExtension(path.extension());
 }
 
 Result<mdl::EntityModelData> ImageSpriteLoader::load(Logger& logger)

--- a/common/src/io/LoadEntityModel.cpp
+++ b/common/src/io/LoadEntityModel.cpp
@@ -37,6 +37,9 @@
 
 #include <kdl/result.h>
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 namespace tb::io
 {
 
@@ -120,7 +123,7 @@ Result<mdl::EntityModelData> loadEntityModelData(
                auto loader = io::AssimpLoader{path, fs};
                return loader.load(logger);
              }
-             return Error{"Unknown model format: '" + path.string() + "'"};
+             return Error{fmt::format("Unknown model format: {}", path)};
            })
          | kdl::or_else([&](const auto& e) {
              return Result<mdl::EntityModelData>{Error{

--- a/common/src/io/LoadMaterialCollections.cpp
+++ b/common/src/io/LoadMaterialCollections.cpp
@@ -51,6 +51,7 @@
 #include "kdl/vector_utils.h"
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <string>
 
@@ -149,7 +150,7 @@ Result<std::filesystem::path> findShaderTexture(
              {
                return candidates.front();
              }
-             return Error{fmt::format("File not found: {}", texturePath.string())};
+             return Error{fmt::format("File not found: {}", texturePath)};
            });
 }
 
@@ -330,8 +331,7 @@ mdl::ResourceLoader<mdl::Texture> makeTextureResourceLoader(
   return [&, path, name, paletteResult]() -> Result<mdl::Texture> {
     return loadTexture(path, name, extensions, fs, paletteResult)
            | kdl::or_else([&](auto e) -> Result<mdl::Texture> {
-               return Error{
-                 fmt::format("Could not load texture '{}': {}", path.string(), e.msg)};
+               return Error{fmt::format("Could not load texture '{}': {}", path, e.msg)};
              });
   };
 }

--- a/common/src/io/LoadMaterialCollections.cpp
+++ b/common/src/io/LoadMaterialCollections.cpp
@@ -248,13 +248,13 @@ Result<mdl::Material> loadShaderMaterial(
 Result<mdl::Texture> loadTexture(
   const std::filesystem::path& path,
   const std::string& name,
-  const std::vector<std::string>& extensions,
+  const std::vector<std::filesystem::path>& extensions,
   const FileSystem& fs,
   const std::optional<Result<mdl::Palette>>& paletteResult)
 {
   return findMaterialFile(fs, path, extensions)
     .and_then([&](const auto& actualPath) -> Result<mdl::Texture> {
-      const auto extension = kdl::str_to_lower(actualPath.extension().string());
+      const auto extension = kdl::path_to_lower(actualPath.extension());
       if (extension == ".d")
       {
         if (!paletteResult)
@@ -317,14 +317,14 @@ Result<mdl::Texture> loadTexture(
                });
       }
 
-      return Error{"Unknown texture file extension: " + extension};
+      return Error{fmt::format("Unknown texture file extension: {}", extension)};
     });
 }
 
 mdl::ResourceLoader<mdl::Texture> makeTextureResourceLoader(
   const std::filesystem::path& path,
   const std::string& name,
-  const std::vector<std::string>& extensions,
+  const std::vector<std::filesystem::path>& extensions,
   const FileSystem& fs,
   const std::optional<Result<mdl::Palette>>& paletteResult)
 {
@@ -374,7 +374,7 @@ std::string materialCollectionName(
       metadata && std::holds_alternative<std::filesystem::path>(*metadata))
   {
     if (const auto imageFileName = std::get<std::filesystem::path>(*metadata).filename();
-        kdl::ci::str_is_equal(imageFileName.extension().string(), ".wad"))
+        kdl::path_has_extension(kdl::path_to_lower(imageFileName), ".wad"))
     {
       // If the texture was loaded from a WAD file, use the WAD file name as the
       // collection name.

--- a/common/src/io/MaterialUtils.cpp
+++ b/common/src/io/MaterialUtils.cpp
@@ -44,7 +44,7 @@ std::string getMaterialNameFromPathSuffix(
 Result<std::filesystem::path> findMaterialFile(
   const FileSystem& fs,
   const std::filesystem::path& materialPath,
-  const std::vector<std::string>& extensions)
+  const std::vector<std::filesystem::path>& extensions)
 {
   if (fs.pathInfo(materialPath) == PathInfo::File)
   {

--- a/common/src/io/MaterialUtils.h
+++ b/common/src/io/MaterialUtils.h
@@ -53,7 +53,7 @@ std::string getMaterialNameFromPathSuffix(
 Result<std::filesystem::path> findMaterialFile(
   const FileSystem& fs,
   const std::filesystem::path& materialPath,
-  const std::vector<std::string>& extensions);
+  const std::vector<std::filesystem::path>& extensions);
 
 bool checkTextureDimensions(size_t width, size_t height);
 

--- a/common/src/io/Md2Loader.cpp
+++ b/common/src/io/Md2Loader.cpp
@@ -422,7 +422,7 @@ Md2Loader::Md2Loader(
 
 bool Md2Loader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::path_to_lower(path.extension()) != ".md2")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".md2"))
   {
     return false;
   }

--- a/common/src/io/Md3Loader.cpp
+++ b/common/src/io/Md3Loader.cpp
@@ -27,6 +27,7 @@
 #include "render/IndexRangeMapBuilder.h" // IWYU pragma: keep
 #include "render/PrimType.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/range_to_vector.h"
 #include "kdl/result.h"
 #include "kdl/result_fold.h" // IWYU pragma: keep
@@ -309,7 +310,7 @@ Md3Loader::Md3Loader(
 
 bool Md3Loader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::str_to_lower(path.extension().string()) != ".md3")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".md3"))
   {
     return false;
   }

--- a/common/src/io/MdlLoader.cpp
+++ b/common/src/io/MdlLoader.cpp
@@ -30,6 +30,7 @@
 #include "render/IndexRangeMapBuilder.h"
 #include "render/PrimType.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/string_format.h"
 
 #include <fmt/format.h>
@@ -505,7 +506,7 @@ MdlLoader::MdlLoader(std::string name, const Reader& reader, const mdl::Palette&
 
 bool MdlLoader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::str_to_lower(path.extension().string()) != ".mdl")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".mdl"))
   {
     return false;
   }

--- a/common/src/io/MdxLoader.cpp
+++ b/common/src/io/MdxLoader.cpp
@@ -413,7 +413,7 @@ MdxLoader::MdxLoader(std::string name, const Reader& reader, const FileSystem& f
 
 bool MdxLoader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::path_to_lower(path.extension()) != ".mdx")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".mdx"))
   {
     return false;
   }

--- a/common/src/io/PathMatcher.cpp
+++ b/common/src/io/PathMatcher.cpp
@@ -19,18 +19,20 @@
 
 #include "PathMatcher.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/string_compare.h"
 #include "kdl/vector_utils.h"
 
 namespace tb::io
 {
 
-PathMatcher makeExtensionPathMatcher(std::vector<std::string> extensions_)
+PathMatcher makeExtensionPathMatcher(std::vector<std::filesystem::path> extensions_)
 {
   return [extensions = std::move(extensions_)](
            const std::filesystem::path& path, const GetPathInfo&) {
     return std::any_of(extensions.begin(), extensions.end(), [&](const auto& extension) {
-      return kdl::ci::str_is_equal(path.extension().string(), extension);
+      return kdl::path_has_extension(
+        kdl::path_to_lower(path), kdl::path_to_lower(extension));
     });
   };
 }

--- a/common/src/io/PathMatcher.h
+++ b/common/src/io/PathMatcher.h
@@ -32,7 +32,7 @@ enum class PathInfo;
 using GetPathInfo = std::function<PathInfo(const std::filesystem::path&)>;
 using PathMatcher = std::function<bool(const std::filesystem::path&, const GetPathInfo&)>;
 
-PathMatcher makeExtensionPathMatcher(std::vector<std::string> extensions);
+PathMatcher makeExtensionPathMatcher(std::vector<std::filesystem::path> extensions);
 PathMatcher makeFilenamePathMatcher(std::string filename);
 PathMatcher makePathInfoPathMatcher(std::vector<PathInfo> pathInfos);
 

--- a/common/src/io/PathQt.cpp
+++ b/common/src/io/PathQt.cpp
@@ -19,24 +19,43 @@
 
 #include "PathQt.h"
 
-#include <QFile>
+#include <QFileInfo>
+
+#include "kdl/path_utils.h"
 
 namespace tb::io
 {
 
-QString pathAsQString(const std::filesystem::path& path)
+QString pathAsQPath(const std::filesystem::path& path)
 {
   return QFile{path}.fileName();
+}
+
+QString pathAsQString(const std::filesystem::path& path)
+{
+#ifdef _WIN32
+  return QString::fromStdWString(path.wstring());
+#else
+  return QString::fromStdString(path.string());
+#endif
 }
 
 QString pathAsGenericQString(const std::filesystem::path& path)
 {
-  return QFile{path}.fileName();
+#ifdef _WIN32
+  return QString::fromStdWString(path.generic_wstring());
+#else
+  return QString::fromStdString(path.generic_string());
+#endif
 }
 
 std::filesystem::path pathFromQString(const QString& path)
 {
-  return QFile{path}.filesystemFileName();
+#ifdef _WIN32
+  return std::filesystem::path{kdl::parse_path(path.toStdWString())};
+#else
+  return std::filesystem::path{kdl::parse_path(path.toStdString())};
+#endif
 }
 
 } // namespace tb::io

--- a/common/src/io/PathQt.h
+++ b/common/src/io/PathQt.h
@@ -26,9 +26,26 @@
 namespace tb::io
 {
 
+/**
+ * Returns a QString representation of the given path that is usable with Qt's own file
+ * handling classes. These paths use forward slashes as separators on all platforms.
+ */
+QString pathAsQPath(const std::filesystem::path& path);
+
+/**
+ * Returns a platform-specific Qt string representation of the given path.
+ */
 QString pathAsQString(const std::filesystem::path& path);
+
+/**
+ * Returns a generic Qt string representation of the given path using the generic path
+ * separators as per the std::filesystem::path::generic_string function.
+ */
 QString pathAsGenericQString(const std::filesystem::path& path);
 
+/**
+ * Returns a std::filesystem::path representation of the given QString path.
+ */
 std::filesystem::path pathFromQString(const QString& path);
 
 } // namespace tb::io

--- a/common/src/io/ReadFreeImageTexture.cpp
+++ b/common/src/io/ReadFreeImageTexture.cpp
@@ -27,6 +27,7 @@
 #include "mdl/Texture.h"
 #include "mdl/TextureBuffer.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/resource.h"
 #include "kdl/string_utils.h"
 #include "kdl/vector_utils.h"
@@ -222,12 +223,12 @@ std::vector<std::string> getSupportedFreeImageExtensions()
 }
 } // namespace
 
-bool isSupportedFreeImageExtension(const std::string_view extension)
+bool isSupportedFreeImageExtension(const std::filesystem::path& extension)
 {
   InitFreeImage::initialize();
 
   static const auto extensions = getSupportedFreeImageExtensions();
-  return kdl::vec_contains(extensions, kdl::str_to_lower(extension));
+  return kdl::vec_contains(extensions, kdl::path_to_lower(extension));
 }
 
 } // namespace tb::io

--- a/common/src/io/ReadFreeImageTexture.h
+++ b/common/src/io/ReadFreeImageTexture.h
@@ -23,7 +23,7 @@
 #include "Result.h"
 #include "render/GL.h"
 
-#include <string_view>
+#include <filesystem>
 
 namespace tb::mdl
 {
@@ -42,6 +42,6 @@ Result<mdl::Texture> readFreeImageTextureFromMemory(const uint8_t* begin, size_t
 
 Result<mdl::Texture> readFreeImageTexture(Reader& reader);
 
-bool isSupportedFreeImageExtension(std::string_view extension);
+bool isSupportedFreeImageExtension(const std::filesystem::path& extension);
 
 } // namespace tb::io

--- a/common/src/io/ResourceUtils.cpp
+++ b/common/src/io/ResourceUtils.cpp
@@ -86,7 +86,7 @@ static QString imagePathToString(const std::filesystem::path& imagePath)
   const auto fullPath = imagePath.is_absolute()
                           ? imagePath
                           : SystemPaths::findResourceFile("images" / imagePath);
-  return pathAsQString(fullPath);
+  return pathAsQPath(fullPath);
 }
 
 QPixmap loadPixmapResource(const std::filesystem::path& imagePath)

--- a/common/src/io/SkinLoader.cpp
+++ b/common/src/io/SkinLoader.cpp
@@ -29,6 +29,7 @@
 #include "mdl/Material.h"
 #include "mdl/Palette.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/string_format.h"
 
 namespace tb::io
@@ -48,7 +49,7 @@ mdl::Material loadSkin(
 {
   return fs.openFile(path)
          | kdl::and_then([&](auto file) -> Result<mdl::Material, ReadMaterialError> {
-             const auto extension = kdl::str_to_lower(path.extension().string());
+             const auto extension = kdl::path_to_lower(path.extension());
              auto reader = file->reader().buffer();
              return (extension == ".wal" ? readWalTexture(reader, palette)
                                          : readFreeImageTexture(reader))

--- a/common/src/io/SprLoader.cpp
+++ b/common/src/io/SprLoader.cpp
@@ -236,7 +236,7 @@ SprLoader::SprLoader(std::string name, const Reader& reader, const mdl::Palette&
 
 bool SprLoader::canParse(const std::filesystem::path& path, Reader reader)
 {
-  if (kdl::path_to_lower(path.extension()) != ".spr")
+  if (!kdl::path_has_extension(kdl::path_to_lower(path), ".spr"))
   {
     return false;
   }

--- a/common/src/io/SystemPaths.cpp
+++ b/common/src/io/SystemPaths.cpp
@@ -29,7 +29,6 @@
 #include "io/PathInfo.h"
 #include "io/PathQt.h"
 
-#include <optional>
 #include <vector>
 
 namespace tb::io::SystemPaths
@@ -95,7 +94,7 @@ std::filesystem::path findResourceFile(const std::filesystem::path& file)
 
   return io::pathFromQString(QStandardPaths::locate(
     QStandardPaths::AppDataLocation,
-    io::pathAsQString(file),
+    io::pathAsQPath(file),
     QStandardPaths::LocateOption::LocateFile));
 }
 
@@ -113,7 +112,7 @@ std::vector<std::filesystem::path> findResourceDirectories(
 
   const auto dirs = QStandardPaths::locateAll(
     QStandardPaths::AppDataLocation,
-    io::pathAsQString(directory),
+    io::pathAsQPath(directory),
     QStandardPaths::LocateOption::LocateDirectory);
 
   for (const auto& dir : dirs)

--- a/common/src/io/ZipFileSystem.cpp
+++ b/common/src/io/ZipFileSystem.cpp
@@ -23,6 +23,9 @@
 
 #include "kdl/result.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <memory>
 #include <string>
 
@@ -81,7 +84,7 @@ Result<void> ZipFileSystem::doReadDirectory()
         auto stat = mz_zip_archive_file_stat{};
         if (!mz_zip_reader_file_stat(&m_archive, i, &stat))
         {
-          return Error{"mz_zip_reader_file_stat failed for " + path.string()};
+          return Error{fmt::format("mz_zip_reader_file_stat failed for {}", path)};
         }
 
         const auto uncompressedSize = static_cast<size_t>(stat.m_uncomp_size);
@@ -90,7 +93,7 @@ Result<void> ZipFileSystem::doReadDirectory()
 
         if (!mz_zip_reader_extract_to_mem(&m_archive, i, begin, uncompressedSize, 0))
         {
-          return Error{"mz_zip_reader_extract_to_mem failed for " + path.string()};
+          return Error{fmt::format("mz_zip_reader_extract_to_mem failed for {}", path)};
         }
 
         return std::static_pointer_cast<File>(

--- a/common/src/mdl/EntityDefinitionFileSpec.cpp
+++ b/common/src/mdl/EntityDefinitionFileSpec.cpp
@@ -21,6 +21,9 @@
 
 #include "kdl/string_compare.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <cassert>
 #include <string>
 
@@ -113,9 +116,9 @@ const std::filesystem::path& EntityDefinitionFileSpec::path() const
 
 std::string EntityDefinitionFileSpec::asString() const
 {
-  return !valid()    ? ""
-         : builtin() ? "builtin:" + m_path.string()
-                     : "external:" + m_path.string();
+  return !valid()    ? std::string{}
+         : builtin() ? fmt::format("builtin:{}", m_path)
+                     : fmt::format("external:{}", m_path);
 }
 
 EntityDefinitionFileSpec::EntityDefinitionFileSpec(

--- a/common/src/mdl/GameConfig.h
+++ b/common/src/mdl/GameConfig.h
@@ -48,7 +48,7 @@ struct MapFormatConfig
 
 struct PackageFormatConfig
 {
-  std::vector<std::string> extensions;
+  std::vector<std::filesystem::path> extensions;
   std::string format;
 
   kdl_reflect_decl(PackageFormatConfig, extensions, format);
@@ -65,7 +65,7 @@ struct FileSystemConfig
 struct MaterialConfig
 {
   std::filesystem::path root;
-  std::vector<std::string> extensions;
+  std::vector<std::filesystem::path> extensions;
   std::filesystem::path palette;
   std::optional<std::string> property;
   std::filesystem::path shaderSearchPath;

--- a/common/src/mdl/GameFactory.cpp
+++ b/common/src/mdl/GameFactory.cpp
@@ -39,6 +39,9 @@
 #include "kdl/result.h"
 #include "kdl/vector_utils.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <iostream>
 #include <memory>
 #include <string>
@@ -262,9 +265,10 @@ Result<std::vector<std::string>> GameFactory::loadGameConfigs(
              kdl::vec_transform(configFiles, [&](const auto& configFilePath) {
                return loadGameConfig(gamePathConfig, configFilePath)
                       | kdl::transform_error([&](auto e) {
-                          errors.push_back(
-                            "Failed to load game configuration file '"
-                            + configFilePath.string() + "': " + e.msg);
+                          errors.push_back(fmt::format(
+                            "Failed to load game configuration file {}: {}",
+                            configFilePath,
+                            e.msg));
                         });
              });
              return errors;

--- a/common/src/mdl/GameImpl.cpp
+++ b/common/src/mdl/GameImpl.cpp
@@ -42,10 +42,14 @@
 #include "mdl/GameConfig.h"
 #include "mdl/MaterialManager.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/result.h"
 #include "kdl/string_compare.h"
 #include "kdl/string_utils.h"
 #include "kdl/vector_utils.h"
+
+#include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <string>
 #include <vector>
@@ -62,12 +66,12 @@ GameImpl::GameImpl(GameConfig& config, std::filesystem::path gamePath, Logger& l
 Result<std::vector<std::unique_ptr<EntityDefinition>>> GameImpl::loadEntityDefinitions(
   io::ParserStatus& status, const std::filesystem::path& path) const
 {
-  const auto extension = path.extension().string();
+  const auto extension = kdl::path_to_lower(path.extension());
   const auto& defaultColor = m_config.entityConfig.defaultColor;
 
   try
   {
-    if (kdl::ci::str_is_equal(".fgd", extension))
+    if (extension == ".fgd")
     {
       return io::Disk::openFile(path) | kdl::transform([&](auto file) {
                auto reader = file->reader().buffer();
@@ -75,7 +79,7 @@ Result<std::vector<std::unique_ptr<EntityDefinition>>> GameImpl::loadEntityDefin
                return parser.parseDefinitions(status);
              });
     }
-    if (kdl::ci::str_is_equal(".def", extension))
+    if (extension == ".def")
     {
       return io::Disk::openFile(path) | kdl::transform([&](auto file) {
                auto reader = file->reader().buffer();
@@ -83,7 +87,7 @@ Result<std::vector<std::unique_ptr<EntityDefinition>>> GameImpl::loadEntityDefin
                return parser.parseDefinitions(status);
              });
     }
-    if (kdl::ci::str_is_equal(".ent", extension))
+    if (extension == ".ent")
     {
       return io::Disk::openFile(path) | kdl::transform([&](auto file) {
                auto reader = file->reader().buffer();
@@ -92,7 +96,7 @@ Result<std::vector<std::unique_ptr<EntityDefinition>>> GameImpl::loadEntityDefin
              });
     }
 
-    return Error{"Unknown entity definition format: '" + path.string() + "'"};
+    return Error{fmt::format("Unknown entity definition format: {}", path)};
   }
   catch (const ParserException& e)
   {
@@ -143,7 +147,7 @@ Game::PathErrors GameImpl::checkAdditionalSearchPaths(
     const auto absPath = m_gamePath / searchPath;
     if (!absPath.is_absolute() || io::Disk::pathInfo(absPath) != io::PathInfo::Directory)
     {
-      result.emplace(searchPath, "Directory not found: '" + searchPath.string() + "'");
+      result.emplace(searchPath, fmt::format("Directory not found: {}", searchPath));
     }
   }
   return result;
@@ -181,7 +185,7 @@ bool GameImpl::isEntityDefinitionFile(const std::filesystem::path& path) const
   static const auto extensions = {".fgd", ".def", ".ent"};
 
   return std::any_of(extensions.begin(), extensions.end(), [&](const auto& extension) {
-    return kdl::ci::str_is_equal(extension, path.extension().string());
+    return kdl::path_has_extension(kdl::path_to_lower(path), extension);
   });
 }
 

--- a/common/src/mdl/MissingModValidator.cpp
+++ b/common/src/mdl/MissingModValidator.cpp
@@ -31,6 +31,9 @@
 #include "kdl/memory_utils.h"
 #include "kdl/vector_utils.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <cassert>
 #include <filesystem>
 #include <memory>
@@ -124,7 +127,7 @@ void MissingModValidator::doValidate(
   {
     const auto mod = searchPath.string();
     issues.push_back(std::make_unique<MissingModIssue>(
-      entityNode, mod, "Mod '" + mod + "' could not be used: " + message));
+      entityNode, mod, fmt::format("Mod '{}' could not be used: {}", mod, message)));
   }
 
   m_lastMods = std::move(mods);

--- a/common/src/mdl/Palette.cpp
+++ b/common/src/mdl/Palette.cpp
@@ -30,6 +30,9 @@
 #include "kdl/reflection_impl.h"
 #include "kdl/string_format.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <cstring>
 #include <ostream>
 #include <string>
@@ -231,11 +234,11 @@ Result<Palette> loadPalette(const io::File& file, const std::filesystem::path& p
     }
 
     return Error{
-      "Could not load palette file '" + path.string() + "': Unknown palette format"};
+      fmt::format("Could not load palette file {}: Unknown palette format", path)};
   }
   catch (const Exception& e)
   {
-    return Error{"Could not load palette file '" + path.string() + "': " + e.what()};
+    return Error{fmt::format("Could not load palette file {}: {}", path, e.what())};
   }
 }
 

--- a/common/src/mdl/Palette.cpp
+++ b/common/src/mdl/Palette.cpp
@@ -27,6 +27,7 @@
 #include "io/Reader.h"
 #include "mdl/TextureBuffer.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/reflection_impl.h"
 #include "kdl/string_format.h"
 
@@ -216,7 +217,7 @@ Result<Palette> loadPalette(const io::File& file, const std::filesystem::path& p
 {
   try
   {
-    const auto extension = kdl::str_to_lower(path.extension().string());
+    const auto extension = kdl::path_to_lower(path.extension());
     if (extension == ".lmp")
     {
       auto reader = file.reader().buffer();

--- a/common/src/ui/Autosaver.cpp
+++ b/common/src/ui/Autosaver.cpp
@@ -123,7 +123,7 @@ io::PathMatcher makeBackupPathMatcher(std::filesystem::path mapBasename_)
       const auto backupNum = backupExtension.empty() ? "" : backupExtension.substr(1);
 
       return getPathInfo(path) == io::PathInfo::File
-             && kdl::ci::str_is_equal(path.extension().string(), ".map")
+             && kdl::path_to_lower(path.extension()) == ".map"
              && backupBasename == mapBasename && kdl::str_is_numeric(backupNum)
              && kdl::str_to_size(backupNum).value_or(0u) > 0u;
     };

--- a/common/src/ui/ColorModel.cpp
+++ b/common/src/ui/ColorModel.cpp
@@ -24,10 +24,12 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "QtUtils.h"
+#include "io/PathQt.h"
 
 #include "kdl/path_utils.h"
 
 #include <filesystem>
+
 
 namespace tb::ui
 {
@@ -109,10 +111,9 @@ QVariant ColorModel::data(const QModelIndex& index, const int role) const
     case 0:
       return {}; // Leave first cell empty
     case 1:
-      return QString::fromStdString(kdl::path_front(colorPreference->path()).string());
+      return io::pathAsQString(kdl::path_front(colorPreference->path()));
     case 2:
-      return QString::fromStdString(
-        kdl::path_pop_front(colorPreference->path()).generic_string());
+      return io::pathAsGenericQString(kdl::path_pop_front(colorPreference->path()));
       switchDefault();
     }
   }

--- a/common/src/ui/CompilationRunner.cpp
+++ b/common/src/ui/CompilationRunner.cpp
@@ -164,7 +164,7 @@ void CompilationCopyFilesTaskRunner::doExecute()
                | kdl::and_then([&](const auto& pathsToCopy) {
                    const auto pathStrsToCopy = kdl::vec_transform(
                      pathsToCopy,
-                     [](const auto& path) { return "'" + path.string() + "'"; });
+                     [](const auto& path) { return fmt::format("{}", path); });
 
                    m_context << "#### Copying to '" << io::pathAsQString(targetPath)
                              << "/': "
@@ -256,8 +256,7 @@ void CompilationDeleteFilesTaskRunner::doExecute()
     return io::Disk::find(targetDirPath, io::TraversalMode::Recursive, targetPathMatcher)
            | kdl::transform([&](const auto& pathsToDelete) {
                const auto pathStrsToDelete = kdl::vec_transform(
-                 pathsToDelete,
-                 [](const auto& path) { return "'" + path.string() + "'"; });
+                 pathsToDelete, [](const auto& path) { return fmt::format("{}", path); });
                m_context << "#### Deleting: "
                          << QString::fromStdString(kdl::str_join(pathStrsToDelete, ", "))
                          << "\n";

--- a/common/src/ui/GamesPreferencePane.cpp
+++ b/common/src/ui/GamesPreferencePane.cpp
@@ -106,7 +106,7 @@ void GamesPreferencePane::showUserConfigDirClicked()
   auto path = gameFactory.userGameConfigsPath().lexically_normal();
 
   io::Disk::createDirectory(path) | kdl::transform([&](auto) {
-    const auto url = QUrl::fromLocalFile(io::pathAsQString(path));
+    const auto url = QUrl::fromLocalFile(io::pathAsQPath(path));
     QDesktopServices::openUrl(url);
   }) | kdl::transform_error([&](auto e) {
     if (m_document)

--- a/common/src/ui/MapDocument.cpp
+++ b/common/src/ui/MapDocument.cpp
@@ -132,6 +132,9 @@
 #include "vm/vec.h"
 #include "vm/vec_io.h"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -141,6 +144,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
+
 
 namespace tb::ui
 {
@@ -722,7 +726,7 @@ Result<void> MapDocument::loadDocument(
   std::shared_ptr<mdl::Game> game,
   const std::filesystem::path& path)
 {
-  info("Loading document from " + path.string());
+  info(fmt::format("Loading document from {}", path));
 
   clearDocument();
 
@@ -4661,7 +4665,7 @@ void MapDocument::loadEntityDefinitions()
 
   m_entityDefinitionManager->loadDefinitions(path, *m_game, status)
     | kdl::transform([&]() {
-        info("Loaded entity definition file " + path.filename().string());
+        info(fmt::format("Loaded entity definition file {}", path.filename()));
         createEntityDefinitionActions();
       })
     | kdl::transform_error([&](auto e) {

--- a/common/src/ui/MapFrame.cpp
+++ b/common/src/ui/MapFrame.cpp
@@ -237,7 +237,7 @@ void MapFrame::updateTitle()
   setWindowModified(m_document->modified());
   setWindowTitle(
     QString::fromStdString(m_document->filename()) + QString("[*] - TrenchBroom"));
-  setWindowFilePath(io::pathAsQString(m_document->path()));
+  setWindowFilePath(io::pathAsQPath(m_document->path()));
 }
 
 void MapFrame::updateTitleDelayed()
@@ -966,7 +966,7 @@ bool MapFrame::saveDocumentAs()
     const auto fileName = originalPath.filename();
 
     const auto newFileName = QFileDialog::getSaveFileName(
-      this, tr("Save map file"), io::pathAsQString(originalPath), "Map files (*.map)");
+      this, tr("Save map file"), io::pathAsQPath(originalPath), "Map files (*.map)");
     if (newFileName.isEmpty())
     {
       return false;
@@ -1026,7 +1026,7 @@ bool MapFrame::exportDocumentAsMap()
   const auto& originalPath = m_document->path();
 
   const auto newFileName = QFileDialog::getSaveFileName(
-    this, tr("Export Map file"), io::pathAsQString(originalPath), "Map files (*.map)");
+    this, tr("Export Map file"), io::pathAsQPath(originalPath), "Map files (*.map)");
   if (newFileName.isEmpty())
   {
     return false;
@@ -1118,7 +1118,7 @@ bool MapFrame::confirmRevertDocument()
 void MapFrame::loadPointFile()
 {
   const auto defaultDir = !m_document->path().empty()
-                            ? io::pathAsQString(m_document->path().parent_path())
+                            ? io::pathAsQPath(m_document->path().parent_path())
                             : QString{};
 
   const auto fileName = QFileDialog::getOpenFileName(
@@ -1162,7 +1162,7 @@ bool MapFrame::canReloadPointFile() const
 void MapFrame::loadPortalFile()
 {
   const auto defaultDir = !m_document->path().empty()
-                            ? io::pathAsQString(m_document->path().parent_path())
+                            ? io::pathAsQPath(m_document->path().parent_path())
                             : QString{};
 
   const auto fileName = QFileDialog::getOpenFileName(

--- a/common/src/ui/MapFrame.cpp
+++ b/common/src/ui/MapFrame.cpp
@@ -101,6 +101,7 @@
 #include "vm/vec_io.h"
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <cassert>
 #include <chrono>
@@ -951,7 +952,8 @@ bool MapFrame::saveDocument()
     QMessageBox::critical(
       this,
       "",
-      QString::fromStdString("Unknown error while saving " + m_document->path().string()),
+      QString::fromStdString(
+        fmt::format("Unknown error while saving {}", m_document->path())),
       QMessageBox::Ok);
     return false;
   }

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/io/tst_NodeReader.cpp"
         "${COMMON_TEST_SOURCE_DIR}/io/tst_NodeWriter.cpp"
         "${COMMON_TEST_SOURCE_DIR}/io/tst_ObjSerializer.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/io/tst_PathQt.cpp"
         "${COMMON_TEST_SOURCE_DIR}/io/tst_Quake3ShaderParser.cpp"
         "${COMMON_TEST_SOURCE_DIR}/io/tst_ReadDdsTexture.cpp"
         "${COMMON_TEST_SOURCE_DIR}/io/tst_Reader.cpp"

--- a/common/test/src/io/tst_AseLoader.cpp
+++ b/common/test/src/io/tst_AseLoader.cpp
@@ -96,7 +96,7 @@ TEST_CASE("AseLoaderTest")
           const auto* skin = surface.skin(i);
           CHECK(
             skin->relativePath()
-            == kdl::parse_path(skin->relativePath().string(), K(replace_backslashes)));
+            == kdl::parse_path(skin->relativePath().string(), K(convert_separators)));
         }
       }
     }

--- a/common/test/src/io/tst_MaterialUtils.cpp
+++ b/common/test/src/io/tst_MaterialUtils.cpp
@@ -62,7 +62,7 @@ TEST_CASE("findMaterialFile")
   env.createFile("textures/test.jpg", "");
   env.createFile("textures/other.txt", "");
 
-  const auto extensions = std::vector<std::string>{".png", ".jpg"};
+  const auto extensions = std::vector<std::filesystem::path>{".png", ".jpg"};
 
   auto diskFS = DiskFileSystem{env.dir()};
   CHECK(

--- a/common/test/src/io/tst_PathQt.cpp
+++ b/common/test/src/io/tst_PathQt.cpp
@@ -1,0 +1,167 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QString>
+
+#include "QtPrettyPrinters.h" // IWYU pragma: keep
+#include "io/PathQt.h"
+
+#include <fmt/format.h>
+#include <fmt/std.h>
+
+#include <filesystem>
+#include <string>
+
+#include "Catch2.h"
+
+
+namespace tb::io
+{
+
+TEST_CASE("pathAsQPath")
+{
+  using T = std::tuple<std::filesystem::path, QString>;
+
+  // clang-format off
+  #ifdef _WIN32
+  const auto 
+  [fsPath,                             qPath] = GENERATE(values<T>({
+  {LR"()",                              R"()"},
+  {LR"(file.txt)",                      R"(file.txt)"},
+  {LR"(home\user\file.txt)",            R"(home/user/file.txt)"},
+  {LR"(C:\Users\user\file.txt)",        R"(C:/Users/user/file.txt)"},
+  {LR"(C:\Users\Кристиян\ぁ\file.txt)", R"(C:/Users/Кристиян/ぁ/file.txt)"},
+  }));
+  #else
+  const auto 
+  [fsPath,                             qPath] = GENERATE(values<T>({
+  {R"()",                              R"()"},
+  {R"(file.txt)",                      R"(file.txt)"},
+  {R"(/home/user/file.txt)",           R"(/home/user/file.txt)"},
+  {R"(/home/Кристиян/ぁ/file.txt)",    R"(/home/Кристиян/ぁ/file.txt)"},
+  }));
+  #endif
+  // clang-format on
+
+  CAPTURE(fmt::format("{}", fsPath));
+
+  CHECK(pathAsQPath(fsPath) == qPath);
+}
+
+TEST_CASE("pathAsQString")
+{
+  using T = std::tuple<std::filesystem::path, std::string>;
+
+  // clang-format off
+  #ifdef _WIN32
+  const auto 
+  [fsPath,                             qPath] = GENERATE(values<T>({
+  {LR"()",                              R"()"},
+  {LR"(file.txt)",                      R"(file.txt)"},
+  {LR"(home\user\file.txt)",            R"(home\user\file.txt)"},
+  {LR"(C:\Users\user\file.txt)",        R"(C:\Users\user\file.txt)"},
+  {LR"(C:\Users\Кристиян\ぁ\file.txt)", R"(C:\Users\Кристиян\ぁ\file.txt)"},
+  }));
+  #else
+  const auto 
+  [fsPath,                             qPath] = GENERATE(values<T>({
+  {R"()",                              R"()"},
+  {R"(file.txt)",                      R"(file.txt)"},
+  {R"(/home/user/file.txt)",           R"(/home/user/file.txt)"},
+  {R"(/home/Кристиян/ぁ/file.txt)",    R"(/home/Кристиян/ぁ/file.txt)"},
+  }));
+  #endif
+  // clang-format on
+
+  CAPTURE(fmt::format("{}", fsPath));
+
+  CHECK(pathAsQString(fsPath) == QString::fromStdString(qPath));
+}
+
+TEST_CASE("pathAsGenericQString")
+{
+  using T = std::tuple<std::filesystem::path, QString>;
+
+  // clang-format off
+  #ifdef _WIN32
+  const auto 
+  [fsPath,                             qPath] = GENERATE(values<T>({
+  {LR"()",                              R"()"},
+  {LR"(file.txt)",                      R"(file.txt)"},
+  {LR"(home\user\file.txt)",           R"(home/user/file.txt)"},
+  {LR"(C:\Users\user\file.txt)",        R"(C:/Users/user/file.txt)"},
+  {LR"(C:\Users\Кристиян\ぁ\file.txt)", R"(C:/Users/Кристиян/ぁ/file.txt)"},
+  }));
+  #else
+  const auto 
+  [fsPath,                             qPath] = GENERATE(values<T>({
+  {R"()",                              R"()"},
+  {R"(file.txt)",                      R"(file.txt)"},
+  {R"(/home/user/file.txt)",           R"(/home/user/file.txt)"},
+  {R"(/home/Кристиян/ぁ/file.txt)",    R"(/home/Кристиян/ぁ/file.txt)"},
+  }));
+  #endif
+  // clang-format on
+
+  CAPTURE(fmt::format("{}", fsPath));
+
+  CHECK(pathAsGenericQString(fsPath) == qPath);
+}
+
+TEST_CASE("pathFromQString")
+{
+  using T = std::tuple<QString, std::filesystem::path>;
+
+  // clang-format off
+  #ifdef _WIN32
+  const auto 
+  [qPath,                              fsPath] = GENERATE(values<T>({
+  {R"()",                              LR"()"},
+  {R"(file.txt)",                      LR"(file.txt)"},
+  {R"(home\user\file.txt)",            LR"(home\user\file.txt)"},
+  {R"(C:\Users\user\file.txt)",        LR"(C:\Users\user\file.txt)"},
+  {R"(C:\Users\Кристиян\ぁ\file.txt)", LR"(C:\Users\Кристиян\ぁ\file.txt)"},
+  {R"(C:/Users/user/file.txt)",        LR"(C:\Users\user\file.txt)"},
+  {R"(C:/Users/Кристиян/ぁ/file.txt)", LR"(C:\Users\Кристиян\ぁ\file.txt)"},
+  }));
+  #else 
+  const auto 
+  [qPath,                              fsPath] = GENERATE(values<T>({
+  {R"()",                              R"()"},
+  {R"(file.txt)",                      R"(file.txt)"},
+  {R"(C:\Users\user\file.txt)",        R"(C:/Users/user/file.txt)"},
+  {R"(/home/user/file.txt)",           R"(/home/user/file.txt)"},
+  {R"(/home/Кристиян/ぁ/file.txt)",    R"(/home/Кристиян/ぁ/file.txt)"},
+  }));
+  #endif
+  // clang-format on
+
+  CAPTURE(qPath);
+
+  // We cannot just use a CHECK macro here because it triggers Catch2's builtin string
+  // conversion for std::filesystem::path, which throws on windows if the path contains
+  // wide characters. Instead, we use fmt::format, which handles everything correctly.
+  if (pathFromQString(qPath) != fsPath)
+  {
+    CAPTURE(fmt::format("{}", pathFromQString(qPath)), fmt::format("{}", fsPath));
+    FAIL();
+  }
+}
+
+} // namespace tb::io

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -23,6 +23,8 @@
 
 #include "PreferenceManager.h"
 
+#include <kdl/path_utils.h>
+
 #include "vm/approx.h"
 
 #include <filesystem>
@@ -31,6 +33,7 @@
 #include <string>
 
 #include "Catch2.h"
+
 
 inline std::ostream& operator<<(std::ostream& lhs, const QJsonValue& rhs)
 {

--- a/common/test/src/tst_Preferences.cpp
+++ b/common/test/src/tst_Preferences.cpp
@@ -17,17 +17,11 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QKeySequence>
 #include <QString>
 #include <QTextStream>
 
-#include "Color.h"
 #include "PreferenceManager.h"
-#include "mdl/EntityDefinition.h"
-#include "mdl/Tag.h"
-#include "mdl/TagMatcher.h"
-#include "ui/Actions.h"
-
-#include "kdl/vector_utils.h"
 
 #include "vm/approx.h"
 
@@ -181,45 +175,11 @@ void testPrefs(const std::map<std::filesystem::path, QJsonValue>& prefs)
   CHECK(getValue(prefs, "RecentDocuments/0") == QJsonValue{QJsonValue::Undefined});
 }
 
-} // namespace
-
-TEST_CASE("PreferencesTest.read")
-{
-  CHECK(parsePreferencesFromJson(QByteArray())
-          .is_error_type<PreferenceErrors::JsonParseError>());
-  CHECK(parsePreferencesFromJson(QByteArray("abc"))
-          .is_error_type<PreferenceErrors::JsonParseError>());
-  CHECK(parsePreferencesFromJson(QByteArray(R"({"foo": "bar",})"))
-          .is_error_type<PreferenceErrors::JsonParseError>());
-
-  // Valid JSON
-  CHECK(parsePreferencesFromJson(QByteArray(R"({"foo": "bar"})")).is_success());
-  CHECK(parsePreferencesFromJson(QByteArray("{}")).is_success());
-
-  readPreferencesFromFile("fixture/test/preferences-v2.json")
-    | kdl::transform(
-      [](const std::map<std::filesystem::path, QJsonValue>& prefs) { testPrefs(prefs); })
-    | kdl::transform_error([](const auto&) { FAIL_CHECK(); });
-}
-
-TEST_CASE("PreferencesTest.testWriteRead")
-{
-  const auto fromFile =
-    readPreferencesFromFile("fixture/test/preferences-v2.json") | kdl::value();
-
-  const QByteArray serialized = writePreferencesToJson(fromFile);
-  parsePreferencesFromJson(serialized)
-    | kdl::transform([&](const std::map<std::filesystem::path, QJsonValue>& prefs) {
-        CHECK(fromFile == prefs);
-      })
-    | kdl::transform_error([](const auto&) { FAIL_CHECK(); });
-}
-
 /**
  * Helper template so we don't need to use out parameters in the tests
  */
 template <class Serializer, class PrimitiveType>
-static std::optional<PrimitiveType> maybeDeserialize(const QJsonValue& string)
+std::optional<PrimitiveType> maybeDeserialize(const QJsonValue& string)
 {
   const auto serializer = Serializer{};
   auto result = PrimitiveType{};
@@ -227,14 +187,14 @@ static std::optional<PrimitiveType> maybeDeserialize(const QJsonValue& string)
 }
 
 template <class Serializer, class PrimitiveType>
-static QJsonValue serialize(const PrimitiveType& value)
+QJsonValue serialize(const PrimitiveType& value)
 {
   const auto serializer = Serializer{};
   return serializer.writeToJson(value);
 }
 
 template <class Serializer, class PrimitiveType>
-static void testSerialize(const QJsonValue& str, const PrimitiveType& value)
+void testSerialize(const QJsonValue& str, const PrimitiveType& value)
 {
   const auto testDeserializeOption = maybeDeserialize<Serializer, PrimitiveType>(str);
   const auto testSerialize = serialize<Serializer, PrimitiveType>(value);
@@ -245,253 +205,81 @@ static void testSerialize(const QJsonValue& str, const PrimitiveType& value)
   CHECK(testSerialize == str);
 }
 
-TEST_CASE("PreferencesTest.serializeBool")
+} // namespace
+
+TEST_CASE("Preferences")
 {
-  CHECK_FALSE((maybeDeserialize<PreferenceSerializer, bool>(QJsonValue{""}).has_value()));
-  CHECK_FALSE(
-    (maybeDeserialize<PreferenceSerializer, bool>(QJsonValue{"0"}).has_value()));
-
-  testSerialize<PreferenceSerializer, bool>(QJsonValue{false}, false);
-  testSerialize<PreferenceSerializer, bool>(QJsonValue{true}, true);
-}
-
-TEST_CASE("PreferencesTest.serializefloat")
-{
-  CHECK_FALSE(
-    (maybeDeserialize<PreferenceSerializer, float>(QJsonValue{"1.25"}).has_value()));
-
-  testSerialize<PreferenceSerializer, float>(QJsonValue{1.25}, 1.25f);
-}
-
-TEST_CASE("PreferencesTest.serializeint")
-{
-  CHECK_FALSE((maybeDeserialize<PreferenceSerializer, int>(QJsonValue{"0"}).has_value()));
-  CHECK_FALSE(
-    (maybeDeserialize<PreferenceSerializer, int>(QJsonValue{"-1"}).has_value()));
-
-  testSerialize<PreferenceSerializer, int>(QJsonValue{0}, 0);
-  testSerialize<PreferenceSerializer, int>(QJsonValue{-1}, -1);
-  testSerialize<PreferenceSerializer, int>(QJsonValue{1000}, 1000);
-}
-
-TEST_CASE("PreferencesTest.serializeKeyboardShortcut")
-{
-  testSerialize<PreferenceSerializer, QKeySequence>(
-    QJsonValue{"Alt+Shift+W"}, QKeySequence::fromString("Alt+Shift+W"));
-  testSerialize<PreferenceSerializer, QKeySequence>(
-    QJsonValue{"Meta+W"},
-    QKeySequence::fromString("Meta+W")); // "Meta" in Qt = Control in macOS
-}
-
-TEST_CASE("PreferencesTest.testWxViewShortcutsAndMenuShortcutsRecognized")
-{
-  // All map view shortcuts, and all binadable menu items before the Qt port
-  const auto preferenceKeys = std::vector<std::string>{
-    "Controls/Map view/Create brush",
-    "Controls/Map view/Toggle clip side",
-    "Controls/Map view/Perform clip",
-    // The Qt port dropped these - now they're merged with the "Move objects" actions
-    //            "Controls/Map view/Move vertices up; Move vertices forward",
-    //            "Controls/Map view/Move vertices down; Move vertices backward",
-    //            "Controls/Map view/Move vertices left",
-    //            "Controls/Map view/Move vertices right",
-    //            "Controls/Map view/Move vertices backward; Move vertices up",
-    //            "Controls/Map view/Move vertices forward; Move vertices down",
-    //            "Controls/Map view/Move rotation center up; Move rotation center
-    //            forward", "Controls/Map view/Move rotation center down; Move rotation
-    //            center backward", "Controls/Map view/Move rotation center left",
-    //            "Controls/Map view/Move rotation center right",
-    //            "Controls/Map view/Move rotation center backward; Move rotation center
-    //            up", "Controls/Map view/Move rotation center forward; Move rotation
-    //            center down",
-    "Controls/Map view/Move objects up; Move objects forward",
-    "Controls/Map view/Move objects down; Move objects backward",
-    "Controls/Map view/Move objects left",
-    "Controls/Map view/Move objects right",
-    "Controls/Map view/Move objects backward; Move objects up",
-    "Controls/Map view/Move objects forward; Move objects down",
-    "Controls/Map view/Roll objects clockwise",
-    "Controls/Map view/Roll objects counter-clockwise",
-    "Controls/Map view/Yaw objects clockwise",
-    "Controls/Map view/Yaw objects counter-clockwise",
-    "Controls/Map view/Pitch objects clockwise",
-    "Controls/Map view/Pitch objects counter-clockwise",
-    "Controls/Map view/Flip objects horizontally",
-    "Controls/Map view/Flip objects vertically",
-    "Controls/Map view/Duplicate and move objects up; Duplicate and move objects forward",
-    "Controls/Map view/Duplicate and move objects down; Duplicate and move objects "
-    "backward",
-    "Controls/Map view/Duplicate and move objects left",
-    "Controls/Map view/Duplicate and move objects right",
-    "Controls/Map view/Duplicate and move objects backward; Duplicate and move objects "
-    "up",
-    "Controls/Map view/Duplicate and move objects forward; Duplicate and move objects "
-    "down",
-    "Controls/Map view/Move textures up",
-    "Controls/Map view/Move textures up (fine)",
-    "Controls/Map view/Move textures up (coarse)",
-    "Controls/Map view/Move textures down",
-    "Controls/Map view/Move textures down (fine)",
-    "Controls/Map view/Move textures down (coarse)",
-    "Controls/Map view/Move textures left",
-    "Controls/Map view/Move textures left (fine)",
-    "Controls/Map view/Move textures left (coarse)",
-    "Controls/Map view/Move textures right",
-    "Controls/Map view/Move textures right (fine)",
-    "Controls/Map view/Move textures right (coarse)",
-    "Controls/Map view/Rotate textures clockwise",
-    "Controls/Map view/Rotate textures clockwise (fine)",
-    "Controls/Map view/Rotate textures clockwise (coarse)",
-    "Controls/Map view/Rotate textures counter-clockwise",
-    "Controls/Map view/Rotate textures counter-clockwise (fine)",
-    "Controls/Map view/Rotate textures counter-clockwise (coarse)",
-    "Controls/Map view/Cycle map view",
-    "Controls/Map view/Reset camera zoom",
-    "Controls/Map view/Cancel",
-    "Controls/Map view/Deactivate current tool",
-    "Controls/Map view/Make structural",
-    "Controls/Map view/View Filter > Toggle show entity classnames",
-    "Controls/Map view/View Filter > Toggle show group bounds",
-    "Controls/Map view/View Filter > Toggle show brush entity bounds",
-    "Controls/Map view/View Filter > Toggle show point entity bounds",
-    "Controls/Map view/View Filter > Toggle show point entities",
-    "Controls/Map view/View Filter > Toggle show point entity models",
-    "Controls/Map view/View Filter > Toggle show brushes",
-    "Controls/Map view/View Filter > Show textures",
-    "Controls/Map view/View Filter > Hide textures",
-    "Controls/Map view/View Filter > Hide faces",
-    "Controls/Map view/View Filter > Shade faces",
-    "Controls/Map view/View Filter > Use fog",
-    "Controls/Map view/View Filter > Show edges",
-    "Controls/Map view/View Filter > Show all entity links",
-    "Controls/Map view/View Filter > Show transitively selected entity links",
-    "Controls/Map view/View Filter > Show directly selected entity links",
-    "Controls/Map view/View Filter > Hide entity links",
-    "Menu/File/Export/Wavefront OBJ...",
-    "Menu/File/Load Point File...",
-    "Menu/File/Reload Point File",
-    "Menu/File/Unload Point File",
-    "Menu/File/Load Portal File...",
-    "Menu/File/Reload Portal File",
-    "Menu/File/Unload Portal File",
-    "Menu/File/Reload Texture Collections",
-    "Menu/File/Reload Entity Definitions",
-    "Menu/Edit/Repeat",
-    "Menu/Edit/Paste at Original Position",
-    "Menu/Edit/Clear Repeatable Commands",
-    "Menu/Edit/Duplicate",
-    "Menu/Edit/Delete",
-    "Menu/Edit/Select All",
-    "Menu/Edit/Select Siblings",
-    "Menu/Edit/Select Touching",
-    "Menu/Edit/Select Inside",
-    "Menu/Edit/Select Tall",
-    "Menu/Edit/Select by Line Number",
-    "Menu/Edit/Select None",
-    "Menu/Edit/Group",
-    "Menu/Edit/Ungroup",
-    "Menu/Edit/Tools/Brush Tool",
-    "Menu/Edit/Tools/Clip Tool",
-    "Menu/Edit/Tools/Rotate Tool",
-    "Menu/Edit/Tools/Scale Tool",
-    "Menu/Edit/Tools/Shear Tool",
-    "Menu/Edit/Tools/Vertex Tool",
-    "Menu/Edit/Tools/Edge Tool",
-    "Menu/Edit/Tools/Face Tool",
-    "Menu/Edit/CSG/Convex Merge",
-    "Menu/Edit/CSG/Subtract",
-    "Menu/Edit/CSG/Hollow",
-    "Menu/Edit/CSG/Intersect",
-    "Menu/Edit/Snap Vertices to Integer",
-    "Menu/Edit/Snap Vertices to Grid",
-    "Menu/Edit/Texture Lock",
-    "Menu/Edit/UV Lock",
-    "Menu/Edit/Replace Texture...",
-    "Menu/View/Grid/Show Grid",
-    "Menu/View/Grid/Snap to Grid",
-    "Menu/View/Grid/Increase Grid Size",
-    "Menu/View/Grid/Decrease Grid Size",
-    "Menu/View/Grid/Set Grid Size 0.125",
-    "Menu/View/Grid/Set Grid Size 0.25",
-    "Menu/View/Grid/Set Grid Size 0.5",
-    "Menu/View/Grid/Set Grid Size 1",
-    "Menu/View/Grid/Set Grid Size 2",
-    "Menu/View/Grid/Set Grid Size 4",
-    "Menu/View/Grid/Set Grid Size 8",
-    "Menu/View/Grid/Set Grid Size 16",
-    "Menu/View/Grid/Set Grid Size 32",
-    "Menu/View/Grid/Set Grid Size 64",
-    "Menu/View/Grid/Set Grid Size 128",
-    "Menu/View/Grid/Set Grid Size 256",
-    "Menu/View/Camera/Move to Next Point",
-    "Menu/View/Camera/Move to Previous Point",
-    "Menu/View/Camera/Focus on Selection",
-    "Menu/View/Camera/Move Camera to...",
-    "Menu/View/Isolate",
-    "Menu/View/Hide",
-    "Menu/View/Show All",
-    "Menu/View/Switch to Map Inspector",
-    "Menu/View/Switch to Entity Inspector",
-    "Menu/View/Switch to Face Inspector",
-    "Menu/View/Toggle Info Panel",
-    "Menu/View/Toggle Inspector",
-    "Menu/View/Maximize Current View",
-    "Menu/Run/Compile...",
-    "Menu/Run/Launch...",
-  };
-
-  auto& actionsMap = ui::ActionManager::instance().actionsMap();
-  for (const auto& preferenceKey : preferenceKeys)
+  SECTION("readPreferencesFromFile")
   {
-    CAPTURE(preferenceKey);
+    CHECK(parsePreferencesFromJson(QByteArray())
+            .is_error_type<PreferenceErrors::JsonParseError>());
+    CHECK(parsePreferencesFromJson(QByteArray("abc"))
+            .is_error_type<PreferenceErrors::JsonParseError>());
+    CHECK(parsePreferencesFromJson(QByteArray(R"({"foo": "bar",})"))
+            .is_error_type<PreferenceErrors::JsonParseError>());
 
-    const auto preferencePath = preferenceKey;
-    CHECK(actionsMap.find(preferencePath) != actionsMap.end());
+    // Valid JSON
+    CHECK(parsePreferencesFromJson(QByteArray(R"({"foo": "bar"})")).is_success());
+    CHECK(parsePreferencesFromJson(QByteArray("{}")).is_success());
+
+    readPreferencesFromFile("fixture/test/preferences-v2.json")
+      | kdl::transform([](const std::map<std::filesystem::path, QJsonValue>& prefs) {
+          testPrefs(prefs);
+        })
+      | kdl::transform_error([](const auto&) { FAIL_CHECK(); });
   }
-}
 
-TEST_CASE("PreferencesTest.testWxEntityShortcuts")
-{
-  auto hellKnight =
-    mdl::PointEntityDefinition{"monster_hell_knight", {0, 0, 0}, {}, "", {}, {}, {}};
-  const auto defs = std::vector<mdl::EntityDefinition*>{&hellKnight};
-
-  const auto actions = ui::ActionManager::instance().createEntityDefinitionActions(defs);
-  const auto actualPrefPaths = kdl::vec_transform(
-    actions, [](const auto& action) { return action.preferencePath(); });
-
-  // example keys from 2019.6 for "monster_hell_knight" entity
-  const auto preferenceKeys = std::vector<std::string>{
-    "Entities/monster_hell_knight/Create",
-    "Entities/monster_hell_knight/Toggle" // new in 2020.1
-  };
-
-  for (const auto& preferenceKey : preferenceKeys)
+  SECTION("PreferencesTest.testWriteRead")
   {
-    CAPTURE(preferenceKey);
-    CHECK(kdl::vec_contains(actualPrefPaths, preferenceKey));
+    const auto fromFile =
+      readPreferencesFromFile("fixture/test/preferences-v2.json") | kdl::value();
+
+    const QByteArray serialized = writePreferencesToJson(fromFile);
+    parsePreferencesFromJson(serialized)
+      | kdl::transform([&](const std::map<std::filesystem::path, QJsonValue>& prefs) {
+          CHECK(fromFile == prefs);
+        })
+      | kdl::transform_error([](const auto&) { FAIL_CHECK(); });
   }
-}
 
-TEST_CASE("PreferencesTest.testWxTagShortcuts")
-{
-  const auto tags = std::vector<mdl::SmartTag>{
-    mdl::SmartTag{"Detail", {}, std::make_unique<mdl::ContentFlagsTagMatcher>(1 << 27)}};
-  const auto actions = ui::ActionManager::instance().createTagActions(tags);
-  const auto actualPrefPaths = kdl::vec_transform(
-    actions, [](const auto& action) { return action.preferencePath(); });
-
-  // example keys from 2019.6 for "Detail" tag
-  const auto preferenceKeys = std::vector<std::string>{
-    "Filters/Tags/Detail/Toggle Visible",
-    "Tags/Detail/Disable",
-    "Tags/Detail/Enable",
-  };
-
-  for (const auto& preferenceKey : preferenceKeys)
+  SECTION("serializeBool")
   {
-    CAPTURE(preferenceKey);
-    CHECK(kdl::vec_contains(actualPrefPaths, preferenceKey));
+    CHECK_FALSE(
+      (maybeDeserialize<PreferenceSerializer, bool>(QJsonValue{""}).has_value()));
+    CHECK_FALSE(
+      (maybeDeserialize<PreferenceSerializer, bool>(QJsonValue{"0"}).has_value()));
+
+    testSerialize<PreferenceSerializer, bool>(QJsonValue{false}, false);
+    testSerialize<PreferenceSerializer, bool>(QJsonValue{true}, true);
+  }
+
+  SECTION("serializefloat")
+  {
+    CHECK_FALSE(
+      (maybeDeserialize<PreferenceSerializer, float>(QJsonValue{"1.25"}).has_value()));
+
+    testSerialize<PreferenceSerializer, float>(QJsonValue{1.25}, 1.25f);
+  }
+
+  SECTION("serializeint")
+  {
+    CHECK_FALSE(
+      (maybeDeserialize<PreferenceSerializer, int>(QJsonValue{"0"}).has_value()));
+    CHECK_FALSE(
+      (maybeDeserialize<PreferenceSerializer, int>(QJsonValue{"-1"}).has_value()));
+
+    testSerialize<PreferenceSerializer, int>(QJsonValue{0}, 0);
+    testSerialize<PreferenceSerializer, int>(QJsonValue{-1}, -1);
+    testSerialize<PreferenceSerializer, int>(QJsonValue{1000}, 1000);
+  }
+
+  SECTION("serializeKeyboardShortcut")
+  {
+    testSerialize<PreferenceSerializer, QKeySequence>(
+      QJsonValue{"Alt+Shift+W"}, QKeySequence::fromString("Alt+Shift+W"));
+    testSerialize<PreferenceSerializer, QKeySequence>(
+      QJsonValue{"Meta+W"},
+      QKeySequence::fromString("Meta+W")); // "Meta" in Qt = Control in macOS
   }
 }
 

--- a/lib/kdl/include/kdl/path_utils.h
+++ b/lib/kdl/include/kdl/path_utils.h
@@ -99,6 +99,12 @@ inline std::filesystem::path path_pop_front(const std::filesystem::path& path)
   return path_clip(path, 1, path_length(path));
 }
 
+inline bool path_has_extension(
+  const std::filesystem::path& path, const std::filesystem::path extension)
+{
+  return path.extension() == extension;
+}
+
 inline std::filesystem::path path_add_extension(
   std::filesystem::path path, const std::filesystem::path& extension)
 {

--- a/lib/kdl/include/kdl/path_utils.h
+++ b/lib/kdl/include/kdl/path_utils.h
@@ -30,12 +30,17 @@
 namespace kdl
 {
 
+template <typename char_type>
 inline std::filesystem::path parse_path(
-  std::string str, const bool replace_backslashes = true)
+  std::basic_string<char_type> str, const bool convert_separators = true)
 {
-  if (replace_backslashes)
+  if (convert_separators)
   {
-    std::ranges::replace_if(str, [](char c) { return c == '\\'; }, '/');
+    constexpr auto pref_sep = char_type(std::filesystem::path::preferred_separator);
+    const auto win_sep = char_type('\\');
+    const auto x_sep = char_type('/');
+    std::ranges::replace_if(
+      str, [&](const auto c) { return c == win_sep || c == x_sep; }, pref_sep);
   }
   return std::filesystem::path{std::move(str)};
 }

--- a/lib/kdl/test/src/tst_path_utils.cpp
+++ b/lib/kdl/test/src/tst_path_utils.cpp
@@ -25,20 +25,21 @@
 
 namespace kdl
 {
+using namespace std::string_literals;
 using std::filesystem::path;
 
 TEST_CASE("parse_path")
 {
-  CHECK(parse_path(R"()") == path{R"()"});
-  CHECK(parse_path(R"(/)") == path{R"(/)"});
-  CHECK(parse_path(R"(\)") == path{R"(/)"});
-  CHECK(parse_path(R"(\)", !K(replace_backslashes)) == path{R"(\)"});
-  CHECK(parse_path(R"(a/b/c)") == path{R"(a/b/c)"});
-  CHECK(parse_path(R"(a\b\c)") == path{R"(a/b/c)"});
-  CHECK(parse_path(R"(a\b\c)", !K(replace_backslashes)) == path{R"(a\b\c)"});
+  CHECK(parse_path(R"()"s) == path{R"()"});
+  CHECK(parse_path(R"(/)"s) == path{R"(/)"});
+  CHECK(parse_path(R"(\)"s) == path{R"(/)"});
+  CHECK(parse_path(R"(\)"s, !K(replace_backslashes)) == path{R"(\)"});
+  CHECK(parse_path(R"(a/b/c)"s) == path{R"(a/b/c)"});
+  CHECK(parse_path(R"(a\b\c)"s) == path{R"(a/b/c)"});
+  CHECK(parse_path(R"(a\b\c)"s, !K(replace_backslashes)) == path{R"(a\b\c)"});
 }
 
-TEST_CASE("path_length")
+TEST_CASE("path_length"s)
 {
   CHECK(path_length(path{}) == 0);
   CHECK(path_length(path{""}) == 0);

--- a/lib/kdl/test/src/tst_path_utils.cpp
+++ b/lib/kdl/test/src/tst_path_utils.cpp
@@ -151,6 +151,16 @@ TEST_CASE("path_pop_front")
   CHECK(path_pop_front(path{"asdf/blah"}) == path{"blah"});
 }
 
+TEST_CASE("path_has_extension")
+{
+  CHECK(path_has_extension(path{}, ""));
+  CHECK(path_has_extension(path{"blah"}, ""));
+  CHECK_FALSE(path_has_extension(path{"blah.map"}, "map"));
+  CHECK(path_has_extension(path{"blah.map"}, ".map"));
+  CHECK(path_has_extension(path{"asdf/blah.map"}, ".map"));
+  CHECK_FALSE(path_has_extension(path{"asdf/blah.MAP"}, ".map"));
+}
+
 TEST_CASE("path_add_extension")
 {
   CHECK(path_add_extension(path{}, path{}) == path{});


### PR DESCRIPTION
We use QFileInfo instead of QFile because it's more light weight. Also we implement pathAsGenericQString by simply replacing all backslashes with forward slashes.