### PR TITLE
Format numbers using the current locale in the UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,12 @@ find_package(Qt6 COMPONENTS Core Widgets OpenGL OpenGLWidgets Network Svg Test R
 # The googletest target links to this
 find_package(Threads)
 
+# Use the fast-float library for from_chars on AppleClang, where std::from_chars is not
+# available for floating point types.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+find_package(FastFloat CONFIG REQUIRED)
+endif()
+
 # Populate version variables using git
 get_git_describe("${GIT_EXECUTABLE}" "${CMAKE_SOURCE_DIR}" GIT_DESCRIBE)
 get_app_version(GIT_DESCRIBE APP_VERSION_YEAR APP_VERSION_NUMBER)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -113,7 +113,7 @@ get_build_platform(APP_PLATFORM_NAME)
 add_executable(TrenchBroom WIN32 MACOSX_BUNDLE)
 target_sources(TrenchBroom PRIVATE ${APP_SOURCE} ${INDEX_OUTPUT_PATH} ${DOC_MANUAL_TARGET_FILES_ABSOLUTE} ${DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE} ${DOC_MANUAL_TARGET_IMAGE_FILES_ABSOLUTE})
 
-target_link_libraries(TrenchBroom common) # common already comes with all its dependencies, no need to repeat them here
+target_link_libraries(TrenchBroom PRIVATE common fmt::fmt-header-only)
 # Xcode "new build system" does't allow custom commands to be depended on by two unrelated targets
 # In this case, ${INDEX_OUTPUT_PATH} is depended on by TrenchBroom and GenerateManual
 # so we must make TrenchBroom depend on GenerateManual (see #3608)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1043,7 +1043,9 @@ set(COMMON_HEADER
 add_library(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})
 set_target_properties(common PROPERTIES AUTOMOC TRUE)
 target_include_directories(common PUBLIC ${COMMON_SOURCE_DIR})
-target_link_libraries(common PUBLIC tinyxml2::tinyxml2 kdl upd vm GLEW::GLEW miniz::miniz freeimage::FreeImage freetype OpenGL::GL Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg fmt::fmt-header-only assimp::assimp)
+target_link_libraries(common 
+  PUBLIC kdl vm Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets Qt6::Svg
+  PRIVATE GLEW::GLEW OpenGL::GL upd tinyxml2::tinyxml2 miniz::miniz freeimage::FreeImage freetype assimp::assimp fmt::fmt-header-only)
 
 # use precompiled headers on CMake 3.16 or later
 if (TB_ENABLE_PCH AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -177,10 +177,6 @@ TrenchBroomApp::TrenchBroomApp(int& argc, char** argv)
   signal(SIGSEGV, CrashHandler);
 #endif
 
-  // always set this locale so that we can properly parse floats from text files
-  // regardless of the platforms locale
-  std::setlocale(LC_NUMERIC, "C");
-
   setApplicationName("TrenchBroom");
   // Needs to be "" otherwise Qt adds this to the paths returned by QStandardPaths
   // which would cause preferences to move from where they were with wx

--- a/common/src/mdl/EntityColor.cpp
+++ b/common/src/mdl/EntityColor.cpp
@@ -82,21 +82,16 @@ Color parseEntityColor(const std::string& str)
   const auto range = detectColorRange(components);
   assert(range != ColorRange::Mixed);
 
-  int r = 0, g = 0, b = 0;
-  if (range == ColorRange::Byte)
-  {
-    r = std::atoi(components[0].c_str());
-    g = std::atoi(components[1].c_str());
-    b = std::atoi(components[2].c_str());
-  }
-  else if (range == ColorRange::Float)
-  {
-    r = static_cast<int>(std::atof(components[0].c_str()) * 255.0);
-    g = static_cast<int>(std::atof(components[1].c_str()) * 255.0);
-    b = static_cast<int>(std::atof(components[2].c_str()) * 255.0);
-  }
-
-  return {r, g, b};
+  return range == ColorRange::Byte ? 
+  Color{
+      kdl::str_to_int(components[0]).value_or(0),
+      kdl::str_to_int(components[1]).value_or(0),
+      kdl::str_to_int(components[2]).value_or(0),
+  } : Color{
+    static_cast<int>(kdl::str_to_double(components[0]).value_or(0.0) * 255.0),
+    static_cast<int>(kdl::str_to_double(components[1]).value_or(0.0) * 255.0),
+    static_cast<int>(kdl::str_to_double(components[2]).value_or(0.0) * 255.0),
+  };
 }
 
 std::string entityColorAsString(const Color& color, const ColorRange::Type colorRange)

