### PR TITLE
Allow either '/' or '\' as path separators for paths used in compilation profiles

### DIFF
--- a/common/src/ui/CompilationRun.cpp
+++ b/common/src/ui/CompilationRun.cpp
@@ -20,7 +20,6 @@
 #include "CompilationRun.h"
 
 #include "Ensure.h"
-#include "el/EvaluationContext.h"
 #include "el/Interpolate.h"
 #include "mdl/CompilationProfile.h"
 #include "ui/CompilationContext.h"


### PR DESCRIPTION
Closes #4816.