### PR TITLE
Manually trigger ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI Builds
 on:
-  # Run on pushes to tags, the "master" branch, and PR's
   push:
     tags:
       - '**'
     branches:
       - master
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.

--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -1,5 +1,11 @@
 name: CPP Linter
-on: [pull_request]
+on:
+  push:
+    tags:
+      - '**'
+    branches:
+      - master
+  workflow_dispatch:
 
 permissions:
   # This grants the GITHUB_TOKEN the necessary permissions for use with nuget.

--- a/.github/workflows/clean-commit.yml
+++ b/.github/workflows/clean-commit.yml
@@ -1,5 +1,6 @@
 name: Check Commits
-on: [pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   clean_commit_job:


### PR DESCRIPTION
We are using a lot of minutes on github CI, so we stop running CI every time we push to a PR and introduce a new command to trigger CI manually. 