### PR TITLE
Fix update check for release candidates

### DIFF
--- a/common/src/ui/UpdateVersion.h
+++ b/common/src/ui/UpdateVersion.h
@@ -38,6 +38,9 @@ struct SemanticVersion
   kdl_reflect_decl(SemanticVersion, major, minor, patch, rc);
 };
 
+std::strong_ordering operator<=>(const SemanticVersion& lhs, const SemanticVersion& rhs);
+bool operator==(const SemanticVersion& lhs, const SemanticVersion& rhs);
+
 struct TemporalVersion
 {
   int year;
@@ -47,9 +50,12 @@ struct TemporalVersion
   kdl_reflect_decl(TemporalVersion, year, no, rc);
 };
 
+std::strong_ordering operator<=>(const TemporalVersion& lhs, const TemporalVersion& rhs);
+bool operator==(const TemporalVersion& lhs, const TemporalVersion& rhs);
+
 using UpdateVersion = std::variant<SemanticVersion, TemporalVersion>;
 
-std::partial_ordering operator<=>(const UpdateVersion& lhs, const UpdateVersion& rhs);
+std::strong_ordering operator<=>(const UpdateVersion& lhs, const UpdateVersion& rhs);
 bool operator==(const UpdateVersion& lhs, const UpdateVersion& rhs);
 std::ostream& operator<<(std::ostream& lhs, const UpdateVersion& rhs);
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -160,6 +160,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/ui/tst_Undo.cpp"
         "${COMMON_TEST_SOURCE_DIR}/ui/tst_UpdateLinkedGroupsCommand.cpp"
         "${COMMON_TEST_SOURCE_DIR}/ui/tst_UpdateLinkedGroupsHelper.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/ui/tst_UpdateVersion.cpp"
         "${COMMON_TEST_SOURCE_DIR}/ui/tst_Validator.cpp"
 )
 
@@ -193,7 +194,7 @@ target_include_directories(common-test-utils PUBLIC ${COMMON_TEST_SOURCE_DIR})
 target_link_libraries(common-test-utils PRIVATE common Catch2::Catch2 Qt6::Test)
 
 macro(configure_test_target TARGET)
-    target_link_libraries(${TARGET} PRIVATE common common-test-utils Catch2::Catch2 fmt::fmt-header-only)
+    target_link_libraries(${TARGET} PRIVATE common common-test-utils Catch2::Catch2 upd fmt::fmt-header-only)
     set_target_properties(${TARGET} PROPERTIES AUTOMOC TRUE)
 
     set_compiler_config(${TARGET})

--- a/common/test/src/ui/tst_UpdateVersion.cpp
+++ b/common/test/src/ui/tst_UpdateVersion.cpp
@@ -43,14 +43,15 @@ TEST_CASE("UpdateVersion")
 
   CHECK_FALSE(
     UpdateVersion{SemanticVersion{1, 2, 3, 1}}
-    < UpdateVersion{SemanticVersion{1, 2, 3, _}});
-  CHECK_FALSE(
-    UpdateVersion{SemanticVersion{1, 2, 3, 1}}
     < UpdateVersion{SemanticVersion{1, 2, 3, 1}});
   CHECK(
     UpdateVersion{SemanticVersion{1, 2, 3, 1}}
     < UpdateVersion{SemanticVersion{1, 2, 3, 2}});
+
   CHECK(
+    UpdateVersion{SemanticVersion{1, 2, 3, 1}}
+    < UpdateVersion{SemanticVersion{1, 2, 3, _}});
+  CHECK_FALSE(
     UpdateVersion{SemanticVersion{1, 2, 3, _}}
     < UpdateVersion{SemanticVersion{1, 2, 3, 2}});
 
@@ -72,14 +73,15 @@ TEST_CASE("UpdateVersion")
 
   CHECK_FALSE(
     UpdateVersion{TemporalVersion{2022, 2, 1}}
-    < UpdateVersion{TemporalVersion{2022, 2, _}});
-  CHECK_FALSE(
-    UpdateVersion{TemporalVersion{2022, 2, 1}}
     < UpdateVersion{TemporalVersion{2022, 2, 1}});
   CHECK(
     UpdateVersion{TemporalVersion{2022, 2, 1}}
     < UpdateVersion{TemporalVersion{2022, 2, 2}});
+
   CHECK(
+    UpdateVersion{TemporalVersion{2022, 2, 1}}
+    < UpdateVersion{TemporalVersion{2022, 2, _}});
+  CHECK_FALSE(
     UpdateVersion{TemporalVersion{2022, 2, _}}
     < UpdateVersion{TemporalVersion{2022, 2, 1}});
 


### PR DESCRIPTION
Release candidates were ordered greater than the corresponding release versions, but that is of course wrong, because then a release candidate never gets updated to the released version.

Note that this requires another release candidate to be released before the 2025.3 release.