### PR TITLE
[Proposal] Implementation for FGD colour types

### DIFF
--- a/common/src/io/EntParser.cpp
+++ b/common/src/io/EntParser.cpp
@@ -304,6 +304,15 @@ auto withDefaultValue(
         }
         return flagValueType;
       },
+      [&](ColorPropertyValue colorValueType) -> mdl::PropertyValueType {
+        const auto values = parseColorPropertyValueOptionalValues(
+          parseString(element, "value"), colorValueType.components.size());
+        for (size_t i = 0; i < colorValueType.components.size(); ++i)
+        {
+          colorValueType.components[i].defaultValue = values[i];
+        }
+        return colorValueType;
+      },
       [&](Unknown unknownValueType) -> mdl::PropertyValueType {
         if (hasAttribute(element, "value"))
         {

--- a/common/src/io/FgdParser.h
+++ b/common/src/io/FgdParser.h
@@ -145,6 +145,8 @@ private:
   mdl::PropertyDefinition parseChoicesPropertyDefinition(
     ParserStatus& status, std::string propertyKey);
   mdl::PropertyDefinition parseFlagsPropertyDefinition(std::string propertyKey);
+  mdl::PropertyDefinition parseColorPropertyDefinition(
+    ParserStatus& status, const std::string& typeName, std::string propertyKey);
   mdl::PropertyDefinition parseUnknownPropertyDefinition(
     ParserStatus& status, std::string propertyKey);
 

--- a/common/src/mdl/PropertyDefinition.h
+++ b/common/src/mdl/PropertyDefinition.h
@@ -105,6 +105,46 @@ struct Flags
   kdl_reflect_decl(Flags, defaultValue, flags);
 };
 
+enum class ColorValueType
+{
+  Any,
+  Float,
+  Byte
+};
+
+std::ostream& operator<<(std::ostream& lhs, ColorValueType rhs);
+
+enum class ColorComponentType
+{
+  Red,
+  Green,
+  Blue,
+  Alpha,
+  LightBrightness,
+  Other
+};
+
+std::ostream& operator<<(std::ostream& lhs, ColorComponentType rhs);
+
+struct ColorComponent
+{
+  ColorValueType valueType;
+  ColorComponentType componentType;
+  std::optional<float> defaultValue = std::nullopt;
+
+  kdl_reflect_decl(ColorComponent, valueType, componentType, defaultValue);
+};
+
+struct ColorPropertyValue
+{
+  std::vector<ColorComponent> components;
+
+  kdl_reflect_decl(ColorPropertyValue, components);
+};
+
+std::vector<std::optional<float>> parseColorPropertyValueOptionalValues(
+  const std::string_view& value, const size_t minimumNumValues);
+
 struct Unknown
 {
   std::optional<std::string> defaultValue = std::nullopt;
@@ -123,6 +163,7 @@ using PropertyValueType = std::variant<
   PropertyValueTypes::Float,
   PropertyValueTypes::Choice,
   PropertyValueTypes::Flags,
+  PropertyValueTypes::ColorPropertyValue,
   PropertyValueTypes::Unknown>;
 
 std::ostream& operator<<(std::ostream& lhs, const PropertyValueType& rhs);


### PR DESCRIPTION
I've been looking into implementing #1048 - at least support for `color1` and `color255`. This is a proposed initial implementation that I would like feedback on before I go too much further.

The code in this initial commit only implements the colour type and FGD parsing.

### Details

⇒ This implementation breaks colours down into components which allows a single type to work for any combination of colour values in any order. This might seem overdone but my thinking is:
- There are at least 4 known colour configurations: color1 & color255 with rgb values, as well as both of those with an additional value for brightness
- Even if color1 is specified, the brightness value is not limited between 0 and 1 - it is (usually?) an integer and the value can be increased as high as the user wants
- The additional complexity to have each component have a separate value type is relatively small
- It provides significant flexibility for future extension - for example, each component having their own min/max values, or additional values such as alpha transparency
- The additional metadata allows the smart property editor to be more useful (e.g. brightness as a slider)
- This same style could be applied to future types as well as existing types, simplifying other implementations - e.g. TargetSource and TargetDestination could be combined into a single type called Target with a field called Direction (Source, Destination, Both)

⇒ At the moment I attempt to keep backwards compatibility with the existing hard-coded colour property names, however this complicates the parsing code a bit and it may be reasonable to just update the included FGDs instead and expect users with custom FGDs to update their types as needed.

⇒ I've added custom types called `lightcolor1` and `lightcolor255` as colour types with an additional component for brightness, instead of trying to overload `color1` and `color255` with different behaviour based on some assumption about default values or property names.
- In the future this could be possibly be made more explicit or even be fully customisable in the FGD with some new syntax, an example could be something like: `name(color255:rgb)` or `name(color1:rgbl)` where `l` would represent light brightness. Valve uses similar syntax for some type hints in their Source 2 editor (e.g. https://github.com/SteamDatabase/GameTracking-Dota2/blob/a0d3b14b2e3053eb169310d6fe1fc33f7cfc0664/game/core/vdata_base.fgd#L21)

⇒ UI Mockup (not implemented at this point):
<img width="515" height="177" alt="image" src="https://github.com/user-attachments/assets/00b8ccf8-457b-4154-ad87-28c466c28be8" />

### Questions

- Am I heading in the right direction or is this not the right general approach?
- Is splitting colour values into components like this overthinking it? If so, what is the alternative to support 4+ different styles of colour properties?
- Is it reasonable to remove the backwards compatibility with the hard-coded property names such as `_color`, `_color2` in favour of updating the FGD with the correct color types?
- Is adding the extra `lightcolor` type names a reasonable approach?
- There's overlap between the existing `ColorRange` type and my `ColorValueType` enum, should this be refactored so they are shared? I wanted to use an enum instead of an integer for type safety.
- There's an enum called `Component` in TestUtils.h that has some overlap with my `ColorComponentType` enum, however I'm not sure if it would be a good idea or not to refactor that one as they are being used in different contexts.
- Feedback on naming in general (it would be more consistent to use `Color` instead of `ColorPropertyValue` as the type name, but this created far too many conflicts)