### PR TITLE
Enable ccache on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,16 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
-      - name: Set up ccache
+      - name: Windows - Set up ccache
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: |
+          echo "CCACHE_DIR=${{ github.workspace }}\\.ccache" >> $env:GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $env:GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=6" >> $env:GITHUB_ENV
+          echo "CCACHE_MAXSIZE=1G" >> $env:GITHUB_ENV
+          echo "CCACHE_SLOPPINESS=file_stat_matches,file_macro,time_macros" >> $env:GITHUB_ENV
+
+      - name: Linux / macOS - Set up ccache
         if: ${{ matrix.os != 'windows-2022' }}
         run: |
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
@@ -58,7 +67,6 @@ jobs:
 
       - name: Restore ccache files
         uses: actions/cache@v4.2.3
-        if: ${{ matrix.os != 'windows-2022' }}
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.os }}-${{ matrix.tb-build-type }}-${{ github.run_id }}
@@ -87,6 +95,7 @@ jobs:
       - name: Windows - Install dependencies
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
+          choco install ccache
           # Chocolatey was taking 3 minutes to install pandoc; just install it directly
           Invoke-WebRequest 'https://github.com/jgm/pandoc/releases/download/2.11.3.1/pandoc-2.11.3.1-windows-x86_64.zip' -OutFile 'pandoc.zip'
           if ("668A62A8990DEB2753753DF0C8D3F1BE567026FE" -ne (Get-FileHash -Path 'pandoc.zip' -Algorithm SHA1).Hash) { exit }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           echo "CCACHE_DIR=${{ github.workspace }}\\.ccache" >> $env:GITHUB_ENV
           echo "CCACHE_COMPRESS=true" >> $env:GITHUB_ENV
           echo "CCACHE_COMPRESSLEVEL=6" >> $env:GITHUB_ENV
-          echo "CCACHE_MAXSIZE=1G" >> $env:GITHUB_ENV
+          echo "CCACHE_MAXSIZE=500M" >> $env:GITHUB_ENV
           echo "CCACHE_SLOPPINESS=file_stat_matches,file_macro,time_macros" >> $env:GITHUB_ENV
 
       - name: Linux / macOS - Set up ccache
@@ -55,7 +55,7 @@ jobs:
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
           echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
-          echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=500M" >> $GITHUB_ENV
           echo "CCACHE_SLOPPINESS=file_stat_matches,file_macro,time_macros" >> $GITHUB_ENV
 
       # See: https://github.com/actions/checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,6 @@ jobs:
       - name: Windows - Build
         if: ${{ matrix.os == 'windows-2022' }}
         run: cmd.exe /c CI-windows.bat
-        env:
-          TB_ARCH: ${{ matrix.tb-arch }}
 
       - name: Windows - Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,29 +40,12 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
-      - name: Set up ccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('CCACHE_DIR', '${{ github.workspace }}/.ccache');
-            core.exportVariable('CCACHE_COMPRESS', 'true');
-            core.exportVariable('CCACHE_COMPRESSLEVEL', '6');
-            core.exportVariable('CCACHE_MAXSIZE', '500M');
-            core.exportVariable('CCACHE_SLOPPINESS', 'file_stat_matches,file_macro,time_macros');
-
       # See: https://github.com/actions/checkout
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
-
-      - name: Restore ccache files
-        uses: actions/cache@v4.2.3
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.os }}-${{ matrix.tb-build-type }}-${{ github.run_id }}
-          restore-keys: ccache-${{ matrix.os }}-${{ matrix.tb-build-type }}
 
       - name: "Create directory '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}'"
         run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
@@ -87,7 +70,6 @@ jobs:
       - name: Windows - Install dependencies
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
-          choco install ccache
           # Chocolatey was taking 3 minutes to install pandoc; just install it directly
           Invoke-WebRequest 'https://github.com/jgm/pandoc/releases/download/2.11.3.1/pandoc-2.11.3.1-windows-x86_64.zip' -OutFile 'pandoc.zip'
           if ("668A62A8990DEB2753753DF0C8D3F1BE567026FE" -ne (Get-FileHash -Path 'pandoc.zip' -Algorithm SHA1).Hash) { exit }
