### PR TITLE
Activate map window when creating it

### DIFF
--- a/app/TrenchBroom/src/Main.cpp
+++ b/app/TrenchBroom/src/Main.cpp
@@ -39,7 +39,7 @@
 #include "ui/Contracts.h"
 #include "ui/CrashReporter.h"
 #include "ui/FileEventFilter.h"
-#include "ui/FrameManager.h"
+#include "ui/MapWindowManager.h"
 #include "ui/QPathUtils.h"
 #include "ui/QPreferenceStore.h"
 #include "ui/RecentDocuments.h"

--- a/lib/TbUiLib/CMakeLists.txt
+++ b/lib/TbUiLib/CMakeLists.txt
@@ -92,7 +92,6 @@ add_library(TbUiLib STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/FlyModeHelper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/FormWithSectionsLayout.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/FourPaneMapView.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/FrameManager.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/GameDialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/GameEngineDialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/GameEngineProfileEditor.h
@@ -122,7 +121,6 @@ add_library(TbUiLib STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/LayerListBox.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/LimitedKeySequenceEdit.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapDocument.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapFrame.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapInspector.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapView.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapView2D.h
@@ -133,6 +131,8 @@ add_library(TbUiLib STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapViewContainer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapViewLayout.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapViewToolBox.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapWindow.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MapWindowManager.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MaterialBrowser.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MaterialBrowserView.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/MaterialCollectionEditor.h
@@ -319,7 +319,6 @@ add_library(TbUiLib STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src/FlyModeHelper.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/FormWithSectionsLayout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/FourPaneMapView.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/FrameManager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/GameDialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/GameEngineDialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/GameEngineProfileEditor.cpp
@@ -349,7 +348,6 @@ add_library(TbUiLib STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src/LayerListBox.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/LimitedKeySequenceEdit.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapDocument.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/MapFrame.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapInspector.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapView.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapView2D.cpp
@@ -359,6 +357,8 @@ add_library(TbUiLib STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapViewBase.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapViewContainer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MapViewToolBox.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/MapWindow.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/MapWindowManager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MaterialBrowser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MaterialBrowserView.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/MaterialCollectionEditor.cpp

--- a/lib/TbUiLib/include/ui/Action.h
+++ b/lib/TbUiLib/include/ui/Action.h
@@ -44,7 +44,7 @@ namespace ui
 {
 class ActionExecutionContext;
 class MapDocument;
-class MapFrame;
+class MapWindow;
 class MapViewBase;
 
 using ExecuteFn = std::function<void(ActionExecutionContext&)>;

--- a/lib/TbUiLib/include/ui/ActionExecutionContext.h
+++ b/lib/TbUiLib/include/ui/ActionExecutionContext.h
@@ -32,7 +32,7 @@ namespace ui
 {
 class AppController;
 class MapDocument;
-class MapFrame;
+class MapWindow;
 class MapViewBase;
 
 class ActionExecutionContext
@@ -41,12 +41,12 @@ private:
   ActionContext::Type m_actionContext;
 
   AppController& m_appController;
-  MapFrame* m_mapFrame;
+  MapWindow* m_mapWindow;
   MapViewBase* m_mapView;
 
 public:
   ActionExecutionContext(
-    AppController& appController, MapFrame* mapFrame, MapViewBase* mapView);
+    AppController& appController, MapWindow* mapWindow, MapViewBase* mapView);
 
   bool hasDocument() const;
   bool hasActionContext(ActionContext::Type actionContext) const;
@@ -54,8 +54,8 @@ public:
   const AppController& appController() const;
   AppController& appController();
 
-  const MapFrame& mapFrame() const;
-  MapFrame& mapFrame();
+  const MapWindow& mapWindow() const;
+  MapWindow& mapWindow();
 
   const MapViewBase& mapView() const;
   MapViewBase& mapView();

--- a/lib/TbUiLib/include/ui/AppController.h
+++ b/lib/TbUiLib/include/ui/AppController.h
@@ -53,7 +53,7 @@ namespace ui
 {
 class AboutDialog;
 class ActionManager;
-class FrameManager;
+class MapWindowManager;
 class RecentDocuments;
 class WelcomeWindow;
 
@@ -71,7 +71,7 @@ private:
   upd::HttpClient* m_httpClient = nullptr;
   upd::Updater* m_updater = nullptr;
 
-  FrameManager* m_frameManager = nullptr;
+  MapWindowManager* m_mapWindowManager = nullptr;
   RecentDocuments* m_recentDocuments = nullptr;
   std::unique_ptr<ActionManager> m_actionManager;
   std::unique_ptr<WelcomeWindow> m_welcomeWindow;
@@ -102,7 +102,7 @@ public:
 
   upd::Updater& updater();
 
-  FrameManager& frameManager();
+  MapWindowManager& mapWindowManager();
 
   const RecentDocuments& recentDocuments() const;
   RecentDocuments& recentDocuments();

--- a/lib/TbUiLib/include/ui/MapWindow.h
+++ b/lib/TbUiLib/include/ui/MapWindow.h
@@ -79,7 +79,7 @@ class SignalDelayer;
 class SwitchableMapViewContainer;
 class Tool;
 
-class MapFrame : public QMainWindow
+class MapWindow : public QMainWindow
 {
   Q_OBJECT
 private:
@@ -129,8 +129,8 @@ private:
   SignalDelayer* m_updateStatusBarSignalDelayer = nullptr;
 
 public:
-  MapFrame(AppController& appController, std::unique_ptr<MapDocument> document);
-  ~MapFrame() override;
+  MapWindow(AppController& appController, std::unique_ptr<MapDocument> document);
+  ~MapWindow() override;
 
   void positionOnScreen(QWidget* reference);
   const MapDocument& document() const;

--- a/lib/TbUiLib/include/ui/MapWindowManager.h
+++ b/lib/TbUiLib/include/ui/MapWindowManager.h
@@ -48,19 +48,19 @@ namespace ui
 {
 class AppController;
 class MapDocument;
-class MapFrame;
+class MapWindow;
 
-class FrameManager : public QObject
+class MapWindowManager : public QObject
 {
   Q_OBJECT
 private:
   AppController& m_appController;
-  bool m_singleFrame;
-  std::vector<MapFrame*> m_frames;
+  bool m_singleMapWindow;
+  std::vector<MapWindow*> m_mapWindows;
 
 public:
-  FrameManager(AppController& appController, bool singleFrame);
-  ~FrameManager() override;
+  MapWindowManager(AppController& appController, bool singleMapWindow);
+  ~MapWindowManager() override;
 
   Result<void> createDocument(
     const mdl::EnvironmentConfig& environmentConfig,
@@ -77,18 +77,18 @@ public:
     std::filesystem::path path,
     kdl::task_manager& taskManager);
 
-  std::vector<MapFrame*> frames() const;
-  MapFrame* topFrame() const;
-  bool allFramesClosed() const;
+  std::vector<MapWindow*> mapWindows() const;
+  MapWindow* topMapWindow() const;
+  bool allMapWindowsClosed() const;
 
 private:
   void onFocusChange(QWidget* old, QWidget* now);
 
-  bool shouldCreateFrameForDocument() const;
-  MapFrame* createFrame(std::unique_ptr<MapDocument> document);
-  void removeFrame(MapFrame* frame);
+  bool shouldCreateWindowForDocument() const;
+  MapWindow* createMapWindow(std::unique_ptr<MapDocument> document);
+  void removeMapWindow(MapWindow* mapWindow);
 
-  friend class MapFrame;
+  friend class MapWindow;
 };
 
 } // namespace ui

--- a/lib/TbUiLib/include/ui/ObjExportDialog.h
+++ b/lib/TbUiLib/include/ui/ObjExportDialog.h
@@ -28,13 +28,13 @@ class QRadioButton;
 
 namespace tb::ui
 {
-class MapFrame;
+class MapWindow;
 
 class ObjExportDialog : public QDialog
 {
   Q_OBJECT
 private:
-  MapFrame* m_mapFrame;
+  MapWindow* m_mapWindow;
 
   QLineEdit* m_exportPathEdit = nullptr;
   QPushButton* m_browseExportPathButton = nullptr;
@@ -44,7 +44,7 @@ private:
   QPushButton* m_closeButton = nullptr;
 
 public:
-  explicit ObjExportDialog(MapFrame* mapFrame);
+  explicit ObjExportDialog(MapWindow* mapWindow);
 
   void updateExportPath();
 

--- a/lib/TbUiLib/src/ActionExecutionContext.cpp
+++ b/lib/TbUiLib/src/ActionExecutionContext.cpp
@@ -20,8 +20,8 @@
 #include "ui/ActionExecutionContext.h"
 
 #include "ui/MapDocument.h"
-#include "ui/MapFrame.h"
 #include "ui/MapViewBase.h"
+#include "ui/MapWindow.h"
 
 #include "kd/const_overload.h"
 #include "kd/contracts.h"
@@ -30,18 +30,18 @@ namespace tb::ui
 {
 
 ActionExecutionContext::ActionExecutionContext(
-  AppController& appController, MapFrame* mapFrame, MapViewBase* mapView)
+  AppController& appController, MapWindow* mapWindow, MapViewBase* mapView)
   : m_actionContext(mapView != nullptr ? mapView->actionContext() : ActionContext::Any)
   , m_appController{appController}
-  , m_mapFrame{mapFrame}
+  , m_mapWindow{mapWindow}
   , m_mapView{mapView}
 {
-  contract_pre(m_mapFrame == nullptr || m_mapView != nullptr);
+  contract_pre(m_mapWindow == nullptr || m_mapView != nullptr);
 }
 
 bool ActionExecutionContext::hasDocument() const
 {
-  return m_mapFrame != nullptr;
+  return m_mapWindow != nullptr;
 }
 
 bool ActionExecutionContext::hasActionContext(
@@ -69,16 +69,16 @@ AppController& ActionExecutionContext::appController()
   return KDL_CONST_OVERLOAD(appController());
 }
 
-const MapFrame& ActionExecutionContext::mapFrame() const
+const MapWindow& ActionExecutionContext::mapWindow() const
 {
   contract_pre(hasDocument());
 
-  return *m_mapFrame;
+  return *m_mapWindow;
 }
 
-MapFrame& ActionExecutionContext::mapFrame()
+MapWindow& ActionExecutionContext::mapWindow()
 {
-  return KDL_CONST_OVERLOAD(mapFrame());
+  return KDL_CONST_OVERLOAD(mapWindow());
 }
 
 const MapViewBase& ActionExecutionContext::mapView() const
@@ -96,7 +96,7 @@ MapViewBase& ActionExecutionContext::mapView()
 
 const mdl::Map& ActionExecutionContext::map() const
 {
-  return mapFrame().document().map();
+  return mapWindow().document().map();
 }
 
 mdl::Map& ActionExecutionContext::map()

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -35,9 +35,9 @@
 #include "ui/ActionExecutionContext.h"
 #include "ui/AppController.h" // IWYU pragma: keep
 #include "ui/Inspector.h"
-#include "ui/MapFrame.h"
 #include "ui/MapView.h"
 #include "ui/MapViewBase.h"
+#include "ui/MapWindow.h"
 
 #include "kd/contracts.h"
 
@@ -156,7 +156,7 @@ void ActionManager::createViewActions()
     QKeySequence{Qt::Key_Return},
     [](auto& context) { context.mapView().assembleBrush(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().assembleBrushToolActive();
+      return context.hasDocument() && context.mapWindow().assembleBrushToolActive();
     },
   });
   addAction(Action{
@@ -166,7 +166,7 @@ void ActionManager::createViewActions()
     QKeySequence{Qt::CTRL | Qt::Key_Return},
     [](auto& context) { context.mapView().toggleClipSide(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().clipToolActive();
+      return context.hasDocument() && context.mapWindow().clipToolActive();
     },
   });
   addAction(Action{
@@ -176,7 +176,7 @@ void ActionManager::createViewActions()
     QKeySequence{Qt::Key_Return},
     [](auto& context) { context.mapView().performClip(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().clipToolActive();
+      return context.hasDocument() && context.mapWindow().clipToolActive();
     },
   });
 
@@ -546,7 +546,7 @@ void ActionManager::createViewActions()
     QObject::tr("Reveal in texture browser"),
     ActionContext::View3D | ActionContext::AnySelection | ActionContext::AnyOrNoTool,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().revealMaterial(); },
+    [](auto& context) { context.mapWindow().revealMaterial(); },
     [](const auto& context) { return context.hasDocument(); },
   });
   addAction(Action{
@@ -803,7 +803,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Save Document"),
     ActionContext::Any,
     QKeySequence::Save,
-    [](auto& context) { context.mapFrame().saveDocument(); },
+    [](auto& context) { context.mapWindow().saveDocument(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   fileMenu.addItem(addAction(Action{
@@ -811,7 +811,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Save Document as..."),
     ActionContext::Any,
     QKeySequence::SaveAs,
-    [](auto& context) { context.mapFrame().saveDocumentAs(); },
+    [](auto& context) { context.mapWindow().saveDocumentAs(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
 
@@ -821,7 +821,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Wavefront OBJ..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().exportDocumentAsObj(); },
+    [](auto& context) { context.mapWindow().exportDocumentAsObj(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   exportMenu.addItem(addAction(Action{
@@ -829,7 +829,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Map..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().exportDocumentAsMap(); },
+    [](auto& context) { context.mapWindow().exportDocumentAsMap(); },
     [](const auto& context) { return context.hasDocument(); },
     std::nullopt,
     QObject::tr("Exports the current map to a .map file. Layers marked Omit From Export "
@@ -843,7 +843,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Load Point File..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().loadPointFile(); },
+    [](auto& context) { context.mapWindow().loadPointFile(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   fileMenu.addItem(addAction(Action{
@@ -851,9 +851,9 @@ void ActionManager::createFileMenu()
     QObject::tr("Reload Point File"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().reloadPointFile(); },
+    [](auto& context) { context.mapWindow().reloadPointFile(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canReloadPointFile();
+      return context.hasDocument() && context.mapWindow().canReloadPointFile();
     },
   }));
   fileMenu.addItem(addAction(Action{
@@ -861,9 +861,9 @@ void ActionManager::createFileMenu()
     QObject::tr("Unload Point File"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().unloadPointFile(); },
+    [](auto& context) { context.mapWindow().unloadPointFile(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canUnloadPointFile();
+      return context.hasDocument() && context.mapWindow().canUnloadPointFile();
     },
   }));
   fileMenu.addSeparator();
@@ -872,7 +872,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Load Portal File..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().loadPortalFile(); },
+    [](auto& context) { context.mapWindow().loadPortalFile(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   fileMenu.addItem(addAction(Action{
@@ -880,9 +880,9 @@ void ActionManager::createFileMenu()
     QObject::tr("Reload Portal File"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().reloadPortalFile(); },
+    [](auto& context) { context.mapWindow().reloadPortalFile(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canReloadPortalFile();
+      return context.hasDocument() && context.mapWindow().canReloadPortalFile();
     },
   }));
   fileMenu.addItem(addAction(Action{
@@ -890,9 +890,9 @@ void ActionManager::createFileMenu()
     QObject::tr("Unload Portal File"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().unloadPortalFile(); },
+    [](auto& context) { context.mapWindow().unloadPortalFile(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canUnloadPortalFile();
+      return context.hasDocument() && context.mapWindow().canUnloadPortalFile();
     },
   }));
   fileMenu.addSeparator();
@@ -901,7 +901,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Reload Material Collections"),
     ActionContext::Any,
     QKeySequence{Qt::Key_F5},
-    [](auto& context) { context.mapFrame().reloadMaterialCollections(); },
+    [](auto& context) { context.mapWindow().reloadMaterialCollections(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   fileMenu.addItem(addAction(Action{
@@ -909,7 +909,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Reload Entity Definitions"),
     ActionContext::Any,
     QKeySequence{Qt::Key_F6},
-    [](auto& context) { context.mapFrame().reloadEntityDefinitions(); },
+    [](auto& context) { context.mapWindow().reloadEntityDefinitions(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   fileMenu.addSeparator();
@@ -918,7 +918,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Revert Document"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().revertDocument(); },
+    [](auto& context) { context.mapWindow().revertDocument(); },
     [](const auto& context) { return context.hasDocument(); },
     std::nullopt,
     QObject::tr("Discards any unsaved changes and reloads the map file."),
@@ -928,7 +928,7 @@ void ActionManager::createFileMenu()
     QObject::tr("Close Document"),
     ActionContext::Any,
     QKeySequence::Close,
-    [](auto& context) { context.mapFrame().closeDocument(); },
+    [](auto& context) { context.mapWindow().closeDocument(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
 }
@@ -942,9 +942,9 @@ void ActionManager::createEditMenu()
       QObject::tr("Undo"),
       ActionContext::Any,
       QKeySequence::Undo,
-      [](auto& context) { context.mapFrame().undo(); },
+      [](auto& context) { context.mapWindow().undo(); },
       [](const auto& context) {
-        return context.hasDocument() && context.mapFrame().canUndo();
+        return context.hasDocument() && context.mapWindow().canUndo();
       },
     }),
     MenuEntryType::Undo);
@@ -954,9 +954,9 @@ void ActionManager::createEditMenu()
       QObject::tr("Redo"),
       ActionContext::Any,
       QKeySequence::Redo,
-      [](auto& context) { context.mapFrame().redo(); },
+      [](auto& context) { context.mapWindow().redo(); },
       [](const auto& context) {
-        return context.hasDocument() && context.mapFrame().canRedo();
+        return context.hasDocument() && context.mapWindow().canRedo();
       },
     }),
     MenuEntryType::Redo);
@@ -966,7 +966,7 @@ void ActionManager::createEditMenu()
     QObject::tr("Repeat Last Commands"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_R},
-    [](auto& context) { context.mapFrame().repeatLastCommands(); },
+    [](auto& context) { context.mapWindow().repeatLastCommands(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   editMenu.addItem(addAction(Action{
@@ -974,9 +974,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Clear Repeatable Commands"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_R},
-    [](auto& context) { context.mapFrame().clearRepeatableCommands(); },
+    [](auto& context) { context.mapWindow().clearRepeatableCommands(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().hasRepeatableCommands();
+      return context.hasDocument() && context.mapWindow().hasRepeatableCommands();
     },
   }));
   editMenu.addSeparator();
@@ -986,9 +986,9 @@ void ActionManager::createEditMenu()
       QObject::tr("Cut"),
       ActionContext::Any,
       QKeySequence::Cut,
-      [](auto& context) { context.mapFrame().cutSelection(); },
+      [](auto& context) { context.mapWindow().cutSelection(); },
       [](const auto& context) {
-        return context.hasDocument() && context.mapFrame().canCopySelection();
+        return context.hasDocument() && context.mapWindow().canCopySelection();
       },
     }),
     MenuEntryType::Cut);
@@ -998,9 +998,9 @@ void ActionManager::createEditMenu()
       QObject::tr("Copy"),
       ActionContext::Any,
       QKeySequence::Copy,
-      [](auto& context) { context.mapFrame().copySelection(); },
+      [](auto& context) { context.mapWindow().copySelection(); },
       [](const auto& context) {
-        return context.hasDocument() && context.mapFrame().canCopySelection();
+        return context.hasDocument() && context.mapWindow().canCopySelection();
       },
     }),
     MenuEntryType::Copy);
@@ -1010,9 +1010,9 @@ void ActionManager::createEditMenu()
       QObject::tr("Paste"),
       ActionContext::Any,
       QKeySequence::Paste,
-      [](auto& context) { context.mapFrame().pasteAtCursorPosition(); },
+      [](auto& context) { context.mapWindow().pasteAtCursorPosition(); },
       [](const auto& context) {
-        return context.hasDocument() && context.mapFrame().canPaste();
+        return context.hasDocument() && context.mapWindow().canPaste();
       },
     }),
     MenuEntryType::Paste);
@@ -1022,9 +1022,9 @@ void ActionManager::createEditMenu()
       QObject::tr("Paste at Original Position"),
       ActionContext::Any,
       QKeySequence{Qt::CTRL | Qt::ALT | Qt::Key_V},
-      [](auto& context) { context.mapFrame().pasteAtOriginalPosition(); },
+      [](auto& context) { context.mapWindow().pasteAtOriginalPosition(); },
       [](const auto& context) {
-        return context.hasDocument() && context.mapFrame().canPaste();
+        return context.hasDocument() && context.mapWindow().canPaste();
       },
     }),
     MenuEntryType::PasteAtOriginalPosition);
@@ -1033,9 +1033,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Duplicate"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_D},
-    [](auto& context) { context.mapFrame().duplicateSelection(); },
+    [](auto& context) { context.mapWindow().duplicateSelection(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDuplicateSelection();
+      return context.hasDocument() && context.mapWindow().canDuplicateSelection();
     },
     std::filesystem::path{"DuplicateObjects.svg"},
   }));
@@ -1050,9 +1050,9 @@ void ActionManager::createEditMenu()
       QKeySequence::Delete
 #endif
     },
-    [](auto& context) { context.mapFrame().deleteSelection(); },
+    [](auto& context) { context.mapWindow().deleteSelection(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDeleteSelection();
+      return context.hasDocument() && context.mapWindow().canDeleteSelection();
     },
   }));
   editMenu.addSeparator();
@@ -1085,9 +1085,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Move..."),
     ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyOrNoTool,
     QKeySequence{Qt::CTRL | Qt::ALT | Qt::Key_M},
-    [](auto& context) { context.mapFrame().moveSelectedObjects(); },
+    [](auto& context) { context.mapWindow().moveSelectedObjects(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canMoveSelectedObjects();
+      return context.hasDocument() && context.mapWindow().canMoveSelectedObjects();
     },
   }));
 
@@ -1097,9 +1097,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Convex Merge"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_J},
-    [](auto& context) { context.mapFrame().csgConvexMerge(); },
+    [](auto& context) { context.mapWindow().csgConvexMerge(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDoCsgConvexMerge();
+      return context.hasDocument() && context.mapWindow().canDoCsgConvexMerge();
     },
   }));
   csgMenu.addItem(addAction(Action{
@@ -1107,9 +1107,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Subtract"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_K},
-    [](auto& context) { context.mapFrame().csgSubtract(); },
+    [](auto& context) { context.mapWindow().csgSubtract(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDoCsgSubtract();
+      return context.hasDocument() && context.mapWindow().canDoCsgSubtract();
     },
   }));
   csgMenu.addItem(addAction(Action{
@@ -1117,9 +1117,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Hollow"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_K},
-    [](auto& context) { context.mapFrame().csgHollow(); },
+    [](auto& context) { context.mapWindow().csgHollow(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDoCsgHollow();
+      return context.hasDocument() && context.mapWindow().canDoCsgHollow();
     },
   }));
   csgMenu.addItem(addAction(Action{
@@ -1127,9 +1127,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Intersect"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_L},
-    [](auto& context) { context.mapFrame().csgIntersect(); },
+    [](auto& context) { context.mapWindow().csgIntersect(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDoCsgIntersect();
+      return context.hasDocument() && context.mapWindow().canDoCsgIntersect();
     },
   }));
 
@@ -1139,9 +1139,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Snap Vertices to Integer"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_V},
-    [](auto& context) { context.mapFrame().snapVerticesToInteger(); },
+    [](auto& context) { context.mapWindow().snapVerticesToInteger(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSnapVertices();
+      return context.hasDocument() && context.mapWindow().canSnapVertices();
     },
   }));
   vertexEditingMenu.addItem(addAction(Action{
@@ -1149,9 +1149,9 @@ void ActionManager::createEditMenu()
     QObject::tr("Snap Vertices to Grid"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::ALT | Qt::SHIFT | Qt::Key_V},
-    [](auto& context) { context.mapFrame().snapVerticesToGrid(); },
+    [](auto& context) { context.mapWindow().snapVerticesToGrid(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSnapVertices();
+      return context.hasDocument() && context.mapWindow().canSnapVertices();
     },
   }));
 
@@ -1161,7 +1161,7 @@ void ActionManager::createEditMenu()
     QObject::tr("Texture Lock"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().toggleAlignmentLock(); },
+    [](auto& context) { context.mapWindow().toggleAlignmentLock(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto&) { return pref(Preferences::AlignmentLock); },
     std::filesystem::path{"AlignmentLock.svg"},
@@ -1171,7 +1171,7 @@ void ActionManager::createEditMenu()
     QObject::tr("UV Lock"),
     ActionContext::Any,
     QKeySequence{Qt::Key_U},
-    [](auto& context) { context.mapFrame().toggleUVLock(); },
+    [](auto& context) { context.mapWindow().toggleUVLock(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto&) { return pref(Preferences::UVLock); },
     std::filesystem::path{"UVLock.svg"},
@@ -1182,7 +1182,7 @@ void ActionManager::createEditMenu()
     QObject::tr("Replace Texture..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().replaceMaterial(); },
+    [](auto& context) { context.mapWindow().replaceMaterial(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
 }
@@ -1195,9 +1195,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Select All"),
     ActionContext::Any,
     QKeySequence::SelectAll,
-    [](auto& context) { context.mapFrame().selectAll(); },
+    [](auto& context) { context.mapWindow().selectAll(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelect();
+      return context.hasDocument() && context.mapWindow().canSelect();
     },
   }));
   selectionMenu.addItem(addAction(Action{
@@ -1205,9 +1205,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Invert Selection"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::ALT | Qt::Key_A},
-    [](auto& context) { context.mapFrame().selectInverse(); },
+    [](auto& context) { context.mapWindow().selectInverse(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelectInverse();
+      return context.hasDocument() && context.mapWindow().canSelectInverse();
     },
   }));
   selectionMenu.addItem(addAction(Action{
@@ -1215,9 +1215,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Deselect All"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_A},
-    [](auto& context) { context.mapFrame().selectNone(); },
+    [](auto& context) { context.mapWindow().selectNone(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDeselect();
+      return context.hasDocument() && context.mapWindow().canDeselect();
     },
   }));
   selectionMenu.addSeparator();
@@ -1226,9 +1226,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Select Siblings"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_B},
-    [](auto& context) { context.mapFrame().selectSiblings(); },
+    [](auto& context) { context.mapWindow().selectSiblings(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelectSiblings();
+      return context.hasDocument() && context.mapWindow().canSelectSiblings();
     },
   }));
   selectionMenu.addItem(addAction(Action{
@@ -1236,9 +1236,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Select Touching"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_T},
-    [](auto& context) { context.mapFrame().selectTouching(); },
+    [](auto& context) { context.mapWindow().selectTouching(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelectByBrush();
+      return context.hasDocument() && context.mapWindow().canSelectByBrush();
     },
   }));
   selectionMenu.addItem(addAction(Action{
@@ -1246,9 +1246,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Select Inside"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_E},
-    [](auto& context) { context.mapFrame().selectInside(); },
+    [](auto& context) { context.mapWindow().selectInside(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelectByBrush();
+      return context.hasDocument() && context.mapWindow().canSelectByBrush();
     },
   }));
   selectionMenu.addItem(addAction(Action{
@@ -1256,9 +1256,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Select Tall"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_E},
-    [](auto& context) { context.mapFrame().selectTall(); },
+    [](auto& context) { context.mapWindow().selectTall(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelectTall();
+      return context.hasDocument() && context.mapWindow().canSelectTall();
     },
   }));
   selectionMenu.addItem(addAction(Action{
@@ -1266,9 +1266,9 @@ void ActionManager::createSelectionMenu()
     QObject::tr("Select by Line Number..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().selectByLineNumber(); },
+    [](auto& context) { context.mapWindow().selectByLineNumber(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canSelect();
+      return context.hasDocument() && context.mapWindow().canSelect();
     },
   }));
 }
@@ -1281,9 +1281,9 @@ void ActionManager::createGroupsMenu()
     QObject::tr("Group Selected Objects"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_G},
-    [](auto& context) { context.mapFrame().groupSelectedObjects(); },
+    [](auto& context) { context.mapWindow().groupSelectedObjects(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canGroupSelectedObjects();
+      return context.hasDocument() && context.mapWindow().canGroupSelectedObjects();
     },
   }));
   groupsMenu.addItem(addAction(Action{
@@ -1291,9 +1291,9 @@ void ActionManager::createGroupsMenu()
     QObject::tr("Ungroup Selected Objects"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_G},
-    [](auto& context) { context.mapFrame().ungroupSelectedObjects(); },
+    [](auto& context) { context.mapWindow().ungroupSelectedObjects(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canUngroupSelectedObjects();
+      return context.hasDocument() && context.mapWindow().canUngroupSelectedObjects();
     },
   }));
   groupsMenu.addItem(addAction(Action{
@@ -1301,9 +1301,9 @@ void ActionManager::createGroupsMenu()
     QObject::tr("Rename Selected Groups"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::ALT | Qt::Key_G},
-    [](auto& context) { context.mapFrame().renameSelectedGroups(); },
+    [](auto& context) { context.mapWindow().renameSelectedGroups(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canRenameSelectedGroups();
+      return context.hasDocument() && context.mapWindow().canRenameSelectedGroups();
     },
   }));
   groupsMenu.addSeparator();
@@ -1358,12 +1358,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Brush Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_B},
-    [](auto& context) { context.mapFrame().toggleAssembleBrushTool(); },
+    [](auto& context) { context.mapWindow().toggleAssembleBrushTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleAssembleBrushTool();
+      return context.hasDocument() && context.mapWindow().canToggleAssembleBrushTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().assembleBrushToolActive();
+      return context.hasDocument() && context.mapWindow().assembleBrushToolActive();
     },
     std::filesystem::path{"BrushTool.svg"},
   }));
@@ -1372,12 +1372,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Clip Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_C},
-    [](auto& context) { context.mapFrame().toggleClipTool(); },
+    [](auto& context) { context.mapWindow().toggleClipTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleClipTool();
+      return context.hasDocument() && context.mapWindow().canToggleClipTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().clipToolActive();
+      return context.hasDocument() && context.mapWindow().clipToolActive();
     },
     std::filesystem::path{"ClipTool.svg"},
   }));
@@ -1386,12 +1386,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Rotate Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_R},
-    [](auto& context) { context.mapFrame().toggleRotateTool(); },
+    [](auto& context) { context.mapWindow().toggleRotateTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleRotateTool();
+      return context.hasDocument() && context.mapWindow().canToggleRotateTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().rotateToolActive();
+      return context.hasDocument() && context.mapWindow().rotateToolActive();
     },
     std::filesystem::path{"RotateTool.svg"},
   }));
@@ -1400,12 +1400,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Scale Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_T},
-    [](auto& context) { context.mapFrame().toggleScaleTool(); },
+    [](auto& context) { context.mapWindow().toggleScaleTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleScaleTool();
+      return context.hasDocument() && context.mapWindow().canToggleScaleTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().scaleToolActive();
+      return context.hasDocument() && context.mapWindow().scaleToolActive();
     },
     std::filesystem::path{"ScaleTool.svg"},
   }));
@@ -1414,12 +1414,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Shear Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_G},
-    [](auto& context) { context.mapFrame().toggleShearTool(); },
+    [](auto& context) { context.mapWindow().toggleShearTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleShearTool();
+      return context.hasDocument() && context.mapWindow().canToggleShearTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().shearToolActive();
+      return context.hasDocument() && context.mapWindow().shearToolActive();
     },
     std::filesystem::path{"ShearTool.svg"},
   }));
