### PR TITLE
Run `validate()` before scrolling to cell

### DIFF
--- a/lib/TbUiLib/include/ui/CellView.h
+++ b/lib/TbUiLib/include/ui/CellView.h
@@ -70,6 +70,7 @@ public:
   template <class L>
   void scrollToCell(L&& visitor)
   {
+    validate();
 
     for (const auto& group : m_layout.groups())
     {


### PR DESCRIPTION
This fixes the issue outlined in #5130.

The changes here ensure that our material browser's layout is reloaded before scrolling to the target cell. This ensures that if there is any reason that the cell view is invalid, it reloads it so we can be scrolling to the correct cell / material. Otherwise, it shows the material browser / cell view but no action is taken. This fixes filtering the material browser, choosing the Entity tab, and then attempting to use "Reveal [texture] in Material Browser" (full details in #5130).

This change also follows how many of the methods in `CellView` work - many of them run `validate()` before performing their respective actions.

**To test:**

1. Open Trenchbroom and add some materials to some brushes
2. In the Face tab / material browser, at the bottom, use the filter search box to filter down your material results
3. Switch to the Entity tab
4. Right-click on a brush, and click "Reveal [material] in Material Browser"
5. It should jump back to the Material Browser, with the filter cleared, and it should correctly select the material you are trying to reveal
