### PR TITLE
Improvements to FGD model handling

### DIFF
--- a/app/resources/games/Halflife/HalfLife.fgd
+++ b/app/resources/games/Halflife/HalfLife.fgd
@@ -607,15 +607,15 @@
 //
 
 
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_9mmclip.mdl" }) = ammo_9mmclip : "9mm Pistol Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_9mmarclip.mdl" }) = ammo_9mmAR : "9mm Assault Rifle Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_chainammo.mdl" }) = ammo_9mmbox : "box of 200 9mm shells" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_argrenade.mdl" }) = ammo_ARgrenades : "Assault Grenades" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_shotshell.mdl" }) = ammo_buckshot : "Shotgun Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_357ammobox.mdl" }) = ammo_357 : "357 Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_rpgammo.mdl" }) = ammo_rpgclip : "RPG Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_gaussammo.mdl" }) = ammo_gaussclip : "Gauss Gun Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_crossbow_clip.mdl" }) = ammo_crossbow : "Crossbow Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_9mmclip.mdl") = ammo_9mmclip : "9mm Pistol Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_9mmarclip.mdl") = ammo_9mmAR : "9mm Assault Rifle Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_chainammo.mdl") = ammo_9mmbox : "box of 200 9mm shells" []
+@PointClass base(Weapon, Targetx) studio("models/w_argrenade.mdl") = ammo_ARgrenades : "Assault Grenades" []
+@PointClass base(Weapon, Targetx) studio("models/w_shotshell.mdl") = ammo_buckshot : "Shotgun Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_357ammobox.mdl") = ammo_357 : "357 Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_rpgammo.mdl") = ammo_rpgclip : "RPG Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_gaussammo.mdl") = ammo_gaussclip : "Gauss Gun Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_crossbow_clip.mdl") = ammo_crossbow : "Crossbow Ammo" []
 
 @SolidClass base(Target, ZHLT) = button_target : "Target Button"
 [
@@ -1671,12 +1671,12 @@
 @PointClass base(Targetname) = info_null : "info_null (spotlight target)" []
 
 @PointClass base(PlayerClass) = info_player_coop : "Player cooperative start" []
-@PointClass base(PlayerClass, Sequence) model({ "path": "models/player.mdl", "frame": sequence, "skin": skin }) = info_player_deathmatch : "Player deathmatch start" 
+@PointClass base(PlayerClass, Sequence) studio("models/player.mdl") = info_player_deathmatch : "Player deathmatch start" 
 [
 	target(target_destination) : "Target"
 	master(string) : "Master"
 ]
-@PointClass base(PlayerClass, Sequence) model({ "path": "models/player.mdl", "frame": sequence, "skin": skin }) = info_player_start : "Player 1 start" []
+@PointClass base(PlayerClass, Sequence) studio("models/player.mdl") = info_player_start : "Player 1 start" []
 
 @PointClass base(Targetname) size(-4 -4 -4, 4 4 4) color(200 100 50) = info_target : "Beam Target" []
 @PointClass size(-8 -8 0, 8 8 16) base(PlayerClass, Targetname) = info_teleport_destination : "Teleport destination" []
@@ -1685,13 +1685,13 @@
 // items
 //
 
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_oxygen.mdl" }) = item_airtank : "Oxygen tank" []
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_antidote.mdl" }) = item_antidote : "Poison antidote" []
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_battery.mdl" }) = item_battery : "HEV battery" []
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_medkit.mdl" }) = item_healthkit : "Small Health Kit" []
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_longjump.mdl" }) = item_longjump : "Longjump Module" []
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_security.mdl" }) = item_security : "Security card" []
-@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) model({ "path": "models/w_suit.mdl" }) = item_suit : "HEV Suit" 
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_oxygen.mdl") = item_airtank : "Oxygen tank" []
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_antidote.mdl") = item_antidote : "Poison antidote" []
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_battery.mdl") = item_battery : "HEV battery" []
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_medkit.mdl") = item_healthkit : "Small Health Kit" []
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_longjump.mdl") = item_longjump : "Longjump Module" []
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_security.mdl") = item_security : "Security card" []
+@PointClass size(-16 -16 0, 16 16 36) base(Weapon, Targetx) studio("models/w_suit.mdl") = item_suit : "HEV Suit" 
 [
 	spawnflags(Flags) =
 	[
@@ -1791,8 +1791,8 @@
 // monsters
 //
 
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/controller.mdl", "frame": sequence, "skin": skin }) = monster_alien_controller : "Controller"  []
-@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) model({ "path": "models/agrunt.mdl", "frame": sequence, "skin": skin }) = monster_alien_grunt : "Alien Grunt" 
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/controller.mdl") = monster_alien_controller : "Controller"  []
+@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) studio("models/agrunt.mdl") = monster_alien_grunt : "Alien Grunt" 
 [
 	netname(string) : "Squad Name"
 	spawnflags(Flags) =
@@ -1800,7 +1800,7 @@
 		32 : "SquadLeader" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/islave.mdl", "frame": sequence, "skin": skin }) = monster_alien_slave : "Vortigaunt" 
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/islave.mdl") = monster_alien_slave : "Vortigaunt" 
 [
 	netname(string) : "Squad Name"
 	spawnflags(Flags) =
@@ -1809,7 +1809,7 @@
 		64 : "IgnorePlayer" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-360 -360 -172, 360 360 8) model({ "path": "models/apache.mdl", "frame": sequence, "skin": skin }) = monster_apache : "Apache" 
+@PointClass base(Monster, Sequence) size(-360 -360 -172, 360 360 8) studio("models/apache.mdl") = monster_apache : "Apache" 
 [
 	spawnflags(Flags) = 
 	[
@@ -1817,9 +1817,9 @@
 		64 : "Start Inactive" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) model({ "path": "models/baby_headcrab.mdl", "frame": sequence, "skin": skin }) = monster_babycrab : "Baby Headcrab" []
-@PointClass base(RenderFields, Sequence) size(-16 -16 -36, 16 16 0) model({ "path": "models/barnacle.mdl", "frame": sequence, "skin": skin }) = monster_barnacle : "Barnacle Monster" []
-@PointClass base(Monster,TalkMonster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/barney.mdl", "frame": sequence, "skin": skin }) = monster_barney : "Barney" []
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) studio("models/baby_headcrab.mdl") = monster_babycrab : "Baby Headcrab" []
+@PointClass base(RenderFields, Sequence) size(-16 -16 -36, 16 16 0) studio("models/barnacle.mdl") = monster_barnacle : "Barnacle Monster" []
+@PointClass base(Monster,TalkMonster, Sequence) size(-16 -16 0, 16 16 72) studio("models/barney.mdl") = monster_barney : "Barney" []
 @PointClass base(RenderFields,Appearflags, Angles, Sequence) size(-16 -16 0, 16 16 72) = monster_barney_dead : "Dead Barney" 
 [
       pose(Choices) : "Pose" : 0 =
@@ -1829,14 +1829,14 @@
 		2 : "On stomach"
 	]
 ]
-@PointClass base(Monster, Sequence) size(-95 -95 0, 95 95 190) model({ "path": "models/big_mom.mdl", "frame": sequence, "skin": skin }) = monster_bigmomma : "Big Mamma" 
+@PointClass base(Monster, Sequence) size(-95 -95 0, 95 95 190) studio("models/big_mom.mdl") = monster_bigmomma : "Big Mamma" 
 [
 	netname(string) : "First node" : ""
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/floater.mdl", "frame": sequence, "skin": skin }) = monster_bloater : "Bloater" []
-@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) model({ "path": "models/bullsquid.mdl", "frame": sequence, "skin": skin }) = monster_bullchicken : "BullChicken" []
-@PointClass base(Monster, Sequence) size(-3 -3 0, 3 3 3) model({ "path": "models/roach.mdl", "frame": sequence, "skin": skin }) = monster_cockroach : "Cockroach" []
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 16) model({ "path": "models/aflock.mdl", "frame": sequence, "skin": skin }) = monster_flyer_flock : "Flock of Flyers" 
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/floater.mdl") = monster_bloater : "Bloater" []
+@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) studio("models/bullsquid.mdl") = monster_bullchicken : "BullChicken" []
+@PointClass base(Monster, Sequence) size(-3 -3 0, 3 3 3) studio("models/roach.mdl") = monster_cockroach : "Cockroach" []
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 16) studio("models/aflock.mdl") = monster_flyer_flock : "Flock of Flyers" 
 [
 	iFlockSize(Integer) : "Flock Size" : 8
 	flFlockRadius(Integer) : "Flock Radius" : 128
@@ -1846,7 +1846,7 @@
 	model(studio) : "model"
 
 ]
