### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,7 @@
+permissions:
+  # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.
+  packages: write
+
 on:
   # Run on pushes to tags, the "master" branch, and PR's
   push:
@@ -87,9 +91,9 @@ jobs:
             -StorePasswordInClearText `
             -Name GitHubPackages `
             -UserName "${{ env.USERNAME }}" `
-            -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+            -Password "${{ secrets.GITHUB_TOKEN }}"
           .$(${{ env.VCPKG_EXE }} fetch nuget) `
-            setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" `
+            setapikey "${{ secrets.GITHUB_TOKEN }}" `
             -Source "${{ env.FEED_URL }}"
 
       - name: Windows - Build
@@ -127,9 +131,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${{ env.USERNAME }}" \
-            -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+            -Password "${{ secrets.GITHUB_TOKEN }}"
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
             -Source "${{ env.FEED_URL }}"
 
       - name: Linux - Build
@@ -209,9 +213,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${{ env.USERNAME }}" \
-            -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+            -Password "${{ secrets.GITHUB_TOKEN }}"
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
             -Source "${{ env.FEED_URL }}"
 
       - name: macOS - Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
-permissions:
-  # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.
-  packages: write
+name: CI Builds
 
 on:
   # Run on pushes to tags, the "master" branch, and PR's
@@ -11,16 +9,15 @@ on:
       - master
   pull_request:
 
-name: CI
-
 jobs:
-  # Job key
   ci:
-    # Label displayed in UI
-    name: CI
     runs-on: ${{ matrix.os }}
+
+    permissions:
+      # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.
+      packages: write
+
     strategy:
-      # Don't cancel the macOS build if the Linux build fails, etc.
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
@@ -37,7 +34,6 @@ jobs:
     env:
       # Record pull request head commit SHA
       TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      TB_OS_IMAGE: ${{ matrix.os }}
       # Set up environment variables required for caching vcpkg packages using NuGet
       # See https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages?pivots=windows-runner
       USERNAME: TrenchBroom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,12 +189,12 @@ jobs:
           # this issue can always reoccur when brew updates their python formula
           brew unlink python@3.12
           brew link --overwrite python@3.12
-          brew install cmake p7zip pandoc ninja autoconf automake
+          brew install p7zip pandoc ninja autoconf automake
 
       - name: macOS 14 - Install dependencies
         if: ${{ matrix.os == 'macos-14' }}
         run: |
-          brew install cmake p7zip pandoc ninja autoconf automake
+          brew install p7zip pandoc ninja autoconf automake
 
       - name: macOS 14 - Import signing certificates
         if: ${{ env.TB_SIGN_MAC_BUNDLE == 'true' }}

--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -1,21 +1,19 @@
-name: cpp-linter
-
-permissions:
-  # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.
-  packages: write
+name: CPP Linter
 
 on: [pull_request]
 
 jobs:
   cpp-linter:
     runs-on: ubuntu-22.04
+
     permissions:
+      # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.
+      packages: write
       pull-requests: write
 
     env:
       # Record pull request head commit SHA
       TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      TB_OS_IMAGE: ${{ matrix.os }}
       # Set up environment variables required for caching vcpkg packages using NuGet
       # See https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages?pivots=windows-runner
       USERNAME: TrenchBroom

--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -1,4 +1,9 @@
 name: cpp-linter
+
+permissions:
+  # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.
+  packages: write
+
 on: [pull_request]
 
 jobs:
@@ -11,10 +16,15 @@ jobs:
       # Record pull request head commit SHA
       TB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       TB_OS_IMAGE: ${{ matrix.os }}
-      # Tells vcpkg where binary packages are stored.
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
-      # Let's use GitHub Action cache as storage for the vcpkg Binary Caching feature.
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      # Set up environment variables required for caching vcpkg packages using NuGet
+      # See https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages?pivots=windows-runner
+      USERNAME: TrenchBroom
+      VCPKG_EXE: ${{ github.workspace }}/vcpkg/vcpkg
+      FEED_URL: https://nuget.pkg.github.com/TrenchBroom/index.json
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/TrenchBroom/index.json,readwrite"
+      # Set up environment variables required for Mono (on macOS)
+      # See https://formulae.brew.sh/formula/mono
+      MONO_GAC_PREFIX: "$HOMEBREW_PREFIX"
 
     steps:
       - name: Checkout code
@@ -23,29 +33,34 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: "Create directory '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}'"
-        run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-        shell: bash
-
-      # Set env vars needed for vcpkg to leverage the GitHub Actions cache as a storage
-      # for Binary Caching.
-      - name: Set vcpkg environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       # Dependencies
-      - name: Install common Linux dependencies
-        run: |
-          sudo apt update
-          sudo apt install build-essential libxi-dev libxrandr-dev libxxf86vm-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libglm-dev pandoc cmake p7zip-full ninja-build xvfb libglew-dev libfreeimage-dev libfreetype6-dev libtinyxml2-dev libassimp-dev
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.7.0'
+
+      - name: Bootstrap vcpkg
+        shell: bash
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install build-essential libxi-dev libxrandr-dev libxxf86vm-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libglm-dev pandoc cmake p7zip-full ninja-build xvfb libglew-dev libfreeimage-dev libfreetype6-dev libtinyxml2-dev libassimp-dev libfuse2
+
+      - name: Add NuGet sources
+        shell: bash
+        run: |
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            sources add \
+            -Source "${{ env.FEED_URL }}" \
+            -StorePasswordInClearText \
+            -Name GitHubPackages \
+            -UserName "${{ env.USERNAME }}" \
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "${{ env.FEED_URL }}"
 
       - name: Run cmake
         run: |
@@ -53,7 +68,7 @@ jobs:
           cd build
           cmake .. -GNinja -DCMAKE_PREFIX_PATH="cmake/packages;$QT_ROOT_DIR" -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTB_ENABLE_PCH=0
 
-      - name: "Run clang-tidy"
+      - name: Run clang-tidy
         uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:

--- a/.github/workflows/clean-commit.yml
+++ b/.github/workflows/clean-commit.yml
@@ -1,4 +1,5 @@
-name: Pull request
+name: Check Commits
+
 # This workflow is triggered on pull requests for the repository.
 on: [pull_request]
 


### PR DESCRIPTION
- Use github action token for nuget repository caches; this fixes a problem where the cache couldn't be restored.
- Use the nuget repository for the clang-tidy action; this was forgotten and now it didn't cache vcpkg anymore.
- Don't install cmake on macOS, it's already installed and homebrew complained about it.
- Unrelated: macOS builds could no longer be signed because I had to accept changes to Apple's TOS.