--- a/common/src/mdl/EntityRotation.cpp
+++ b/common/src/mdl/EntityRotation.cpp
@@ -217,7 +217,7 @@ vm::mat4x4d entityRotation(
     }
     else
     {
-      const auto angle = static_cast<double>(std::atof(it->value().c_str()));
+      const auto angle = kdl::str_to_double(it->value()).value_or(0.0);
       return vm::rotation_matrix(vm::vec3d{0, 0, 1}, vm::to_radians(angle));
     }
   }
@@ -227,7 +227,7 @@ vm::mat4x4d entityRotation(
     {
       return vm::mat4x4d::identity();
     }
-    const auto angle = static_cast<double>(std::atof(it->value().c_str()));
+    const auto angle = kdl::str_to_double(it->value()).value_or(0.0);
     if (angle == -1.0)
     {
       return vm::mat4x4d::rot_90_y_cw();

--- a/common/src/ui/ClipTool.cpp
+++ b/common/src/ui/ClipTool.cpp
@@ -31,6 +31,7 @@
 #include "render/Camera.h"
 #include "render/RenderService.h"
 #include "ui/MapDocument.h"
+#include "ui/QtUtils.h"
 #include "ui/Selection.h"
 #include "ui/Transaction.h"
 
@@ -357,8 +358,7 @@ private:
     {
       const auto& point = m_points[i].point;
       renderService.renderHandle(vm::vec3f{point});
-      renderService.renderString(
-        fmt::format("{}: {}", i + 1, fmt::streamed(point)), vm::vec3f{point});
+      renderService.renderString(toString(point).toStdString(), vm::vec3f{point});
     }
   }
 

--- a/common/src/ui/MapFrame.cpp
+++ b/common/src/ui/MapFrame.cpp
@@ -1631,11 +1631,11 @@ void MapFrame::moveSelectedObjects()
     "Move Objects",
     "Enter coordinates: X Y Z",
     QLineEdit::Normal,
-    "0.0 0.0 0.0",
+    toString(vm::vec3d{}),
     &ok);
   if (ok)
   {
-    if (const auto offset = vm::parse<double, 3>(str.toStdString()))
+    if (const auto offset = parse<double, 3>(str))
     {
       m_document->translateObjects(*offset);
     }
@@ -2007,11 +2007,11 @@ void MapFrame::moveCameraToPosition()
     "Move Camera",
     "Enter a position (x y z) for the camera.",
     QLineEdit::Normal,
-    "0.0 0.0 0.0",
+    toString(vm::vec3d{}),
     &ok);
   if (ok)
   {
-    if (const auto position = vm::parse<float, 3>(str.toStdString()))
+    if (const auto position = parse<float, 3>(str))
     {
       m_mapView->moveCameraToPosition(*position, true);
     }
@@ -2273,7 +2273,7 @@ void MapFrame::debugSetWindowSize()
     this, "Window Size", "Enter Size (W H)", QLineEdit::Normal, "1920 1080", &ok);
   if (ok)
   {
-    if (const auto size = vm::parse<int, 2>(str.toStdString()))
+    if (const auto size = parse<int, 2>(str))
     {
       resize(size->x(), size->y());
     }

--- a/common/src/ui/MapInspector.cpp
+++ b/common/src/ui/MapInspector.cpp
@@ -38,8 +38,6 @@
 
 #include "kdl/memory_utils.h"
 
-#include "vm/vec_io.h"
-
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -52,13 +50,12 @@ namespace
 
 std::optional<vm::vec3d> parseVec(const QString& qString)
 {
-  const auto string = qString.toStdString();
-  if (const auto vec = vm::parse<double, 3u>(string))
+  if (const auto vec = parse<double, 3u>(qString))
   {
     return *vec;
   }
 
-  if (const auto val = vm::parse<double, 1u>(string))
+  if (const auto val = parse<double, 1u>(qString))
   {
     return vm::vec3d::fill(val->x());
   }
@@ -72,9 +69,8 @@ QString formatVec(const std::optional<vm::bbox3d>& bbox, const bool max)
   {
     const auto& vec = max ? bbox->max : bbox->min;
     // Just print the first component to save space if all components are equal.
-    return QString::fromStdString(
-      vec.x() == vec.y() && vec.y() == vec.z() ? fmt::format("{}", vec.x())
-                                               : fmt::format("{}", fmt::streamed(vec)));
+    return vec.x() == vec.y() && vec.y() == vec.z() ? QString::number(vec.x())
+                                                    : toString(vec);
   }
 
   return QObject::tr("None");

--- a/common/src/ui/QtUtils.h
+++ b/common/src/ui/QtUtils.h
@@ -19,9 +19,11 @@
 
 #pragma once
 
+#include "vm/vec.h"
 #undef CursorShape
 
 #include <QBoxLayout>
+#include <QLocale>
 #include <QObject>
 #include <QPointer>
 #include <QSettings>
@@ -265,5 +267,61 @@ std::string mapStringFromUnicode(MapTextEncoding encoding, const QString& string
  *         (e.g. "Ctrl" on Windows or the Command symbol on macOS)
  */
 QString nativeModifierLabel(int modifier);
+
+template <typename T, size_t S>
+QString toString(const vm::vec<T, S>& vec)
+{
+  const auto locale = QLocale{};
+  return QString{"%1 %2 %3"}
+    .arg(locale.toString(vec.x()))
+    .arg(locale.toString(vec.y()))
+    .arg(locale.toString(vec.z()));
+}
+
+template <std::floating_point T, size_t S>
+std::optional<vm::vec<T, S>> parse(const QString& str)
+{
+  const auto parts = str.split(' ', Qt::SkipEmptyParts);
+  if (parts.size() != S)
+  {
+    return std::nullopt;
+  }
+
+  const auto locale = QLocale{};
+  auto result = vm::vec<T, S>{};
+  for (size_t i = 0; i < S; ++i)
+  {
+    auto ok = false;
+    result[i] = static_cast<T>(locale.toDouble(parts[qsizetype(i)], &ok));
+    if (!ok)
+    {
+      return std::nullopt;
+    }
+  }
+  return result;
+}
+
+template <std::integral T, size_t S>
+std::optional<vm::vec<T, S>> parse(const QString& str)
+{
+  const auto parts = str.split(' ', Qt::SkipEmptyParts);
+  if (parts.size() != S)
+  {
+    return std::nullopt;
+  }
+
+  const auto locale = QLocale{};
+  auto result = vm::vec<T, S>{};
+  for (size_t i = 0; i < S; ++i)
+  {
+    auto ok = false;
+    result[i] = static_cast<T>(locale.toLong(parts[qsizetype(i)], &ok));
+    if (!ok)
+    {
+      return std::nullopt;
+    }
+  }
+  return result;
+}
 
 } // namespace tb::ui

--- a/common/src/ui/RotateObjectsHandle.cpp
+++ b/common/src/ui/RotateObjectsHandle.cpp
@@ -27,6 +27,7 @@
 #include "render/RenderBatch.h"
 #include "render/RenderContext.h"
 #include "render/RenderService.h"
+#include "ui/QtUtils.h"
 
 #include "vm/intersection.h"
 #include "vm/mat_ext.h"
@@ -320,7 +321,7 @@ void RotateObjectsHandle::Handle3D::renderHighlight(
       renderService.setForegroundColor(pref(Preferences::InfoOverlayTextColor));
       renderService.setBackgroundColor(pref(Preferences::InfoOverlayBackgroundColor));
       renderService.renderString(
-        fmt::format("{}", fmt::streamed(m_position)), vm::vec3f{m_position});
+        toString(m_position).toStdString(), vm::vec3f{m_position});
       break;
     case HitArea::XAxis:
       renderService.setForegroundColor(pref(Preferences::XAxisColor));

--- a/common/src/ui/RotateObjectsToolPage.cpp
+++ b/common/src/ui/RotateObjectsToolPage.cpp
@@ -32,14 +32,13 @@
 #include "ui/BorderLine.h"
 #include "ui/Grid.h"
 #include "ui/MapDocument.h"
+#include "ui/QtUtils.h"
 #include "ui/RotateObjectsTool.h"
 #include "ui/SpinControl.h"
 #include "ui/ViewConstants.h"
 
 #include "kdl/memory_utils.h"
 #include "kdl/range_to.h"
-
-#include "vm/vec_io.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -194,8 +193,7 @@ void RotateObjectsToolPage::documentWasNewedOrLoaded(MapDocument*)
 
 void RotateObjectsToolPage::rotationCenterDidChange(const vm::vec3d& center)
 {
-  m_recentlyUsedCentersList->setCurrentText(
-    QString::fromStdString(fmt::format("{}", fmt::streamed(center))));
+  m_recentlyUsedCentersList->setCurrentText(toString(center));
 }
 
 void RotateObjectsToolPage::rotationCenterWasUsed(const vm::vec3d& center)
@@ -206,9 +204,7 @@ void RotateObjectsToolPage::rotationCenterWasUsed(const vm::vec3d& center)
   m_recentlyUsedCentersList->clear();
   m_recentlyUsedCentersList->addItems(
     m_recentlyUsedCenters | std::views::reverse
-    | std::views::transform([](const auto& c) {
-        return QString::fromStdString(fmt::format("{}", fmt::streamed(c)));
-      })
+    | std::views::transform([](const auto& c) { return toString(c); })
     | kdl::to<QStringList>());
 
   if (m_recentlyUsedCentersList->count() > 0)
@@ -236,9 +232,7 @@ void RotateObjectsToolPage::handleHitAreaDidChange(
 
 void RotateObjectsToolPage::centerChanged()
 {
-  if (
-    const auto center =
-      vm::parse<double, 3>(m_recentlyUsedCentersList->currentText().toStdString()))
+  if (const auto center = parse<double, 3>(m_recentlyUsedCentersList->currentText()))
   {
     m_tool.setRotationCenter(*center);
   }

--- a/common/src/ui/ScaleObjectsToolPage.cpp
+++ b/common/src/ui/ScaleObjectsToolPage.cpp
@@ -28,13 +28,13 @@
 #include <QStackedLayout>
 
 #include "ui/MapDocument.h"
+#include "ui/QtUtils.h"
 #include "ui/ScaleObjectsTool.h"
 #include "ui/ViewConstants.h"
 
 #include "kdl/memory_utils.h"
 
 #include "vm/vec.h"
-#include "vm/vec_io.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -66,9 +66,8 @@ void ScaleObjectsToolPage::activate()
                                ? document->selectionBounds().size()
                                : vm::vec3d{0, 0, 0};
 
-  m_sizeTextBox->setText(
-    QString::fromStdString(fmt::format("{}", fmt::streamed(suggestedSize))));
-  m_factorsTextBox->setText("1.0 1.0 1.0");
+  m_sizeTextBox->setText(toString(suggestedSize));
+  m_factorsTextBox->setText(toString(vm::vec3d{1, 1, 1}));
 }
 
 void ScaleObjectsToolPage::createGui()
@@ -132,15 +131,14 @@ std::optional<vm::vec3d> ScaleObjectsToolPage::getScaleFactors() const
   {
   case 0: {
     auto document = kdl::mem_lock(m_document);
-    if (
-      const auto desiredSize = vm::parse<double, 3>(m_sizeTextBox->text().toStdString()))
+    if (const auto desiredSize = parse<double, 3>(m_sizeTextBox->text()))
     {
       return *desiredSize / document->selectionBounds().size();
     }
     return std::nullopt;
   }
   default:
-    return vm::parse<double, 3>(m_factorsTextBox->text().toStdString());
+    return parse<double, 3>(m_factorsTextBox->text());
   }
 }
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -192,7 +192,7 @@ target_include_directories(common-test-utils PUBLIC ${COMMON_TEST_SOURCE_DIR})
 target_link_libraries(common-test-utils PRIVATE common Catch2::Catch2 Qt6::Test)
 
 macro(configure_test_target TARGET)
-    target_link_libraries(${TARGET} PRIVATE common common-test-utils Catch2::Catch2)
+    target_link_libraries(${TARGET} PRIVATE common common-test-utils Catch2::Catch2 fmt::fmt-header-only)
     set_target_properties(${TARGET} PROPERTIES AUTOMOC TRUE)
 
     set_compiler_config(${TARGET})

--- a/dump-shortcuts/CMakeLists.txt
+++ b/dump-shortcuts/CMakeLists.txt
@@ -8,7 +8,7 @@ set(DUMP_SHORTCUTS_SOURCE ${DUMP_SHORTCUTS_SOURCE} ${INDEX_OUTPUT_PATH} ${DOC_MA
 
 add_executable(dump-shortcuts ${DUMP_SHORTCUTS_SOURCE})
 target_include_directories(dump-shortcuts PRIVATE ${DUMP_SHORTCUTS_SOURCE_DIR})
-target_link_libraries(dump-shortcuts PRIVATE common)
+target_link_libraries(dump-shortcuts PRIVATE common fmt::fmt-header-only)
 set_target_properties(dump-shortcuts PROPERTIES AUTOMOC TRUE)
 
 set_compiler_config(dump-shortcuts)

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -83,6 +83,12 @@ target_include_directories(kdl PUBLIC ${KDL_SOURCE_DIR})
 find_package(Threads REQUIRED)
 target_link_libraries(kdl PUBLIC Threads::Threads)
 
+# Use the fast-float library for from_chars on AppleClang, where std::from_chars is not
+# available for floating point types.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+target_link_libraries(kdl PRIVATE FastFloat::fast_float)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(kdl INTERFACE -Wall -Wextra -Wconversion -Wshadow-all -pedantic -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-exit-time-destructors -Wno-poison-system-directories)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/lib/kdl/src/kdl/string_utils.cpp
+++ b/lib/kdl/src/kdl/string_utils.cpp
@@ -293,29 +293,4 @@ std::optional<double> str_to_double(std::string_view str)
 #endif
 }
 
-std::optional<long double> str_to_long_double(std::string_view str)
-{
-  str = skip_whitespace(str);
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 11)
-  // std::from_chars is not yet implemented for double
-  try
-  {
-    return stold(std::string{str});
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
-#else
-  long double value;
-  return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
-           ? std::optional{value}
-           : std::nullopt;
-#endif
-}
-
 } // namespace kdl

--- a/lib/kdl/src/kdl/string_utils.cpp
+++ b/lib/kdl/src/kdl/string_utils.cpp
@@ -20,6 +20,10 @@
 
 #include "kdl/string_utils.h"
 
+#if defined(__APPLE__)
+#include "fast_float/fast_float.h"
+#endif
+
 #include "kdl/reflection_impl.h"
 #include "kdl/string_format.h"
 
@@ -246,22 +250,14 @@ std::optional<std::size_t> str_to_size(std::string_view str)
 std::optional<float> str_to_float(std::string_view str)
 {
   str = skip_whitespace(str);
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 11)
-  // std::from_chars is not yet implemented for float
-  try
-  {
-    return stof(std::string{str});
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
-#else
+
   float value;
+#if defined(__APPLE__)
+  return fast_float::from_chars(str.data(), str.data() + str.size(), value).ec
+             == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
+#else
   return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
            ? std::optional{value}
            : std::nullopt;
@@ -271,22 +267,14 @@ std::optional<float> str_to_float(std::string_view str)
 std::optional<double> str_to_double(std::string_view str)
 {
   str = skip_whitespace(str);
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 11)
-  // std::from_chars is not yet implemented for double
-  try
-  {
-    return stod(std::string{str});
-  }
-  catch (std::invalid_argument&)
-  {
-    return std::nullopt;
-  }
-  catch (std::out_of_range&)
-  {
-    return std::nullopt;
-  }
-#else
+
   double value;
+#if defined(__APPLE__)
+  return fast_float::from_chars(str.data(), str.data() + str.size(), value).ec
+             == std::errc{}
+           ? std::optional{value}
+           : std::nullopt;
+#else
   return std::from_chars(str.data(), str.data() + str.size(), value).ec == std::errc{}
            ? std::optional{value}
            : std::nullopt;

--- a/lib/kdl/src/kdl/string_utils.h
+++ b/lib/kdl/src/kdl/string_utils.h
@@ -312,14 +312,4 @@ std::optional<float> str_to_float(std::string_view str);
  */
 std::optional<double> str_to_double(std::string_view str);
 
-/**
- * Interprets the given string as a long double value value and returns it. If the given
- * string cannot be parsed, returns an empty optional.
- *
- * @param str the string
- * @return the long double value value value or an empty optional if the given string
- * cannot be interpreted as an long double value value
- */
-std::optional<long double> str_to_long_double(std::string_view str);
-
 } // namespace kdl

--- a/lib/kdl/test/src/tst_string_utils.cpp
+++ b/lib/kdl/test/src/tst_string_utils.cpp
@@ -276,15 +276,5 @@ TEST_CASE("string_utils")
     CHECK(str_to_double(" ") == std::nullopt);
     CHECK(str_to_double("") == std::nullopt);
   }
-
-  SECTION("string_format_test.str_to_long_double")
-  {
-    CHECK(str_to_long_double("0") == 0.0L);
-    CHECK(str_to_long_double("1.0") == 1.0L);
-    CHECK(str_to_long_double("  1.0     ") == 1.0L);
-    CHECK(str_to_long_double("a123231.0") == std::nullopt);
-    CHECK(str_to_long_double(" ") == std::nullopt);
-    CHECK(str_to_long_double("") == std::nullopt);
-  }
 }
 } // namespace kdl

