### PR TITLE
Don't clear compilation and game engine profiles

### DIFF
--- a/common/src/mdl/GameConfig.h
+++ b/common/src/mdl/GameConfig.h
@@ -22,8 +22,6 @@
 #include "Color.h"
 #include "el/Expression.h"
 #include "mdl/BrushFaceAttributes.h"
-#include "mdl/CompilationConfig.h"
-#include "mdl/GameEngineConfig.h"
 #include "mdl/Tag.h"
 
 #include "kd/reflection_decl.h"
@@ -140,11 +138,6 @@ struct GameConfig
   std::vector<CompilationTool> compilationTools;
   bool forceEmptyNewMap = false;
 
-  CompilationConfig compilationConfig = {};
-  GameEngineConfig gameEngineConfig = {};
-  bool compilationConfigParseFailed = false;
-  bool gameEngineConfigParseFailed = false;
-
   size_t maxPropertyLength = 1023;
 
   kdl_reflect_decl(
@@ -161,10 +154,6 @@ struct GameConfig
     smartTags,
     softMapBounds,
     compilationTools,
-    compilationConfig,
-    gameEngineConfig,
-    compilationConfigParseFailed,
-    gameEngineConfigParseFailed,
     maxPropertyLength);
 
   /** Returns a folder name to use for user configuration files. */

--- a/common/src/mdl/GameInfo.h
+++ b/common/src/mdl/GameInfo.h
@@ -20,7 +20,9 @@
 #pragma once
 
 #include "Preference.h"
+#include "mdl/CompilationConfig.h"
 #include "mdl/GameConfig.h"
+#include "mdl/GameEngineConfig.h"
 
 #include "kd/reflection_decl.h"
 

--- a/common/src/ui/CompilationDialog.cpp
+++ b/common/src/ui/CompilationDialog.cpp
@@ -66,7 +66,7 @@ void CompilationDialog::createGui()
   setWindowTitle("Compile");
 
   auto& document = m_mapFrame->document();
-  const auto& compilationConfig = document.map().gameInfo().gameConfig.compilationConfig;
+  const auto& compilationConfig = document.map().gameInfo().compilationConfig;
 
   m_profileManager = new CompilationProfileManager{document, compilationConfig};
 

--- a/common/src/ui/GameEngineDialog.cpp
+++ b/common/src/ui/GameEngineDialog.cpp
@@ -55,7 +55,7 @@ void GameEngineDialog::createGui()
 
   const auto* gameInfo = gameManager.gameInfo(m_gameName);
   contract_assert(gameInfo != nullptr);
-  m_profileManager = new GameEngineProfileManager{gameInfo->gameConfig.gameEngineConfig};
+  m_profileManager = new GameEngineProfileManager{gameInfo->gameEngineConfig};
 
   auto* buttons = new QDialogButtonBox{QDialogButtonBox::Close};
 

--- a/common/src/ui/LaunchGameEngineDialog.cpp
+++ b/common/src/ui/LaunchGameEngineDialog.cpp
@@ -67,12 +67,12 @@ void LaunchGameEngineDialog::createGui()
   setWindowTitle("Launch Engine");
 
   const auto& map = m_document.map();
-  const auto& gameConfig = map.gameInfo().gameConfig;
-  auto* gameIndicator = new CurrentGameIndicator{gameConfig.name};
+  const auto& gameInfo = map.gameInfo();
+  auto* gameIndicator = new CurrentGameIndicator{gameInfo.gameConfig.name};
 
   auto* midPanel = new QWidget{this};
 
-  m_config = gameConfig.gameEngineConfig;
+  m_config = gameInfo.gameEngineConfig;
   m_gameEngineList = new GameEngineProfileListBox{m_config};
   m_gameEngineList->setEmptyText(
     R"(Click the 'Configure engines...' button to create a game engine profile.)");
@@ -179,9 +179,9 @@ void LaunchGameEngineDialog::createGui()
 void LaunchGameEngineDialog::reloadConfig()
 {
   const auto& map = m_document.map();
-  const auto& gameConfig = map.gameInfo().gameConfig;
+  const auto& gameInfo = map.gameInfo();
 
-  m_config = gameConfig.gameEngineConfig;
+  m_config = gameInfo.gameEngineConfig;
   m_gameEngineList->setConfig(m_config);
 }
 


### PR DESCRIPTION
This was a leftover from a previous refactoring. The UI components were still using the old profile members of GameConfig and would therefore display the wrong data in the UI.