@@ -116,7 +98,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu-22.04') }}
         run: |
           sudo apt update
-          sudo apt install build-essential libxi-dev libxrandr-dev libxxf86vm-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libglm-dev pandoc cmake p7zip-full ninja-build xvfb libglew-dev libfreeimage-dev libfreetype6-dev libtinyxml2-dev libassimp-dev libfuse2 ccache
+          sudo apt install build-essential libxi-dev libxrandr-dev libxxf86vm-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libglm-dev pandoc cmake p7zip-full ninja-build xvfb libglew-dev libfreeimage-dev libfreetype6-dev libtinyxml2-dev libassimp-dev libfuse2
 
       - name: Linux - Build
         if: ${{ matrix.os == 'ubuntu-22.04' }}
@@ -166,12 +148,12 @@ jobs:
           # this issue can always reoccur when brew updates their python formula
           brew unlink python@3.12
           brew link --overwrite python@3.12
-          brew install cmake p7zip pandoc ninja autoconf automake ccache
+          brew install cmake p7zip pandoc ninja autoconf automake
 
       - name: macOS 14 - Install dependencies
         if: ${{ matrix.os == 'macos-14' }}
         run: |
-          brew install cmake p7zip pandoc ninja autoconf automake ccache
+          brew install cmake p7zip pandoc ninja autoconf automake
 
       - name: macOS 14 - Import signing certificates
         if: ${{ env.TB_SIGN_MAC_BUNDLE == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,23 +40,15 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
-      - name: Windows - Set up ccache
-        if: ${{ matrix.os == 'windows-2022' }}
-        run: |
-          echo "CCACHE_DIR=${{ github.workspace }}\\.ccache" >> $env:GITHUB_ENV
-          echo "CCACHE_COMPRESS=true" >> $env:GITHUB_ENV
-          echo "CCACHE_COMPRESSLEVEL=6" >> $env:GITHUB_ENV
-          echo "CCACHE_MAXSIZE=500M" >> $env:GITHUB_ENV
-          echo "CCACHE_SLOPPINESS=file_stat_matches,file_macro,time_macros" >> $env:GITHUB_ENV
-
-      - name: Linux / macOS - Set up ccache
-        if: ${{ matrix.os != 'windows-2022' }}
-        run: |
-          echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
-          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
-          echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
-          echo "CCACHE_MAXSIZE=500M" >> $GITHUB_ENV
-          echo "CCACHE_SLOPPINESS=file_stat_matches,file_macro,time_macros" >> $GITHUB_ENV
+      - name: Set up ccache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('CCACHE_DIR', '${{ github.workspace }}/.ccache');
+            core.exportVariable('CCACHE_COMPRESS', 'true');
+            core.exportVariable('CCACHE_COMPRESSLEVEL', '6');
+            core.exportVariable('CCACHE_MAXSIZE', '500M');
+            core.exportVariable('CCACHE_SLOPPINESS', 'file_stat_matches,file_macro,time_macros');
 
       # See: https://github.com/actions/checkout
       - name: Checkout code

--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -11,6 +11,8 @@ chmod u+x ./linuxdeploy-plugin-qt-x86_64.AppImage
 # Check versions
 qmake -v
 cmake --version
+ninja --version
+ccache --version
 pandoc --version
 ./linuxdeploy-x86_64.AppImage --version
 ./linuxdeploy-plugin-qt-x86_64.AppImage --plugin-version

--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -35,7 +35,7 @@ cmake .. \
 
 ccache -z
 cmake --build . --config Release -- -j $(nproc) || exit 1
-ccache -s
+ccache -sv
 
 # Run tests (wxgtk needs an X server running for the app to initialize)
 

--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -12,12 +12,9 @@ chmod u+x ./linuxdeploy-plugin-qt-x86_64.AppImage
 qmake -v
 cmake --version
 ninja --version
-ccache --version
 pandoc --version
 ./linuxdeploy-x86_64.AppImage --version
 ./linuxdeploy-plugin-qt-x86_64.AppImage --plugin-version
-
-ccache -p
 
 # Build TB
 
@@ -28,14 +25,12 @@ cmake .. \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_FLAGS="-Werror" \
   -DCMAKE_EXE_LINKER_FLAGS="-Wl,--fatal-warnings" \
-  -DTB_ENABLE_CCACHE=1 \
+  -DTB_ENABLE_CCACHE=0 \
   -DTB_ENABLE_PCH=0 \
   -DCMAKE_INSTALL_PREFIX=/usr \
   || exit 1
 
-ccache -z
 cmake --build . --config Release -- -j $(nproc) || exit 1
-ccache -sv
 
 # Run tests (wxgtk needs an X server running for the app to initialize)
 

--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -65,7 +65,7 @@ cmake .. \
 
 ccache -z
 cmake --build . --config "$TB_BUILD_TYPE" || exit 1
-ccache -s
+ccache -sv
 
 BUILD_DIR=$(pwd)
 

--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -5,6 +5,8 @@
 # Check versions
 qmake -v
 cmake --version
+ninja --version
+ccache --version
 pandoc --version
 
 # CCache configuration

--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -6,11 +6,7 @@
 qmake -v
 cmake --version
 ninja --version
-ccache --version
 pandoc --version
-
-# CCache configuration
-ccache -p
 
 # Qt install prefix
 brew --prefix qt@6
@@ -52,7 +48,7 @@ cmake .. \
   -DCMAKE_BUILD_TYPE="$TB_BUILD_TYPE" \
   -DCMAKE_CXX_FLAGS="-Werror" \
   -DCMAKE_EXE_LINKER_FLAGS="-Wl,-fatal_warnings" \
-  -DTB_ENABLE_CCACHE=1 \
+  -DTB_ENABLE_CCACHE=0 \
   -DTB_ENABLE_PCH=0 \
   -DTB_ENABLE_ASAN="$TB_ENABLE_ASAN" \
   -DTB_RUN_MACDEPLOYQT=1 \
@@ -63,9 +59,7 @@ cmake .. \
   -DTB_NOTARIZATION_PASSWORD="$TB_NOTARIZATION_PASSWORD" \
   || exit 1
 
-ccache -z
 cmake --build . --config "$TB_BUILD_TYPE" || exit 1
-ccache -sv
 
 BUILD_DIR=$(pwd)
 

--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -2,8 +2,12 @@ REM Check versions
 qmake -v
 cmake --version
 ninja --version
+ccache --version
 pandoc --version
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+REM CCache configuration
+ccache -p
 
 mkdir cmakebuild
 cd cmakebuild
@@ -13,13 +17,16 @@ REM Don't pass -DCMAKE_CXX_FLAGS="/WX" on the cmake command line; doing so wipes
 set CXXFLAGS="/WX"
 
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=0 -DTB_RUN_WINDEPLOYQT=1
+cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=1 -DTB_RUN_WINDEPLOYQT=1
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+ccache -z
 cmake --build . --config Release
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+
+ccache -s
 
 set BUILD_DIR="%cd%"
 

--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -26,7 +26,7 @@ cmake --build . --config Release
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-ccache -s
+ccache -sv
 
 set BUILD_DIR="%cd%"
 

--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -1,6 +1,7 @@
 REM Check versions
 qmake -v
 cmake --version
+ninja --version
 pandoc --version
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
@@ -11,7 +12,8 @@ REM Treat warnings as errors
 REM Don't pass -DCMAKE_CXX_FLAGS="/WX" on the cmake command line; doing so wipes out necessary cmake-provided defaults such as "/EHsc"
 set CXXFLAGS="/WX"
 
-cmake .. -G"Visual Studio 17 2022" -T v143 -A "%TB_ARCH%" -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_RUN_WINDEPLOYQT=1
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=0 -DTB_RUN_WINDEPLOYQT=1
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
@@ -21,22 +23,22 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 set BUILD_DIR="%cd%"
 
-cd lib\vm\test\Release
+cd lib\vm\test
 vm-test.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 cd "%BUILD_DIR%"
 
-cd lib\kdl\test\Release
+cd lib\kdl\test
 kdl-test.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 cd "%BUILD_DIR%"
 
-cd lib\upd\test\Release
+cd lib\upd\test
 upd-test.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 cd "%BUILD_DIR%"
 
-cd common\test\Release
+cd common\test
 common-test.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
@@ -44,7 +46,7 @@ common-regression-test.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 cd "%BUILD_DIR%"
 
-cd common\benchmark\Release
+cd common\benchmark
 common-benchmark.exe
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 cd "%BUILD_DIR%"

--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -2,12 +2,8 @@ REM Check versions
 qmake -v
 cmake --version
 ninja --version
-ccache --version
 pandoc --version
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-REM CCache configuration
-ccache -p
 
 mkdir cmakebuild
 cd cmakebuild
@@ -17,16 +13,13 @@ REM Don't pass -DCMAKE_CXX_FLAGS="/WX" on the cmake command line; doing so wipes
 set CXXFLAGS="/WX"
 
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=1 -DTB_RUN_WINDEPLOYQT=1
+cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=0 -DTB_RUN_WINDEPLOYQT=1
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-ccache -z
 cmake --build . --config Release
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-ccache -sv
 
 set BUILD_DIR="%cd%"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Using target_link_library to link an object library to qt requires 3.12
 # 3.14 is required for generator expressions in install(CODE)
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.25)
 
 # Fix warning with Ninja and cotire (see https://github.com/sakra/cotire/issues/81)
 if(POLICY CMP0058)
@@ -42,6 +42,9 @@ if(TB_ENABLE_CCACHE)
 
   if(CCACHE_PATH)
     message(STATUS "Found ccache: ${CCACHE_PATH}")
+
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+    cmake_policy(SET CMP0141 NEW)
 
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PATH}")
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PATH}")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -207,7 +207,7 @@ endif()
 
 # Generate a small stripped PDB for release builds so we get stack traces with symbols
 if(COMPILER_IS_MSVC)
