### PR TITLE
Add new "Re-run compilation..." menu item

### DIFF
--- a/lib/TbUiLib/include/ui/ActionBuilder.h
+++ b/lib/TbUiLib/include/ui/ActionBuilder.h
@@ -42,6 +42,7 @@ struct PopulateMenuResult
   QAction* redoAction = nullptr;
   QAction* pasteAction = nullptr;
   QAction* pasteAtOriginalPositionAction = nullptr;
+  QAction* rerunAction = nullptr;
 };
 
 PopulateMenuResult populateMenuBar(

--- a/lib/TbUiLib/include/ui/ActionMenu.h
+++ b/lib/TbUiLib/include/ui/ActionMenu.h
@@ -41,6 +41,7 @@ enum class MenuEntryType
   Copy,
   Paste,
   PasteAtOriginalPosition,
+  Rerun,
   None
 };
 

--- a/lib/TbUiLib/include/ui/CompilationDialog.h
+++ b/lib/TbUiLib/include/ui/CompilationDialog.h
@@ -61,6 +61,11 @@ public:
   explicit CompilationDialog(
     AppController& appController, MapDocument& document, QWidget* parent = nullptr);
 
+  bool selectProfileAndCompile(const std::string& profileName);
+
+signals:
+  void compilationProfileUsed(const std::string& profileName);
+
 private:
   void createGui();
 

--- a/lib/TbUiLib/include/ui/CompilationProfileManager.h
+++ b/lib/TbUiLib/include/ui/CompilationProfileManager.h
@@ -60,6 +60,7 @@ public:
 
   const mdl::CompilationProfile* selectedProfile() const;
   const mdl::CompilationConfig& config() const;
+  void selectProfileByIndex(int index) const;
 
 private:
   void updateGui();

--- a/lib/TbUiLib/include/ui/MapWindow.h
+++ b/lib/TbUiLib/include/ui/MapWindow.h
@@ -29,6 +29,7 @@
 #include <chrono>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -68,6 +69,7 @@ namespace ui
 {
 class Action;
 class AppController;
+class CompilationDialog;
 class Console;
 class InfoPanel;
 class Inspector;
@@ -107,8 +109,10 @@ private:
   QComboBox* m_gridChoice = nullptr;
   QLabel* m_statusBarLabel = nullptr;
 
-  QPointer<QDialog> m_compilationDialog;
+  QPointer<CompilationDialog> m_compilationDialog;
   QPointer<ObjExportDialog> m_objExportDialog;
+
+  std::optional<std::string> m_lastCompilationProfileName;
 
   NotifierConnection m_notifierConnection;
 
@@ -120,6 +124,7 @@ private: // special menu entries
   QMenu* m_recentDocumentsMenu;
   QAction* m_undoAction;
   QAction* m_redoAction;
+  QAction* m_rerunAction = nullptr;
 
 private:
   SignalDelayer* m_updateTitleSignalDelayer = nullptr;
@@ -381,6 +386,8 @@ public:
 
   void showCompileDialog();
   bool closeCompileDialog();
+  void rerunLastCompilation();
+  bool hasLastCompilationProfile() const;
 
   void showLaunchEngineDialog();
 
@@ -402,6 +409,11 @@ public:
   MapViewBase* currentMapViewBase();
 
 private:
+  void setLastCompilationProfileName(const std::string& name);
+  void clearLastCompilationProfileName();
+  void loadLastCompilationProfileName();
+  void updateRerunAction() const;
+
   bool canCompile() const;
   bool canLaunch() const;
 

--- a/lib/TbUiLib/src/ActionBuilder.cpp
+++ b/lib/TbUiLib/src/ActionBuilder.cpp
@@ -122,6 +122,10 @@ PopulateMenuResult populateMenuBar(
       {
         result.pasteAtOriginalPositionAction = &qtAction;
       }
+      else if (actionItem.entryType == MenuEntryType::Rerun)
+      {
+        result.rerunAction = &qtAction;
+      }
     },
     [&](const auto& thisLambda, const Menu& menu) {
       auto* parentMenu = currentMenu;

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -1855,6 +1855,18 @@ void ActionManager::createRunMenu()
     [](auto& context) { context.mapWindow().showLaunchEngineDialog(); },
     [](const auto& context) { return context.hasDocument(); },
   }));
