### PR TITLE
Ensure the KeyboardPreferences icon is vertically aligned in the top bar

### DIFF
--- a/app/resources/graphics/images/KeyboardPreferences.svg
+++ b/app/resources/graphics/images/KeyboardPreferences.svg
@@ -49,7 +49,7 @@
        id="grid4147"
        empspacing="4" /></sodipodi:namedview><g
      id="g3"
-     transform="translate(0,-168)"><rect
+     transform="translate(0,-171)"><rect
        style="fill:none;fill-opacity:1;stroke:#3f3f3f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
        id="rect836"
        width="28"


### PR DESCRIPTION
Hey! I will copy and paste what I explained in my email re: the keyboard icon 😄 

----

This is a small, silly change but it's been bothering me 😄 I figured I'd email you before opening a pull request, but I'm more than happy to open one.

The preferences icons in TrenchBroom are vertically aligned in the top bar except for the keyboard icon:

<img width="561" height="74" alt="Screenshot 2026-01-01 at 9 43 45 AM" src="https://github.com/user-attachments/assets/67ee842a-183f-483c-8e6e-52c6ae5ac352" />

It looks like the transform in the actual keyboard SVG was not adjusted so it's perfectly vertically centered within its view box. Using the attached file for the keyboard, we can achieve it being vertically centered:

<img width="550" height="67" alt="Screenshot 2026-01-01 at 9 49 56 AM" src="https://github.com/user-attachments/assets/7b35552a-0aa8-4a0a-8e6e-a8cc94be34fc" />

