### PR TITLE
Disable reloading materials and entity definitions while processing resources

### DIFF
--- a/lib/TbUiLib/include/ui/MapWindow.h
+++ b/lib/TbUiLib/include/ui/MapWindow.h
@@ -51,6 +51,7 @@ namespace gl
 {
 class ContextManager;
 class Material;
+class ResourceId;
 } // namespace gl
 
 namespace mdl
@@ -183,6 +184,8 @@ private: // notification handlers
   void transactionUndone(const std::string& name, bool observable, bool isModification);
 
   void preferenceDidChange(const std::filesystem::path& path);
+  void resourcesWereProcessed(const std::vector<gl::ResourceId>& resourceIds);
+
   void gridDidChange();
   void toolActivated(Tool& tool);
   void toolDeactivated(Tool& tool);
@@ -228,6 +231,9 @@ public:
 
   void reloadMaterialCollections();
   void reloadEntityDefinitions();
+  bool canReloadMaterialCollections() const;
+  bool canReloadEntityDefinitions() const;
+
   void closeDocument();
 
   void undo();

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -902,7 +902,9 @@ void ActionManager::createFileMenu()
     ActionContext::Any,
     QKeySequence{Qt::Key_F5},
     [](auto& context) { context.mapWindow().reloadMaterialCollections(); },
-    [](const auto& context) { return context.hasDocument(); },
+    [](const auto& context) {
+      return context.hasDocument() && context.mapWindow().canReloadMaterialCollections();
+    },
   }));
   fileMenu.addItem(addAction(Action{
     "Menu/File/Reload Entity Definitions",
@@ -910,7 +912,9 @@ void ActionManager::createFileMenu()
     ActionContext::Any,
     QKeySequence{Qt::Key_F6},
     [](auto& context) { context.mapWindow().reloadEntityDefinitions(); },
-    [](const auto& context) { return context.hasDocument(); },
+    [](const auto& context) {
+      return context.hasDocument() && context.mapWindow().canReloadEntityDefinitions();
+    },
   }));
   fileMenu.addSeparator();
   fileMenu.addItem(addAction(Action{

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -41,6 +41,8 @@
 
 #include "PreferenceManager.h"
 #include "Preferences.h"
+#include "gl/GlManager.h"
+#include "gl/ResourceManager.h"
 #include "mdl/Autosaver.h"
 #include "mdl/BrushFace.h"
 #include "mdl/BrushNode.h"
@@ -750,6 +752,10 @@ void MapWindow::connectObservers()
   m_notifierConnection +=
     prefs.preferenceDidChangeNotifier.connect(this, &MapWindow::preferenceDidChange);
 
+  auto& resourceManager = m_appController.glManager().resourceManager();
+  m_notifierConnection += resourceManager.resourcesWereProcessedNotifier.connect(
+    this, &MapWindow::resourcesWereProcessed);
+
   m_notifierConnection +=
     m_document->documentWasLoadedNotifier.connect(this, &MapWindow::documentWasLoaded);
   m_notifierConnection +=
@@ -852,6 +858,11 @@ void MapWindow::preferenceDidChange(const std::filesystem::path& path)
   }
 
   updateShortcuts();
+}
+
+void MapWindow::resourcesWereProcessed(const std::vector<gl::ResourceId>&)
+{
+  updateActionState();
 }
 
 void MapWindow::gridDidChange()
@@ -1245,6 +1256,16 @@ void MapWindow::reloadMaterialCollections()
 void MapWindow::reloadEntityDefinitions()
 {
   mdl::reloadEntityDefinitions(m_document->map());
+}
+
+bool MapWindow::canReloadMaterialCollections() const
+{
+  return !m_appController.glManager().resourceManager().needsProcessing();
+}
+
+bool MapWindow::canReloadEntityDefinitions() const
+{
+  return !m_appController.glManager().resourceManager().needsProcessing();
 }
 
 void MapWindow::closeDocument()

--- a/lib/TbUiLib/test/src/tst_MapWindow.cpp
+++ b/lib/TbUiLib/test/src/tst_MapWindow.cpp
@@ -20,7 +20,12 @@
 #include <QApplication>
 #include <QComboBox>
 
+#include "Result.h"
 #include "gl/GlManager.h"
+#include "gl/Resource.h"
+#include "gl/ResourceManager.h"
+#include "gl/TestGl.h"
+#include "gl/TestUtils.h"
 #include "mdl/GameConfigFixture.h"
 #include "mdl/Grid.h"
 #include "mdl/Map.h"
@@ -35,6 +40,13 @@
 
 namespace tb::ui
 {
+
+// Simple resource type for testing resource processing
+struct TestResource
+{
+  void upload(gl::Gl&) const {}
+  void drop(gl::Gl&) const {}
+};
 
 TEST_CASE("MapWindow")
 {
@@ -83,6 +95,56 @@ TEST_CASE("MapWindow")
     CHECK(loadedGridSize != changedGridSize);
     CHECK(gridChoice->currentIndex() == loadedGridIndex);
     CHECK(gridChoice->currentData().toInt() == loadedGridSize);
+  }
+
+  SECTION("canReloadMaterialCollections returns false when resources need processing")
+  {
+    using TestResourceT = gl::Resource<TestResource>;
+
+    // Verify initial state: no resources pending processing
+    REQUIRE(!appController.glManager().resourceManager().needsProcessing());
+    CHECK(window.canReloadMaterialCollections());
+
+    // Add a resource that needs processing
+    auto testResource = std::make_shared<TestResourceT>(
+      []() { return Result<TestResource>{TestResource{}}; });
+    appController.glManager().resourceManager().addResource(testResource);
+
+    REQUIRE(appController.glManager().resourceManager().needsProcessing());
+    CHECK(!window.canReloadMaterialCollections());
+
+    // Process all resources synchronously
+    auto testGl = gl::TestGl{};
+    const auto processContext = gl::ProcessContext{testGl, [](auto, auto) {}};
+    gl::processResourcesSync(appController.glManager().resourceManager(), processContext);
+
+    REQUIRE(!appController.glManager().resourceManager().needsProcessing());
+    CHECK(window.canReloadMaterialCollections());
+  }
+
+  SECTION("canReloadEntityDefinitions returns false when resources need processing")
+  {
+    using TestResourceT = gl::Resource<TestResource>;
+
+    // Verify initial state: no resources pending processing
+    REQUIRE(!appController.glManager().resourceManager().needsProcessing());
+    CHECK(window.canReloadEntityDefinitions());
+
+    // Add a resource that needs processing
+    auto testResource = std::make_shared<TestResourceT>(
+      []() { return Result<TestResource>{TestResource{}}; });
+    appController.glManager().resourceManager().addResource(testResource);
+
+    REQUIRE(appController.glManager().resourceManager().needsProcessing());
+    CHECK(!window.canReloadEntityDefinitions());
+
+    // Process all resources synchronously
+    auto testGl = gl::TestGl{};
+    const auto processContext = gl::ProcessContext{testGl, [](auto, auto) {}};
+    gl::processResourcesSync(appController.glManager().resourceManager(), processContext);
+
+    REQUIRE(!appController.glManager().resourceManager().needsProcessing());
+    CHECK(window.canReloadEntityDefinitions());
   }
 }
 


### PR DESCRIPTION
Closes #5187.

Repeatedly reloading materials can lead to a crash if the file system is rebuilt while resources are still loading, so we disable the actions while rsources are still being processed.