-@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 128) model({ "path": "models/garg.mdl", "frame": sequence, "skin": skin }) = monster_gargantua : "Gargantua" []
+@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 128) studio("models/garg.mdl") = monster_gargantua : "Gargantua" []
 @PointClass base(Monster, RenderFields, Sequence) size(-16 -16 -36, 16 16 36) studio() = monster_generic : "Generic Script Monster" 
 [
 	spawnflags(Flags) = 
@@ -1856,10 +1856,10 @@
 	model(studio) : "model"
 	body(Integer) : "Body" : 0
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/gman.mdl", "frame": sequence, "skin": skin }) = monster_gman : "G-Man" []
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/hgrunt.mdl", "frame": sequence, "skin": skin }) = monster_grunt_repel : "Human Grunt (Repel)" []
-@PointClass base(Weapon, Targetx, RenderFields, Sequence) model({ "path": "models/w_grenade.mdl", "frame": sequence, "skin": skin }) = monster_handgrenade : "Live Handgrenade" []
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) model({ "path": "models/headcrab.mdl", "frame": sequence, "skin": skin }) = monster_headcrab : "Head Crab" []
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/gman.mdl") = monster_gman : "G-Man" []
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/hgrunt.mdl") = monster_grunt_repel : "Human Grunt (Repel)" []
+@PointClass base(Weapon, Targetx, RenderFields, Sequence) studio("models/w_grenade.mdl") = monster_handgrenade : "Live Handgrenade" []
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) studio("models/headcrab.mdl") = monster_headcrab : "Head Crab" []
 @PointClass base(Appearflags,RenderFields, Angles, Sequence) size(-16 -16 0, 16 16 72) = monster_hevsuit_dead : "Dead HEV Suit" 
 [
       pose(Choices) : "Pose" : 0 =
@@ -1870,7 +1870,7 @@
 		3 : "On Table"
 	]
 ]
