### PR TITLE
Fix CI builds

### DIFF
--- a/vcpkg-overlay-ports/openexr/portfile.cmake
+++ b/vcpkg-overlay-ports/openexr/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/openexr
     REF "v${VERSION}"
-    SHA512 0c43337fda2979b328202488a43711afb5d680781c933aa0d74970a3dcda1135fbd01228cb10e81e4628c0d19da2d3e5b781e147d609cdc8a796d2a51a90932f
+    SHA512 adaab57718ef76c5eea587ccf9b3f03bf4c984b32bd90768c93408ccabf8c326a53110c585e302f1194fc0ddf7ea63175ec663a09e68cd2cc5ce8da194058709
     HEAD_REF main
     PATCHES
       0001-hide-symbols-by-default.patch
@@ -44,6 +44,7 @@ if(OPENEXR_INSTALL_TOOLS)
             exrmakepreview
             exrmaketiled
             exrmanifest
+            exrmetrics
             exrmultipart
             exrmultiview
             exrstdattr

--- a/vcpkg-overlay-ports/openexr/vcpkg.json
+++ b/vcpkg-overlay-ports/openexr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openexr",
-  "version": "3.3.2",
+  "version": "3.3.5",
   "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
   "homepage": "https://www.openexr.com/",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
CI fails on macOS 13 at the moment:

> For some reason libfreeimage is building against libIex 3.4 and then later linked against libIex 3.3, causing incompatibilities.

> 3.4 only came out 2 weeks ago so there is a chance there is some form of misconfiguration here

FYI @Jan200101