### PR TITLE
Ensure that OpenGL resources are eventually released

### DIFF
--- a/lib/TbMdlLib/include/mdl/Map.h
+++ b/lib/TbMdlLib/include/mdl/Map.h
@@ -105,9 +105,9 @@ private:
   std::unique_ptr<GameFileSystem> m_gameFileSystem;
 
   kdl::task_manager& m_taskManager;
+  gl::ResourceManager& m_resourceManager;
   Logger& m_logger;
 
-  std::unique_ptr<gl::ResourceManager> m_resourceManager;
   std::unique_ptr<EntityDefinitionManager> m_entityDefinitionManager;
   std::unique_ptr<EntityModelManager> m_entityModelManager;
   std::unique_ptr<gl::MaterialManager> m_materialManager;
@@ -195,6 +195,7 @@ public: // misc
     std::unique_ptr<WorldNode> worldNode,
     const vm::bbox3d& worldBounds,
     kdl::task_manager& taskManager,
+    gl::ResourceManager& resourceManager,
     Logger& logger);
 
   Map(
@@ -205,6 +206,7 @@ public: // misc
     const vm::bbox3d& worldBounds,
     std::filesystem::path path,
     kdl::task_manager& taskManager,
+    gl::ResourceManager& resourceManager,
     Logger& logger);
 
   ~Map();
@@ -216,6 +218,7 @@ public: // misc
     MapFormat mapFormat,
     const vm::bbox3d& worldBounds,
     kdl::task_manager& taskManager,
+    gl::ResourceManager& resourceManager,
     Logger& logger);
 
   static Result<std::unique_ptr<Map>> loadMap(
@@ -226,6 +229,7 @@ public: // misc
     const vm::bbox3d& worldBounds,
     std::filesystem::path path,
     kdl::task_manager& taskManager,
+    gl::ResourceManager& resourceManager,
     Logger& logger);
 
   Logger& logger();

