### PR TITLE
Update Quetoo game configuration and entity definitions

### DIFF
--- a/app/TrenchBroom/resources/games/Quetoo/GameConfig.cfg
+++ b/app/TrenchBroom/resources/games/Quetoo/GameConfig.cfg
@@ -4,7 +4,7 @@
     "icon": "Icon.png",
     "experimental": true,
     "fileformats": [
-        { "format": "Quake2" }
+        { "format": "Quake3" }
     ],
     "filesystem": {
         "searchpath": "default",
@@ -13,7 +13,7 @@
     "materials": {
         "root": "textures",
         "extensions": [ ".jpg", ".png", ".tga" ],
-        "excludes": [ "*_nm", "*_norm", "*_local", "*_bump", "*_h", "*_height", "*_g", "*_gloss", "*_s", "*_spec", "*_glow", "*_luma" ]
+        "excludes": [ "*_nm", "*_norm", "*_local", "*_bump", "*_h", "*_height", "*_g", "*_gloss", "*_s", "*_spec", "*_glow", "*_luma", "*_fx" ]
     },
     "entities": {
         "definitions": [ "Quetoo.fgd" ],
@@ -27,6 +27,13 @@
                 "match": "classname",
                 "pattern": "trigger_*",
                 "material": "common/trigger"
+            },
+            {
+                "name": "Weather",
+                "attribs": [ "transparent" ],
+                "match": "classname",
+                "pattern": "misc_weather",
+                "material": "common/weather"
             }
         ],
         "brushface": [
@@ -96,8 +103,8 @@
         },
         "surfaceflags": [
             {
-                "name": "light",
-                "description": "Surface emits light"
+                "name": "",
+                "description": ""
             },
             {
                 "name": "slick",
@@ -146,10 +153,6 @@
             {
                 "name": "material",
                 "description": "Surface is not drawn, but material stages are"
-            },
-            {
-                "name": "decal",
-                "description": "Surface is an alpha blended decal (optimization)"
             }
         ],
         "contentflags": [

--- a/app/TrenchBroom/resources/games/Quetoo/Quetoo.fgd
+++ b/app/TrenchBroom/resources/games/Quetoo/Quetoo.fgd
@@ -4,15 +4,15 @@
 	phong(integer) : "The Phong shading threshold for this model, in degrees" : 60
 ]
 
-@BaseClass = Targetname [ 
-	targetname(target_source) : "The target name of this entity if it is to be triggered" 
+@BaseClass = Targetname [
+	targetname(target_source) : "The target name of this entity if it is to be triggered"
 ]
 
-@BaseClass = Target [ 
-	target(target_destination) : "The entity to target" 
+@BaseClass = Target [
+	target(target_destination) : "The entity to target"
 ]
 
-@BaseClass size(-16 -16 -16, 16 16 16) = Item 
+@BaseClass size(-16 -16 -16, 16 16 16) = Item
 [
 	spawnflags(Flags) =
 	[
@@ -40,13 +40,14 @@
 @PointClass base(TeamFlag) color(255 0 0) = item_flag_team1 : "Red flag" []
 @PointClass base(TeamFlag) color(0 0 255) = item_flag_team2 : "Blue flag" []
 @PointClass base(TeamFlag) color(255 255 0) = item_flag_team3 : "Yellow flag" []
-@PointClass base(TeamFlag) color(0 0 255) = item_flag_team4 : "Green flag" []
+@PointClass base(TeamFlag) color(0 255 0) = item_flag_team4 : "Green flag" []
 
-@BaseClass base(Item) size(-16 -6 -6, 16 6 6) = Weapon []
+@BaseClass base(Item) size(-16 -16 -16, 16 16 16) = Weapon []
 @PointClass base(Weapon) color(225 200 40) studio("") = weapon_blaster : "Blaster" []
 @PointClass base(Weapon) color(220 160 0) studio("") = weapon_shotgun : "Shotgun" []
 @PointClass base(Weapon) color(220 160 0) studio("") = weapon_supershotgun : "Super shotgun" []
 @PointClass base(Weapon) color(255 255 0) studio("") = weapon_machinegun : "Machinegun" []
+@PointClass base(Weapon) color(0 160 0) studio("") = weapon_handgrenades : "Hand Grenades" []
 @PointClass base(Weapon) color(0 160 0) studio("") = weapon_grenadelauncher : "Grenade launcher" []
 @PointClass base(Weapon) color(200 0 0) studio("") = weapon_rocketlauncher : "Rocket launcher" []
 @PointClass base(Weapon) color(100 200 255) studio("") = weapon_hyperblaster : "Hyperblaster" []
@@ -54,9 +55,9 @@
 @PointClass base(Weapon) color(0 0 200) studio("") = weapon_railgun : "Rail gun" []
 @PointClass base(Weapon) color(80 255 40) studio("") = weapon_bfg : "BFG10K" []
 
-@BaseClass base(Item) size(-10 -8 -8, 10 8 8) = Ammo []
+@BaseClass base(Item) size(-16 -16 -16, 16 16 16) = Ammo []
 @PointClass base(Ammo) color(220 160 0) studio("") = ammo_shells : "Shells for the Shotgun and Super Shotgun" []
-@PointClass base(Ammo) color(255 255 0) studio("") = ammo_bullets : "Bullets for the machinegun" []
+@PointClass base(Ammo) color(255 255 0) studio("") = ammo_bullets : "Bullets for the Machinegun" []
 @PointClass base(Ammo) color(0 160 0) studio("") = ammo_grenades : "Grenades for the Grenade Launcher" []
 @PointClass base(Ammo) color(200 0 0) studio("") = ammo_rockets : "Rockets for the Rocket Launcher" []
 @PointClass base(Ammo) color(100 200 255) studio("") = ammo_cells : "Cells for the Hyperblaster" []
@@ -71,7 +72,7 @@
 	speed(integer) : "Speed of the button's displacement" : 40
 	wait(integer) : "Number of seconds the button stays pressed (-1 = indefinitely)" : 1
 	lip(integer) : "Lip remaining at end of move" : 4
-	sounds(integer) : "The sound set for the button (-1 = silent)" : 0
+	sounds(integer) : "The sound set for the button (0 default, -1 silent)" : 0
 	health(integer) : "If set, the button must be killed instead of touched to use"
 ]
 
@@ -90,7 +91,7 @@
 	spawnflags(Flags) =
 	[
 		1 : "The door to moves to its destination when spawned, and operates in reverse" : 0
-		2 : "The door will wait in both the start and end states for a trigger event" : 0
+		16 : "The door will wait in both the start and end states for a trigger event" : 0
 	]
 	message(string) : "An optional string printed when the door is first touched"
 	angle(integer) : "Determines the opening direction of the door (up = -1, down = -2)"
@@ -99,7 +100,7 @@
 	wait(integer) : "Wait before returning (-1 = never return)" : 3
 	lip(integer) : "The lip remaining at end of move" : 8
 	dmg(integer) : "The damage inflicted on players who block the door as it closes" : 2
-	sounds(integer) : "The sound set for the door (0 metal, 1 stone, -1 silent)" : 0
+	sounds(integer) : "The sound set for the door (0 default, 1 stone, -1 silent)" : 0
 ]
 
 @SolidClass base(Phong, Targetname) color(0 255 255) = func_door_rotating : "A door which rotates about an origin on its Z axis. By default, doors open when a player walks close to them."
@@ -107,18 +108,18 @@
 	spawnflags(Flags) =
 	[
 		1 : "The door to moves to its destination when spawned, and operates in reverse" : 0
-		2 : "The door will wait in both the start and end states for a trigger event" : 0
-		4 : "The door will rotate in the opposite (negative) direction along its axis" : 0
+		2 : "The door will rotate in the opposite (negative) direction along its axis" : 0
+		4 : "The door will wait in both the start and end states for a trigger event" : 0
 		8 : "The door will rotate along its X axis" : 0
 		16 : "The door will rotate along its Y axis" : 0
 	]
 	message(string) : "An optional string printed when the door is first touched"
 	health(integer) : "If set, door must take damage to open"
 	speed(integer) : "The speed with which the door opens" : 100
-	rotation(integer) : "The rotation the door will open, in degrees": 90
+	rotation(integer) : "The rotation the door will open, in degrees" : 90
 	wait(integer) : "Wait before returning (-1 = never return)" : 3
 	dmg(integer) : "The damage inflicted on players who block the door as it closes" : 2
-	sounds(integer) : "The sound set for the door (0 metal, 1 stone, -1 silent)" : 0
+	sounds(integer) : "The sound set for the door (0 default, 1 stone, -1 silent)" : 0
 ]
 
 @SolidClass base(Phong, Targetname) color(0 255 255) = func_door_secret : "A secret door which opens when shot, or when targeted. The door first slides back, and then to the side."
@@ -135,9 +136,10 @@
 	speed(integer) : "The speed with which the door opens" : 100
 	wait(integer) : "Wait before returning (-1 = never return)" : 3
 	dmg(integer) : "The damage inflicted on players who block the door as it closes" : 2
+	sounds(integer) : "The sound set for the door (0 default, 1 stone, -1 silent)" : 0
 ]
 
-@SolidClass base(Phong) color(0 255 180) = func_group : "Groups brushes together in Trenchbroom for convenience. When the map is compiled, these entities are merged back into worldspawn." []
+@SolidClass base(Phong) color(0 255 180) = func_group : "Groups brushes together in TrenchBroom for convenience. When the map is compiled, these entities are merged back into worldspawn." []
 
 @SolidClass base(Phong, Targetname) color(0 255 255) = func_plat : "Rising platform the player can ride to reach higher places. Platforms must be placed in the raised position, so they will operate and be lit correctly, but they spawn in the lowered position. If the platform is the target of a trigger or button, it will start out disabled and in the extended position."
 [
@@ -149,10 +151,10 @@
 	accel(integer) : "The platform acceleration" : 500
 	lip(integer) : "The lip remaining at end of move" : 8
 	height(integer) : "If set, this will determine the extent of the platform's movement, rather than implicitly using the platform's height"
-	sounds(integer) : "The sound set for the platform (0 metal, 1 stone, -1 silent)"
+	sounds(integer) : "The sound set for the platform (0 default, 1 stone, -1 silent)"
 ]
 
-@SolidClass base(Targetname) color(0 255 255) = func_rotating : "Solid entity that rotates continuously. Rotates on the Z axis by default and requires an origin brush. It will always start on in the game and is not targetable."
+@SolidClass base(Phong, Targetname) color(0 255 255) = func_rotating : "Solid entity that rotates continuously. Rotates on the Z axis by default and requires an origin brush. It will always start on in the game and is not targetable."
 [
 	spawnflags(Flags) =
 	[
@@ -160,8 +162,8 @@
 		2 : "Will cause the entity to rotate in the opposite direction" : 0
 		4 : "The entity will rotate on the X axis" : 0
 		8 : "The entity will rotate on the Y axis" : 0
-		16 : "The entity will inflict damage when touced" : 0
-		32 : "IThe entity will stop rotating when blocked" : 0
+		16 : "The entity will inflict damage when touched" : 0
+		32 : "The entity will stop rotating when blocked" : 0
 	]
 	speed(integer) : "The speed at which the entity rotates" : 100
 	dmg(integer) : "The damage to inflict to players who touch or block the entity" : 2
@@ -174,7 +176,7 @@
 		1 : "The timer will begin firing once spawned" : 0
 	]
 	wait(integer) : "Delay in seconds between each triggering of all targets" : 1
-	random(integer) : "Random time variance in seconds added to 'wait' delay (default 0.5 * wait)"
+	random(integer) : "Random time variance in seconds added to 'wait' delay (default 0)"
 	delay(integer) : "Additional delay before the first firing when start_on" : 0
 ]
 