-@PointClass base(Appearflags,RenderFields, Angles) size(-16 -16 0, 16 16 72) model({ "path": "models/hgrunt.mdl", "frame": sequence, "skin": skin }) = monster_hgrunt_dead : "Dead Human Grunt" 
+@PointClass base(Appearflags,RenderFields, Angles) size(-16 -16 0, 16 16 72) studio("models/hgrunt.mdl") = monster_hgrunt_dead : "Dead Human Grunt" 
 [
       pose(Choices) : "Pose" : 0 =
 	[
@@ -1892,7 +1892,7 @@
 		46 : "deadsitting"
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) model({ "path": "models/houndeye.mdl", "frame": sequence, "skin": skin }) = monster_houndeye : "Houndeye" 
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) studio("models/houndeye.mdl") = monster_houndeye : "Houndeye" 
 [
 	netname(string) : "Squad Name"
 	spawnflags(Flags) =
@@ -1900,8 +1900,8 @@
 		32 : "SquadLeader" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/hassassin.mdl", "frame": sequence, "skin": skin }) = monster_human_assassin : "Human Assassin" []
-@PointClass base(Monster) size(-16 -16 0, 16 16 72) model({ "path": "models/hgrunt.mdl", "frame": sequence, "skin": skin }) = monster_human_grunt : "Human Grunt (camo)" 
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/hassassin.mdl") = monster_human_assassin : "Human Assassin" []
+@PointClass base(Monster) size(-16 -16 0, 16 16 72) studio("models/hgrunt.mdl") = monster_human_grunt : "Human Grunt (camo)" 
 [
 	spawnflags(Flags) =
 	[
@@ -2002,9 +2002,9 @@
 		81 : "plunger"
 	]
 ]
-@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) model({ "path": "models/icky.mdl", "frame": sequence, "skin": skin }) = monster_ichthyosaur : "Ichthyosaur" []
-@PointClass base(Monster, Sequence) size(-6 -6 0, 6 6 6) model({ "path": "models/leech.mdl", "frame": sequence, "skin": skin }) = monster_leech : "Leech" []
-@PointClass base(Monster, Sequence) size(-16 -16 -32, 16 16 32) model({ "path": "models/miniturret.mdl", "frame": sequence, "skin": skin }) = monster_miniturret : "Mini Auto Turret"
+@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) studio("models/icky.mdl") = monster_ichthyosaur : "Ichthyosaur" []
+@PointClass base(Monster, Sequence) size(-6 -6 0, 6 6 6) studio("models/leech.mdl") = monster_leech : "Leech" []
+@PointClass base(Monster, Sequence) size(-16 -16 -32, 16 16 32) studio("models/miniturret.mdl") = monster_miniturret : "Mini Auto Turret"
 [
 	orientation(Choices) : "Orientation" : 0 =
 	[
@@ -2017,17 +2017,17 @@
 		64 : "Start Inactive" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-192 -192 0, 192 192 384) model({ "path": "models/nihilanth.mdl", "frame": sequence, "skin": skin }) = monster_nihilanth : "Nihilanth"  []
-@PointClass base(Monster, Sequence) size(-480 -480 -112, 480 480 24) model({ "path": "models/osprey.mdl", "frame": sequence, "skin": skin }) = monster_osprey : "Osprey"
+@PointClass base(Monster, Sequence) size(-192 -192 0, 192 192 384) studio("models/nihilanth.mdl") = monster_nihilanth : "Nihilanth"  []
+@PointClass base(Monster, Sequence) size(-480 -480 -112, 480 480 24) studio("models/osprey.mdl") = monster_osprey : "Osprey"
 [
 	spawnflags(Flags) = 
 	[
 		64 : "Start Inactive" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-6 -6 0, 6 6 6) model({ "path": "models/bigrat.mdl", "frame": sequence, "skin": skin }) = monster_rat : "Rat (no ai)" []
-@PointClass base(Weapon,Targetx,RenderFields, Sequence) model({ "path": "models/w_satchel.mdl", "frame": sequence, "skin": skin }) = monster_satchelcharge : "Live Satchel Charge" []
-@PointClass base(Monster, TalkMonster) size(-16 -16 0, 16 16 72) model({ "path": "models/scientist.mdl", "frame": sequence, "skin": skin }) = monster_scientist : "Scared Scientist" 
+@PointClass base(Monster, Sequence) size(-6 -6 0, 6 6 6) studio("models/bigrat.mdl") = monster_rat : "Rat (no ai)" []
+@PointClass base(Weapon,Targetx,RenderFields, Sequence) studio("models/w_satchel.mdl") = monster_satchelcharge : "Live Satchel Charge" []
+@PointClass base(Monster, TalkMonster) size(-16 -16 0, 16 16 72) studio("models/scientist.mdl") = monster_scientist : "Scared Scientist" 
 [
       body(Choices) : "Body" : -1 =
 	[
@@ -2169,7 +2169,7 @@
 		127 : "kneel"
 	]
 ]
-@PointClass base(Appearflags,RenderFields, Angles) size(-16 -16 0, 16 16 72) model({ "path": "models/scientist.mdl", "frame": sequence, "skin": skin }) = monster_scientist_dead : "Dead Scientist" 
+@PointClass base(Appearflags,RenderFields, Angles) size(-16 -16 0, 16 16 72) studio("models/scientist.mdl") = monster_scientist_dead : "Dead Scientist" 
 [
 	body(Choices) : "Body" : -1 =
 	[
@@ -2199,7 +2199,7 @@
 		42 : "dead_table3"
 	]
 ]
-@PointClass base(Monster) size(-14 -14 22, 14 14 72) model({ "path": "models/scientist.mdl", "frame": sequence, "skin": skin }) = monster_sitting_scientist : "Sitting Scientist" 
+@PointClass base(Monster) size(-14 -14 22, 14 14 72) studio("models/scientist.mdl") = monster_sitting_scientist : "Sitting Scientist" 
 [
 	body(Choices) : "Body" : -1 =
 	[
@@ -2218,7 +2218,7 @@
 		75 : "sitting3"
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/sentry.mdl", "frame": sequence, "skin": skin }) = monster_sentry : "Sentry Turret Gun"
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/sentry.mdl") = monster_sentry : "Sentry Turret Gun"
 [
 	spawnflags(Flags) = 
 	[
@@ -2226,8 +2226,8 @@
 		64 : "Start Inactive" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) model({ "path": "models/w_squeak.mdl", "frame": sequence, "skin": skin }) = monster_snark : "Armed Snark" []
-@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) model({ "path": "models/tentacle2.mdl", "frame": sequence, "skin": skin }) = monster_tentacle : "Tentacle Arm" 
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 36) studio("models/w_squeak.mdl") = monster_snark : "Armed Snark" []
+@PointClass base(Monster, Sequence) size(-32 -32 0, 32 32 64) studio("models/tentacle2.mdl") = monster_tentacle : "Tentacle Arm" 
 [
 	sweeparc(integer) : "Sweep Arc" : 130
 	sound(Choices) : "Tap Sound" : -1 =
@@ -2245,7 +2245,7 @@
 		1 : "Instant On" : 1
 	]
 ]
-@PointClass base(Monster, Sequence) size(-32 -32 -32, 32 32 32) model({ "path": "models/turret.mdl", "frame": sequence, "skin": skin }) = monster_turret : "Auto Turret"
+@PointClass base(Monster, Sequence) size(-32 -32 -32, 32 32 32) studio("models/turret.mdl") = monster_turret : "Auto Turret"
 [
 	orientation(Choices) : "Orientation" : 0 =
 	[
@@ -2258,7 +2258,7 @@
 		64 : "Start Inactive" : 0
 	]
 ]
-@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) model({ "path": "models/zombie.mdl", "frame": sequence, "skin": skin }) = monster_zombie : "Scientist Zombie" []
+@PointClass base(Monster, Sequence) size(-16 -16 0, 16 16 72) studio("models/zombie.mdl") = monster_zombie : "Scientist Zombie" []
 @PointClass base(Targetname, Angles) size(-16 -16 -16, 16 16 16) = monstermaker : "Monster Maker"
 [
 	target(string) : "Target On Release" 
@@ -2665,14 +2665,14 @@
 // weapons
 //
 
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_crowbar.mdl" }) = weapon_crowbar : "Crowbar" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_9mmhandgun.mdl" }) = weapon_9mmhandgun : "9mm Handgun" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_357.mdl" }) = weapon_357 : "357 Handgun" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_9mmar.mdl" }) = weapon_9mmAR : "9mm Assault Rifle" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_shotgun.mdl" }) = weapon_shotgun : "Shotgun" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_rpg.mdl" }) = weapon_rpg : "RPG" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_gauss.mdl" }) = weapon_gauss : "Gauss Gun" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_crossbow.mdl", "frame": sequence }) = weapon_crossbow : "Crossbow" 
+@PointClass base(Weapon, Targetx) studio("models/w_crowbar.mdl") = weapon_crowbar : "Crowbar" []
+@PointClass base(Weapon, Targetx) studio("models/w_9mmhandgun.mdl") = weapon_9mmhandgun : "9mm Handgun" []
+@PointClass base(Weapon, Targetx) studio("models/w_357.mdl") = weapon_357 : "357 Handgun" []
+@PointClass base(Weapon, Targetx) studio("models/w_9mmar.mdl") = weapon_9mmAR : "9mm Assault Rifle" []
+@PointClass base(Weapon, Targetx) studio("models/w_shotgun.mdl") = weapon_shotgun : "Shotgun" []
+@PointClass base(Weapon, Targetx) studio("models/w_rpg.mdl") = weapon_rpg : "RPG" []
+@PointClass base(Weapon, Targetx) studio("models/w_gauss.mdl") = weapon_gauss : "Gauss Gun" []
+@PointClass base(Weapon, Targetx) studio("models/w_crossbow.mdl") = weapon_crossbow : "Crossbow" 
 [
 	sequence(choices) : "Placement" : 0 =
 	[
@@ -2680,13 +2680,13 @@
 		1 : "Realistic (tilted)"
 	]
 ]
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_egon.mdl" }) = weapon_egon : "Egon Gun" []
+@PointClass base(Weapon, Targetx) studio("models/w_egon.mdl") = weapon_egon : "Egon Gun" []
 @PointClass base(Weapon, Targetx) size(-16 -16 -5, 16 16 27) = weapon_tripmine : "Tripmine Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_satchel.mdl" }) = weapon_satchel : "Satchel Charge Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_grenade.mdl" }) = weapon_handgrenade : "Handgrenade Ammo" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_squeak.mdl" }) = weapon_snark : "Squeak Grenade" []
