### PR TITLE
Use GCC 13 on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,9 @@ jobs:
       - name: Linux - Install dependencies
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt update
-          sudo apt install build-essential libxi-dev libxrandr-dev libxxf86vm-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libglm-dev pandoc cmake p7zip-full ninja-build xvfb libglew-dev libfreeimage-dev libfreetype6-dev libtinyxml2-dev libassimp-dev libfuse2
+          sudo apt install gcc-13 g++-13 build-essential libxi-dev libxrandr-dev libxxf86vm-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev libglm-dev pandoc cmake p7zip-full ninja-build xvfb libglew-dev libfreeimage-dev libfreetype6-dev libtinyxml2-dev libassimp-dev libfuse2
 
       - name: Linux - Add NuGet sources
         if: ${{ matrix.os == 'ubuntu-22.04' }}
@@ -131,6 +132,12 @@ jobs:
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
             setapikey "${{ secrets.GITHUB_TOKEN }}" \
             -Source "${{ env.FEED_URL }}"
+
+      - name: Linux - Set compiler version
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: |
+          echo "CC=gcc-13" >> $GITHUB_ENV
+          echo "CXX=g++-13" >> $GITHUB_ENV
 
       - name: Linux - Build
         if: ${{ matrix.os == 'ubuntu-22.04' }}