@@ -213,8 +215,8 @@
 	lip(integer) : "Lip remaining at end of move" : 0
 ]
 
-@PointClass base(Targetname) color(0 180 0) size(-4 -4 -4, 4 4 4) = info_null : "A positional target for spotlights, etc. These are inhibited in the game and are only useful to the editor and BSP compiler." []
-@PointClass base(Targetname) color(0 180 180) size(-4 -4 -4, 4 4 4) = info_notnull : "A positional target for other entities. Unlike info_null, these are available in the game and can be targeted by other entities (e.g. info_player_intermission)."[]
+@PointClass base(Targetname) color(0 180 0) size(-4 -4 -4, 4 4 4) = info_null : "A positional target for other entities, etc. These are inhibited in the game and are only useful to the editor and BSP compiler." []
+@PointClass base(Targetname) color(0 180 180) size(-4 -4 -4, 4 4 4) = info_notnull : "A positional target for other entities. Unlike info_null, these are available in the game and can be targeted by other entities (e.g. info_player_intermission)." []
 
 @BaseClass size(-16 -16 -24, 16 16 32) = Spawn [
 	angle(integer) : "The angle at which the player will face when spawned"
@@ -225,58 +227,62 @@
 @PointClass base(Spawn) color(0 0 255) = info_player_team2 : "Player spawn point for blue team in teams or CTF gameplay." []
 @PointClass base(Spawn) color(255 255 0) = info_player_team3 : "Player spawn point for yellow team in teams or CTF gameplay." []
 @PointClass base(Spawn) color(0 255 0) = info_player_team4 : "Player spawn point for green team in teams or CTF gameplay." []
+@PointClass base(Spawn) color(128 128 128) = info_player_team_any : "Player spawn point for any team in teams or CTF gameplay." []
 @PointClass base(Spawn, Target) color(0 255 255) = info_player_intermission : "Camera for intermission screen between matches."
 [
 	angles(string) : "The pitch yaw roll angles for the camera (e.g. 20 270 0)."
 ]
 
-@PointClass base(Target) color(255 255 255) size(-6 -6 -6, 6 6 6) = light : "Point light source."
+@PointClass base(Target) color(255 212 63) size(-8 -8 -8, 8 8 8) = light : "Point light source."
 [
-	light(integer) : "Light radius" : 300
-	_color(string) : "Light color as 3 decimal values from 0.0 - 1.0" : "1 1 1"
-	_intensity(float) : "Light intensity as a positive scalar value" : "1"
-	_size(integer) : "Light size, to simulate area lights and cast penumbrae" : 16
-]
-
-@PointClass base(Target) color(200 255 255) size(-6 -6 -6, 6 6 6) = light_spot : "Point light source with attenuation cone."
-[
-	angle(integer) : "Spotlight direction (up = -1, down = -2, yaw = positive value)"
-	light(integer) : "Spotlight radius" : 300
-	_color(string) : "Spotlight color as 3 decimal values from 0.0 - 1.0" : "1 1 1"
-	_cone(integer) : "Spotlight attenuation cone width, in degrees" : 22
-	_intensity(float) : "Spotlight intensity as a positive scalar value" : "1"
-	_size(integer) : "Spotlight size, to simulate area lights and cast penumbrae" : 16
-]
-
-@PointClass base(Target) color(255 255 0) size(-16 -16 -16, 16 16 16) = light_sun : "Directional sun light source."
-[
-	_color(string) : "Sun color as 3 decimal values from 0.0 - 1.0" : "1 1 1"
-	_intensity(float) : "Sun intensity as a positive scalar value" : "1"
-	_size(integer) : "Sun size, to simulate area lights and cast penumbrae" : 256
+	radius(integer) : "Light radius" : 300
+	color(string) : "Light color as 3 decimal values from 0.0 - 1.0" : "1 1 1"
+	intensity(float) : "Light intensity as a positive scalar value" : "1"
+	team(string) : "Specifies what 'team' the light is on to get key/values from" : ""
+	team_master(string) : "Setting this value makes this light the 'master' of the specified team. Can be any value." : ""
+	style(choices) : "String of A(0.0) to Z(1.0) that modulates over time as a defined style. Each additional character adds 100ms to the sequence" : "m" =
+	[
+		//Ripped from q1/q2
+		"m" : "Normal"
+		"mmnmmommommnonmmonqnmmo" : "Flicker"
+		"mmamammmmammamamaaamammma" : "Fluorescent Flicker"
+		"abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba" : "Slow Strong Pulse"
+		"jklmnopqrstuvwxyzyxwvutsrqponmlkj" : "Gentle Pulse"
+		"abcdefghijklmnopqrrqponmlkjihgfedcba" : "Slow Pulse (no black)"
+		"mmmmmaaaaammmmmaaaaaabcdefgabcdefg" : "Candle"
+		"mmmaaaabcdefgmmmmaaaammmaamm" : "Candle 2"
+		"mmmaaammmaaammmabcdefaaaammmmabcdefmmmaaaa" : "Candle 3"
+		"mamamamamama" : "Fast Strobe"
+		"aaaaaaaazzzzzzzz" : "Slow Strobe"
+		//Custom
+		"mzqqmmgzzgmmgzmggzg" : "Flame Flicker"
+		"qqzqzz" : "Soft Flicker"
+	]
 ]
 
 @SolidClass color(180 180 150) = misc_dust : "Dust volumes emit configurable sprites, like localized weather. These are useful for creating dust, bubbles, foam, mist, etc. These are typically contents atmospheric."
 [
 	acceleration(string) : "The sprite acceleration" : "0 0 0"
-	_color(string) : "The sprite HSVA color as 4 decimal values" : "0 0 1 1"
+	color(string) : "The sprite HSVA color as 4 decimal values" : "0 0 1 1"
 	dir(string) : "The sprite directional axis (0 0 0 is billboard)" : "0 0 0"
 	density(float) : "The sprite density" : "1"
-	_end_color(string) : "The sprite HSVA end color as 4 decimal values" : "0 0 0 0"
+	end_color(string) : "The sprite HSVA end color as 4 decimal values" : "0 0 0 0"
 	height(float) : "The sprite height. Setting this will cause size to be ignored" : "0"
+	hz(float) : "The emission rate, in events-per-second" : "10"
 	lifetime(float) : "The sprite lifetime in seconds" : "10"
 	lighting(float) : "The sprite lighting scalar" : "1"
 	rotation(float) : "The sprite rotation in degrees" : "0"
 	rotation_velocity(float) : "The sprite rotation velocity in degrees per second" : "0"
-	_size(float) : "The sprite size" : "1"
+	size(float) : "The sprite size" : "1"
 	size_velocity(float) : "The sprite size velocity" : "0"
 	size_acceleration(float) : "The sprite size acceleration" : "0"
 	softness(float) : "The sprite softness scalar" : "1"
 	sprite(string) : "The sprite image name" : "particle1"
 	velocity(string) : "The sprite velocity" : "0 0 0"
-	width(float): "The sprite width. Setting this will cause size to be ignored" : "0"
+	width(float) : "The sprite width. Setting this will cause size to be ignored" : "0"
 ]
 
-@PointClass color(255 80 20) size(-6 -6 -6, 6 6 6) = misc_fireball : "Spawns an intermittent fireball that damages players. These are typically used above lava traps for ambiance."
+@PointClass color(255 80 20) size(-8 -8 -8, 8 8 8) = misc_fireball : "Spawns an intermittent fireball that damages players. These are typically used above lava traps for ambiance."
 [
 	angles(string) : "The angles at which the fireball will fly"
 	dmg(integer) : "The damage inflicted to entities that touch the fireball" : 4
@@ -285,28 +291,18 @@
 	wait(float) : "The interval in seconds between fireball emissions" : "5"
 ]
 
-@PointClass color(255 120 20) size(-16 -16 -16, 16 16 16) = misc_flame : "Client-side flame emitter, useful for torches and ambience."
+@PointClass color(255 120 20) size(-8 -8 -8, 8 8 8) = misc_flame : "Client-side flame emitter, useful for torches and ambience."
 [
 	density(float) : "The flame density" : "1"
- 	drift(float) : "The factor of randomized drift applied to the emission rate"
+	drift(float) : "The factor of randomized drift applied to the emission rate"
 	hz(float) : "The emission rate, in events-per-second" : "10"
 	radius(float) : "The flame radius" : "16"
 	sound(string) : "The looping sound to play, or 'none' to disable" : "world/fire"
 ]
 
-@SolidClass color(230 230 230) = misc_fog : "Fog volumes. When compiled, fog brushes are merged into the world. Fog volumes are processed during the lighting compile phase. These are typically contents atmospheric, but can be contents water, etc. Omit _color to use the material color."
+@SolidClass color(230 230 230) = misc_fog : "Fog volumes. When compiled, fog brushes are merged into the world. Fog volumes are processed during the lighting compile phase. These are typically contents atmospheric, but can be contents water, etc."
 [
-	_color(string) : "The sprite HSVA color as 4 decimal values" : "0 0 1 1"
-	absorption(float) : "The fog absorption, or how much light color it absorbs" : ".5"
 	density(float) : "The fog density, or thickness" : "1"
-	noise(float) : "The fog noise, or variation in density" : "0"
-	frequency(float) : "The simplex noise frequency - effectively the scale of the noise texture" : "32"
-	amplitude(float) : "The simplex noise amplitude - effectively the upper limit of noise values" : "1"
-	lacunarity(float) : "The simplex noise lacunarity - multiplier per-octave of frequency" : "2"
-	persistence(float) : "The simplex noise persistence - multiplier per-octave of amplitude" : "0.5"
-	octaves(float) : "The number of octaves to sample" : "5"
-	seed(float) : "The simplex noise permutation vector seed" : "0"
-	offset(string) : "An offset added to the noise calculation" : "0 0 0"
 ]
 
 @PointClass color(80 180 80) size(-16 -16 -16, 16 16 16) = misc_model : "Client-side emission of static models (non-interactive map objects). These are useful for placing trees, torches, and other non-brush scenery."
@@ -333,44 +329,44 @@
 @PointClass base(Target) color(220 200 20) size(-4 -4 -4, 4 4 4) = misc_sparks : "Client-side emission of spark effects."
 [
 	angle(integer) : "Sparks direction (up = -1, down = -2, yaw = positive value)"
+	count(integer) : "The count of sparks to emit per emission" : 12
 	drift(float) : "The factor of randomized drift applied to the emission rate"
-	hz(float) : "The emission rate, in events-per-second" : "0"
+	hz(float) : "The emission rate, in events-per-second" : "0.5"
 	target(target_source) : "The name of the entity to target to resolve the sparks direction."
 ]
 
 @PointClass color(120 120 200) size(-24 -24 -24, 24 24 24) = misc_sprite : "Highly configurable client-side emission of sprites. These are useful for light volumes, blood dripping from walls, or anything else you can think of. If two instances of this entity are teamed, the game will emit randomized instances that mix the properties of both teammates."
 [
 	acceleration(string) : "The sprite acceleration" : "0 0 0"
-	_color(string) : "The sprite HSVA color as 4 decimal values" : "0 0 1 1"
+	color(string) : "The sprite HSVA color as 4 decimal values" : "0 0 1 1"
 	count(integer) : "The count of sprites to emit per emission" : 1
 	dir(string) : "The sprite directional axis (0 0 0 is billboard)" : "0 0 0"
 	density(float) : "The sprite density" : "1"
 	drift(float) : "The factor of randomized drift applied to the emission rate"
-	_end_color(string) : "The sprite HSVA end color as 4 decimal values" : "0 0 0 0"
+	end_color(string) : "The sprite HSVA end color as 4 decimal values" : "0 0 0 0"
 	height(float) : "The sprite height. Setting this will cause size to be ignored" : "0"
+	hz(float) : "The emission rate, in events-per-second" : "0.5"
 	lifetime(float) : "The sprite lifetime in seconds" : "10"
 	lighting(float) : "The sprite lighting scalar" : "1"
 	rotation(float) : "The sprite rotation in degrees" : "0"
 	rotation_velocity(float) : "The sprite rotation velocity in degrees per second" : "0"
-	_size(float) : "The sprite size" : "1"
+	size(float) : "The sprite size" : "1"
 	size_velocity(float) : "The sprite size velocity" : "0"
 	size_acceleration(float) : "The sprite size acceleration" : "0"
 	softness(float) : "The sprite softness scalar" : "1"
 	sprite(string) : "The sprite image name" : "particle1"
 	team(string) : "The team name, for emitting randomized sprites that mix properties"
 	velocity(string) : "The sprite velocity" : "0 0 0"
-	width(float): "The sprite width. Setting this will cause size to be ignored" : "0"
+	width(float) : "The sprite width. Setting this will cause size to be ignored" : "0"
 ]
 
-@PointClass base(Target) color(220 220 220) size(-10 -10 -10, 10 10 10) = misc_steam : "Client-side emission of steam effects."
+@PointClass base(Target) color(220 220 220) size(-8 -8 -8, 8 8 8) = misc_steam : "Client-side emission of steam effects."
 [
 	count(integer) : "The count of sprites to emit per emission" : 1
-	density(float) : "The flame density" : "1"
- 	drift(float) : "The factor of randomized drift applied to the emission rate"
-	hz(float) : "The emission rate, in events-per-second" : "10"
-	radius(float) : "The flame radius" : "16"
+	drift(float) : "The factor of randomized drift applied to the emission rate"
+	hz(float) : "The emission rate, in events-per-second" : "24"
 	size(float) : "The initial sprite size" : "32"
-	sound(string): "The looping sound to play, or 'none' to disable" : "world/steam"
+	sound(string) : "The looping sound to play, or 'none' to disable" : "world/steam"
 	target(target_source) : "The name of the entity to target to resolve the steam direction and velocity"
 	velocity(string) : "The steam velocity (if not specified via target)" : "0 0 32"
 ]
@@ -383,9 +379,17 @@
 	]
 ]
 
