### PR TITLE
Fix loading MDX models

### DIFF
--- a/common/src/io/MdxLoader.cpp
+++ b/common/src/io/MdxLoader.cpp
@@ -299,9 +299,9 @@ auto parseMeshVertices(Reader& reader, const size_t count)
 
   for (size_t i = 0; i < count; ++i)
   {
-    const auto vertexIndex = reader.readSize<int32_t>();
     const auto u = reader.readFloat<float>();
     const auto v = reader.readFloat<float>();
+    const auto vertexIndex = reader.readSize<int32_t>();
     vertices.push_back({vertexIndex, {u, v}});
   }
 
@@ -315,6 +315,8 @@ auto parseMeshes(Reader reader, const size_t commandCount)
   auto vertexCount = reader.readInt<int32_t>();
   for (size_t i = 0; i < commandCount && vertexCount != 0; ++i)
   {
+    /* const auto subObjectId = */ reader.readInt<int32_t>();
+
     const auto type =
       vertexCount < 0 ? render::PrimType::TriangleFan : render::PrimType::TriangleStrip;
     auto vertices = parseMeshVertices(reader, size_t(std::abs(vertexCount)));

--- a/common/src/mdl/ModelDefinition.cpp
+++ b/common/src/mdl/ModelDefinition.cpp
@@ -26,6 +26,7 @@
 #include "el/Value.h"
 #include "el/VariableStore.h"
 
+#include "kdl/path_utils.h"
 #include "kdl/reflection_impl.h"
 #include "kdl/string_compare.h"
 #include "kdl/string_format.h"
@@ -44,8 +45,9 @@ std::filesystem::path path(el::EvaluationContext& context, const el::Value& valu
   {
     return {};
   }
-  const auto& path = value.stringValue(context);
-  return kdl::cs::str_is_prefix(path, ":") ? path.substr(1) : path;
+  const auto& str = value.stringValue(context);
+  const auto path = kdl::cs::str_is_prefix(str, ":") ? str.substr(1) : str;
+  return kdl::parse_path(path);
 }
 
 size_t index(el::EvaluationContext& context, const el::Value& value)


### PR DESCRIPTION
There were two bugs in the MDX loader which actually prevented it from working at all. Additionally, TB did not load model paths correctly from entity definitions on macOS and Linux if they contained Windows path separators.

Closes #4809.