### PR TITLE
Avoid unnecessary rebuilds during developments

### DIFF
--- a/lib/TbUiLib/cmake/GenerateVersion.cmake
+++ b/lib/TbUiLib/cmake/GenerateVersion.cmake
@@ -6,4 +6,10 @@ get_app_version(GIT_DESCRIBE APP_VERSION_YEAR APP_VERSION_NUMBER APP_VERSION_RC)
 get_app_version_str(APP_VERSION_YEAR APP_VERSION_NUMBER APP_VERSION_RC APP_VERSION_STR)
 get_build_platform(APP_PLATFORM_NAME)
 
-configure_file("${SRC}" "${DST}" @ONLY)
+# Generate to a temporary file first
+set(TEMP_FILE "${DST}.tmp")
+configure_file("${SRC}" "${TEMP_FILE}" @ONLY)
+
+# Copy only if contents differ (avoids unnecessary timestamp changes)
+file(COPY_FILE "${TEMP_FILE}" "${DST}" ONLY_IF_DIFFERENT)
+file(REMOVE "${TEMP_FILE}")


### PR DESCRIPTION
The GenerateVersion.cmake script now generates the Version.h header to a temporary file, compares it with the existing file, and only overwrites the target file if the contents differ. This prevents unnecessary rebuilds of TbUiLib when the version information hasn't changed, regardless of the source of potential changes (git tags, APP_BUILD_TYPE, or any other variable).

Changes:
- Generate to DST.tmp first instead of directly to DST
- Compare both files if the target exists
- Only move the temp file to replace the target if contents differ
- Clean up the temp file if no changes are needed