### PR TITLE
Fix missing entity definition actions in keyboard shortcuts

### DIFF
--- a/common/src/ui/MapDocument.cpp
+++ b/common/src/ui/MapDocument.cpp
@@ -129,6 +129,11 @@ void MapDocument::createEntityDefinitionActions()
     m_map->entityDefinitionManager().definitions());
 }
 
+void MapDocument::clearEntityDefinitionActions()
+{
+  m_entityDefinitionActions.clear();
+}
+
 void MapDocument::loadPointFile(std::filesystem::path path)
 {
   static_assert(
@@ -245,16 +250,19 @@ void MapDocument::connectObservers()
 void MapDocument::mapWasCreated(mdl::Map&)
 {
   createTagActions();
+  createEntityDefinitionActions();
 }
 
 void MapDocument::mapWasLoaded(mdl::Map&)
 {
   createTagActions();
+  createEntityDefinitionActions();
 }
 
 void MapDocument::mapWasCleared(mdl::Map&)
 {
   clearTagActions();
+  clearEntityDefinitionActions();
 }
 
 void MapDocument::entityDefinitionsDidChange()

--- a/common/src/ui/MapDocument.h
+++ b/common/src/ui/MapDocument.h
@@ -130,7 +130,9 @@ private: // tag and entity definition actions
 
   void createTagActions();
   void clearTagActions();
+
   void createEntityDefinitionActions();
+  void clearEntityDefinitionActions();
 
 public: // point file management
   mdl::PointTrace* pointTrace();


### PR DESCRIPTION
The entity definition actions must be created when a map is created or loaded, not just when the entity definitions are changed.