### PR TITLE
Don't crash when dragging an entity into the map after rotating vertices

### DIFF
--- a/common/src/ui/ToolBox.cpp
+++ b/common/src/ui/ToolBox.cpp
@@ -299,7 +299,6 @@ void ToolBox::deactivateAllTools()
   while (!m_modalToolStack.empty())
   {
     deactivateTool(*m_modalToolStack.back());
-    m_modalToolStack.pop_back();
   }
 }
 


### PR DESCRIPTION
Closes #4864