-@PointClass base(Targetname) color(255 0 0) size(-32 -32 -24, 32 32 -16) = misc_teleporter_dest : "Teleport destination for misc_teleporters."
+@PointClass base(Targetname) color(63 255 127) size(-32 -32 -24, 32 32 -16) = misc_teleporter_dest : "Teleport destination for misc_teleporters."
 [
 	angle(integer) : "Direction in which player will look when teleported"
+]
+
+@SolidClass color(150 180 200) = misc_weather : "Weather volumes emit rain, snow, or ash particles within their brushes. These are typically contents atmospheric."
+[
+	weather(string) : "Weather type: rain, snow, or ash" : "rain"
+	sound(string) : "Ambient sound sample (default per weather type, 'none' to disable)"
+	density(string) : "Density multiplier for particle count" : "1.0"
+	hz(string) : "Spawn rate in Hz" : "5"
 ]
 
 @PointClass base(Target, Targetname) color(128 76 0) size(-8 -8 -8, 8 8 8) = path_corner : "Path corner for func_trains."
@@ -393,20 +397,20 @@
 	spawnflags(Flags) =
 	[
 		1 : "The path corner teleports the train as soon as it is selected" : 0
-		2 : "Suppress the default teleport effects"
+		2 : "Suppress the default teleport effects" : 0
 	]
 	target(string) : "The next corner in the path"
 	pathtarget(string) : "An entity to be used by this path corner when targeted"
 ]
 