--- a/lib/vm/CMakeLists.txt
+++ b/lib/vm/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(vm INTERFACE
     "${VM_INCLUDE_DIR}/vm/constexpr_util.h"
     "${VM_INCLUDE_DIR}/vm/convex_hull.h"
     "${VM_INCLUDE_DIR}/vm/distance.h"
+    "${VM_INCLUDE_DIR}/vm/from_chars.h"
     "${VM_INCLUDE_DIR}/vm/intersection.h"
     "${VM_INCLUDE_DIR}/vm/line_io.h"
     "${VM_INCLUDE_DIR}/vm/line.h"
@@ -55,6 +56,12 @@ elseif(MSVC EQUAL 1)
     target_compile_options(vm INTERFACE /w44365)
 else()
     message(FATAL_ERROR "Cannot set compile options for target")
+endif()
+
+# Use the fast-float library for from_chars on AppleClang, where std::from_chars is not
+# available for floating point types.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+target_link_libraries(vm INTERFACE FastFloat::fast_float)
 endif()
 
 add_subdirectory(test)

--- a/lib/vm/include/vm/from_chars.h
+++ b/lib/vm/include/vm/from_chars.h
@@ -1,0 +1,59 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the "Software"), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify, merge,
+ publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#if defined(__APPLE__)
+#include "fast_float/fast_float.h"
+#else
+#endif
+
+#include <charconv>
+#include <concepts>
+
+namespace vm
+{
+
+template <typename C, std::integral I>
+auto from_chars(const C* first, const C* last, I& value, const int base = 10)
+{
+  return std::from_chars(first, last, value, base);
+}
+
+template <
+  typename C,
+  std::floating_point F,
+  typename Fmt =
+#if defined(__APPLE__)
+    fast_float::chars_format
+#else
+    std::chars_format
+#endif
+  >
+auto from_chars(const C* first, const C* last, F& value, const Fmt fmt = Fmt::general)
+{
+#if defined(__APPLE__)
+  return fast_float::from_chars(first, last, value, fmt);
+#else
+  return std::from_chars(first, last, value, fmt);
+#endif
+}
+
+} // namespace vm

