### PR TITLE
Update Quake2.fgd line # 527 : misc_gib_leg

### DIFF
--- a/app/resources/games/Quake2/Quake2.fgd
+++ b/app/resources/games/Quake2/Quake2.fgd
@@ -524,7 +524,7 @@
 // set angle for gib direction, otherwise it just drops
 @PointClass base(Appearflags) color(255 0 0) size(-8 -8 -8, 8 8 8) model({ "path": ":models/objects/gibs/arm/tris.md2" }) = misc_gib_arm : "arm gib, use with target_spawner" []
 @PointClass base(Appearflags) color(255 0 0) size(-8 -8 -8, 8 8 8) model({ "path": ":models/objects/gibs/head/tris.md2" }) = misc_gib_head : "head gib, use with target_spawner" []
-@PointClass base(Appearflags) color(255 0 0) size(-8 -8 -8, 8 8 8) model({ "path": ":models/objects/gibs/arm/tris.md2" }) = misc_gib_leg : "leg gib, use with target_spawner" []
+@PointClass base(Appearflags) color(255 0 0) size(-8 -8 -8, 8 8 8) model({ "path": ":models/objects/gibs/leg/tris.md2" }) = misc_gib_leg : "leg gib, use with target_spawner" []
 
 
 


### PR DESCRIPTION
Back port from my Quake2RE FGD fixes. The original line incorrectly points to the arm gib and not the leg gib model. This just corrects that to display the correct gib model in TrenchBroom when placing `misc_gib_leg`.