-@PointClass base(Weapon, Targetx) model({ "path": "models/w_hgun.mdl" }) = weapon_hornetgun : "Hornet Gun" []
-@PointClass size(-16 -16 0, 16 16 64) color(0 128 0) model({ "path": "models/w_chainammo.mdl" }) =  weaponbox : "Weapon/Ammo Container" []
+@PointClass base(Weapon, Targetx) studio("models/w_satchel.mdl") = weapon_satchel : "Satchel Charge Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_grenade.mdl") = weapon_handgrenade : "Handgrenade Ammo" []
+@PointClass base(Weapon, Targetx) studio("models/w_squeak.mdl") = weapon_snark : "Squeak Grenade" []
+@PointClass base(Weapon, Targetx) studio("models/w_hgun.mdl") = weapon_hornetgun : "Hornet Gun" []
+@PointClass size(-16 -16 0, 16 16 64) color(0 128 0) studio("models/w_chainammo.mdl") =  weaponbox : "Weapon/Ammo Container" []
 
 @PointClass base(Weapon, Targetx) = world_items : "World Items" 
 [
@@ -2703,15 +2703,15 @@
 // Xen
 //
 
-@PointClass base(Target, Targetname, RenderFields, Angles) size(-48 -48 0, 48 48 32 ) model({ "path": "models/light.mdl" }) = xen_plantlight : "Xen Plant Light" []
-@PointClass base(Targetname, RenderFields, Angles) size(-8 -8 0, 8 8 32 ) model({ "path": "models/hair.mdl" }) = xen_hair : "Xen Hair" 
+@PointClass base(Target, Targetname, RenderFields, Angles) size(-48 -48 0, 48 48 32 ) studio("models/light.mdl") = xen_plantlight : "Xen Plant Light" []
+@PointClass base(Targetname, RenderFields, Angles) size(-8 -8 0, 8 8 32 ) studio("models/hair.mdl") = xen_hair : "Xen Hair" 
 [
 	spawnflags(Flags) = 
 	[
 		1 : "Sync Movement" 	: 0
 	]
 ]
-@PointClass base(Targetname, RenderFields, Angles) size(-24 -24 0, 24 24 188 ) model({ "path": "models/tree.mdl" }) = xen_tree : "Xen Tree" []
-@PointClass base(Targetname, RenderFields, Angles) size(-16 -16 0, 16 16 64 ) model({ "path": "models/fungus(small).mdl" }) = xen_spore_small : "Xen Spore (small)" []
-@PointClass base(Targetname, RenderFields, Angles) size(-40 -40 0, 40 40 120 ) model({ "path": "models/fungus.mdl" }) = xen_spore_medium : "Xen Spore (medium)" []
-@PointClass base(Targetname, RenderFields, Angles) size(-90 -90 0, 90 90 220 ) model({ "path": "models/fungus(large).mdl" }) = xen_spore_large : "Xen Spore (large)" []
+@PointClass base(Targetname, RenderFields, Angles) size(-24 -24 0, 24 24 188 ) studio("models/tree.mdl") = xen_tree : "Xen Tree" []
+@PointClass base(Targetname, RenderFields, Angles) size(-16 -16 0, 16 16 64 ) studio("models/fungus(small).mdl") = xen_spore_small : "Xen Spore (small)" []
+@PointClass base(Targetname, RenderFields, Angles) size(-40 -40 0, 40 40 120 ) studio("models/fungus.mdl") = xen_spore_medium : "Xen Spore (medium)" []
+@PointClass base(Targetname, RenderFields, Angles) size(-90 -90 0, 90 90 220 ) studio("models/fungus(large).mdl") = xen_spore_large : "Xen Spore (large)" []

--- a/common/src/el/Expression.h
+++ b/common/src/el/Expression.h
@@ -287,4 +287,6 @@ VisitorResultType_t<Visitor> ExpressionNode::accept(const Visitor& visitor) cons
     *m_expression);
 }
 