-@PointClass base(Targetname) color(255 255 80) size(-6 -6 -6, 6 6 6) = target_light : "Emits a user-defined light when used. Lights can be chained with teams. Use this entity to add switched lights. Use the wait key to synchronize color cycles with other entities."
+@PointClass base(Targetname) color(255 255 80) size(-8 -8 -8, 8 8 8) = target_light : "Emits a user-defined light when used. Lights can be chained with teams. Use this entity to add switched lights. Use the wait key to synchronize color cycles with other entities."
 [
 	spawnflags(Flags) =
 	[
 		1 : "The light will start on" : 0
 	]
-	_color(string) : "The light color" : "1 1 1"
-	light(float) : "The light radius in units" : "300"
+	color(string) : "The light color" : "1 1 1"
+	radius(float) : "The light radius in units" : "300"
 	delay(float) : "The delay before activating, in seconds" : "0"
 	team(string) : "The team name for alternating lights"
 	wait(float) : "If specified, an additional cycle will fire after this interval" : "0"
@@ -436,7 +440,7 @@
 
 @SolidClass base(trigger_once) = trigger_multiple : "Triggers multiple targets at fixed intervals."
 [
-	wait(float) : "Interval in seconds between activations": "0.2"
+	wait(float) : "Interval in seconds between activations" : "0.2"
 ]
 
 @SolidClass base(Target, Targetname) = trigger_once : "Triggers multiple targets once."
@@ -458,10 +462,11 @@
 	killtarget(string) : "The name of the entity or team to kill on activation"
 ]
 