--- a/lib/vm/include/vm/mat_io.h
+++ b/lib/vm/include/vm/mat_io.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "vm/from_chars.h"
 #include "vm/mat.h"
 
 #include <optional>
@@ -36,7 +37,7 @@ namespace vm
  *     C ::= number of columns
  *  COMP ::= WS, FLOAT;
  *    WS ::= " " | \\t | \\n | \\r | "(" | ")";
- * FLOAT ::= any floating point number parseable by std::atof
+ * FLOAT ::= any floating point number parseable by std::from_chars
  *
  * @tparam T the component type
  * @tparam R the number of rows
@@ -59,7 +60,12 @@ std::optional<mat<T, R, C>> parse(const std::string_view str)
       {
         return std::nullopt;
       }
-      result[c][r] = static_cast<T>(std::atof(str.data() + pos));
+      if (
+        from_chars(str.data() + pos, str.data() + str.length(), result[c][r]).ec
+        != std::errc{})
+      {
+        return std::nullopt;
+      }
       if ((pos = str.find_first_of(blank, pos)) == std::string::npos)
       {
         if ((r * C) + c < R * C - 1u)

--- a/lib/vm/include/vm/vec_io.h
+++ b/lib/vm/include/vm/vec_io.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "vm/from_chars.h"
 #include "vm/vec.h"
 
 #include <optional>
@@ -44,7 +45,12 @@ std::optional<vec<T, S>> doParse(const std::string_view str, size_t& pos)
     {
       return std::nullopt;
     }
-    result[i] = static_cast<T>(std::atof(str.data() + pos));
+    if (
+      from_chars(str.data() + pos, str.data() + str.length(), result[i]).ec
+      != std::errc{})
+    {
+      return std::nullopt;
+    }
     if ((pos = str.find_first_of(blank, pos)) == std::string::npos)
     {
       if (i < S - 1)
@@ -64,7 +70,7 @@ std::optional<vec<T, S>> doParse(const std::string_view str, size_t& pos)
  *     S ::= number of components
  *  COMP ::= WS, FLOAT;
  *    WS ::= " " | \\t | \\n | \\r | "(" | ")";
- * FLOAT ::= any floating point number parseable by std::atof
+ * FLOAT ::= any floating point number parseable by std::from_chars
  *
  * @tparam T the component type
  * @tparam S the number of components

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,6 +37,11 @@
       "name": "tinyxml2",
       "version>=": "9.0.0",
       "platform": "!linux"
+    },
+    {
+      "name": "fast-float",
+      "version>=": "6.1.4",
+      "platform": "osx"
     }
   ],
   "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",


### PR DESCRIPTION
Number formatting and parsing in the UI is currently inconsistent. Some controls use the current locale settings, (e.g. using `,` as the decimal separator on a German system), and some don't. With this PR, all UI widgets will use the current locale when editing numbers.

A non-obvious exception are numbers in the entity attributes grid, but here, we are actually editing strings, so formatting doesn't apply. This might change in the future.

Closes #3933 