### PR TITLE
Ensure entity key column width resized properly

### DIFF
--- a/lib/TbUiLib/src/EntityPropertyGrid.cpp
+++ b/lib/TbUiLib/src/EntityPropertyGrid.cpp
@@ -417,6 +417,10 @@ void EntityPropertyGrid::updateControls()
     m_table->setColumnHidden(
       EntityPropertyModel::ColumnProtected, !shouldShowProtectedProperties);
     m_addProtectedPropertyButton->setHidden(!shouldShowProtectedProperties);
+
+    // QHeaderView::ResizeToContents on ColumnKey does not reliably recompute the
+    // width when the table is updated via dataChanged/beginInsertRows, so force it.
+    m_table->resizeColumnToContents(EntityPropertyModel::ColumnKey);
   });
   updateControlsEnabled();
 }


### PR DESCRIPTION
Closes #5183.

* The calculation and resizing of column width can happen too early when changing to the Entity view table, so we are now ensuring that the key column is resized based on its contents in the delayed update call.
* There are others online complaining about finnicky behaviour of column width calculations in Qt. [This post](https://runebook.dev/en/docs/qt/qtableview/resizeColumnToContents) goes a bit deeper into it and some solutions.
* We specifically are only resizing the key (initially defined as having resize mode of `QHeaderView::ResizeToContents`) and not the value (initially defined as having resize mode of `QHeaderView::Stretch`), as the value is adaptive to the space.

**To test:**

* Use the build, create a new map, and add some entities
* On some of the entities, define some long entity key like `a_really_really_really_really_really_long_name` with a value
* Click back and forth between Map, Entity, and Face view
* Any time you come back to Entity view, the `a_really_really_really_really_really_long_name` key should be fully visible and not truncated