### PR TITLE
Always run windeployqt on Windows

### DIFF
--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -13,7 +13,7 @@ REM Don't pass -DCMAKE_CXX_FLAGS="/WX" on the cmake command line; doing so wipes
 set CXXFLAGS="/WX"
 
 call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=0 -DTB_RUN_WINDEPLOYQT=1
+cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release -DTB_ENABLE_PCH=0 -DTB_ENABLE_CCACHE=0
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -190,9 +190,9 @@ if(WIN32)
             COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:TrenchBroom>"
             COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:TrenchBroom>")
 
-    # If requested, run windeployqt which copies the Qt dlls into the deployable folder, along with necessary
-    # runtime dlls by the compiler
-    if(TB_RUN_WINDEPLOYQT)
+    # Run windeployqt which copies the Qt dlls into the deployable folder, along with necessary runtime dlls by the compiler
+    # Only copy translations on release builds, as deploying them takes significantly longer
+    if(NOT TB_SKIP_WINDEPLOYQT)
         message(STATUS "windeployqt requested")
 
         # Get windeployqt path (hack)
@@ -201,7 +201,12 @@ if(WIN32)
         message(STATUS "windeployqt found: ${TB_WINDEPLOYQT_PATH}")
 
         add_custom_command(TARGET TrenchBroom POST_BUILD
-                COMMAND "${TB_WINDEPLOYQT_PATH}" --no-compiler-runtime "$<TARGET_FILE_DIR:TrenchBroom>")
+                COMMAND "${TB_WINDEPLOYQT_PATH}"
+                        --no-compiler-runtime
+                        $<$<CONFIG:Debug>:--no-translations>
+                        "$<TARGET_FILE_DIR:TrenchBroom>")
+    else()
+        message(STATUS "windeployqt skipped")
     endif()
 endif()
 


### PR DESCRIPTION
Avoids the need to have Qt on the PATH on Windows. Does not deploy Qt translations in Debug mode, which makes windeployqt significantly faster.

I also added an option `TB_SKIP_WINDEPLOYQT` in case someone wants to never run windeployqt.

Fixes #4774

Calling windeployqt with --no-translations adds approximately 150ms to the 12s build on average. Benchmarks:

```
PS D:\Github\TrenchBroom\build> cmake . -DTB_SKIP_WINDEPLOYQT=0
...
-- windeployqt requested
-- windeployqt found: C:/Qt/6.9.0/msvc2022_64/bin/windeployqt.exe
...
PS D:\Github\TrenchBroom\build> hyperfine 'cmake --build .' --warmup 2
Benchmark 1: cmake --build .
  Time (mean ± σ):     12.438 s ±  0.052 s    [User: 5.864 s, System: 7.807 s]
  Range (min … max):   12.369 s … 12.538 s    10 runs
PS D:\Github\TrenchBroom\build> cmake . -DTB_SKIP_WINDEPLOYQT=1
...
-- windeployqt skipped
...
PS D:\Github\TrenchBroom\build> hyperfine 'cmake --build .' --warmup 2
Benchmark 1: cmake --build .
  Time (mean ± σ):     12.280 s ±  0.046 s    [User: 5.897 s, System: 7.593 s]
  Range (min … max):   12.181 s … 12.333 s    10 runs
```