### PR TITLE
Run windeployqt for dump-shortcuts

### DIFF
--- a/dump-shortcuts/CMakeLists.txt
+++ b/dump-shortcuts/CMakeLists.txt
@@ -25,4 +25,22 @@ if(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:tinyxml2::tinyxml2>" "$<TARGET_FILE_DIR:dump-shortcuts>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:miniz::miniz>" "$<TARGET_FILE_DIR:dump-shortcuts>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GLEW::GLEW>" "$<TARGET_FILE_DIR:dump-shortcuts>")
+
+    # Run windeployqt which copies the Qt dlls into the deployable folder, along with necessary runtime dlls by the compiler
+    if(NOT TB_SKIP_WINDEPLOYQT)
+        message(STATUS "windeployqt requested")
+
+        # Get windeployqt path (hack)
+        get_target_property(TB_QMAKE_PATH Qt6::qmake IMPORTED_LOCATION)
+        string(REPLACE "qmake" "windeployqt" TB_WINDEPLOYQT_PATH "${TB_QMAKE_PATH}")
+        message(STATUS "windeployqt found: ${TB_WINDEPLOYQT_PATH}")
+
+        add_custom_command(TARGET dump-shortcuts POST_BUILD
+                COMMAND "${TB_WINDEPLOYQT_PATH}"
+                        --no-compiler-runtime
+                        --no-translations
+                        "$<TARGET_FILE_DIR:dump-shortcuts>")
+    else()
+        message(STATUS "windeployqt skipped")
+    endif()        
 endif()


### PR DESCRIPTION
This solves an issue when compiling and Qt is not on the path (which isn't required for the main app anymore). dump-shortcuts attempts to run with every build and fails due to the missing binaries, causing minor annoyances due to the app compiling successfully but the overall build failing.

The only change to behaviour from the main app's windeployqt is that translations are never copied, as they are not needed to dump shortcuts. Other than that its just a copy-paste from `app/CMakeLists.txt`.