### PR TITLE
Fix mnemonics suppression not working on Qt 6.8

### DIFF
--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -34,6 +34,12 @@ extern void qt_set_sequence_auto_mnemonic(bool b);
 
 int main(int argc, char* argv[])
 {
+  // We can't use auto mnemonics in TrenchBroom. e.g. by default with Qt, Alt+D opens the
+  // "Debug" menu, Alt+S activates the "Show default properties" checkbox in the entity
+  // inspector. Flying with Alt held down and pressing WASD is a fundamental behaviour in
+  // TB, so we can't have shortcuts randomly activating.
+  qt_set_sequence_auto_mnemonic(false);
+  
   // Set OpenGL defaults
   // Needs to be done here before QApplication is created
   // (see: https://doc.qt.io/qt-5/qsurfaceformat.html#setDefaultFormat)


### PR DESCRIPTION
Discussed in https://github.com/TrenchBroom/TrenchBroom/issues/4782

`qt_set_sequence_auto_mnemonic` is already declared in this file but unused. I am not familiar with TB codebase enough to understand why there are two `main()`s but putting that extern function inside this main and that seems to work.

Only mnemonics key bind is disabled. Widget text underline is still present for mysterious reasons. I can spend some effort to find out a way to disable widget text underline if this issue has enough interest (as in supporting Qt 6.8+).

This change seems to be in conflict with the change from this commit https://github.com/TrenchBroom/TrenchBroom/commit/2577e31c13a2597656108db428a94dbf31271c15 (related to https://github.com/TrenchBroom/TrenchBroom/issues/3140 and https://github.com/TrenchBroom/TrenchBroom/pull/3155). So I think it would be best if this is tested on Windows and whatnot (which I unfortunately do not have access to). This works on my machine, yes.

Tested on Plasma Wayland and Qt 6.8.1