### PR TITLE
Update kdl and upd to be static libraries

### DIFF
--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -76,7 +76,7 @@ set(KDL_HEADER
   "${KDL_SOURCE_DIR}/kdl/zip_iterator.h"
 )
 
-add_library(kdl ${KDL_SOURCE} ${KDL_HEADER})
+add_library(kdl STATIC ${KDL_SOURCE} ${KDL_HEADER})
 target_include_directories(kdl PUBLIC ${KDL_SOURCE_DIR})
 
 # task_manager.h uses <thread>, etc., which requires this on Linux

--- a/lib/upd/CMakeLists.txt
+++ b/lib/upd/CMakeLists.txt
@@ -45,7 +45,7 @@ elseif (APPLE)
   set(LIB_UPDATE_SCRIPT "${LIB_UPDATE_SOURCE_DIR}/scripts/install_update.sh" CACHE INTERNAL "Path to the update script")
 endif()
 
-add_library(upd ${LIB_UPDATE_SOURCE} ${LIB_UPDATE_HEADER})
+add_library(upd STATIC ${LIB_UPDATE_SOURCE} ${LIB_UPDATE_HEADER})
 set_target_properties(upd PROPERTIES AUTOMOC TRUE)
 target_include_directories(upd PUBLIC ${LIB_UPDATE_SOURCE_DIR})
 target_link_libraries(upd PUBLIC Qt6::Widgets Qt6::Network)


### PR DESCRIPTION
Both kdl and upd are only really used internally and never linked so explicitly setting it as static ensures it will be included directly in the final executable