+  const ExpressionNode UndefinedLiteralNode = ExpressionNode{LiteralExpression{Value::Undefined}};
+
 } // namespace tb::el

--- a/common/src/el/Expression.h
+++ b/common/src/el/Expression.h
@@ -223,6 +223,7 @@ enum class BinaryOperation
   NotEqual,
   BoundedRange,
   Case,
+  Coalesce,
 };
 
 struct BinaryExpression

--- a/common/src/io/ELParser.cpp
+++ b/common/src/io/ELParser.cpp
@@ -77,6 +77,7 @@ auto tokenNames()
     {BitwiseShiftRight, "'>>'"},
     {DoubleOBrace, "'{{'"},
     {DoubleCBrace, "'}}'"},
+    {Coalesce, "'??'"},
     {Null, "'null'"},
     {Eof, "end of file"},
   };
@@ -258,6 +259,13 @@ ELTokenizer::Token ELTokenizer::emitToken()
         {
           advance(2);
           return Token{ELToken::Range, c, c + 2, offset(c), line, column};
+        }
+        break;
+      case '?':
+        if (lookAhead() == '?')
+        {
+          advance(2);
+          return Token{ELToken::Coalesce, c, c + 2, offset(c), line, column};
         }
         break;
       case '=':
@@ -675,6 +683,7 @@ el::ExpressionNode ELParser::parseCompoundTerm(el::ExpressionNode lhs)
     {ELToken::NotEqual, el::BinaryOperation::NotEqual},
     {ELToken::Range, el::BinaryOperation::BoundedRange},
     {ELToken::Case, el::BinaryOperation::Case},