@@ -1428,12 +1428,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Vertex Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_V},
-    [](auto& context) { context.mapFrame().toggleVertexTool(); },
+    [](auto& context) { context.mapWindow().toggleVertexTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleVertexTool();
+      return context.hasDocument() && context.mapWindow().canToggleVertexTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().vertexToolActive();
+      return context.hasDocument() && context.mapWindow().vertexToolActive();
     },
     std::filesystem::path{"VertexTool.svg"},
   }));
@@ -1442,12 +1442,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Edge Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_E},
-    [](auto& context) { context.mapFrame().toggleEdgeTool(); },
+    [](auto& context) { context.mapWindow().toggleEdgeTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleEdgeTool();
+      return context.hasDocument() && context.mapWindow().canToggleEdgeTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().edgeToolActive();
+      return context.hasDocument() && context.mapWindow().edgeToolActive();
     },
     std::filesystem::path{"EdgeTool.svg"},
   }));
@@ -1456,12 +1456,12 @@ void ActionManager::createToolsMenu()
     QObject::tr("Face Tool"),
     ActionContext::Any,
     QKeySequence{Qt::Key_F},
-    [](auto& context) { context.mapFrame().toggleFaceTool(); },
+    [](auto& context) { context.mapWindow().toggleFaceTool(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canToggleFaceTool();
+      return context.hasDocument() && context.mapWindow().canToggleFaceTool();
     },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().faceToolActive();
+      return context.hasDocument() && context.mapWindow().faceToolActive();
     },
     std::filesystem::path{"FaceTool.svg"},
   }));