+  runMenu.addItem(
+    addAction(Action{
+      "Menu/Run/Rerun...",
+      QObject::tr("Re-run compilation"),
+      ActionContext::Any,
+      QKeySequence{},
+      [](auto& context) { context.mapWindow().rerunLastCompilation(); },
+      [](const auto& context) {
+        return context.hasDocument() && context.mapWindow().hasLastCompilationProfile();
+      },
+    }),
+    MenuEntryType::Rerun);
 }
 
 void ActionManager::createDebugMenu()

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -236,10 +236,27 @@ void CompilationDialog::closeEvent(QCloseEvent* event)
   event->accept();
 }
 
+bool CompilationDialog::selectProfileAndCompile(const std::string& profileName)
+{
+  const auto& profiles = m_profileManager->config().profiles;
+  for (size_t i = 0; i < profiles.size(); ++i)
+  {
+    if (profiles[i].name == profileName)
+    {
+      m_profileManager->selectProfileByIndex(static_cast<int>(i));
+      startCompilation(false);
+      return true;
+    }
+  }
+  return false;
+}
+
 void CompilationDialog::compilationStarted()
 {
   const auto* profile = m_profileManager->selectedProfile();
   contract_assert(profile != nullptr);
+
+  emit compilationProfileUsed(profile->name);
 
   m_currentRunLabel->setText(QString::fromStdString("Running " + profile->name));
   m_output->setText("");

--- a/lib/TbUiLib/src/CompilationProfileManager.cpp
+++ b/lib/TbUiLib/src/CompilationProfileManager.cpp
@@ -122,6 +122,14 @@ const mdl::CompilationConfig& CompilationProfileManager::config() const
   return m_config;
 }
 
+void CompilationProfileManager::selectProfileByIndex(const int index) const
+{
+  if (index >= 0 && index < m_profileList->count())
+  {
+    m_profileList->setCurrentRow(index);
+  }
+}
+
 void CompilationProfileManager::addProfile()
 {
   m_config.profiles.push_back(mdl::CompilationProfile{"unnamed", "${MAP_DIR_PATH}", {}});

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -29,6 +29,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPushButton>
+#include <QSettings>
 #include <QStatusBar>
 #include <QString>
 #include <QStringList>
@@ -178,6 +179,7 @@ MapWindow::MapWindow(AppController& appController, std::unique_ptr<MapDocument> 
   updateActionState();
   updateUndoRedoActions();
   updateToolBarWidgets();
+  loadLastCompilationProfileName();
 
   m_document->setTargetLogger(m_console);
   m_document->setViewEffectsService(m_mapView);
@@ -303,6 +305,7 @@ void MapWindow::createMenus()
   m_recentDocumentsMenu = createMenuResult.recentDocumentsMenu;
   m_undoAction = createMenuResult.undoAction;
   m_redoAction = createMenuResult.redoAction;
+  m_rerunAction = createMenuResult.rerunAction;
 
   addRecentDocumentsMenu();
 }
@@ -794,6 +797,7 @@ void MapWindow::documentWasLoaded()
   updateActionState();
   updateUndoRedoActions();
   updateRecentDocumentsMenu();
+  loadLastCompilationProfileName();
 }
 
 void MapWindow::documentWasSaved()