--- a/Build.md
+++ b/Build.md
@@ -100,6 +100,9 @@ If you have a debian-based distribution, open a command prompt and execute this 
 sudo apt-get install g++ libxi-dev libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libglew-dev libxrandr-dev build-essential libglm-dev libxxf86vm-dev libfreetype6-dev libfreeimage-dev libtinyxml2-dev pandoc cmake p7zip-full ninja-build curl
 ```
 
+> [!IMPORTANT]
+> You need to use GCC 13 or later to compile TrenchBroom.
+
 ### Build TrenchBroom
 
 Create a subdirectory in TrenchBroom directory called `build`.

--- a/common/src/io/MapFileSerializer.cpp
+++ b/common/src/io/MapFileSerializer.cpp
@@ -52,7 +52,7 @@ class QuakeFileSerializer : public MapFileSerializer
 {
 public:
   explicit QuakeFileSerializer(std::ostream& stream)
-    : MapFileSerializer(stream)
+    : MapFileSerializer{stream}
   {
   }
 
@@ -61,16 +61,16 @@ private:
   {
     writeFacePoints(stream, face);
     writeMaterialInfo(stream, face);
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), "\n");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "\n");
   }
 
 protected:
   void writeFacePoints(std::ostream& stream, const mdl::BrushFace& face) const
   {
-    const mdl::BrushFace::Points& points = face.points();
+    const auto& points = face.points();
 
     fmt::format_to(
-      std::ostreambuf_iterator<char>(stream),
+      std::ostreambuf_iterator<char>{stream},
       "( {} {} {} ) ( {} {} {} ) ( {} {} {} )",
       points[0].x(),
       points[0].y(),
@@ -83,25 +83,25 @@ protected:
       points[2].z());
   }
 
-  static bool shouldQuoteMaterialName(const std::string& materialName)
+  static bool shouldQuoteMaterialName(const auto& materialName)
   {
     return materialName.empty()
            || materialName.find_first_of("\"\\ \t") != std::string::npos;
   }
 
-  static std::string quoteMaterialName(const std::string& materialName)
+  static std::string quoteMaterialName(const auto& materialName)
   {
-    return "\"" + kdl::str_escape(materialName, "\"") + "\"";
+    return fmt::format(R"("{}")", kdl::str_escape(materialName, R"(")"));
   }
 
   void writeMaterialInfo(std::ostream& stream, const mdl::BrushFace& face) const
   {
-    const std::string& materialName = face.attributes().materialName().empty()
-                                        ? mdl::BrushFaceAttributes::NoMaterialName
-                                        : face.attributes().materialName();
+    const auto& materialName = face.attributes().materialName().empty()
+                                 ? mdl::BrushFaceAttributes::NoMaterialName
+                                 : face.attributes().materialName();
 
     fmt::format_to(
-      std::ostreambuf_iterator<char>(stream),
+      std::ostreambuf_iterator<char>{stream},
       " {} {} {} {} {} {}",
       shouldQuoteMaterialName(materialName) ? quoteMaterialName(materialName)
                                             : materialName,
@@ -114,14 +114,14 @@ protected:
 
   void writeValveMaterialInfo(std::ostream& stream, const mdl::BrushFace& face) const
   {
-    const std::string& materialName = face.attributes().materialName().empty()
-                                        ? mdl::BrushFaceAttributes::NoMaterialName
-                                        : face.attributes().materialName();
-    const vm::vec3d uAxis = face.uAxis();
-    const vm::vec3d vAxis = face.vAxis();
+    const auto& materialName = face.attributes().materialName().empty()
+                                 ? mdl::BrushFaceAttributes::NoMaterialName
+                                 : face.attributes().materialName();
+    const auto uAxis = face.uAxis();
+    const auto vAxis = face.vAxis();
 
     fmt::format_to(
-      std::ostreambuf_iterator<char>(stream),
+      std::ostreambuf_iterator<char>{stream},
       " {} [ {} {} {} {} ] [ {} {} {} {} ] {} {} {}",
       shouldQuoteMaterialName(materialName) ? quoteMaterialName(materialName)
                                             : materialName,
@@ -146,7 +146,7 @@ class Quake2FileSerializer : public QuakeFileSerializer
 {
 public:
   explicit Quake2FileSerializer(std::ostream& stream)
-    : QuakeFileSerializer(stream)
+    : QuakeFileSerializer{stream}
   {
   }
 
@@ -161,14 +161,14 @@ private:
       writeSurfaceAttributes(stream, face);
     }
 
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), "\n");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "\n");
   }
 
 protected:
   void writeSurfaceAttributes(std::ostream& stream, const mdl::BrushFace& face) const
   {
     fmt::format_to(
-      std::ostreambuf_iterator<char>(stream),
+      std::ostreambuf_iterator<char>{stream},
       " {} {} {}",
       face.resolvedSurfaceContents(),
       face.resolvedSurfaceFlags(),
@@ -180,7 +180,7 @@ class Quake2ValveFileSerializer : public Quake2FileSerializer
 {
 public:
   explicit Quake2ValveFileSerializer(std::ostream& stream)
-    : Quake2FileSerializer(stream)
+    : Quake2FileSerializer{stream}
   {
   }
 
@@ -195,7 +195,7 @@ private:
       writeSurfaceAttributes(stream, face);
     }
 
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), "\n");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "\n");
   }
 };
 
@@ -206,7 +206,7 @@ private:
 
 public:
   explicit DaikatanaFileSerializer(std::ostream& stream)
-    : Quake2FileSerializer(stream)
+    : Quake2FileSerializer{stream}
     , SurfaceColorFormat(" %d %d %d")
   {
   }
@@ -226,14 +226,14 @@ private:
       writeSurfaceColor(stream, face);
     }
 
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), "\n");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "\n");
   }
 
 protected:
   void writeSurfaceColor(std::ostream& stream, const mdl::BrushFace& face) const
   {
     fmt::format_to(
-      std::ostreambuf_iterator<char>(stream),
+      std::ostreambuf_iterator<char>{stream},
       " {} {} {}",
       static_cast<int>(face.resolvedColor().r()),
       static_cast<int>(face.resolvedColor().g()),
@@ -245,7 +245,7 @@ class Hexen2FileSerializer : public QuakeFileSerializer
 {
 public:
   explicit Hexen2FileSerializer(std::ostream& stream)
-    : QuakeFileSerializer(stream)
+    : QuakeFileSerializer{stream}
   {
   }
 
@@ -255,7 +255,7 @@ private:
     writeFacePoints(stream, face);
     writeMaterialInfo(stream, face);
     fmt::format_to(
-      std::ostreambuf_iterator<char>(stream), " 0\n"); // extra value written here
+      std::ostreambuf_iterator<char>{stream}, " 0\n"); // extra value written here
   }
 };
 
@@ -263,7 +263,7 @@ class ValveFileSerializer : public QuakeFileSerializer
 {
 public:
   explicit ValveFileSerializer(std::ostream& stream)
-    : QuakeFileSerializer(stream)
+    : QuakeFileSerializer{stream}
   {
   }
 
@@ -272,7 +272,7 @@ private:
   {
     writeFacePoints(stream, face);
     writeValveMaterialInfo(stream, face);
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), "\n");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "\n");
   }
 };
 
@@ -304,8 +304,8 @@ std::unique_ptr<NodeSerializer> MapFileSerializer::create(
 }
 
 MapFileSerializer::MapFileSerializer(std::ostream& stream)
-  : m_line(1)
-  , m_stream(stream)
+  : m_line{1}
+  , m_stream{stream}
 {
 }
 
@@ -315,8 +315,8 @@ void MapFileSerializer::doBeginFile(
   ensure(m_nodeToPrecomputedString.empty(), "MapFileSerializer may not be reused");
 
   // collect nodes
-  std::vector<std::variant<const mdl::BrushNode*, const mdl::PatchNode*>>
-    nodesToSerialize;
+  auto nodesToSerialize =
+    std::vector<std::variant<const mdl::BrushNode*, const mdl::PatchNode*>>{};
   nodesToSerialize.reserve(rootNodes.size());
 
   mdl::Node::visitAll(
@@ -366,16 +366,16 @@ void MapFileSerializer::doEndFile() {}
 
 void MapFileSerializer::doBeginEntity(const mdl::Node* /* node */)
 {
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "// entity {}\n", entityNo());
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "// entity {}\n", entityNo());
   ++m_line;
   m_startLineStack.push_back(m_line);
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "{{\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "{{\n");
   ++m_line;
 }
 
 void MapFileSerializer::doEndEntity(const mdl::Node* node)
 {
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "}}\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "}}\n");
   ++m_line;
   setFilePosition(node);
 }
@@ -383,7 +383,7 @@ void MapFileSerializer::doEndEntity(const mdl::Node* node)
 void MapFileSerializer::doEntityProperty(const mdl::EntityProperty& attribute)
 {
   fmt::format_to(
-    std::ostreambuf_iterator<char>(m_stream),
+    std::ostreambuf_iterator<char>{m_stream},
     "\"{}\" \"{}\"\n",
     escapeEntityProperties(attribute.key()),
     escapeEntityProperties(attribute.value()));
@@ -392,10 +392,10 @@ void MapFileSerializer::doEntityProperty(const mdl::EntityProperty& attribute)
 
 void MapFileSerializer::doBrush(const mdl::BrushNode* brush)
 {
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "// brush {}\n", brushNo());
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "// brush {}\n", brushNo());
   ++m_line;
   m_startLineStack.push_back(m_line);
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "{{\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "{{\n");
   ++m_line;
 
   // write pre-serialized brush faces
@@ -403,11 +403,11 @@ void MapFileSerializer::doBrush(const mdl::BrushNode* brush)
   ensure(
     it != std::end(m_nodeToPrecomputedString),
     "attempted to serialize a brush which was not passed to doBeginFile");
-  const PrecomputedString& precomputedString = it->second;
+  const auto& precomputedString = it->second;
   m_stream << precomputedString.string;
   m_line += precomputedString.lineCount;
 
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "}}\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "}}\n");
   ++m_line;
   setFilePosition(brush);
 }
@@ -422,7 +422,7 @@ void MapFileSerializer::doBrushFace(const mdl::BrushFace& face)
 
 void MapFileSerializer::doPatch(const mdl::PatchNode* patchNode)
 {
-  fmt::format_to(std::ostreambuf_iterator<char>(m_stream), "// brush {}\n", brushNo());
+  fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "// brush {}\n", brushNo());
   ++m_line;
   m_startLineStack.push_back(m_line);
 
@@ -431,7 +431,7 @@ void MapFileSerializer::doPatch(const mdl::PatchNode* patchNode)
   ensure(
     it != std::end(m_nodeToPrecomputedString),
     "attempted to serialize a patch which was not passed to doBeginFile");
-  const PrecomputedString& precomputedString = it->second;
+  const auto& precomputedString = it->second;
   m_stream << precomputedString.string;
   m_line += precomputedString.lineCount;
 
@@ -440,14 +440,14 @@ void MapFileSerializer::doPatch(const mdl::PatchNode* patchNode)
 
 void MapFileSerializer::setFilePosition(const mdl::Node* node)
 {
-  const size_t start = startLine();
+  const auto start = startLine();
   node->setFilePosition(start, m_line - start);
 }
 
 size_t MapFileSerializer::startLine()
 {
   assert(!m_startLineStack.empty());
-  const size_t result = m_startLineStack.back();
+  const auto result = m_startLineStack.back();
   m_startLineStack.pop_back();
   return result;
 }
@@ -458,45 +458,45 @@ size_t MapFileSerializer::startLine()
 MapFileSerializer::PrecomputedString MapFileSerializer::writeBrushFaces(
   const mdl::Brush& brush) const
 {
-  std::stringstream stream;
-  for (const mdl::BrushFace& face : brush.faces())
+  auto stream = std::stringstream{};
+  for (const auto& face : brush.faces())
   {
     doWriteBrushFace(stream, face);
   }
-  return PrecomputedString{stream.str(), brush.faces().size()};
+  return {stream.str(), brush.faces().size()};
 }
 
 MapFileSerializer::PrecomputedString MapFileSerializer::writePatch(
   const mdl::BezierPatch& patch) const
 {
   size_t lineCount = 0u;
-  std::stringstream stream;
+  auto stream = std::stringstream{};
 
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "{{\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "{{\n");
   ++lineCount;
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "patchDef2\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "patchDef2\n");
   ++lineCount;
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "{{\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "{{\n");
   ++lineCount;
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "{}\n", patch.materialName());
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "{}\n", patch.materialName());
   ++lineCount;
   fmt::format_to(
-    std::ostreambuf_iterator<char>(stream),
+    std::ostreambuf_iterator<char>{stream},
     "( {} {} 0 0 0 )\n",
     patch.pointRowCount(),
     patch.pointColumnCount());
   ++lineCount;
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "(\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "(\n");
   ++lineCount;
 
   for (size_t row = 0u; row < patch.pointRowCount(); ++row)
   {
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), "( ");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "( ");
     for (size_t col = 0u; col < patch.pointColumnCount(); ++col)
     {
       const auto& p = patch.controlPoint(row, col);
       fmt::format_to(
-        std::ostreambuf_iterator<char>(stream),
+        std::ostreambuf_iterator<char>{stream},
         "( {} {} {} {} {} ) ",
         p[0],
         p[1],
@@ -504,18 +504,18 @@ MapFileSerializer::PrecomputedString MapFileSerializer::writePatch(
         p[3],
         p[4]);
     }
-    fmt::format_to(std::ostreambuf_iterator<char>(stream), ")\n");
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, ")\n");
     ++lineCount;
   }
 
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), ")\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, ")\n");
   ++lineCount;
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "}}\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "}}\n");
   ++lineCount;
-  fmt::format_to(std::ostreambuf_iterator<char>(stream), "}}\n");
+  fmt::format_to(std::ostreambuf_iterator<char>{stream}, "}}\n");
   ++lineCount;
 
-  return PrecomputedString{stream.str(), lineCount};
+  return {stream.str(), lineCount};
 }
 
 } // namespace tb::io

--- a/common/src/ui/Autosaver.cpp
+++ b/common/src/ui/Autosaver.cpp
@@ -30,10 +30,11 @@
 #include "kdl/path_utils.h"
 #include "kdl/result.h"
 #include "kdl/result_fold.h"
-#include "kdl/string_compare.h"
 #include "kdl/string_format.h"
 #include "kdl/string_utils.h"
 #include "kdl/vector_utils.h"
+
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>
@@ -92,7 +93,7 @@ Result<std::vector<std::filesystem::path>> thinBackups(
 std::filesystem::path makeBackupName(
   const std::filesystem::path& mapBasename, const size_t index)
 {
-  return kdl::path_add_extension(mapBasename, "." + kdl::str_to_string(index) + ".map");
+  return kdl::path_add_extension(mapBasename, fmt::format(".{}.map", index));
 }
 
 Result<void> cleanBackups(

--- a/common/src/ui/MapDocument.cpp
+++ b/common/src/ui/MapDocument.cpp
@@ -1261,13 +1261,17 @@ std::vector<mdl::EntityNodeBase*> MapDocument::allSelectedEntityNodes() const
 
   result = kdl::vec_sort_and_remove_duplicates(std::move(result));
 
+  if (result.size() == 1)
+  {
+    return result;
+  }
+
   // Don't select worldspawn together with any other entities
-  return result.size() == 1
-           ? result
-           : kdl::vec_filter(std::move(result), [](const auto* entityNode) {
-               return entityNode->entity().classname()
-                      != mdl::EntityPropertyValues::WorldspawnClassname;
-             });
+  return result | std::views::filter([](const auto* entityNode) {
+           return entityNode->entity().classname()
+                  != mdl::EntityPropertyValues::WorldspawnClassname;
+         })
+         | kdl::to_vector;
 }
 
 std::vector<mdl::BrushNode*> MapDocument::allSelectedBrushNodes() const

--- a/common/src/ui/MapDocument.cpp
+++ b/common/src/ui/MapDocument.cpp
@@ -1620,14 +1620,15 @@ void MapDocument::selectFacesWithMaterial(const mdl::Material* material)
 
 void MapDocument::selectBrushesWithMaterial(const mdl::Material* material)
 {
-  const auto selectableNodes =
-    mdl::collectSelectableNodes(std::vector<mdl::Node*>{m_world.get()}, *m_editorContext);
   const auto brushes =
-    selectableNodes | std::views::filter([&](const auto& node) {
-      return std::ranges::any_of(
-        mdl::collectSelectableBrushFaces({node}, *m_editorContext),
-        [&](const auto& faceHandle) { return faceHandle.face().material() == material; });
-    })
+    mdl::collectSelectableNodes(std::vector<mdl::Node*>{m_world.get()}, *m_editorContext)
+    | std::views::filter([&](const auto& node) {
+        return std::ranges::any_of(
+          mdl::collectSelectableBrushFaces({node}, *m_editorContext),
+          [&](const auto& faceHandle) {
+            return faceHandle.face().material() == material;
+          });
+      })
     | kdl::to_vector;
 
   auto transaction = Transaction{*this, "Select Brushes with Material"};

--- a/common/src/ui/MapViewBase.cpp
+++ b/common/src/ui/MapViewBase.cpp
@@ -1420,13 +1420,12 @@ QMenu* MapViewBase::makeEntityGroupsMenu(const mdl::EntityDefinitionType type)
   auto document = kdl::mem_lock(m_document);
   for (const auto& group : document->entityDefinitionManager().groups())
   {
-    const auto definitionsWithType =
-      filterAndSort(group.definitions, type, mdl::EntityDefinitionSortOrder::Name);
     auto creatableDefinitions =
-      definitionsWithType | std::views::filter([](const auto* d) {
-        return !kdl::cs::str_is_equal(
-          d->name, mdl::EntityPropertyValues::WorldspawnClassname);
-      });
+      filterAndSort(group.definitions, type, mdl::EntityDefinitionSortOrder::Name)
+      | std::views::filter([](const auto* d) {
+          return !kdl::cs::str_is_equal(
+            d->name, mdl::EntityPropertyValues::WorldspawnClassname);
+        });
 
     if (!std::ranges::empty(creatableDefinitions))
     {

--- a/common/src/ui/ModEditor.cpp
+++ b/common/src/ui/ModEditor.cpp
@@ -42,7 +42,6 @@
 
 #include <cassert>
 #include <ranges>
-#include <string>
 
 namespace tb::ui
 {

--- a/common/test/src/mdl/tst_BezierPatch.cpp
+++ b/common/test/src/mdl/tst_BezierPatch.cpp
@@ -83,7 +83,7 @@ TEST_CASE("BezierPatch")
       using T = std::tuple<vm::axis::type, std::vector<BezierPatch::Point>>;
 
       // clang-format off
-      const auto&
+      const auto
       [axis, expectedPoints] = GENERATE(values<T>({
       {vm::axis::x, {
         {-1,  1,  2}, {0,  1,  1}, {1,  1,  0},

--- a/common/test/src/ui/tst_QtUtils.cpp
+++ b/common/test/src/ui/tst_QtUtils.cpp
@@ -56,7 +56,7 @@ TEST_CASE("QtUtils")
   {
     using T = std::tuple<QLocale, vm::vec3d, QString>;
 
-    const auto& [locale, vec, expectedString] = GENERATE_COPY(values<T>({
+    const auto [locale, vec, expectedString] = GENERATE_COPY(values<T>({
       {en_US, {1.1, 2.2, 3.3}, "1.1 2.2 3.3"},
       {en_US, {1, 2, 3}, "1 2 3"},
       {de_DE, {1.1, 2.2, 3.3}, "1,1 2,2 3,3"},
@@ -74,7 +74,7 @@ TEST_CASE("QtUtils")
   {
     using T = std::tuple<QLocale, QString, std::optional<vm::vec3d>>;
 
-    const auto& [locale, str, expectedVec] = GENERATE_COPY(values<T>({
+    const auto [locale, str, expectedVec] = GENERATE_COPY(values<T>({
       {en_US, "asdf", std::nullopt},
       {en_US, "1.1 2.2 3.3", vm::vec3d{1.1, 2.2, 3.3}},
       {en_US, "1 2 3", vm::vec3d{1, 2, 3}},

--- a/common/test/src/ui/tst_UpdateVersion.cpp
+++ b/common/test/src/ui/tst_UpdateVersion.cpp
@@ -99,7 +99,7 @@ TEST_CASE("parseUpdateVersion")
   using T = std::tuple<QString, std::optional<UpdateVersion>>;
 
   // clang-format off
-  const auto& 
+  const auto 
   [str,           expectedVersion] = GENERATE(values<T>({
   {"",            std::nullopt},
   {"asdf",        std::nullopt},

--- a/lib/kdl/src/kdl/range_io.h
+++ b/lib/kdl/src/kdl/range_io.h
@@ -28,8 +28,11 @@
 namespace kdl
 {
 
-#ifdef _MSC_VER
-// MSVC issues a warning about infinite recursion with a range of grouped iterators
+#if !defined(__clang__) && defined(__GNUC__)
+// MSVC and GCC issue a warning about infinite recursion with a range of grouped iterators
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
+#elif defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4717)
 #endif
@@ -40,7 +43,9 @@ std::ostream& operator<<(std::ostream& lhs, const range<I>& rhs)
   return lhs << make_streamable(rhs);
 }
 
-#ifdef _MSC_VER
+#if !defined(__clang__) && defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 

--- a/lib/kdl/src/kdl/vector_set.h
+++ b/lib/kdl/src/kdl/vector_set.h
@@ -37,7 +37,6 @@ class vector_set : public set_adapter<std::vector<T, Allocator>, Compare>
 private:
   using vec_type = std::vector<T, Allocator>;
   using base = set_adapter<vec_type, Compare>;
-  using base::m_cmp;
   using base::m_data;
 
 public:
@@ -113,7 +112,7 @@ public:
     : base(std::vector<T, Allocator>(alloc), cmp)
   {
     m_data.insert(std::end(m_data), first, last);
-    detail::sort_unique(m_data, m_cmp);
+    detail::sort_unique(m_data, base::key_comp());
     assert(check_invariant());
   }
 
@@ -140,7 +139,7 @@ public:
   {
     m_data.reserve(capacity);
     m_data.insert(std::end(m_data), first, last);
-    detail::sort_unique(m_data, m_cmp);
+    detail::sort_unique(m_data, base::key_comp());
     assert(check_invariant());
   }
 
@@ -209,7 +208,7 @@ public:
   vector_set& operator=(std::initializer_list<typename base::value_type> values)
   {
     m_data = values;
-    detail::sort_unique(m_data, m_cmp);
+    detail::sort_unique(m_data, base::key_comp());
     return *this;
   }
 
@@ -223,7 +222,7 @@ public:
   vector_set& operator=(std::vector<typename base::value_type> values)
   {
     m_data = values;
-    detail::sort_unique(m_data, m_cmp);
+    detail::sort_unique(m_data, base::key_comp());
     return *this;
   }
 

--- a/lib/upd/test/src/upd/tst_GithubApi.cpp
+++ b/lib/upd/test/src/upd/tst_GithubApi.cpp
@@ -59,42 +59,43 @@ TEST_CASE("GithubApi")
         bool,
         std::optional<Release<TestVersion>>>;
 
-      const auto& [availableReleases, currentVersion, includePreReleases, expectedRelease] =
-        GENERATE(values<T>({
-          {{}, TestVersion{1}, false, std::nullopt},
-          {{
-             Release<TestVersion>{TestVersion{3}, false, false, "v3", "", {}},
-             Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
-             Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
-           },
-           TestVersion{2},
-           false,
-           Release<TestVersion>{TestVersion{3}, false, false, "v3", "", {}}},
-          {{
-             Release<TestVersion>{TestVersion{3}, false, true, "v3", "", {}},
-             Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
-             Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
-           },
-           TestVersion{2},
-           false,
-           std::nullopt},
-          {{
-             Release<TestVersion>{TestVersion{3}, true, false, "v3", "", {}},
-             Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
-             Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
-           },
-           TestVersion{2},
-           false,
-           std::nullopt},
-          {{
-             Release<TestVersion>{TestVersion{3}, true, false, "v3", "", {}},
-             Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
-             Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
-           },
-           TestVersion{2},
-           true,
-           Release<TestVersion>{TestVersion{3}, true, false, "v3", "", {}}},
-        }));
+      const auto
+        [availableReleases, currentVersion, includePreReleases, expectedRelease] =
+          GENERATE(values<T>({
+            {{}, TestVersion{1}, false, std::nullopt},
+            {{
+               Release<TestVersion>{TestVersion{3}, false, false, "v3", "", {}},
+               Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
+               Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
+             },
+             TestVersion{2},
+             false,
+             Release<TestVersion>{TestVersion{3}, false, false, "v3", "", {}}},
+            {{
+               Release<TestVersion>{TestVersion{3}, false, true, "v3", "", {}},
+               Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
+               Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
+             },
+             TestVersion{2},
+             false,
+             std::nullopt},
+            {{
+               Release<TestVersion>{TestVersion{3}, true, false, "v3", "", {}},
+               Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
+               Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
+             },
+             TestVersion{2},
+             false,
+             std::nullopt},
+            {{
+               Release<TestVersion>{TestVersion{3}, true, false, "v3", "", {}},
+               Release<TestVersion>{TestVersion{2}, false, false, "v2", "", {}},
+               Release<TestVersion>{TestVersion{1}, false, false, "v1", "", {}},
+             },
+             TestVersion{2},
+             true,
+             Release<TestVersion>{TestVersion{3}, true, false, "v3", "", {}}},
+          }));
 
       CAPTURE(availableReleases, currentVersion, includePreReleases);
 
@@ -136,7 +137,7 @@ TEST_CASE("GithubApi")
     {
       using T = std::tuple<QByteArray, QString>;
 
-      const auto& [body, expectedError] = GENERATE(values<T>({
+      const auto [body, expectedError] = GENERATE(values<T>({
         {R"()", "illegal value"},
         {R"([)", "unterminated array"},
         {R"(asdf)", "illegal value"},
@@ -163,7 +164,7 @@ TEST_CASE("GithubApi")
     {
       using T = std::tuple<QByteArray, QList<Release<TestVersion>>>;
 
-      const auto& [body, expectedReleases] = GENERATE(values<T>({
+      const auto [body, expectedReleases] = GENERATE(values<T>({
         {R"([])", {}},
         {
           R"([{

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,7 +44,7 @@
       "platform": "osx"
     }
   ],
-  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
+  "builtin-baseline": "b1b19307e2d2ec1eefbdb7ea069de7d4bcd31f01",
   "overrides": [
     {
       "name": "catch2",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "fmt",
-      "version>=": "9.1.0#1"
+      "version>=": "11.2.0"
     },
     {
       "name": "freeimage",


### PR DESCRIPTION
By default, we compile with GCC 11, but this version of GCC doesn't properly support the ranges library.