### PR TITLE
Add new context menu to console text view with "clear" option

### DIFF
--- a/lib/TbUiLib/include/ui/CompilationDialog.h
+++ b/lib/TbUiLib/include/ui/CompilationDialog.h
@@ -77,6 +77,7 @@ private slots:
 
   void selectedProfileChanged();
   void profileChanged();
+  void showContextMenu(const QPoint& pos);
 
 private:
   void saveProfile();

--- a/lib/TbUiLib/include/ui/Console.h
+++ b/lib/TbUiLib/include/ui/Console.h
@@ -51,6 +51,8 @@ private:
   void logToConsole(LogLevel level, const std::string& message);
 
   void logCachedMessages();
+
+  void showContextMenu(const QPoint& pos);
 };
 
 } // namespace tb::ui

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -24,6 +24,7 @@
 #include <QCloseEvent>
 #include <QDialogButtonBox>
 #include <QLabel>
+#include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QTextEdit>
@@ -75,6 +76,12 @@ void CompilationDialog::createGui()
   m_output = new QTextEdit{};
   m_output->setReadOnly(true);
   m_output->setFont(Fonts::fixedWidthFont());
+  m_output->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(
+    m_output,
+    &QWidget::customContextMenuRequested,
+    this,
+    &CompilationDialog::showContextMenu);
 
   auto* outputLayout = new QVBoxLayout{};
   outputLayout->setContentsMargins(0, 0, 0, 0);
@@ -255,6 +262,14 @@ void CompilationDialog::selectedProfileChanged()
 void CompilationDialog::profileChanged()
 {
   updateCompileButtons();
+}
+
+void CompilationDialog::showContextMenu(const QPoint& pos)
+{
+  auto* menu = m_output->createStandardContextMenu();
+  menu->addSeparator();
+  menu->addAction(tr("Clear"), m_output, &QTextEdit::clear);
+  menu->popup(m_output->mapToGlobal(pos));
 }
 
 void CompilationDialog::saveProfile()

--- a/lib/TbUiLib/src/Console.cpp
+++ b/lib/TbUiLib/src/Console.cpp
@@ -20,6 +20,7 @@
 #include "ui/Console.h"
 
 #include <QDebug>
+#include <QMenu>
 #include <QMutexLocker>
 #include <QScrollBar>
 #include <QTextEdit>
@@ -69,6 +70,9 @@ Console::Console(QWidget* parent)
   m_textView = new QTextEdit{};
   m_textView->setReadOnly(true);
   m_textView->setWordWrapMode(QTextOption::NoWrap);
+  m_textView->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(
+    m_textView, &QWidget::customContextMenuRequested, this, &Console::showContextMenu);
 
   auto* sizer = new QVBoxLayout{};
   sizer->setContentsMargins(0, 0, 0, 0);
@@ -120,6 +124,14 @@ void Console::logCachedMessages()
     logToConsole(level, messageStr);
     FileLogger::instance().log(level, message);
   });
+}
+
+void Console::showContextMenu(const QPoint& pos)
+{
+  auto* menu = m_textView->createStandardContextMenu();
+  menu->addSeparator();
+  menu->addAction(tr("Clear"), m_textView, &QTextEdit::clear);
+  menu->popup(m_textView->mapToGlobal(pos));
 }
 
 } // namespace tb::ui


### PR DESCRIPTION
Hey there!

When I was working on wiring up my Quake set up in the Compile Map section, I kept running into issues and wanted to see the most recent console logs without getting confused about previous runs. I wanted to reach for a "Clear" option in the console text area, but couldn't find one. This PR adds a custom context menu to the console text area, with a new "clear" option. This works in both the Info Panel and the Compile Map dialog.

I'm new to Qt, so let me know if there's a better way. I couldn't find a way to add a clear option to the default right-click menu. Also if this is solved by other means in Trenchbroom happy to close this PR - I just couldn't find anywhere.