### PR TITLE
Don't crash when building an entity renderer for out of bounds skin or frame

### DIFF
--- a/lib/TbMdlLib/src/EntityModel.cpp
+++ b/lib/TbMdlLib/src/EntityModel.cpp
@@ -465,11 +465,8 @@ const gl::Material* EntityModelSurface::skin(const size_t index) const
 std::unique_ptr<gl::MaterialIndexRangeRenderer> EntityModelSurface::buildRenderer(
   const size_t skinIndex, const size_t frameIndex) const
 {
-  contract_pre(frameIndex < frameCount());
-  contract_pre(skinIndex < skinCount());
-
-  return m_meshes[frameIndex] ? m_meshes[frameIndex]->buildRenderer(skin(skinIndex))
-                              : nullptr;
+  const auto* mesh = frameIndex < frameCount() ? m_meshes[frameIndex].get() : nullptr;
+  return mesh ? mesh->buildRenderer(skin(skinIndex)) : nullptr;
 }
 
 // EntityModelData

--- a/lib/TbMdlLib/test/src/tst_EntityModel.cpp
+++ b/lib/TbMdlLib/test/src/tst_EntityModel.cpp
@@ -172,9 +172,7 @@ TEST_CASE("EntityModel")
       surface.addMesh(frame, builder.vertices(), builder.indices());
 
       // even if the surface doesn't have any skins, we can still make a renderer
-      /* EXPECTED:
       CHECK(modelData.buildRenderer(0, 0));
-      ACTUAL: crashes */
     }
 
     SECTION("Out of bounds frame index")


### PR DESCRIPTION
This used to be an assert + undefined behavior if the frame index was out of
bounds, or just an assert and a missing skin if the skin index is out of bounds.
The function can return null, so we allow out of bounds frame indices by
returning null, and out of bounds skin indices by returning a renderer with its
material missing.