@@ -2146,9 +2150,106 @@ void MapWindow::showCompileDialog()
 {
   if (!m_compilationDialog)
   {
-    m_compilationDialog = new CompilationDialog{m_appController, *m_document, this};
+    auto* dialog = new CompilationDialog{m_appController, *m_document, this};
+    connect(
+      dialog,
+      &CompilationDialog::compilationProfileUsed,
+      this,
+      [this](const std::string& profileName) {
+        setLastCompilationProfileName(profileName);
+      });
+    m_compilationDialog = dialog;
   }
   showModelessDialog(m_compilationDialog);
+}
+
+void MapWindow::rerunLastCompilation()
+{
+  if (!m_lastCompilationProfileName)
+  {
+    return;
+  }
+  showCompileDialog();
+  if (!m_compilationDialog->selectProfileAndCompile(*m_lastCompilationProfileName))
+  {
+    clearLastCompilationProfileName();
+  }
+}
+
+bool MapWindow::hasLastCompilationProfile() const
+{
+  return m_lastCompilationProfileName.has_value();
+}
+
+namespace
+{
+
+QString lastCompilationProfileSettingsKey(const std::string& gameName)
+{
+  return QString::fromLatin1("Compilation/LastProfile/%1")
+    .arg(QString::fromStdString(gameName));
+}
+
+} // namespace
+
+void MapWindow::setLastCompilationProfileName(const std::string& name)
+{
+  m_lastCompilationProfileName = name;
+
+  const auto key =
+    lastCompilationProfileSettingsKey(m_document->map().gameInfo().gameConfig.name);
+  auto settings = QSettings{};
+  settings.setValue(key, QString::fromStdString(name));
+
+  updateRerunAction();
+}
+
+void MapWindow::clearLastCompilationProfileName()
+{
+  m_lastCompilationProfileName = std::nullopt;
+
+  const auto key =
+    lastCompilationProfileSettingsKey(m_document->map().gameInfo().gameConfig.name);
+  auto settings = QSettings{};
+  settings.remove(key);
+
+  updateRerunAction();
+}
+
+void MapWindow::loadLastCompilationProfileName()
+{
+  const auto key =
+    lastCompilationProfileSettingsKey(m_document->map().gameInfo().gameConfig.name);
+  const auto settings = QSettings{};
+  const auto value = settings.value(key);
+  if (value.isValid())
+  {
+    m_lastCompilationProfileName = value.toString().toStdString();
+  }
+  else
+  {
+    m_lastCompilationProfileName = std::nullopt;
+  }
+
+  updateRerunAction();
+}
+
+void MapWindow::updateRerunAction() const
+{
+  if (!m_rerunAction)
+  {
+    return;
+  }
+
+  if (!m_lastCompilationProfileName)
+  {
+    m_rerunAction->setText(tr("Re-run compilation..."));
+  }
+  else
+  {
+    m_rerunAction->setText(tr("Re-run \"%1\" compilation...")
+                             .arg(QString::fromStdString(*m_lastCompilationProfileName)));
+  }
 }
 
 bool MapWindow::closeCompileDialog()


### PR DESCRIPTION
Hey there! This was a fun little project today. I'll go through some of my logic for the changes below. Once again, I am a beginner with Qt so I am happy to adjust anything and learn from it.

This PR addresses some of the discussion in #1971.

**Something to note: functionality that's missing from your comment is "or the first compilation profile if no profile has been run yet". Determining what the first profile is and keeping that in sync added some complexity which (to me) felt overkill, and instead I went with the flow outlined below. If you'd like me to add this in though, I can probably find an elegant way to do it.**

* We added a new "Re-run compilation" menu item which changes based on context, inspired by the logic found within the "Undo" menu item
* This menu item transforms based on if there is a compilation profile which was previously run. It remains disabled if it has not recorded one ever being run
* If a re-run was attempted and could not be found, the stored settings value is removed, and thus the menu item is "reset" to its disabled state until another compilation run is attempted
* The solution _may_ be overkill with using `optional` in here. I did it because I tested and technically you can have a compilation profile as an empty string which throws off if there's a valid compilation profile or not. So, in the end we deal with null vs. any string at all. Happy to change this if you don't want optional in here