### PR TITLE
fix: typos in KdLib chunk_view.h breaking GCC 15+ builds

### DIFF
--- a/lib/KdLib/include/kd/ranges/chunk_view.h
+++ b/lib/KdLib/include/kd/ranges/chunk_view.h
@@ -96,10 +96,10 @@ public:
       requires std::
         sized_sentinel_for<std::ranges::sentinel_t<V>, std::ranges::iterator_t<V>>
     {
-      const auto dist = std::ranges::end(i->parent_->base_) - *i.parent->current_;
-      return dist < i.parent_->remainder
+      const auto dist = std::ranges::end(i.parent_->base_) - *i.parent_->current_;
+      return dist < i.parent_->remainder_
                ? dist == 0 ? 0 : 1
-               : detail::div_ceil(dist - i.parent_->remainder_, i.parent->n_) + 1;
+               : detail::div_ceil(dist - i.parent_->remainder_, i.parent_->n_) + 1;
     }
 
     friend constexpr difference_type operator-(


### PR DESCRIPTION
GCC 15 and Clang 21 enforce -Wtemplate-body, which checks template bodies even when they are not instantiated. This caught four typos in chunk_view outer_iterator's sentinel difference operator:

- i->parent_ should be i.parent_ (arrow vs dot)
- i.parent->current_ should be i.parent_->current_ (missing underscore)
- i.parent_->remainder should be i.parent_->remainder_ (missing underscore)
- i.parent->n_ should be i.parent_->n_ (missing underscore)