-    set_target_properties(TrenchBroom PROPERTIES LINK_FLAGS_RELEASE "/DEBUG /PDBSTRIPPED:Release/TrenchBroom-stripped.pdb /PDBALTPATH:TrenchBroom-stripped.pdb")
+    set_target_properties(TrenchBroom PROPERTIES LINK_FLAGS_RELEASE "/DEBUG /PDBSTRIPPED:app/TrenchBroom-stripped.pdb /PDBALTPATH:TrenchBroom-stripped.pdb")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -153,7 +153,7 @@ macro(set_compiler_config TARGET)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:/Ox>")
 
         # Generate debug symbols even for Release; we build a stripped pdb in Release mode, see TrenchBroomApp.cmake
-        target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:/Zi>")
+        target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:/Z7>")
     else()
         message(FATAL_ERROR "Cannot set compile options for target ${TARGET}")
     endif()

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -47,7 +47,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "App
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(kdl-test PRIVATE -Wall -Wextra -pedantic)
 elseif(MSVC EQUAL 1)
-    target_compile_options(kdl-test PRIVATE /W3 /EHsc /MP)
+    target_compile_options(kdl-test PRIVATE /W4 /EHsc /MP)
 else()
     message(FATAL_ERROR "Cannot set compile options")
 endif()

--- a/lib/vm/test/CMakeLists.txt
+++ b/lib/vm/test/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "App
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(vm-test PRIVATE -Wall -Wextra -Wconversion -pedantic)
 elseif(MSVC EQUAL 1)
-    target_compile_options(vm-test PRIVATE /W3 /EHsc /MP)
+    target_compile_options(vm-test PRIVATE /W4 /EHsc /MP)
 else()
     message(FATAL_ERROR "Cannot set compile options for target")
 endif()


### PR DESCRIPTION
Originally, this PR was supposed to enable ccache on Windows. Eventually it turned out though that caching ccache's cache on github thrashes the vcpkg binary cache, so we don't gain much in the end. That's why the last commit disables ccache on CI again. I decided to keep the rest of the PR because the other changes are useful on their own.