### PR TITLE
Fix glTF rotation

### DIFF
--- a/common/src/io/AssimpLoader.cpp
+++ b/common/src/io/AssimpLoader.cpp
@@ -649,6 +649,13 @@ AssimpComputedMeshData computeMeshData(
   return {meshIndex, builder.vertices(), builder.indices()};
 }
 
+// These follow the Quake coordinate system, which is X forward, Y left, Z up.
+bool usesQuakeCoordinates(const aiScene& scene)
+{
+  auto const isHl1 = scene.mRootNode->FindNode(AiMdlHl1NodeBodyparts) != nullptr;
+  return isHl1;
+}
+
 aiMatrix4x4 getAxisTransform(const aiScene& scene)
 {
   if (scene.mMetaData)
@@ -668,15 +675,28 @@ aiMatrix4x4 getAxisTransform(const aiScene& scene)
 
     if (!metadataPresent)
     {
-      // By default, all 3D data from is provided in a right-handed coordinate system.
-      // +X to the right. -Z into the screen. +Y upwards.
-      upAxis = 1;
-      upAxisSign = 1;
-      frontAxis = 2;
-      frontAxisSign = 1;
-      coordAxis = 0;
-      coordAxisSign = 1;
-      unitScale = 1.0f;
+      if (usesQuakeCoordinates(scene))
+      {
+        upAxis = 1;
+        upAxisSign = 1;
+        frontAxis = 2;
+        frontAxisSign = 1;
+        coordAxis = 0;
+        coordAxisSign = 1;
+        unitScale = 1.0f;
+      }
+      else
+      {
+        // By default, all 3D data from assimp is provided in a right-handed coordinate
+        // system. +X to the right. -Z into the screen. +Y upwards.
+        upAxis = 1;
+        upAxisSign = 1;
+        frontAxis = 0;
+        frontAxisSign = -1;
+        coordAxis = 2;
+        coordAxisSign = 1;
+        unitScale = 1.0f;
+      }
     }
 
     auto up = aiVector3D{};


### PR DESCRIPTION
Fixes #4447 
~~I still don't know *why* this is necessary, but this is the fix.~~
See comments below

As a test model, I use this chair:
![image](https://github.com/user-attachments/assets/e0a0ba88-1913-48ae-99c5-b92f57b79526)

It points towards +Z, which is [forward in glTF](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units).

This is TrenchBroom 2025.3 RC3:
![image](https://github.com/user-attachments/assets/9309559d-f723-4114-932d-594bc9878fa3)

This is TrenchBroom after this commit:
![image](https://github.com/user-attachments/assets/ee76aa6d-0e1c-4e2d-915b-c808899ecdc5)

I can also confirm that this now all looks correct in-engine.
