### PR TITLE
Revert commandline parser changes

### DIFF
--- a/app/src/Main.cpp
+++ b/app/src/Main.cpp
@@ -85,8 +85,10 @@ int main(int argc, char* argv[])
   tb::ui::TrenchBroomApp app(argc, argv);
 
   app.askForAutoUpdates();
-  app.triggerAutoUpdateCheck();
-  app.openFilesOrWelcomeFrame();
+  app.parseCommandLineAndShowFrame();
 
+  // start the update check only now after we have asked the user whether they want to
+  // enable the automatic check and once we have set the draft update preference
+  app.triggerAutoUpdateCheck();
   return app.exec();
 }

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -27,7 +27,6 @@
 #include <memory>
 #include <vector>
 
-class QCommandLineParser;
 class QMenu;
 class QNetworkAccessManager;
 class QSettings;
@@ -59,7 +58,6 @@ class TrenchBroomApp : public QApplication
 {
   Q_OBJECT
 private:
-  std::unique_ptr<QCommandLineParser> m_commandLineParser;
   QNetworkAccessManager* m_networkManager = nullptr;
   upd::HttpClient* m_httpClient = nullptr;
   upd::Updater* m_updater = nullptr;
@@ -82,11 +80,11 @@ public:
   void askForAutoUpdates();
   void triggerAutoUpdateCheck();
 
+  void parseCommandLineAndShowFrame();
+
   mdl::GameManager& gameManager();
   upd::Updater& updater();
   FrameManager* frameManager();
-
-  void openFilesOrWelcomeFrame();
 
 private:
   static QPalette darkPalette();
@@ -115,6 +113,7 @@ public:
 #ifdef __APPLE__
   bool event(QEvent* event) override;
 #endif
+  void openFilesOrWelcomeFrame(const QStringList& fileNames);
 
   void showWelcomeWindow();
   void closeWelcomeWindow();

--- a/common/src/ui/GetVersion.cpp
+++ b/common/src/ui/GetVersion.cpp
@@ -21,25 +21,12 @@
 
 #include "Version.h"
 
-#include <optional>
-
 namespace tb::ui
 {
-namespace
-{
-
-auto overrideBuildVersion = std::optional<QString>{};
-
-}
-
-void setBuildVersion(QString buildVersion)
-{
-  overrideBuildVersion = std::move(buildVersion);
-}
 
 QString getBuildVersion()
 {
-  return overrideBuildVersion.value_or(VERSION_STR);
+  return VERSION_STR;
 }
 
 QString getBuildIdStr()

--- a/common/src/ui/GetVersion.h
+++ b/common/src/ui/GetVersion.h
@@ -24,8 +24,6 @@
 namespace tb::ui
 {
 
-void setBuildVersion(QString buildVersion);
-
 QString getBuildVersion();
 QString getBuildIdStr();
 QString getBuildType();


### PR DESCRIPTION
This also removes the option to set the build version on startup. Parsing the arguments in the constructor breaks the test runner.