### PR TITLE
Proposition: Use entity key-values for displaying models in editor

### DIFF
--- a/common/src/io/FgdParser.cpp
+++ b/common/src/io/FgdParser.cpp
@@ -374,6 +374,7 @@ EntityDefinitionClassInfo FgdParser::parseClassInfo(
       kdl::ci::str_is_equal(typeName, "model")
       || kdl::ci::str_is_equal(typeName, "studio")
       || kdl::ci::str_is_equal(typeName, "studioprop")
+      || kdl::ci::str_is_equal(typeName, "lightprop")
       || kdl::ci::str_is_equal(typeName, "sprite")
       || kdl::ci::str_is_equal(typeName, "iconsprite"))
     {
@@ -381,8 +382,7 @@ EntityDefinitionClassInfo FgdParser::parseClassInfo(
       {
         status.warn(token.location(), "Found multiple model properties");
       }
-      classInfo.modelDefinition =
-        parseModel(status, kdl::ci::str_is_equal(typeName, "sprite"));
+      classInfo.modelDefinition = parseModel(status);
     }
     else if (kdl::ci::str_is_equal(typeName, "decal"))
     {
@@ -453,21 +453,14 @@ std::vector<std::string> FgdParser::parseSuperClasses()
 }
 
 mdl::ModelDefinition FgdParser::parseModel(
-  ParserStatus& status, const bool allowEmptyExpression)
+  ParserStatus& status)
 {
   m_tokenizer.nextToken(FgdToken::OParenthesis);
 
-  if (allowEmptyExpression && m_tokenizer.peekToken().hasType(FgdToken::CParenthesis))
+  if (m_tokenizer.peekToken().hasType(FgdToken::CParenthesis))
   {
-    const auto location = m_tokenizer.location();
     m_tokenizer.skipToken();
-
-    auto defaultModel = el::MapExpression{{
-      {"path", el::ExpressionNode{el::VariableExpression{"model"}, location}},
-      {"scale", el::ExpressionNode{el::VariableExpression{"scale"}, location}},
-    }};
-    auto defaultExp = el::ExpressionNode{std::move(defaultModel), location};
-    return mdl::ModelDefinition{std::move(defaultExp)};
+    return mdl::ModelDefinition();
   }
 
   return io::parseModelDefinition(m_tokenizer, status, FgdToken::CParenthesis)

--- a/common/src/io/FgdParser.h
+++ b/common/src/io/FgdParser.h
@@ -121,7 +121,7 @@ private:
   void skipMainClass();
 
   std::vector<std::string> parseSuperClasses();
-  mdl::ModelDefinition parseModel(ParserStatus& status, bool allowEmptyExpression);
+  mdl::ModelDefinition parseModel(ParserStatus& status);
   mdl::DecalDefinition parseDecal();
   std::string parseNamedValue(ParserStatus& status, const std::string& name);
   void skipClassProperty(ParserStatus& status);


### PR DESCRIPTION
Replaces #4856

Ensures greater compatibilitry and closer-to-expected behaviour along with other FGD-based editors such as hammer.

Entity key-values will always override path (using "model"), scale, frame (using "sequence"), and skin

See: https://developer.valvesoftware.com/wiki/FGD

Alternative #4870
Unlike the other proposition, this should be more efficient (process fewer EL expressions), and work even if not loading FGDs. By always overriding specific model properties in this way, we don't have to check if the given model expression is explicitly a map, thus ensuring greater compatibility with more complex expressions (e.g. something to the effect of `model({{ if X then {MapExpression} else {MapExpression} }})`).