--- a/lib/TbMdlLib/test-utils/include/mdl/MapFixture.h
+++ b/lib/TbMdlLib/test-utils/include/mdl/MapFixture.h
@@ -38,6 +38,11 @@ namespace tb
 {
 class Logger;
 
+namespace gl
+{
+class ResourceManager;
+}
+
 namespace mdl
 {
 class Map;
@@ -65,6 +70,7 @@ class MapFixture
 {
 private:
   std::unique_ptr<kdl::task_manager> m_taskManager;
+  std::unique_ptr<gl::ResourceManager> m_resourceManager;
   std::unique_ptr<Logger> m_logger;
   std::unique_ptr<Map> m_map;
 

--- a/lib/TbMdlLib/test-utils/src/MapFixture.cpp
+++ b/lib/TbMdlLib/test-utils/src/MapFixture.cpp
@@ -21,6 +21,7 @@
 
 #include "Logger.h"
 #include "gl/Resource.h"
+#include "gl/ResourceManager.h"
 #include "mdl/Map.h"
 #include "mdl/TestUtils.h"
 
@@ -31,6 +32,7 @@ namespace tb::mdl
 
 MapFixture::MapFixture()
   : m_taskManager{createTestTaskManager()}
+  , m_resourceManager{std::make_unique<gl::ResourceManager>()}
   , m_logger{std::make_unique<NullLogger>()}
 {
 }
@@ -51,6 +53,7 @@ Map& MapFixture::create(MapFixtureConfig config)
       mapFormat,
       vm::bbox3d{8129.0},
       *m_taskManager,
+      *m_resourceManager,
       *m_logger)
     | kdl::transform([&](auto map) {
         m_map = std::move(map);
@@ -78,6 +81,7 @@ Map& MapFixture::load(const std::filesystem::path& path, MapFixtureConfig config
       vm::bbox3d{8129.0},
       absPath,
       *m_taskManager,
+      *m_resourceManager,
       *m_logger)
     | kdl::transform([&](auto map) {
         m_map = std::move(map);

--- a/lib/TbMdlLib/test/src/tst_Map.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map.cpp
@@ -22,6 +22,7 @@
 #include "fs/TestEnvironment.h"
 #include "gl/Material.h"
 #include "gl/MaterialManager.h"
+#include "gl/ResourceManager.h"
 #include "gl/TextureResource.h"
 #include "mdl/Brush.h"
 #include "mdl/BrushBuilder.h"
@@ -99,6 +100,7 @@ TEST_CASE("Map")
   SECTION("create")
   {
     auto taskManager = createTestTaskManager();
+    auto resourceManager = gl::ResourceManager{};
     auto logger = NullLogger{};
 
     SECTION("Calling create sets worldspawn and notifies observers")
@@ -110,6 +112,7 @@ TEST_CASE("Map")
         MapFormat::Standard,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             CHECK(
@@ -141,6 +144,7 @@ TEST_CASE("Map")
         MapFormat::Valve,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             const auto* defaultLayerNode = map->worldNode().defaultLayer();
@@ -176,6 +180,7 @@ TEST_CASE("Map")
         MapFormat::Valve,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             const auto* valveVersionProperty =
@@ -202,6 +207,7 @@ TEST_CASE("Map")
         MapFormat::Valve,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             const auto* materialConfigProperty =
@@ -227,6 +233,7 @@ TEST_CASE("Map")
         MapFormat::Valve,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             const auto* defaultLayerNode = map->worldNode().defaultLayer();
@@ -259,6 +266,7 @@ TEST_CASE("Map")
         MapFormat::Standard,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             REQUIRE(map->entityDefinitionManager().definitions().size() == 1);
@@ -272,6 +280,7 @@ TEST_CASE("Map")
   SECTION("loadMap")
   {
     auto taskManager = createTestTaskManager();
+    auto resourceManager = gl::ResourceManager{};
     auto logger = NullLogger{};
 
     SECTION("Sets world bounds, game and file path")
@@ -292,6 +301,7 @@ TEST_CASE("Map")
         worldBounds,
         path,
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([&](auto map) {
             CHECK(map->worldBounds() == worldBounds);
@@ -320,6 +330,7 @@ TEST_CASE("Map")
           vm::bbox3d{8192.0},
           makeAbsolute("fixture/test/mdl/Map/valveFormatMapWithoutFormatTag.map"),
           *taskManager,
+          resourceManager,
           logger)
           | kdl::transform([&](auto map) {
               CHECK(map->worldNode().mapFormat() == mdl::MapFormat::Valve);
@@ -338,6 +349,7 @@ TEST_CASE("Map")
           vm::bbox3d{8192.0},
           makeAbsolute("fixture/test/mdl/Map/standardFormatMapWithoutFormatTag.map"),
           *taskManager,
+          resourceManager,
           logger)
           | kdl::transform([&](auto map) {
               CHECK(map->worldNode().mapFormat() == mdl::MapFormat::Standard);
@@ -356,6 +368,7 @@ TEST_CASE("Map")
           vm::bbox3d{8192.0},
           makeAbsolute("fixture/test/mdl/Map/emptyMapWithoutFormatTag.map"),
           *taskManager,
+          resourceManager,
           logger)
           | kdl::transform([&](auto map) {
               // an empty map detects as Valve because Valve is listed first in the game
@@ -377,6 +390,7 @@ TEST_CASE("Map")
           vm::bbox3d{8192.0},
           makeAbsolute("fixture/test/mdl/Map/mixedFormats.map"),
           *taskManager,
+          resourceManager,
           logger));
       }
     }
@@ -402,6 +416,7 @@ TEST_CASE("Map")
         vm::bbox3d{8192.0},
         makeAbsolute("fixture/test/mdl/Map/valveFormatMapWithoutFormatTag.map"),
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([&](auto map) {
             REQUIRE(map->entityDefinitionManager().definitions().size() == 1);
@@ -415,6 +430,7 @@ TEST_CASE("Map")
   SECTION("reload")
   {
     auto taskManager = createTestTaskManager();
+    auto resourceManager = gl::ResourceManager{};
     auto logger = NullLogger{};
 
     auto gameInfo = DefaultGameInfo;
@@ -433,6 +449,7 @@ TEST_CASE("Map")
       vm::bbox3d{8192.0},
       path,
       *taskManager,
+      resourceManager,
       logger)
       | kdl::and_then([&](auto map) {
           REQUIRE(map->worldBounds() == worldBounds);
@@ -2001,6 +2018,7 @@ TEST_CASE("Map")
   SECTION("Entity definition file handling")
   {
     auto taskManager = createTestTaskManager();
+    auto resourceManager = gl::ResourceManager{};
     auto logger = NullLogger{};
 
     SECTION("Add and convert properties")
@@ -2022,6 +2040,7 @@ TEST_CASE("Map")
         MapFormat::Standard,
         vm::bbox3d{8192.0},
         *taskManager,
+        resourceManager,
         logger)
         | kdl::transform([](auto map) {
             CHECK(

--- a/lib/TbUiLib/include/ui/AppController.h
+++ b/lib/TbUiLib/include/ui/AppController.h
@@ -43,6 +43,11 @@ class Updater;
 
 namespace tb
 {
+namespace gl
+{
+class ResourceManager;
+}
+
 namespace mdl
 {
 class GameManager;
@@ -64,6 +69,8 @@ private:
   std::unique_ptr<kdl::task_manager> m_taskManager;
   std::unique_ptr<mdl::EnvironmentConfig> m_environmentConfig;
   std::unique_ptr<mdl::GameManager> m_gameManager;
+
+  std::unique_ptr<gl::ResourceManager> m_resourceManager;
 
   QNetworkAccessManager* m_networkManager = nullptr;
   QTimer* m_recentDocumentsReloadTimer = nullptr;
@@ -95,6 +102,8 @@ public:
   ~AppController() override;
 
   kdl::task_manager& taskManager();
+
+  gl::ResourceManager& resourceManager();
 
   const mdl::EnvironmentConfig& environmentConfig() const;
 

--- a/lib/TbUiLib/include/ui/MapDocument.h
+++ b/lib/TbUiLib/include/ui/MapDocument.h
@@ -44,6 +44,11 @@ namespace tb
 class Logger;
 class LoggingHub;
 
+namespace gl
+{
+class ResourceManager;
+}
+
 namespace mdl
 {
 enum class MapFormat;
@@ -147,6 +152,7 @@ public:
 private:
   // pointer so that MapDocument can be moveable
   kdl::task_manager* m_taskManager;
+  gl::ResourceManager* m_resourceManager;
   std::unique_ptr<LoggingHub> m_loggingHub;
 
   std::unique_ptr<mdl::Map> m_map;
@@ -165,7 +171,8 @@ private:
   NotifierConnection m_notifierConnection;
 
 public:
-  explicit MapDocument(kdl::task_manager& taskManager);
+  explicit MapDocument(
+    kdl::task_manager& taskManager, gl::ResourceManager& resourceManager);
 
   MapDocument(MapDocument&&) noexcept;
   MapDocument& operator=(MapDocument&&) noexcept;
@@ -175,7 +182,8 @@ public:
     const mdl::GameInfo& gameInfo,
     mdl::MapFormat mapFormat,
     const vm::bbox3d& worldBounds,
-    kdl::task_manager& taskManager);
+    kdl::task_manager& taskManager,
+    gl::ResourceManager& resourceManager);
 
   static Result<std::unique_ptr<MapDocument>> loadDocument(
     const mdl::EnvironmentConfig& environmentConfig,
@@ -183,7 +191,8 @@ public:
     mdl::MapFormat mapFormat,
     const vm::bbox3d& worldBounds,
     std::filesystem::path path,
-    kdl::task_manager& taskManager);
+    kdl::task_manager& taskManager,
+    gl::ResourceManager& resourceManager);
 
   ~MapDocument();
 

--- a/lib/TbUiLib/include/ui/MapWindowManager.h
+++ b/lib/TbUiLib/include/ui/MapWindowManager.h
@@ -36,6 +36,11 @@ class task_manager;
 
 namespace tb
 {
+namespace gl
+{
+class ResourceManager;
+}
+
 namespace mdl
 {
 enum class MapFormat;

--- a/lib/TbUiLib/src/AppController.cpp
+++ b/lib/TbUiLib/src/AppController.cpp
@@ -29,6 +29,7 @@
 #include "Preferences.h"
 #include "fs/DiskIO.h"
 #include "fs/PathInfo.h"
+#include "gl/ResourceManager.h"
 #include "mdl/EnvironmentConfig.h"
 #include "mdl/GameManager.h"
 #include "mdl/MapHeader.h"
@@ -153,6 +154,7 @@ AppController::AppController(
   : m_taskManager{std::move(taskManager)}
   , m_environmentConfig{std::move(environmentConfig)}
   , m_gameManager{std::move(gameManager)}
+  , m_resourceManager{std::make_unique<gl::ResourceManager>()}
   , m_networkManager{new QNetworkAccessManager{this}}
   , m_recentDocumentsReloadTimer{new QTimer{this}}
   , m_httpClient{new upd::QtHttpClient{*m_networkManager}}
@@ -189,6 +191,11 @@ AppController::~AppController() = default;
 kdl::task_manager& AppController::taskManager()
 {
   return *m_taskManager;
+}
+
+gl::ResourceManager& AppController::resourceManager()
+{
+  return *m_resourceManager;
 }
 
 const mdl::EnvironmentConfig& AppController::environmentConfig() const

--- a/lib/TbUiLib/src/MapDocument.cpp
+++ b/lib/TbUiLib/src/MapDocument.cpp
@@ -67,8 +67,10 @@ namespace tb::ui
 
 const vm::bbox3d MapDocument::DefaultWorldBounds(-32768.0, 32768.0);
 
-MapDocument::MapDocument(kdl::task_manager& taskManager)
+MapDocument::MapDocument(
+  kdl::task_manager& taskManager, gl::ResourceManager& resourceManager)
   : m_taskManager{&taskManager}
+  , m_resourceManager{&resourceManager}
   , m_loggingHub{std::make_unique<LoggingHub>()}
 {
   connectObservers();
@@ -82,9 +84,10 @@ Result<std::unique_ptr<MapDocument>> MapDocument::createDocument(
   const mdl::GameInfo& gameInfo,
   mdl::MapFormat mapFormat,
   const vm::bbox3d& worldBounds,
-  kdl::task_manager& taskManager)
+  kdl::task_manager& taskManager,
+  gl::ResourceManager& resourceManager)
 {
-  auto document = std::make_unique<MapDocument>(taskManager);
+  auto document = std::make_unique<MapDocument>(taskManager, resourceManager);
   return document->create(environmentConfig, gameInfo, mapFormat, worldBounds)
          | kdl::transform([&]() { return std::move(document); });
 }
@@ -95,9 +98,10 @@ Result<std::unique_ptr<MapDocument>> MapDocument::loadDocument(
   mdl::MapFormat mapFormat,
   const vm::bbox3d& worldBounds,
   std::filesystem::path path,
-  kdl::task_manager& taskManager)
+  kdl::task_manager& taskManager,
+  gl::ResourceManager& resourceManager)
 {
-  auto document = std::make_unique<MapDocument>(taskManager);
+  auto document = std::make_unique<MapDocument>(taskManager, resourceManager);
   return document->load(
            environmentConfig, gameInfo, mapFormat, worldBounds, std::move(path))
          | kdl::transform([&]() { return std::move(document); });
@@ -128,6 +132,7 @@ Result<void> MapDocument::create(
            mapFormat,
            worldBounds,
            *m_taskManager,
+           *m_resourceManager,
            logger())
          | kdl::transform([&](auto map) {
              setMap(std::move(map));
@@ -150,6 +155,7 @@ Result<void> MapDocument::load(
            worldBounds,
            std::move(path),
            *m_taskManager,
+           *m_resourceManager,
            logger())
          | kdl::transform([&](auto map) {
              setMap(std::move(map));

--- a/lib/TbUiLib/src/MapWindowManager.cpp
+++ b/lib/TbUiLib/src/MapWindowManager.cpp
@@ -65,7 +65,8 @@ Result<void> MapWindowManager::createDocument(
              gameInfo,
              mapFormat,
              worldBounds,
-             m_appController.taskManager())
+             m_appController.taskManager(),
+             m_appController.resourceManager())
            | kdl::transform([&](auto document) { createMapWindow(std::move(document)); });
   }
 
@@ -90,7 +91,8 @@ Result<void> MapWindowManager::loadDocument(
              mapFormat,
              worldBounds,
              std::move(path),
-             m_appController.taskManager())
+             m_appController.taskManager(),
+             m_appController.resourceManager())
            | kdl::transform([&](auto document) { createMapWindow(std::move(document)); });
   }
 

--- a/lib/TbUiLib/test-utils/include/ui/MapDocumentFixture.h
+++ b/lib/TbUiLib/test-utils/include/ui/MapDocumentFixture.h
@@ -35,22 +35,31 @@ namespace tb
 {
 class Logger;
 
+namespace gl
+{
+class ResourceManager;
+}
+
 namespace ui
 {
 class MapDocument;
 
 Result<std::unique_ptr<MapDocument>> createFixtureDocument(
-  mdl::MapFixtureConfig& config, kdl::task_manager& taskManager);
+  mdl::MapFixtureConfig& config,
+  kdl::task_manager& taskManager,
+  gl::ResourceManager& resourceManager);
 
 Result<std::unique_ptr<MapDocument>> loadFixtureDocument(
   const std::filesystem::path& path,
   mdl::MapFixtureConfig& config,
-  kdl::task_manager& taskManager);
+  kdl::task_manager& taskManager,
+  gl::ResourceManager& resourceManager);
 
 class MapDocumentFixture
 {
 private:
   std::unique_ptr<kdl::task_manager> m_taskManager;
+  std::unique_ptr<gl::ResourceManager> m_resourceManager;
   std::unique_ptr<MapDocument> m_document;
 
   std::optional<mdl::MapFixtureConfig> m_config;

--- a/lib/TbUiLib/test/src/tst_MapDocument.cpp
+++ b/lib/TbUiLib/test/src/tst_MapDocument.cpp
@@ -19,6 +19,7 @@
 
 #include "Logger.h"
 #include "Observer.h"
+#include "gl/ResourceManager.h"
 #include "mdl/EntityNode.h"
 #include "mdl/EnvironmentConfig.h"
 #include "mdl/GameConfigFixture.h"
@@ -41,6 +42,7 @@ TEST_CASE("MapDocument")
   auto logger = NullLogger{};
   const auto environmentConfig = mdl::EnvironmentConfig{};
   auto taskManager = createTestTaskManager();
+  auto resourceManager = gl::ResourceManager{};
 
   SECTION("createDocument")
   {
@@ -49,7 +51,8 @@ TEST_CASE("MapDocument")
       mdl::Quake2GameInfo,
       mdl::MapFormat::Valve,
       vm::bbox3d{8192.0},
-      *taskManager)
+      *taskManager,
+      resourceManager)
       | kdl::transform([&](auto document) {
           SECTION("creates a new map with the given game")
           {
@@ -66,7 +69,8 @@ TEST_CASE("MapDocument")
                       mdl::Quake2GameInfo,
                       mdl::MapFormat::Valve,
                       vm::bbox3d{8192.0},
-                      *taskManager)
+                      *taskManager,
+                      resourceManager)
                     | kdl::value();
 
     auto documentWasLoaded = Observer<>{document->documentWasLoadedNotifier};
@@ -105,7 +109,8 @@ TEST_CASE("MapDocument")
       mdl::MapFormat::Valve,
       vm::bbox3d{8192.0},
       path,
-      *taskManager)
+      *taskManager,
+      resourceManager)
       | kdl::transform([&](auto document) {
           SECTION("loads map at given path")
           {
@@ -123,7 +128,8 @@ TEST_CASE("MapDocument")
                       mdl::Quake2GameInfo,
                       mdl::MapFormat::Valve,
                       vm::bbox3d{8192.0},
-                      *taskManager)
+                      *taskManager,
+                      resourceManager)
                     | kdl::value();
 
     auto documentWasLoaded = Observer<>{document->documentWasLoadedNotifier};
@@ -162,7 +168,8 @@ TEST_CASE("MapDocument")
                       mdl::Quake2GameInfo,
                       mdl::MapFormat::Valve,
                       vm::bbox3d{8192.0},
-                      *taskManager)
+                      *taskManager,
+                      resourceManager)
                     | kdl::value();
 
     const auto path =


### PR DESCRIPTION
Closes #5087

The resource manager was previously owned by the map, and had its
lifecycle tied to it. As a result, OpenGL resources held by it were not
released properly because the resource manager would only be processed
right before a draw call.

This change is an improvement because after closing a map, its resources
will eventually be released when the next map is opened and rendered.

This is also a preparation for a shared cache of resources so that a
single resources can be shared by several maps, even across map loads.