### PR TITLE
Update CI builds to use latest Qt 6.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.7.0'
+          version: '6.8.*'
 
       # Windows
       - name: Windows - Bootstrap vcpkg

--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.7.0'
+          version: '6.8.*'
 
       - name: Bootstrap vcpkg
         shell: bash

--- a/Build.md
+++ b/Build.md
@@ -26,9 +26,9 @@ TrenchBroom uses [vcpkg](https://vcpkg.io/) to manage build dependencies except 
 
 ### Qt
 
-TrenchBroom depends on Qt version 6.7. It might work with later versions, but earlier versions will definitely not work. The easiest way to install a specific version of Qt for your platform is the official installer, which requires you to create an account. Follow [these instructions](https://doc.qt.io/qt-6/qt-online-installation.html) to download and and run the Qt installer. Then, install the latest version of Qt 6.7 for your platform.
+TrenchBroom depends on Qt version 6.8. It might work with later versions, but earlier versions will definitely not work. The easiest way to install a specific version of Qt for your platform is the official installer, which requires you to create an account. Follow [these instructions](https://doc.qt.io/qt-6/qt-online-installation.html) to download and and run the Qt installer. Then, install the latest version of Qt 6.8 for your platform.
 
-Note the path where Qt was installed. For example, on Windows the default installation path would look like `C:\Qt\6.7.3\`. We will refer to this path later on as `<QT_INSTALL_DIR>`.
+Note the path where Qt was installed. For example, on Windows the default installation path would look like `C:\Qt\6.8.3\`. We will refer to this path later on as `<QT_INSTALL_DIR>`.
 
 > [!IMPORTANT]
 > You need to build against Qt 6.9 on macOS 26.

--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -28,7 +28,7 @@
 #include "io/SystemPaths.h"
 
 static_assert(
-  QT_VERSION >= QT_VERSION_CHECK(6, 7, 0), "TrenchBroom requires Qt 6.7.0 or later");
+  QT_VERSION >= QT_VERSION_CHECK(6, 8, 0), "TrenchBroom requires Qt 6.8.0 or later");
 
 extern void qt_set_sequence_auto_mnemonic(bool b);
 


### PR DESCRIPTION
Tested Windows CI build and everything is working fine. I wasn't sure whether I should update the minimum version and build instructions, so let me know if I should undo those.

Resolves #4913