+    {ELToken::Coalesce, el::BinaryOperation::Coalesce},
   };
 
   while (m_tokenizer.peekToken().hasType(ELToken::CompoundTerm))

--- a/common/src/io/ELParser.h
+++ b/common/src/io/ELParser.h
@@ -70,15 +70,16 @@ constexpr auto BitwiseShiftLeft = Type{1} << 33;
 constexpr auto BitwiseShiftRight = Type{1} << 34;
 constexpr auto DoubleOBrace = Type{1} << 35;
 constexpr auto DoubleCBrace = Type{1} << 36;
-constexpr auto Null = Type{1} << 37;
-constexpr auto Eof = Type{1} << 38;
+constexpr auto Coalesce = Type{1} << 37;
+constexpr auto Null = Type{1} << 38;
+constexpr auto Eof = Type{1} << 39;
 constexpr auto Literal = String | Number | Boolean | Null;
 constexpr auto UnaryOperator = Addition | Subtraction | LogicalNegation | BitwiseNegation;
 constexpr auto SimpleTerm = Name | Literal | OParen | OBracket | OBrace | UnaryOperator;
 constexpr auto CompoundTerm =
   Addition | Subtraction | Multiplication | Division | Modulus | LogicalAnd | LogicalOr
   | Less | LessOrEqual | Equal | NotEqual | GreaterOrEqual | Greater | Case | BitwiseAnd