-@PointClass base(Target) color(128 128 128) = trigger_always : "Triggers targets once at level spawn." 
+@PointClass base(Target) color(128 128 128) = trigger_always : "Triggers targets once at level spawn."
 [
-	killtarget(string) : "Kill Target"
-	delay(integer) : "Time before triggering"
+	killtarget(string) : "The name of the entity or team to kill on activation"
+	delay(integer) : "The delay in seconds between activation and firing of targets"
+	message(string) : "An optional message to display when this trigger fires"
 ]
 
 @SolidClass base(Phong, Targetname) color(128 128 128) = trigger_hurt : "A trigger that inflicts damage when touched."
@@ -476,7 +481,7 @@
 	dmg(integer) : "The damage this trigger inflicts per activation" : 2
 ]
 
-@PointClass base(Target) color(128 128 128) = trigger_exec : "Executes a console command or script file when activated." 
+@PointClass base(Target) color(128 128 128) = trigger_exec : "Executes a console command or script file when activated."
 [
 	command(string) : "The console command(s) to execute."
 	script(string) : "The script file (.cfg) to execute."
@@ -491,27 +496,19 @@
 		2 : "The pusher emits sprite effects to indicate its location" : 0
 	]
 	angles(string) : "The direction to push the player in" : "0 0 0"
