### PR TITLE
Fix crash when setting texture filter

### DIFF
--- a/lib/TbUiLib/include/ui/ViewPreferencePane.h
+++ b/lib/TbUiLib/include/ui/ViewPreferencePane.h
@@ -60,8 +60,7 @@ private:
   void updateControls() override;
   bool validate() override;
 
-  std::optional<size_t> findFilterMode(int minFilter, int magFilter) const;
-  int findThemeIndex(const QString& theme);
+  int findThemeIndex(const QString& theme) const;
 private slots:
   void layoutChanged(int index);
   void link2dCamerasChanged(int state);

--- a/lib/TbUiLib/src/ViewPreferencePane.cpp
+++ b/lib/TbUiLib/src/ViewPreferencePane.cpp
@@ -61,6 +61,13 @@ const auto FilterModes = std::array<FilterMode, 6>{
   FilterMode{GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR, "Linear (mipmapped, interpolated)"},
 };
 
+std::optional<size_t> findFilterMode(const int minFilter, const int magFilter)
+{
+  return kdl::index_of(FilterModes, [&](const FilterMode& filterMode) {
+    return filterMode.minFilter == minFilter && filterMode.magFilter == magFilter;
+  });
+}
+
 constexpr int brightnessToUI(const float value)
 {
   return int(vm::round(100.0f * (value - 1.0f)));
@@ -355,15 +362,7 @@ bool ViewPreferencePane::validate()
   return true;
 }
 
-std::optional<size_t> ViewPreferencePane::findFilterMode(
-  const int minFilter, const int magFilter) const
-{
-  return kdl::index_of(FilterModes, [&](const FilterMode& filterMode) {
-    return filterMode.minFilter == minFilter && filterMode.magFilter == magFilter;
-  });
-}
-
-int ViewPreferencePane::findThemeIndex(const QString& theme)
+int ViewPreferencePane::findThemeIndex(const QString& theme) const
 {
   return m_themeCombo->findText(theme);
 }


### PR DESCRIPTION
The texture filter is stored as two individual ints, but only certain combinations are valid. When one of the values is set, but the other isn't, we run into a contract violation, so ignore invalid values.