### PR TITLE
Add MSVC flag /bigobj so debug builds work on Windows

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -149,6 +149,10 @@ macro(set_compiler_config TARGET)
         # workaround /external generating some spurious warnings
         # https://developercommunity.visualstudio.com/content/problem/220812/experimentalexternal-generates-a-lot-of-c4193-warn.html
         target_compile_options(${TARGET} PRIVATE /wd4193)
+        
+        # required to compile large objects; only needed in debug mode currently as release mode strips enough sections
+        # https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file
+        target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:DEBUG>:/bigobj>")
 
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:/Ox>")
 


### PR DESCRIPTION
It seems that at some point the Debug build on Windows exceeded a default limit of its PE format which is 16-bit by default. This causes every Windows build of TB to fail unless the `/bigobj` flag is added to the compile parameters, which increases that limit to 32-bit.

I did some research online and found that there's no real downside to having this flag enabled, with the exception of `/bigobj` not being compatible with MSVC versions prior to 2005. As I doubt that's a concern for TB, I think this flag should be enabled. I am not experienced with CMake but this looked like the correct place to put it, but if it should go elsewhere please move it or let me know where I should move it to.

This is not needed in Release mode at this point so I have set it to only apply this in Debug. However I don't think there's any impact if it was to be enabled for all builds, as it only relates to the object files pre-linking and not the resulting executable.

- https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170
- https://developercommunity.visualstudio.com/t/Enable-bigobj-by-default/1031214
- https://stackoverflow.com/questions/15110580/penalty-of-the-msvs-compiler-flag-bigobj