### PR TITLE
Add popup menu actions to copy material names

### DIFF
--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -19,6 +19,8 @@
 
 #include "ui/MapViewBase.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QDebug>
 #include <QMenu>
 #include <QMimeData>
@@ -1313,6 +1315,12 @@ void MapViewBase::showPopupMenuLater()
         .arg(QString::fromStdString(faceHandle->face().attributes().materialName())),
       mapWindow,
       [=] { mapWindow->revealMaterial(material); });
+
+    menu.addAction(tr("Copy Material Name"), mapWindow, [=] {
+      auto* clipboard = QApplication::clipboard();
+      clipboard->setText(
+        QString::fromStdString(faceHandle->face().attributes().materialName()));
+    });
 
     menu.addSeparator();
   }

--- a/lib/TbUiLib/src/MaterialBrowserView.cpp
+++ b/lib/TbUiLib/src/MaterialBrowserView.cpp
@@ -19,6 +19,8 @@
 
 #include "ui/MaterialBrowserView.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QMenu>
 #include <QTextStream>
 
@@ -476,6 +478,13 @@ void MaterialBrowserView::doContextMenu(
 
     menu.addAction(tr("Select Brushes"), this, [&, material = &cellData(*cell)]() {
       selectBrushesWithMaterial(m_document.map(), material->name());
+    });
+
+    menu.addSeparator();
+
+    menu.addAction(tr("Copy Name"), this, [&, material = &cellData(*cell)]() {
+      auto* clipboard = QApplication::clipboard();
+      clipboard->setText(QString::fromStdString(material->name()));
     });
 
     menu.exec(event->globalPos());


### PR DESCRIPTION
Adds actions to the map view and material browser popup menus.

I figured this would be useful for making surface/texture lights, whether it's via entities or an external RAD file. The map view one avoids having to switch to the material browser. And both avoid having to select any faces, in the event that's not an immediate option (e.g. locked layers).

<img width="1556" height="925" alt="Screenshot_2026-02-13_15-08-21" src="https://github.com/user-attachments/assets/38d5807b-2ee9-476a-a511-198fefbdfca4" />
<img width="350" height="475" alt="Screenshot_2026-02-13_15-09-21" src="https://github.com/user-attachments/assets/0dd4a72f-0cda-4e9c-a7c2-0049e16a3500" />