@@ -1473,7 +1473,7 @@ void ActionManager::createToolsMenu()
     [](auto& context) { context.mapView().deactivateCurrentTool(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
-      return context.hasDocument() && !context.mapFrame().anyModalToolActive();
+      return context.hasDocument() && !context.mapWindow().anyModalToolActive();
     },
     std::filesystem::path{"NoTool.svg"},
   }));
@@ -1488,7 +1488,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Show Grid"),
     ActionContext::Any,
     QKeySequence{Qt::Key_0},
-    [](auto& context) { context.mapFrame().toggleShowGrid(); },
+    [](auto& context) { context.mapWindow().toggleShowGrid(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().visible();
@@ -1499,7 +1499,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Snap to Grid"),
     ActionContext::Any,
     QKeySequence{Qt::ALT | Qt::Key_0},
-    [](auto& context) { context.mapFrame().toggleSnapToGrid(); },
+    [](auto& context) { context.mapWindow().toggleSnapToGrid(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().snap();
@@ -1510,9 +1510,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Increase Grid Size"),
     ActionContext::Any,
     QKeySequence{Qt::Key_Plus},
-    [](auto& context) { context.mapFrame().incGridSize(); },
+    [](auto& context) { context.mapWindow().incGridSize(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canIncGridSize();
+      return context.hasDocument() && context.mapWindow().canIncGridSize();
     },
   }));
   gridMenu.addItem(addAction(Action{
@@ -1520,9 +1520,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Decrease Grid Size"),
     ActionContext::Any,
     QKeySequence{Qt::Key_Minus},
-    [](auto& context) { context.mapFrame().decGridSize(); },
+    [](auto& context) { context.mapWindow().decGridSize(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canDecGridSize();
+      return context.hasDocument() && context.mapWindow().canDecGridSize();
     },
   }));
   gridMenu.addSeparator();
@@ -1531,7 +1531,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 0.125"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().setGridSize(-3); },
+    [](auto& context) { context.mapWindow().setGridSize(-3); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == -3;
@@ -1542,7 +1542,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 0.25"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().setGridSize(-2); },
+    [](auto& context) { context.mapWindow().setGridSize(-2); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == -2;
@@ -1553,7 +1553,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 0.5"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().setGridSize(-1); },
+    [](auto& context) { context.mapWindow().setGridSize(-1); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == -1;
@@ -1564,7 +1564,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 1"),
     ActionContext::Any,
     QKeySequence{Qt::Key_1},
-    [](auto& context) { context.mapFrame().setGridSize(0); },
+    [](auto& context) { context.mapWindow().setGridSize(0); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 0;
@@ -1575,7 +1575,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 2"),
     ActionContext::Any,
     QKeySequence{Qt::Key_2},
-    [](auto& context) { context.mapFrame().setGridSize(1); },
+    [](auto& context) { context.mapWindow().setGridSize(1); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 1;
@@ -1586,7 +1586,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 4"),
     ActionContext::Any,
     QKeySequence{Qt::Key_3},
-    [](auto& context) { context.mapFrame().setGridSize(2); },
+    [](auto& context) { context.mapWindow().setGridSize(2); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 2;
@@ -1597,7 +1597,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 8"),
     ActionContext::Any,
     QKeySequence{Qt::Key_4},
-    [](auto& context) { context.mapFrame().setGridSize(3); },
+    [](auto& context) { context.mapWindow().setGridSize(3); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 3;
@@ -1608,7 +1608,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 16"),
     ActionContext::Any,
     QKeySequence{Qt::Key_5},
-    [](auto& context) { context.mapFrame().setGridSize(4); },
+    [](auto& context) { context.mapWindow().setGridSize(4); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 4;
@@ -1619,7 +1619,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 32"),
     ActionContext::Any,
     QKeySequence{Qt::Key_6},
-    [](auto& context) { context.mapFrame().setGridSize(5); },
+    [](auto& context) { context.mapWindow().setGridSize(5); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 5;
@@ -1630,7 +1630,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 64"),
     ActionContext::Any,
     QKeySequence{Qt::Key_7},
-    [](auto& context) { context.mapFrame().setGridSize(6); },
+    [](auto& context) { context.mapWindow().setGridSize(6); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 6;
@@ -1641,7 +1641,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 128"),
     ActionContext::Any,
     QKeySequence{Qt::Key_8},
-    [](auto& context) { context.mapFrame().setGridSize(7); },
+    [](auto& context) { context.mapWindow().setGridSize(7); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 7;
@@ -1652,7 +1652,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Set Grid Size 256"),
     ActionContext::Any,
     QKeySequence{Qt::Key_9},
-    [](auto& context) { context.mapFrame().setGridSize(8); },
+    [](auto& context) { context.mapWindow().setGridSize(8); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
       return context.hasDocument() && context.map().grid().size() == 8;
@@ -1665,9 +1665,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Move Camera to Next Point"),
     ActionContext::Any,
     QKeySequence{Qt::Key_Period},
-    [](auto& context) { context.mapFrame().moveCameraToNextPoint(); },
+    [](auto& context) { context.mapWindow().moveCameraToNextPoint(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canMoveCameraToNextPoint();
+      return context.hasDocument() && context.mapWindow().canMoveCameraToNextPoint();
     },
   }));
   cameraMenu.addItem(addAction(Action{
@@ -1675,9 +1675,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Move Camera to Previous Point"),
     ActionContext::Any,
     QKeySequence{Qt::Key_Comma},
-    [](auto& context) { context.mapFrame().moveCameraToPreviousPoint(); },
+    [](auto& context) { context.mapWindow().moveCameraToPreviousPoint(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canMoveCameraToPreviousPoint();
+      return context.hasDocument() && context.mapWindow().canMoveCameraToPreviousPoint();
     },
   }));
   cameraMenu.addItem(addAction(Action{
@@ -1685,7 +1685,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Reset 2D Cameras"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_U},
-    [](auto& context) { context.mapFrame().reset2dCameras(); },
+    [](auto& context) { context.mapWindow().reset2dCameras(); },
     [](const auto& context) {
       return context.hasDocument() && !pref(Preferences::Link2DCameras);
     },
@@ -1695,9 +1695,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Focus Camera on Selection"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_U},
-    [](auto& context) { context.mapFrame().focusCameraOnSelection(); },
+    [](auto& context) { context.mapWindow().focusCameraOnSelection(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canFocusCamera();
+      return context.hasDocument() && context.mapWindow().canFocusCamera();
     },
   }));
   cameraMenu.addItem(addAction(Action{
@@ -1705,7 +1705,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Move Camera to..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().moveCameraToPosition(); },
+    [](auto& context) { context.mapWindow().moveCameraToPosition(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
 
@@ -1715,9 +1715,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Isolate Selection"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_I},
-    [](auto& context) { context.mapFrame().isolateSelection(); },
+    [](auto& context) { context.mapWindow().isolateSelection(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canIsolateSelection();
+      return context.hasDocument() && context.mapWindow().canIsolateSelection();
     },
   }));
   viewMenu.addItem(addAction(Action{
@@ -1725,9 +1725,9 @@ void ActionManager::createViewMenu()
     QObject::tr("Hide Selection"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::ALT | Qt::Key_I},
-    [](auto& context) { context.mapFrame().hideSelection(); },
+    [](auto& context) { context.mapWindow().hideSelection(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().canHideSelection();
+      return context.hasDocument() && context.mapWindow().canHideSelection();
     },
   }));
   viewMenu.addItem(addAction(Action{
@@ -1735,7 +1735,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Show All"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::SHIFT | Qt::Key_I},
-    [](auto& context) { context.mapFrame().showAll(); },
+    [](auto& context) { context.mapWindow().showAll(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   viewMenu.addSeparator();
@@ -1744,7 +1744,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Show Map Inspector"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_1},
-    [](auto& context) { context.mapFrame().switchToInspectorPage(InspectorPage::Map); },
+    [](auto& context) { context.mapWindow().switchToInspectorPage(InspectorPage::Map); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   viewMenu.addItem(addAction(Action{
@@ -1753,7 +1753,7 @@ void ActionManager::createViewMenu()
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_2},
     [](auto& context) {
-      context.mapFrame().switchToInspectorPage(InspectorPage::Entity);
+      context.mapWindow().switchToInspectorPage(InspectorPage::Entity);
     },
     [](const auto& context) { return context.hasDocument(); },
   }));
@@ -1762,7 +1762,7 @@ void ActionManager::createViewMenu()
     QObject::tr("Show Face Inspector"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_3},
-    [](auto& context) { context.mapFrame().switchToInspectorPage(InspectorPage::Face); },
+    [](auto& context) { context.mapWindow().switchToInspectorPage(InspectorPage::Face); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   viewMenu.addSeparator();
@@ -1771,10 +1771,10 @@ void ActionManager::createViewMenu()
     QObject::tr("Toggle Toolbar"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::ALT | Qt::Key_T},
-    [](auto& context) { context.mapFrame().toggleToolbar(); },
+    [](auto& context) { context.mapWindow().toggleToolbar(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().toolbarVisible();
+      return context.hasDocument() && context.mapWindow().toolbarVisible();
     },
   }));
   viewMenu.addItem(addAction(Action{
@@ -1782,10 +1782,10 @@ void ActionManager::createViewMenu()
     QObject::tr("Toggle Info Panel"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_4},
-    [](auto& context) { context.mapFrame().toggleInfoPanel(); },
+    [](auto& context) { context.mapWindow().toggleInfoPanel(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().infoPanelVisible();
+      return context.hasDocument() && context.mapWindow().infoPanelVisible();
     },
   }));
   viewMenu.addItem(addAction(Action{
@@ -1793,10 +1793,10 @@ void ActionManager::createViewMenu()
     QObject::tr("Toggle Inspector"),
     ActionContext::Any,
     QKeySequence{Qt::CTRL | Qt::Key_5},
-    [](auto& context) { context.mapFrame().toggleInspector(); },
+    [](auto& context) { context.mapWindow().toggleInspector(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().inspectorVisible();
+      return context.hasDocument() && context.mapWindow().inspectorVisible();
     },
   }));
   viewMenu.addItem(addAction(Action{
@@ -1809,10 +1809,10 @@ void ActionManager::createViewMenu()
 #else
     QKeySequence{Qt::CTRL | Qt::Key_Space},
 #endif
-    [](auto& context) { context.mapFrame().toggleMaximizeCurrentView(); },
+    [](auto& context) { context.mapWindow().toggleMaximizeCurrentView(); },
     [](const auto& context) { return context.hasDocument(); },
     [](const auto& context) {
-      return context.hasDocument() && context.mapFrame().currentViewMaximized();
+      return context.hasDocument() && context.mapWindow().currentViewMaximized();
     },
   }));
   viewMenu.addSeparator();
@@ -1834,7 +1834,7 @@ void ActionManager::createRunMenu()
     QObject::tr("Compile Map..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().showCompileDialog(); },
+    [](auto& context) { context.mapWindow().showCompileDialog(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   runMenu.addItem(addAction(Action{
@@ -1842,7 +1842,7 @@ void ActionManager::createRunMenu()
     QObject::tr("Launch Engine..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().showLaunchEngineDialog(); },
+    [](auto& context) { context.mapWindow().showLaunchEngineDialog(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
 }
@@ -1856,7 +1856,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Print Vertices to Console"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugPrintVertices(); },
+    [](auto& context) { context.mapWindow().debugPrintVertices(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   debugMenu.addItem(addAction(Action{
@@ -1864,7 +1864,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Create Brush..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugCreateBrush(); },
+    [](auto& context) { context.mapWindow().debugCreateBrush(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   debugMenu.addItem(addAction(Action{
@@ -1872,7 +1872,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Create Cube..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugCreateCube(); },
+    [](auto& context) { context.mapWindow().debugCreateCube(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   debugMenu.addItem(addAction(Action{
@@ -1880,7 +1880,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Crash..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugCrash(); },
+    [](auto& context) { context.mapWindow().debugCrash(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   debugMenu.addItem(addAction(Action{
@@ -1888,7 +1888,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Throw Exception During Command"),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugThrowExceptionDuringCommand(); },
+    [](auto& context) { context.mapWindow().debugThrowExceptionDuringCommand(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   debugMenu.addItem(addAction(Action{
@@ -1904,7 +1904,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Set Window Size..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugSetWindowSize(); },
+    [](auto& context) { context.mapWindow().debugSetWindowSize(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
   debugMenu.addItem(addAction(Action{
@@ -1912,7 +1912,7 @@ void ActionManager::createDebugMenu()
     QObject::tr("Show Palette..."),
     ActionContext::Any,
     QKeySequence{},
-    [](auto& context) { context.mapFrame().debugShowPalette(); },
+    [](auto& context) { context.mapWindow().debugShowPalette(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
 #endif

--- a/lib/TbUiLib/src/ActionMenu.cpp
+++ b/lib/TbUiLib/src/ActionMenu.cpp
@@ -22,8 +22,8 @@
 #include <QKeySequence>
 #include <QString>
 
-#include "ui/MapFrame.h"
 #include "ui/MapViewBase.h"
+#include "ui/MapWindow.h"
 
 #include <string>
 

--- a/lib/TbUiLib/src/AppController.cpp
+++ b/lib/TbUiLib/src/AppController.cpp
@@ -36,10 +36,10 @@
 #include "ui/ActionManager.h"
 #include "ui/CrashDialog.h"
 #include "ui/FileDialogDefaultDir.h"
-#include "ui/FrameManager.h"
 #include "ui/GameDialog.h"
 #include "ui/MapDocument.h"
-#include "ui/MapFrame.h"
+#include "ui/MapWindow.h"
+#include "ui/MapWindowManager.h"
 #include "ui/PreferenceDialog.h"
 #include "ui/QPathUtils.h"
 #include "ui/RecentDocuments.h"
@@ -95,9 +95,9 @@ auto createGameManager()
            });
 }
 
-auto createFrameManager(AppController& appController)
+auto createMapWindowManager(AppController& appController)
 {
-  return new FrameManager{appController, AppController::useSDI};
+  return new MapWindowManager{appController, AppController::useSDI};
 }
 
 auto createRecentDocuments(QObject* parent)
@@ -157,7 +157,7 @@ AppController::AppController(
   , m_recentDocumentsReloadTimer{new QTimer{this}}
   , m_httpClient{new upd::QtHttpClient{*m_networkManager}}
   , m_updater{new upd::Updater{*m_httpClient, makeUpdateConfig(), this}}
-  , m_frameManager{createFrameManager(*this)}
+  , m_mapWindowManager{createMapWindowManager(*this)}
   , m_recentDocuments{createRecentDocuments(this)}
   , m_actionManager{std::make_unique<ActionManager>()}
   , m_welcomeWindow{std::make_unique<WelcomeWindow>(*this)}
@@ -206,9 +206,9 @@ upd::Updater& AppController::updater()
   return *m_updater;
 }
 
-FrameManager& AppController::frameManager()
+MapWindowManager& AppController::mapWindowManager()
 {
-  return *m_frameManager;
+  return *m_mapWindowManager;
 }
 
 const RecentDocuments& AppController::recentDocuments() const
@@ -267,7 +267,7 @@ bool AppController::newDocument()
   const auto* gameInfo = gameManager().gameInfo(gameName);
   contract_assert(gameInfo != nullptr);
 
-  return m_frameManager->createDocument(
+  return m_mapWindowManager->createDocument(
            environmentConfig(),
            *gameInfo,
            mapFormat,
@@ -328,7 +328,7 @@ bool AppController::openDocument(const std::filesystem::path& path)
              const auto* gameInfo = gameManager().gameInfo(gameName);
              contract_assert(gameInfo != nullptr);
 
-             return m_frameManager->loadDocument(
+             return m_mapWindowManager->loadDocument(
                       environmentConfig(),
                       *gameInfo,
                       mapFormat,
@@ -363,8 +363,8 @@ void AppController::showManual()
 
 void AppController::showPreferences()
 {
-  auto* topFrame = frameManager().topFrame();
-  auto* topDocument = topFrame ? &topFrame->document() : nullptr;
+  auto* topMapWindow = mapWindowManager().topMapWindow();
+  auto* topDocument = topMapWindow ? &topMapWindow->document() : nullptr;
 
   auto dialog = PreferenceDialog{*this, topDocument};
   dialog.exec();

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -39,7 +39,7 @@
 #include "ui/DialogButtonLayout.h"
 #include "ui/LaunchGameEngineDialog.h"
 #include "ui/MapDocument.h" // IWYU pragma: keep
-#include "ui/MapFrame.h"
+#include "ui/MapWindow.h"
 #include "ui/QStyleUtils.h"
 #include "ui/Splitter.h"
 #include "ui/TitledPanel.h"

--- a/lib/TbUiLib/src/CrashReporter.cpp
+++ b/lib/TbUiLib/src/CrashReporter.cpp
@@ -27,10 +27,10 @@
 #include "mdl/Map.h"
 #include "ui/AppController.h"
 #include "ui/CrashDialog.h"
-#include "ui/FrameManager.h"
 #include "ui/GetVersion.h"
 #include "ui/MapDocument.h"
-#include "ui/MapFrame.h"
+#include "ui/MapWindow.h"
+#include "ui/MapWindowManager.h"
 #include "ui/QPathUtils.h"
 #include "ui/SystemPaths.h"
 
@@ -63,9 +63,11 @@ const MapDocument* topDocument()
 {
   if (appControllerForCrashReporter)
   {
-    if (const auto* topFrame = appControllerForCrashReporter->frameManager().topFrame())
+    if (
+      const auto* topMapWindow =
+        appControllerForCrashReporter->mapWindowManager().topMapWindow())
     {
-      return &topFrame->document();
+      return &topMapWindow->document();
     }
   }
   return nullptr;

--- a/lib/TbUiLib/src/FileEventFilter.cpp
+++ b/lib/TbUiLib/src/FileEventFilter.cpp
@@ -23,7 +23,7 @@
 #include <QFileOpenEvent>
 
 #include "ui/AppController.h"
-#include "ui/FrameManager.h"
+#include "ui/MapWindowManager.h"
 
 #include <filesystem>
 
@@ -50,7 +50,7 @@ bool FileEventFilter::eventFilter(QObject* watched, QEvent* event)
   }
   else if (event->type() == QEvent::ApplicationActivate)
   {
-    if (m_appController.frameManager().allFramesClosed())
+    if (m_appController.mapWindowManager().allMapWindowsClosed())
     {
       m_appController.showWelcomeWindow();
     }

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -77,9 +77,9 @@
 #include "ui/EnableDisableTagCallback.h"
 #include "ui/FlashSelectionAnimation.h"
 #include "ui/MapDocument.h"
-#include "ui/MapFrame.h"
 #include "ui/MapViewActivationTracker.h"
 #include "ui/MapViewToolBox.h"
+#include "ui/MapWindow.h"
 #include "ui/SelectionTool.h"
 #include "ui/SignalDelayer.h"
 
@@ -307,8 +307,8 @@ void MapViewBase::updateActionBindings()
 
 void MapViewBase::updateActionStates()
 {
-  auto* mapFrame = dynamic_cast<MapFrame*>(window());
-  auto context = ActionExecutionContext{m_appController, mapFrame, this};
+  auto* mapWindow = dynamic_cast<MapWindow*>(window());
+  auto context = ActionExecutionContext{m_appController, mapWindow, this};
   for (auto& [shortcut, action] : m_shortcuts)
   {
     shortcut->setEnabled(hasFocus() && action->enabled(context));
@@ -322,8 +322,8 @@ void MapViewBase::updateActionStatesDelayed()
 
 void MapViewBase::triggerAction(const Action& action)
 {
-  auto* mapFrame = dynamic_cast<MapFrame*>(window());
-  auto context = ActionExecutionContext{m_appController, mapFrame, this};
+  auto* mapWindow = dynamic_cast<MapWindow*>(window());
+  auto context = ActionExecutionContext{m_appController, mapWindow, this};
   action.execute(context);
 }
 
@@ -1160,11 +1160,11 @@ void MapViewBase::showPopupMenuLater()
   auto* newGroup = findNewGroupForObjects(nodes);
   auto* mergeGroup = findGroupToMergeGroupsInto(map.selection());
 
-  auto* mapFrame = dynamic_cast<MapFrame*>(window());
+  auto* mapWindow = dynamic_cast<MapWindow*>(window());
 
   auto menu = QMenu{};
   const auto addMainMenuAction = [&](const auto& path) -> QAction* {
-    auto* groupAction = mapFrame->findAction(path);
+    auto* groupAction = mapWindow->findAction(path);
     contract_assert(groupAction);
 
     menu.addAction(groupAction);
@@ -1305,8 +1305,8 @@ void MapViewBase::showPopupMenuLater()
     menu.addAction(
       tr("Reveal %1 in Material Browser")
         .arg(QString::fromStdString(faceHandle->face().attributes().materialName())),
-      mapFrame,
-      [=] { mapFrame->revealMaterial(material); });
+      mapWindow,
+      [=] { mapWindow->revealMaterial(material); });
 
     menu.addSeparator();
   }

--- a/lib/TbUiLib/src/MapWindowManager.cpp
+++ b/lib/TbUiLib/src/MapWindowManager.cpp
@@ -17,14 +17,14 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ui/FrameManager.h"
+#include "ui/MapWindowManager.h"
 
 #include <QApplication>
 
 #include "mdl/GameInfo.h"
 #include "ui/AppController.h"
 #include "ui/MapDocument.h"
-#include "ui/MapFrame.h"
+#include "ui/MapWindow.h"
 
 #include "kd/contracts.h"
 
@@ -34,47 +34,47 @@
 namespace tb::ui
 {
 
-FrameManager::FrameManager(AppController& appController, const bool singleFrame)
+MapWindowManager::MapWindowManager(AppController& appController, const bool singleFrame)
   : QObject{&appController}
   , m_appController{appController}
-  , m_singleFrame{singleFrame}
+  , m_singleMapWindow{singleFrame}
 {
-  connect(qApp, &QApplication::focusChanged, this, &FrameManager::onFocusChange);
+  connect(qApp, &QApplication::focusChanged, this, &MapWindowManager::onFocusChange);
 }
 
-FrameManager::~FrameManager() = default;
+MapWindowManager::~MapWindowManager() = default;
 
-std::vector<MapFrame*> FrameManager::frames() const
+std::vector<MapWindow*> MapWindowManager::mapWindows() const
 {
-  return m_frames;
+  return m_mapWindows;
 }
 
-MapFrame* FrameManager::topFrame() const
+MapWindow* MapWindowManager::topMapWindow() const
 {
-  return m_frames.empty() ? nullptr : m_frames.front();
+  return m_mapWindows.empty() ? nullptr : m_mapWindows.front();
 }
 
-Result<void> FrameManager::createDocument(
+Result<void> MapWindowManager::createDocument(
   const mdl::EnvironmentConfig& environmentConfig,
   const mdl::GameInfo& gameInfo,
   mdl::MapFormat mapFormat,
   const vm::bbox3d& worldBounds,
   kdl::task_manager& taskManager)
 {
-  if (shouldCreateFrameForDocument())
+  if (shouldCreateWindowForDocument())
   {
     return MapDocument::createDocument(
              environmentConfig, gameInfo, mapFormat, worldBounds, taskManager)
-           | kdl::transform([&](auto document) { createFrame(std::move(document)); });
+           | kdl::transform([&](auto document) { createMapWindow(std::move(document)); });
   }
 
-  auto* frame = topFrame();
+  auto* frame = topMapWindow();
   contract_assert(frame != nullptr);
 
   return frame->document().create(environmentConfig, gameInfo, mapFormat, worldBounds);
 }
 
-Result<void> FrameManager::loadDocument(
+Result<void> MapWindowManager::loadDocument(
   const mdl::EnvironmentConfig& environmentConfig,
   const mdl::GameInfo& gameInfo,
   mdl::MapFormat mapFormat,
@@ -82,7 +82,7 @@ Result<void> FrameManager::loadDocument(
   std::filesystem::path path,
   kdl::task_manager& taskManager)
 {
-  if (shouldCreateFrameForDocument())
+  if (shouldCreateWindowForDocument())
   {
     return MapDocument::loadDocument(
              environmentConfig,
@@ -91,50 +91,50 @@ Result<void> FrameManager::loadDocument(
              worldBounds,
              std::move(path),
              taskManager)
-           | kdl::transform([&](auto document) { createFrame(std::move(document)); });
+           | kdl::transform([&](auto document) { createMapWindow(std::move(document)); });
   }
 
-  auto* frame = topFrame();
+  auto* frame = topMapWindow();
   contract_assert(frame != nullptr);
 
   return frame->document().load(
     environmentConfig, gameInfo, mapFormat, worldBounds, std::move(path));
 }
 
-bool FrameManager::allFramesClosed() const
+bool MapWindowManager::allMapWindowsClosed() const
 {
-  return m_frames.empty();
+  return m_mapWindows.empty();
 }
 
-void FrameManager::onFocusChange(QWidget* /* old */, QWidget* now)
+void MapWindowManager::onFocusChange(QWidget* /* old */, QWidget* now)
 {
   if (now)
   {
     // The QApplication::focusChanged signal also notifies us of focus changes between
     // child widgets, so get the top-level widget with QWidget::window()
-    if (auto* frame = dynamic_cast<MapFrame*>(now->window()))
+    if (auto* frame = dynamic_cast<MapWindow*>(now->window()))
     {
-      if (auto it = std::ranges::find(m_frames, frame);
-          it != m_frames.end() && it != m_frames.begin())
+      if (auto it = std::ranges::find(m_mapWindows, frame);
+          it != m_mapWindows.end() && it != m_mapWindows.begin())
       {
-        std::rotate(m_frames.begin(), it, std::next(it));
+        std::rotate(m_mapWindows.begin(), it, std::next(it));
       }
     }
   }
 }
 
-bool FrameManager::shouldCreateFrameForDocument() const
+bool MapWindowManager::shouldCreateWindowForDocument() const
 {
-  return !m_singleFrame || m_frames.empty();
+  return !m_singleMapWindow || m_mapWindows.empty();
 }
 
-MapFrame* FrameManager::createFrame(std::unique_ptr<MapDocument> document)
+MapWindow* MapWindowManager::createMapWindow(std::unique_ptr<MapDocument> document)
 {
   contract_pre(document != nullptr);
 
-  auto* frame = new MapFrame{m_appController, std::move(document)};
-  frame->positionOnScreen(topFrame());
-  m_frames.insert(m_frames.begin(), frame);
+  auto* frame = new MapWindow{m_appController, std::move(document)};
+  frame->positionOnScreen(topMapWindow());
+  m_mapWindows.insert(m_mapWindows.begin(), frame);
 
   frame->show();
   frame->raise();
@@ -142,13 +142,13 @@ MapFrame* FrameManager::createFrame(std::unique_ptr<MapDocument> document)
   return frame;
 }
 
-void FrameManager::removeFrame(MapFrame* frame)
+void MapWindowManager::removeMapWindow(MapWindow* mapWindow)
 {
-  // This is called from MapFrame::closeEvent
-  if (auto it = std::ranges::find(m_frames, frame); it != m_frames.end())
+  // This is called from MapWindow::closeEvent
+  if (auto it = std::ranges::find(m_mapWindows, mapWindow); it != m_mapWindows.end())
   {
-    m_frames.erase(it);
-    // MapFrame uses Qt::WA_DeleteOnClose so we don't need to delete it here
+    m_mapWindows.erase(it);
+    // MapWindow uses Qt::WA_DeleteOnClose so we don't need to delete it here
   }
 }
 

--- a/lib/TbUiLib/src/ObjExportDialog.cpp
+++ b/lib/TbUiLib/src/ObjExportDialog.cpp
@@ -34,7 +34,7 @@
 #include "ui/DialogHeader.h"
 #include "ui/FormWithSectionsLayout.h"
 #include "ui/MapDocument.h" // IWYU pragma: keep
-#include "ui/MapFrame.h"
+#include "ui/MapWindow.h"
 #include "ui/QPathUtils.h"
 #include "ui/QStyleUtils.h"
 #include "ui/ViewConstants.h"
@@ -47,11 +47,11 @@
 namespace tb::ui
 {
 
-ObjExportDialog::ObjExportDialog(MapFrame* mapFrame)
-  : QDialog{mapFrame}
-  , m_mapFrame{mapFrame}
+ObjExportDialog::ObjExportDialog(MapWindow* mapWindow)
+  : QDialog{mapWindow}
+  , m_mapWindow{mapWindow}
 {
-  contract_pre(m_mapFrame != nullptr);
+  contract_pre(m_mapWindow != nullptr);
 
   createGui();
   resize(500, 0);
@@ -148,14 +148,14 @@ void ObjExportDialog::createGui()
     options.mtlPathMode = m_relativeToGamePathRadioButton->isChecked()
                             ? mdl::ObjMtlPathMode::RelativeToGamePath
                             : mdl::ObjMtlPathMode::RelativeToExportPath;
-    m_mapFrame->exportDocument(options);
+    m_mapWindow->exportDocument(options);
     close();
   });
 }
 
 void ObjExportDialog::updateExportPath()
 {
-  const auto& map = m_mapFrame->document().map();
+  const auto& map = m_mapWindow->document().map();
   const auto& originalPath = map.path();
   const auto objPath = kdl::path_replace_extension(originalPath, ".obj");
   m_exportPathEdit->setText(pathAsQString(objPath));


### PR DESCRIPTION
On macOS, the map window will sometimes show deactivated without this call. On top of this, we do some cleanup and adapt some terminology.