-	sound(string) : "The sound effect to play when the player is pushed" : "world/jumppad"
+	sound(string) : "The sound effect to play when the player is pushed" : "common/jumppad"
 	speed(integer) : "The speed with which to push the player" : 100
 ]
 
-@SolidClass base(Phong, Target) color(200 200 40) = trigger_teleporter : "Touching this will warp players to the targeted misc_teleporter_dest entity. This is the brush form of misc_teleporter." []
+@SolidClass base(Phong, Target) color(0 255 40) = trigger_teleporter : "Touching this will warp players to the targeted misc_teleporter_dest entity. This is the brush form of misc_teleporter." []
 
 @SolidClass base(Phong) = worldspawn : "The worldspawn entity defines global conditions and behavior for the entire level. All brushes not belonging to an explicit entity implicitly belong to worldspawn."
 [
 	message(string) : "The map title"
-	sky(string) : "The sky environment map" : "unit1_"
-	ambient(string) : "The ambient light level" : "0 0 0"
-	weather(choices) : "Weather effects" : "none" =
-	[
-		"none" : "None"
-		"rain" : "Rain"
-		"snow" : "Snow"
-	]
-	fog_color(string) : "Global fog color, as 3 decimal values from 0.0 - 1.0" : "0 0 0"
-	fog_density(float) : "Global fog density, a single positive scalar value" : "0"
+	sky(string) : "The sky environment map" : "template"
+	ambient(float) : "The ambient light level" : "0"
 	gravity(integer) : "Gravity" : 800
-	gameplay(choices) : "Weather effects" : "deathmatch" =
+	gameplay(choices) : "The gameplay mode" : "deathmatch" =
 	[
 		"deathmatch" : "Deathmatch"
 		"instagib" : "Instagib"
@@ -535,15 +532,11 @@
 		3 : "3"
 		4 : "4"
 	]
-	ctf(choices) : "Enables CTF play" : 0 = [
-		0 : "Disabled"
-		1 : "Enabled"
-		2 : "Auto-balanced"
-	]
-	match(choices) : "Enables match play (round-based elimination with warmup)" : 0 =
+	ctf(choices) : "Enables CTF play" : 0 =
 	[
 		0 : "Disabled"
 		1 : "Enabled"
+		2 : "Auto-balanced"
 	]
 	fraglimit(integer) : "The frag limit" : 20
 	roundlimit(integer) : "The round limit" : 20


### PR DESCRIPTION
Updates the Quetoo game configuration and FGD entity definitions to reflect the current state of the game:

- Switch file format from Quake2 to Quake3
- Add `*_fx` to material excludes
- Add Weather entity brush definition for `misc_weather`
- Update surface flags (remove unused `light`, `material` flags)
- Update entity definitions with new properties and defaults
- Revise entity descriptions and spawnflags