### PR TITLE
Fix ASAN build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,17 @@ jobs:
       - name: macOS - Set up signing environment
         if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14' }}
         run: |
+            if [[ "${{ matrix.tb-build-type }}" == "asan" ]]; then
+              echo "TB_ENABLE_ASAN=true" >> $GITHUB_ENV
+            else
+              echo "TB_ENABLE_ASAN=false" >> $GITHUB_ENV
+            fi
             if [[ "${{ matrix.tb-build-type }}" != "asan" ]] && 
                [[ -n "${{ secrets.ACTIONS_MAC_SIGN_CERTIFICATES_P12 }}" ]] && 
                [[ -n "${{ secrets.ACTIONS_MAC_SIGN_CERTIFICATES_P12_PASSWORD }}" ]] && 
-               [[ -n "${{ secrets.ACTIONS_MAC_SIGN_IDENTITY }}" ]]
-               [[ -n "${{ secrets.ACTIONS_MAC_NOTARIZATION_EMAIL }}" ]]
-               [[ -n "${{ secrets.ACTIONS_MAC_NOTARIZATION_TEAM_ID }}" ]]
+               [[ -n "${{ secrets.ACTIONS_MAC_SIGN_IDENTITY }}" ]] &&
+               [[ -n "${{ secrets.ACTIONS_MAC_NOTARIZATION_EMAIL }}" ]] &&
+               [[ -n "${{ secrets.ACTIONS_MAC_NOTARIZATION_TEAM_ID }}" ]] &&
                [[ -n "${{ secrets.ACTIONS_MAC_NOTARIZATION_PASSWORD }}" ]]; then
               echo "TB_SIGN_MAC_BUNDLE=true" >> $GITHUB_ENV
               echo "TB_SIGN_IDENTITY=${{ secrets.ACTIONS_MAC_SIGN_IDENTITY }}" >> $GITHUB_ENV

--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -o verbose
+# set -o verbose
 
 # install linuxdeploy
 wget -nc https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage


### PR DESCRIPTION
The ASAN build was incorrectly using a Release build, and, on top of that, it was trying to sign / notarize the package.