### PR TITLE
Keep only three versions of each package

### DIFF
--- a/.github/workflows/cleanup-nuget-package-versions.yml
+++ b/.github/workflows/cleanup-nuget-package-versions.yml
@@ -23,7 +23,7 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const packageType = 'nuget';
-            const versionsToKeep = 5;
+            const versionsToKeep = 3;
             const packageNames = new Set();
 
             async function listPackagesForType(packageType) {


### PR DESCRIPTION
We are exceeding the package storage and I'd like to avoid paying for it.