### PR TITLE
Use the zip generator on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
         with:
           name: windows-2022-x64
           path: |
-            cmakebuild/*.7z
-            cmakebuild/*.7z.md5
+            cmakebuild/*.zip
+            cmakebuild/*.zip.md5
 
       # Linux
       - name: Linux - Install dependencies
@@ -195,8 +195,8 @@ jobs:
             cmakebuild/*.AppImage.md5
             cmakebuild/*.dmg
             cmakebuild/*.dmg.md5
-            cmakebuild/*.7z
-            cmakebuild/*.7z.md5
+            cmakebuild/*.zip
+            cmakebuild/*.zip.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -333,10 +333,10 @@ if(WIN32)
             "${APP_DIR}/resources/shader"
             "${APP_DIR}/resources/stylesheets"
             DESTINATION . COMPONENT TrenchBroom)
-    set(CPACK_GENERATOR "7Z")
+    set(CPACK_GENERATOR "ZIP")
     set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY FALSE)
 
-    set(CPACK_PACKAGE_FILE_EXT "7z")
+    set(CPACK_PACKAGE_FILE_EXT "zip")
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateChecksum.bat.in" "${CMAKE_BINARY_DIR}/generate_checksum.bat" @ONLY)
 elseif(APPLE)
     install(TARGETS TrenchBroom BUNDLE DESTINATION . COMPONENT TrenchBroom)


### PR DESCRIPTION
This makes it easier to install a downloaded updated because we don't need a dependency on 7zip for the updater.