### PR TITLE
Invoke documentWasLoadedNotifier after the UI was created

### DIFF
--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -199,7 +199,8 @@ MapWindow::MapWindow(AppController& appController, std::unique_ptr<MapDocument> 
 
   setAcceptDrops(true);
 
-  documentWasLoaded();
+  // act as if the document was loaded to update the UI
+  m_document->documentWasLoadedNotifier();
 }
 
 MapWindow::~MapWindow()


### PR DESCRIPTION
Closes #5073.

This ensures that the UI is initialized correctly. Currently, the notifier is called before the UI has a chance to connect its observers, so we just call it again.