### PR TITLE
Fix asset selection for auto updater

### DIFF
--- a/common/src/ui/UpdateVersion.cpp
+++ b/common/src/ui/UpdateVersion.cpp
@@ -198,15 +198,19 @@ namespace
 auto buildAssetPattern()
 {
 #if defined(_WIN32)
-  return QRegularExpression{R"(TrenchBroom-Win64-AMD64-v\d{4}\.\d+-Release.zip)"};
+  return QRegularExpression{
+    R"(TrenchBroom-Win64-AMD64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
 #elif defined(__APPLE__)
 #if defined(__arm64__)
-  return QRegularExpression{R"(TrenchBroom-macOS-arm64-v\d{4}\.\d+-Release.zip)"};
+  return QRegularExpression{
+    R"(TrenchBroom-macOS-arm64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
 #else
-  return QRegularExpression{R"(TrenchBroom-macOS-x86_64-v\d{4}\.\d+-Release.zip)"};
+  return QRegularExpression{
+    R"(TrenchBroom-macOS-x86_64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
 #endif
 #else
-  return QRegularExpression{R"(TrenchBroom-Linux-x86_64-v\d{4}\.\d+-Release.zip)"};
+  return QRegularExpression{
+    R"(TrenchBroom-Linux-x86_64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
 #endif
 }
 } // namespace

--- a/common/src/ui/UpdateVersion.cpp
+++ b/common/src/ui/UpdateVersion.cpp
@@ -141,9 +141,9 @@ bool operator==(const UpdateVersion& lhs, const UpdateVersion& rhs)
 std::optional<UpdateVersion> parseUpdateVersion(const QString& tag)
 {
   static const auto temporalPattern =
-    QRegularExpression{R"(v(\d{4})\.(\d+)(?:-RC(\d+))?)"};
+    QRegularExpression{R"(^v(\d{4})\.(\d+)(?:-RC(\d+))?$)"};
   static const auto semanticPattern =
-    QRegularExpression{R"(v(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?)"};
+    QRegularExpression{R"(^v(\d+)\.(\d+)\.(\d+)(?:-RC(\d+))?$)"};
 
   if (const auto temporalMatch = temporalPattern.match(tag); temporalMatch.hasMatch())
   {
@@ -199,18 +199,18 @@ auto buildAssetPattern()
 {
 #if defined(_WIN32)
   return QRegularExpression{
-    R"(TrenchBroom-Win64-AMD64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
+    R"(TrenchBroom-Win64-AMD64-v\d{4}\.\d+(?:-RC(\d+))?-Release.zip)"};
 #elif defined(__APPLE__)
 #if defined(__arm64__)
   return QRegularExpression{
-    R"(TrenchBroom-macOS-arm64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
+    R"(TrenchBroom-macOS-arm64-v\d{4}\.\d+(?:-RC(\d+))?-Release.zip)"};
 #else
   return QRegularExpression{
-    R"(TrenchBroom-macOS-x86_64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
+    R"(TrenchBroom-macOS-x86_64-v\d{4}\.\d+(?:-RC(\d+))?-Release.zip)"};
 #endif
 #else
   return QRegularExpression{
-    R"(TrenchBroom-Linux-x86_64-v\d{4}\.\d+(-RC\d+)?-Release.zip)"};
+    R"(TrenchBroom-Linux-x86_64-v\d{4}\.\d+(?:-RC(\d+))?-Release.zip)"};
 #endif
 }
 } // namespace

--- a/common/test/src/ui/tst_UpdateVersion.cpp
+++ b/common/test/src/ui/tst_UpdateVersion.cpp
@@ -17,6 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QList>
+
 #include "ui/UpdateVersion.h"
 
 #include <optional>
@@ -25,7 +27,6 @@
 
 namespace tb::ui
 {
-
 
 TEST_CASE("UpdateVersion")
 {
@@ -91,6 +92,53 @@ TEST_CASE("UpdateVersion")
   CHECK_FALSE(
     UpdateVersion{TemporalVersion{2022, 2, _}}
     < UpdateVersion{SemanticVersion{1, 2, 3, _}});
+}
+
+TEST_CASE("chooseAsset")
+{
+  SECTION("with release candidates")
+  {
+    const auto assets = QList<upd::Asset>{
+      {"TrenchBroom-Win64-AMD64-v2025.3-RC3-Release.zip", QUrl{}, 0},
+      {"TrenchBroom-macOS-arm64-v2025.3-RC3-Release.zip", QUrl{}, 0},
+      {"TrenchBroom-macOS-x86_64-v2025.3-RC3-Release.zip", QUrl{}, 0},
+      {"TrenchBroom-Linux-x86_64-v2025.3-RC3-Release.zip", QUrl{}, 0},
+    };
+
+#if defined(_WIN32)
+    CHECK(chooseAsset(assets) == assets[0]);
+#elif defined(__APPLE__)
+#if defined(__arm64__)
+    CHECK(chooseAsset(assets) == assets[1]);
+#else
+    CHECK(chooseAsset(assets) == assets[2]);
+#endif
+#else
+    CHECK(chooseAsset(assets) == assets[3]);
+#endif
+  }
+
+  SECTION("with release versions")
+  {
+    const auto assets = QList<upd::Asset>{
+      {"TrenchBroom-Win64-AMD64-v2025.3-Release.zip", QUrl{}, 0},
+      {"TrenchBroom-macOS-arm64-v2025.3-Release.zip", QUrl{}, 0},
+      {"TrenchBroom-macOS-x86_64-v2025.3-Release.zip", QUrl{}, 0},
+      {"TrenchBroom-Linux-x86_64-v2025.3-Release.zip", QUrl{}, 0},
+    };
+
+#if defined(_WIN32)
+    CHECK(chooseAsset(assets) == assets[0]);
+#elif defined(__APPLE__)
+#if defined(__arm64__)
+    CHECK(chooseAsset(assets) == assets[1]);
+#else
+    CHECK(chooseAsset(assets) == assets[2]);
+#endif
+#else
+    CHECK(chooseAsset(assets) == assets[3]);
+#endif
+  }
 }
 
 } // namespace tb::ui

--- a/common/test/src/ui/tst_UpdateVersion.cpp
+++ b/common/test/src/ui/tst_UpdateVersion.cpp
@@ -94,6 +94,28 @@ TEST_CASE("UpdateVersion")
     < UpdateVersion{SemanticVersion{1, 2, 3, _}});
 }
 
+TEST_CASE("parseUpdateVersion")
+{
+  using T = std::tuple<QString, std::optional<UpdateVersion>>;
+
+  // clang-format off
+  const auto& 
+  [str,           expectedVersion] = GENERATE(values<T>({
+  {"",            std::nullopt},
+  {"asdf",        std::nullopt},
+  {"v2025.1a",    std::nullopt},
+  {"v3.2.x",      std::nullopt},
+  {"v3.2.1",      SemanticVersion{3, 2, 1}},
+  {"v2025.1",     TemporalVersion{2025, 1}},
+  {"v2025.1-RC2", TemporalVersion{2025, 1, 2}},
+  }));
+  // clang-format on
+
+  CAPTURE(str);
+
+  CHECK(parseUpdateVersion(str) == expectedVersion);
+}
+
 TEST_CASE("chooseAsset")
 {
   SECTION("with release candidates")


### PR DESCRIPTION
The updater didn't consider release candidates when selecting an asset to download. This resulted in a failed update when a newer release candidate version is available.