### PR TITLE
Distribute AppImage builds in a zip archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           name: ubuntu-22.04
           path: |
-            cmakebuild/*.AppImage
+            cmakebuild/*.zip
             cmakebuild/*.md5
 
       # macOS
@@ -196,8 +196,6 @@ jobs:
         with:
           draft: true
           files: |
-            cmakebuild/*.AppImage
-            cmakebuild/*.AppImage.md5
             cmakebuild/*.zip
             cmakebuild/*.zip.md5
         env:

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -374,7 +374,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     install(FILES "${APP_DIR}/resources/linux/copyright"            DESTINATION ${LINUX_RESOURCE_LOCATION} COMPONENT TrenchBroom)
 
     # configure AppImage via an external CPack generator
-    set(CPACK_PACKAGE_FILE_EXT "AppImage")
+    set(CPACK_PACKAGE_FILE_EXT "zip")
     set(TB_LINUXDEPLOY_PATH "../linuxdeploy-x86_64.AppImage")
     get_target_property(TB_QMAKE_PATH Qt6::qmake IMPORTED_LOCATION)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/AppImageGenerator.cmake.in" "${CMAKE_BINARY_DIR}/AppImageGenerator.cmake" @ONLY)

--- a/app/cmake/AppImageGenerator.cmake.in
+++ b/app/cmake/AppImageGenerator.cmake.in
@@ -1,7 +1,7 @@
 execute_process(
   COMMAND
     @CMAKE_COMMAND@ -E env
-      OUTPUT=@CPACK_PACKAGE_FILE_NAME@.@CPACK_PACKAGE_FILE_EXT@
+      OUTPUT=TrenchBroom.AppImage
       QMAKE=@TB_QMAKE_PATH@
     @TB_LINUXDEPLOY_PATH@
     --appdir=${CPACK_TEMPORARY_DIRECTORY}
@@ -10,4 +10,10 @@ execute_process(
     --icon-file=@APP_RESOURCE_DIR@/graphics/images/AppIcon.png
     --icon-filename=trenchbroom
     --plugin qt
+  COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+  COMMAND
+    @CMAKE_COMMAND@ -E tar cv @CPACK_PACKAGE_FILE_NAME@.@CPACK_PACKAGE_FILE_EXT@ --format=zip TrenchBroom.AppImage
+  COMMAND_ERROR_IS_FATAL ANY
 )


### PR DESCRIPTION
This is necessary for the auto update component because it simplifies unpacking and installing the update. This change also renames the AppImage to `TrenchBroom.AppImage`. Like on other platforms, the version information is only part of the zip archive filename.