-  | BitwiseXOr | BitwiseOr | BitwiseShiftLeft | BitwiseShiftRight;
+  | BitwiseXOr | BitwiseOr | BitwiseShiftLeft | BitwiseShiftRight | Coalesce;
 } // namespace ELToken
 
 class ELTokenizer : public Tokenizer<ELToken::Type>

--- a/common/src/io/FgdParser.h
+++ b/common/src/io/FgdParser.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "Color.h"
+#include "el/Expression.h"
 #include "io/EntityDefinitionParser.h"
 #include "io/Parser.h"
 #include "io/Tokenizer.h"
@@ -121,8 +122,10 @@ private:
   void skipMainClass();
 
   std::vector<std::string> parseSuperClasses();
-  mdl::ModelDefinition parseModel(ParserStatus& status, bool allowEmptyExpression);
+  mdl::ModelDefinition parseModel(ParserStatus& status);
   mdl::DecalDefinition parseDecal();
+  el::ExpressionNode parseExpression(ParserStatus& status, FgdToken::Type oToken, FgdToken::Type cToken);
+  el::ExpressionNode parseExpressionWithOverride(ParserStatus& status, FgdToken::Type oToken, FgdToken::Type cToken, std::string overrideKey);
   std::string parseNamedValue(ParserStatus& status, const std::string& name);
   void skipClassProperty(ParserStatus& status);
 


### PR DESCRIPTION
Parsed FGDs now exhibit behaviour closer to expectations in regards to class & entity properties for determining model definition when not using `model()`. That is, by updating the `model` entity property, the displayed model is updated. Likewise for `scale` `sequence` and `skin`.

This behaviour applies only when the Trenchbroom exclusive `model()` class property is not set (in which case it is assumed that either this behaviour is intended to be prevented, or can be defined explicitly or even linked to other entity properties). That is, any use of the `model()` class property will prevent this new behaviour.

This will apply to any class that has a defined model using one of the common model-path properties (`studio` `studioprop` `lightprop` `sprite` `iconsprite`), and will coalesce the entity properties against the class properties for `model` (i.e. `path`) `scale` `sequence` (`frame`) and `skin`. This is functionally equivalent to `model({ "path": model ?? <class-property>, "scale": scale ?? <class-property>, "frame": sequence ?? <class-property>, "skin": skin ?? <class-property> })`.

This should allow for greater compatibility with FGD and MAP files in general.

As a bonus, this means that the displayed model will be updated when the `model` entity property is set, which is useful for cyclers and other similar classes.