### PR TITLE
Fix entity definition shortcuts not working after creating or loading a map

### DIFF
--- a/common/src/ui/MapViewBase.cpp
+++ b/common/src/ui/MapViewBase.cpp
@@ -153,6 +153,12 @@ void MapViewBase::connectObservers()
 {
   auto& map = m_document.map();
   m_notifierConnection +=
+    map.mapWasCreatedNotifier.connect(this, &MapViewBase::mapWasCreated);
+  m_notifierConnection +=
+    map.mapWasLoadedNotifier.connect(this, &MapViewBase::mapWasLoaded);
+  m_notifierConnection +=
+    map.mapWasClearedNotifier.connect(this, &MapViewBase::mapWasCleared);
+  m_notifierConnection +=
     map.documentDidChangeNotifier.connect(this, &MapViewBase::documentDidChange);
   m_notifierConnection += map.materialCollectionsDidChangeNotifier.connect(
     this, &MapViewBase::materialCollectionsDidChange);


### PR DESCRIPTION
Map views must update their shortcuts when a map is created, loaded or cleared. The observer callbacks were there, but not connected to the corresponding notifications.

Closes #4997