### PR TITLE
Escape special characters in `targetname` when determining entity links

### DIFF
--- a/lib/KdLib/include/kd/compact_trie.h
+++ b/lib/KdLib/include/kd/compact_trie.h
@@ -22,6 +22,7 @@
 
 #include "kd/contracts.h"
 #include "kd/string_compare.h"
+#include "kd/string_format.h"
 #include "kd/vector_set.h"
 
 #include <stdexcept>
@@ -32,6 +33,23 @@
 
 namespace kdl
 {
+namespace detail
+{
+
+inline constexpr auto pattern_match_all = '*';
+inline constexpr auto pattern_match_one = '?';
+inline constexpr auto pattern_match_number = '%';
+inline constexpr auto pattern_escape_char = '\\';
+
+inline constexpr std::string_view pattern_special_chars = "*?%\\";
+
+inline bool is_special_char(const char c)
+{
+  return pattern_special_chars.find(c) != std::string_view::npos;
+}
+
+} // namespace detail
+
 /**
  * Maps string keys to values, but with more efficient storage characteristics than a
  * regular std::map. Another difference is that values can be stored multiple times in
@@ -465,7 +483,7 @@ private:
 
         // after this point, we can assume that the pattern is not consumed, but the key
         // might be
-        if (pattern[p_i] == '\\' && p_i < pattern.length() - 1u)
+        if (pattern[p_i] == detail::pattern_escape_char && p_i < pattern.length() - 1u)
         {
           // handle escaped characters in the pattern
           const auto& n = pattern[p_i + 1u];
@@ -474,7 +492,7 @@ private:
           {
             // check the next character in the pattern against the next character in the
             // key
-            if (n == '*' || n == '?' || n == '%' || n == '\\')
+            if (detail::is_special_char(n))
             {
               if (m_key[k_i] == n)
               {
@@ -490,7 +508,7 @@ private:
           else
           {
             // the key is consumed, so continue matching at the children
-            for (const auto& c : {"*", "?", "%", "\\"})
+            for (const auto c : detail::pattern_special_chars)
             {
               const auto it = m_children.find(c);
               if (it != m_children.end())
@@ -500,7 +518,7 @@ private:
             }
           }
         }
-        else if (pattern[p_i] == '*')
+        else if (pattern[p_i] == detail::pattern_match_all)
         {
           // handle '*' in the pattern
           if (p_i == pattern.length() - 1u)
@@ -529,7 +547,7 @@ private:
             }
           }
         }
-        else if (pattern[p_i] == '?')
+        else if (pattern[p_i] == detail::pattern_match_one)
         {
           // handle '?' in the pattern
           if (k_i < m_key.length())
@@ -547,10 +565,11 @@ private:
             }
           }
         }
-        else if (pattern[p_i] == '%')
+        else if (pattern[p_i] == detail::pattern_match_number)
         {
           // handle '%' in the pattern
-          if (p_i < pattern.length() - 1u && pattern[p_i + 1u] == '*')
+          if (
+            p_i < pattern.length() - 1u && pattern[p_i + 1u] == detail::pattern_match_all)
           {
             // handle "%*" in the pattern
             // try to continue matching after "%*"
@@ -779,12 +798,33 @@ private:
       contract_pre(!lhs.empty() && !rhs.empty());
       return lhs[0] < rhs[0];
     }
+
+    bool operator()(const char lhs, const node& rhs) const
+    {
+      return compare(std::string_view{&lhs, 1}, rhs.m_key);
+    }
+
+    bool operator()(const node& lhs, const char rhs) const
+    {
+      return compare(lhs.m_key, std::string_view{&rhs, 1});
+    }
   };
 
 private:
   node m_root = node{""};
 
 public:
+  /**
+   * Escapes any special characters such as '*' in the given string.
+   *
+   * @param str the string to escape
+   * @return the escaped string
+   */
+  static std::string escape(std::string_view str)
+  {
+    return kdl::str_escape(str, detail::pattern_special_chars);
+  }
+
   /**
    * Creates a new empty trie.
    */

--- a/lib/KdLib/test/src/tst_compact_trie.cpp
+++ b/lib/KdLib/test/src/tst_compact_trie.cpp
@@ -23,7 +23,7 @@
 #include <iterator>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_vector.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 namespace kdl
 {
@@ -33,185 +33,191 @@ namespace
 {
 using test_index = compact_trie<std::string>;
 
-void assertMatches(
-  const test_index& index,
-  const std::string& pattern,
-  std::vector<std::string> expectedMatches)
+std::vector<std::string> find(const test_index& index, const std::string& pattern)
 {
-  std::vector<std::string> matches;
+  auto matches = std::vector<std::string>{};
   index.find_matches(pattern, std::back_inserter(matches));
-
-  CHECK_THAT(matches, UnorderedEquals(expectedMatches));
+  return matches;
 }
 
 } // namespace
 
-TEST_CASE("compact_trie_test.insert")
+TEST_CASE("compact_trie")
 {
   test_index index;
-  index.insert("key", "value");
-  index.insert("key2", "value");
-  index.insert("key22", "value2");
-  index.insert("k1", "value3");
-  index.insert("test", "value4");
 
-  assertMatches(index, "whoops", {});
+  SECTION("insert")
+  {
+    index.insert("key", "value");
+    index.insert("key2", "value");
+    index.insert("key22", "value2");
+    index.insert("k1", "value3");
+    index.insert("test", "value4");
 
-  assertMatches(index, "key222", {});
-  assertMatches(index, "key22?", {});
-  assertMatches(index, "key22*", {"value2"});
-  assertMatches(index, "key%%*", {"value", "value2"});
-  assertMatches(index, "key%*", {"value", "value", "value2"});
-  assertMatches(index, "key*", {"value", "value", "value2"});
+    CHECK(find(index, "whoops") == std::vector<std::string>{});
 
-  assertMatches(index, "k*", {"value", "value", "value2", "value3"});
-  assertMatches(index, "k*2", {"value", "value2"});
+    CHECK(find(index, "key222") == std::vector<std::string>{});
+    CHECK(find(index, "key22?") == std::vector<std::string>{});
+    CHECK_THAT(find(index, "key22*"), UnorderedRangeEquals({"value2"}));
+    CHECK_THAT(find(index, "key%%*"), UnorderedRangeEquals({"value", "value2"}));
+    CHECK_THAT(find(index, "key%*"), UnorderedRangeEquals({"value", "value", "value2"}));
+    CHECK_THAT(find(index, "key*"), UnorderedRangeEquals({"value", "value", "value2"}));
 
-  assertMatches(index, "test", {"value4"});
-  assertMatches(index, "test*", {"value4"});
-  assertMatches(index, "test?", {});
-  assertMatches(index, "test%", {});
-  assertMatches(index, "test%*", {"value4"});
+    CHECK_THAT(
+      find(index, "k*"), UnorderedRangeEquals({"value", "value", "value2", "value3"}));
+    CHECK_THAT(find(index, "k*2"), UnorderedRangeEquals({"value", "value2"}));
 
-  index.insert("k", "value4");
+    CHECK_THAT(find(index, "test"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "test*"), UnorderedRangeEquals({"value4"}));
+    CHECK(find(index, "test?") == std::vector<std::string>{});
+    CHECK(find(index, "test%") == std::vector<std::string>{});
+    CHECK_THAT(find(index, "test%*"), UnorderedRangeEquals({"value4"}));
 
-  assertMatches(index, "k", {"value4"});
-  assertMatches(index, "k%", {"value3"});
-  assertMatches(index, "k*", {"value", "value", "value2", "value3", "value4"});
+    index.insert("k", "value4");
 
-  assertMatches(index, "*", {"value", "value", "value2", "value3", "value4", "value4"});
-}
+    CHECK_THAT(find(index, "k"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "k%"), UnorderedRangeEquals({"value3"}));
+    CHECK_THAT(
+      find(index, "k*"),
+      UnorderedRangeEquals({"value", "value", "value2", "value3", "value4"}));
 
-TEST_CASE("compact_trie_test.remove")
-{
-  test_index index;
-  index.insert("andrew", "value");
-  index.insert("andreas", "value");
-  index.insert("andrar", "value2");
-  index.insert("andrary", "value3");
-  index.insert("andy", "value4");
+    CHECK_THAT(
+      find(index, "*"),
+      UnorderedRangeEquals({"value", "value", "value2", "value3", "value4", "value4"}));
+  }
 
-  assertMatches(index, "*", {"value", "value", "value2", "value3", "value4"});
+  SECTION("remove")
+  {
+    index.insert("andrew", "value");
+    index.insert("andreas", "value");
+    index.insert("andrar", "value2");
+    index.insert("andrary", "value3");
+    index.insert("andy", "value4");
 
-  CHECK_FALSE(index.remove("andrary", "value2"));
+    CHECK_THAT(
+      find(index, "*"),
+      UnorderedRangeEquals({"value", "value", "value2", "value3", "value4"}));
 
-  CHECK(index.remove("andrary", "value3"));
-  assertMatches(index, "andrary*", {});
+    CHECK_FALSE(index.remove("andrary", "value2"));
 
-  assertMatches(index, "andrar*", {"value2"});
-  CHECK(index.remove("andrar", "value2"));
-  assertMatches(index, "andrar*", {});
+    CHECK(index.remove("andrary", "value3"));
+    CHECK(find(index, "andrary*") == std::vector<std::string>{});
 
-  assertMatches(index, "andy", {"value4"});
-  CHECK(index.remove("andy", "value4"));
-  assertMatches(index, "andy", {});
+    CHECK_THAT(find(index, "andrar*"), UnorderedRangeEquals({"value2"}));
+    CHECK(index.remove("andrar", "value2"));
+    CHECK(find(index, "andrar*") == std::vector<std::string>{});
 
-  assertMatches(index, "andre*", {"value", "value"});
-  assertMatches(index, "andreas", {"value"});
-  CHECK(index.remove("andreas", "value"));
-  assertMatches(index, "andre*", {"value"});
-  assertMatches(index, "andreas", {});
+    CHECK_THAT(find(index, "andy"), UnorderedRangeEquals({"value4"}));
+    CHECK(index.remove("andy", "value4"));
+    CHECK(find(index, "andy") == std::vector<std::string>{});
 
-  assertMatches(index, "andrew", {"value"});
-  CHECK(index.remove("andrew", "value"));
-  assertMatches(index, "andrew", {});
+    CHECK_THAT(find(index, "andre*"), UnorderedRangeEquals({"value", "value"}));
+    CHECK_THAT(find(index, "andreas"), UnorderedRangeEquals({"value"}));
+    CHECK(index.remove("andreas", "value"));
+    CHECK_THAT(find(index, "andre*"), UnorderedRangeEquals({"value"}));
+    CHECK(find(index, "andreas") == std::vector<std::string>{});
 
-  assertMatches(index, "*", {});
-}
+    CHECK_THAT(find(index, "andrew"), UnorderedRangeEquals({"value"}));
+    CHECK(index.remove("andrew", "value"));
+    CHECK(find(index, "andrew") == std::vector<std::string>{});
 
-TEST_CASE("compact_trie_test.find_matches_with_exact_pattern")
-{
-  test_index index;
-  index.insert("key", "value");
-  index.insert("key2", "value");
-  index.insert("key22", "value2");
-  index.insert("k1", "value3");
+    CHECK(find(index, "*") == std::vector<std::string>{});
+  }
 
-  assertMatches(index, "whoops", {});
-  assertMatches(index, "key222", {});
-  assertMatches(index, "key", {"value"});
-  assertMatches(index, "k", {});
-  assertMatches(index, "k1", {"value3"});
+  SECTION("find_matches_with_exact_pattern")
+  {
+    index.insert("key", "value");
+    index.insert("key2", "value");
+    index.insert("key22", "value2");
+    index.insert("k1", "value3");
 
-  index.insert("key", "value4");
-  assertMatches(index, "key", {"value", "value4"});
+    CHECK(find(index, "whoops") == std::vector<std::string>{});
+    CHECK(find(index, "key222") == std::vector<std::string>{});
+    CHECK_THAT(find(index, "key"), UnorderedRangeEquals({"value"}));
+    CHECK(find(index, "k") == std::vector<std::string>{});
+    CHECK_THAT(find(index, "k1"), UnorderedRangeEquals({"value3"}));
 
-  assertMatches(index, "", {});
-}
+    index.insert("key", "value4");
+    CHECK_THAT(find(index, "key"), UnorderedRangeEquals({"value", "value4"}));
 
-TEST_CASE("compact_trie_test.find_matches_with_wildcards")
-{
-  test_index index;
-  index.insert("key", "value");
-  index.insert("key2", "value");
-  index.insert("key22", "value2");
-  index.insert("k1", "value3");
-  index.insert("test", "value4");
+    CHECK(find(index, "") == std::vector<std::string>{});
+  }
 
-  assertMatches(index, "whoops", {});
-  assertMatches(index, "k??%*", {"value", "value", "value2"});
-  assertMatches(index, "?ey", {"value"});
-  assertMatches(index, "?ey*", {"value", "value", "value2"});
-  assertMatches(index, "?*", {"value", "value", "value2", "value3", "value4"});
-  assertMatches(index, "*??", {"value", "value", "value2", "value3", "value4"});
-  assertMatches(index, "*???", {"value", "value", "value2", "value4"});
-  assertMatches(index, "k*2", {"value", "value2"});
-  assertMatches(index, "k*", {"value", "value", "value2", "value3"});
-  assertMatches(index, "t??t", {"value4"});
-  assertMatches(index, "t??*", {"value4"});
-  assertMatches(index, "t*", {"value4"});
-  assertMatches(index, "*st", {"value4"});
-  assertMatches(index, "t*t", {"value4"});
-  assertMatches(index, "t??t", {"value4"});
+  SECTION("find_matches_with_wildcards")
+  {
+    index.insert("key", "value");
+    index.insert("key2", "value");
+    index.insert("key22", "value2");
+    index.insert("k1", "value3");
+    index.insert("test", "value4");
 
-  index.insert("this2345that", "value5");
-  assertMatches(index, "t*%%%%that", {"value5"});
-  assertMatches(index, "t*%*that", {"value5"});
-  assertMatches(index, "t*%**t", {"value4", "value5"});
-  assertMatches(index, "t*%**", {"value4", "value5"});
-  assertMatches(index, "t*", {"value4", "value5"});
-  assertMatches(index, "t**", {"value4", "value5"});
-  assertMatches(index, "t?*", {"value4", "value5"});
-  assertMatches(index, "t??*", {"value4", "value5"});
-  assertMatches(index, "t???*", {"value4", "value5"});
-  assertMatches(index, "t????*", {"value5"});
-  assertMatches(index, "t*%*", {});
-}
+    CHECK(find(index, "whoops") == std::vector<std::string>{});
+    CHECK_THAT(find(index, "k??%*"), UnorderedRangeEquals({"value", "value", "value2"}));
+    CHECK_THAT(find(index, "?ey"), UnorderedRangeEquals({"value"}));
+    CHECK_THAT(find(index, "?ey*"), UnorderedRangeEquals({"value", "value", "value2"}));
+    CHECK_THAT(
+      find(index, "?*"),
+      UnorderedRangeEquals({"value", "value", "value2", "value3", "value4"}));
+    CHECK_THAT(
+      find(index, "*??"),
+      UnorderedRangeEquals({"value", "value", "value2", "value3", "value4"}));
+    CHECK_THAT(
+      find(index, "*???"), UnorderedRangeEquals({"value", "value", "value2", "value4"}));
+    CHECK_THAT(find(index, "k*2"), UnorderedRangeEquals({"value", "value2"}));
+    CHECK_THAT(
+      find(index, "k*"), UnorderedRangeEquals({"value", "value", "value2", "value3"}));
+    CHECK_THAT(find(index, "t??t"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "t??*"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "t*"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "*st"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "t*t"), UnorderedRangeEquals({"value4"}));
+    CHECK_THAT(find(index, "t??t"), UnorderedRangeEquals({"value4"}));
 
-TEST_CASE("compact_trie_test.find_matches_with_digit_suffix")
-{
-  test_index index;
-  index.insert("key", "value");
-  index.insert("key2", "value");
-  index.insert("key22", "value2");
-  index.insert("key22bs", "value4");
-  index.insert("k1", "value3");
+    index.insert("this2345that", "value5");
+    CHECK_THAT(find(index, "t*%%%%that"), UnorderedRangeEquals({"value5"}));
+    CHECK_THAT(find(index, "t*%*that"), UnorderedRangeEquals({"value5"}));
+    CHECK_THAT(find(index, "t*%**t"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t*%**"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t*"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t**"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t?*"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t??*"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t???*"), UnorderedRangeEquals({"value4", "value5"}));
+    CHECK_THAT(find(index, "t????*"), UnorderedRangeEquals({"value5"}));
+    CHECK(find(index, "t*%*") == std::vector<std::string>{});
+  }
 
-  assertMatches(index, "whoops", {});
-  assertMatches(index, "key%*", {"value", "value", "value2"});
-  assertMatches(index, "key%%*", {"value", "value2"});
-  assertMatches(index, "key2%*", {"value", "value2"});
-  assertMatches(index, "k%*", {"value3"});
+  SECTION("find_matches_with_digit_suffix")
+  {
+    index.insert("key", "value");
+    index.insert("key2", "value");
+    index.insert("key22", "value2");
+    index.insert("key22bs", "value4");
+    index.insert("k1", "value3");
 
-  index.remove("k1", "value3");
-  assertMatches(index, "k%*", {});
-}
+    CHECK(find(index, "whoops") == std::vector<std::string>{});
+    CHECK_THAT(find(index, "key%*"), UnorderedRangeEquals({"value", "value", "value2"}));
+    CHECK_THAT(find(index, "key%%*"), UnorderedRangeEquals({"value", "value2"}));
+    CHECK_THAT(find(index, "key2%*"), UnorderedRangeEquals({"value", "value2"}));
+    CHECK_THAT(find(index, "k%*"), UnorderedRangeEquals({"value3"}));
 
-TEST_CASE("compact_trie_test.get_keys")
-{
-  test_index index;
-  index.insert("key", "value");
-  index.insert("key2", "value");
-  index.insert("key22", "value2");
-  index.insert("key22bs", "value4");
-  index.insert("k1", "value3");
+    index.remove("k1", "value3");
+    CHECK(find(index, "k%*") == std::vector<std::string>{});
+  }
 
-  std::vector<std::string> keys;
-  index.get_keys(std::back_inserter(keys));
+  SECTION("get_keys")
+  {
+    index.insert("key", "value");
+    index.insert("key2", "value");
+    index.insert("key22", "value2");
+    index.insert("key22bs", "value4");
+    index.insert("k1", "value3");
 
-  CHECK_THAT(
-    keys,
-    UnorderedEquals(std::vector<std::string>{"key", "key2", "key22", "key22bs", "k1"}));
+    std::vector<std::string> keys;
+    index.get_keys(std::back_inserter(keys));
+
+    CHECK_THAT(keys, UnorderedRangeEquals({"key", "key2", "key22", "key22bs", "k1"}));
+  }
 }
 
 } // namespace kdl

--- a/lib/KdLib/test/src/tst_compact_trie.cpp
+++ b/lib/KdLib/test/src/tst_compact_trie.cpp
@@ -46,6 +46,19 @@ TEST_CASE("compact_trie")
 {
   test_index index;
 
+  SECTION("escape")
+  {
+    CHECK(test_index::escape("") == "");
+    CHECK(test_index::escape("plain text") == "plain text");
+    CHECK(test_index::escape("literal*?%\\") == "literal\\*\\?\\%\\\\");
+
+    index.insert("literal*?%\\", "value");
+    index.insert("literal1234", "other");
+
+    CHECK_THAT(
+      find(index, test_index::escape("literal*?%\\")), UnorderedRangeEquals({"value"}));
+  }
+
   SECTION("insert")
   {
     index.insert("key", "value");

--- a/lib/TbMdlLib/include/mdl/NodeIndex.h
+++ b/lib/TbMdlLib/include/mdl/NodeIndex.h
@@ -22,6 +22,7 @@
 #include "kd/compact_trie_forward.h"
 
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -39,6 +40,8 @@ private:
 public:
   NodeIndex();
   ~NodeIndex();
+
+  static std::string escapePattern(std::string_view str);
 
   void addNode(Node& node);
   void removeNode(Node& node);

--- a/lib/TbMdlLib/src/EntityLinkManager.cpp
+++ b/lib/TbMdlLib/src/EntityLinkManager.cpp
@@ -267,8 +267,8 @@ void EntityLinkManager::addLinksFrom(EntityNodeBase& sourceNode)
     // sources with missing targets during validation.
     auto& linkTargetsForKey = m_linkSources[&sourceNode][sourcePropertyKey];
 
-    for (const auto* targetNode :
-         m_nodeIndex.findNodes<EntityNodeBase>(sourcePropertyValue))
+    for (const auto* targetNode : m_nodeIndex.findNodes<EntityNodeBase>(
+           NodeIndex::escapePattern(sourcePropertyValue)))
     {
       for (const auto& targetPropertyKey : getLinkTargetPropertyKeys(*targetNode))
       {
@@ -296,8 +296,8 @@ void EntityLinkManager::addLinksTo(EntityNodeBase& targetNode)
     // targets with missing sources during validation.
     auto& linkSourcesForKey = m_linkTargets[&targetNode][targetPropertyKey];
 
-    for (const auto* sourceNode :
-         m_nodeIndex.findNodes<EntityNodeBase>(targetPropertyValue))
+    for (const auto* sourceNode : m_nodeIndex.findNodes<EntityNodeBase>(
+           NodeIndex::escapePattern(targetPropertyValue)))
     {
       for (const auto& sourcePropertyKey : getLinkSourcePropertyKeys(*sourceNode))
       {

--- a/lib/TbMdlLib/src/NodeIndex.cpp
+++ b/lib/TbMdlLib/src/NodeIndex.cpp
@@ -81,6 +81,11 @@ NodeIndex::NodeIndex()
 
 NodeIndex::~NodeIndex() = default;
 
+std::string NodeIndex::escapePattern(std::string_view str)
+{
+  return NodeStringIndex::escape(str);
+}
+
 void NodeIndex::addNode(Node& node)
 {
   const auto addToIndex = [&](const std::string_view key) {

--- a/lib/TbMdlLib/test/src/tst_EntityLinkManager.cpp
+++ b/lib/TbMdlLib/test/src/tst_EntityLinkManager.cpp
@@ -199,6 +199,38 @@ TEST_CASE("EntityLinkManager")
     }
   }
 
+  SECTION("Link names containing backslashes and special characters")
+  {
+    const auto linkValue = R"(path\to\thing*a?%)"s;
+
+    auto sourceNode = EntityNode{Entity{{
+      {SourceProp, linkValue},
+    }}};
+    sourceNode.setDefinition(&sourceDefinition);
+
+    auto targetNode = EntityNode{Entity{{
+      {TargetProp, linkValue},
+    }}};
+    targetNode.setDefinition(&targetDefinition);
+
+    i.addNode(targetNode);
+    i.addNode(sourceNode);
+
+    m.addEntityNode(sourceNode);
+    m.addEntityNode(targetNode);
+
+    CHECK(
+      m.linksFrom(sourceNode)
+      == LinkEndsForKey{
+        {SourceProp, {{&targetNode, TargetProp}}},
+      });
+    CHECK(
+      m.linksTo(targetNode)
+      == LinkEndsForKey{
+        {TargetProp, {{&sourceNode, SourceProp}}},
+      });
+  }
+
   SECTION("No source or prop definitions")
   {
     auto n1 = EntityNode{Entity{{

--- a/lib/TbMdlLib/test/src/tst_Map_NodeIndex.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_NodeIndex.cpp
@@ -33,6 +33,7 @@
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/Matchers.h"
+#include "mdl/NodeIndex.h"
 #include "mdl/TagMatcher.h"
 #include "mdl/TestFactory.h"
 #include "mdl/TestUtils.h"
@@ -71,6 +72,25 @@ TEST_CASE("Map_NodeIndex")
 
     CHECK(map.findNodes("some_key") == std::vector<Node*>{entityNode});
     CHECK(map.findNodes("group") == std::vector<Node*>{groupNode});
+  }
+
+  SECTION("special characters in property keys can be queried with escaped patterns")
+  {
+    auto* literalEntityNode = new EntityNode{Entity{{
+      {"name*?%\\", "literal_value"},
+    }}};
+    auto* wildcardEntityNode = new EntityNode{Entity{{
+      {"name1234", "wildcard_value"},
+    }}};
+
+    addNodes(map, {{parentForNodes(map), {literalEntityNode, wildcardEntityNode}}});
+
+    CHECK_THAT(
+      map.findNodes("name*"),
+      UnorderedEquals(std::vector<Node*>{literalEntityNode, wildcardEntityNode}));
+    CHECK_THAT(
+      map.findNodes(NodeIndex::escapePattern("name*?%\\")),
+      UnorderedEquals(std::vector<Node*>{literalEntityNode}));
   }
 
   SECTION("Removing nodes updates the index")

--- a/lib/TbMdlLib/test/src/tst_NodeIndex.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeIndex.cpp
@@ -48,6 +48,30 @@ TEST_CASE("NodeIndex")
 {
   auto i = NodeIndex{};
 
+  SECTION("escapePattern")
+  {
+    CHECK(NodeIndex::escapePattern("") == "");
+    CHECK(NodeIndex::escapePattern("plain") == "plain");
+    CHECK(NodeIndex::escapePattern("literal*?%\\") == "literal\\*\\?\\%\\\\");
+
+    auto literalEntityNode = EntityNode{Entity{{
+      {"literal*?%\\", "value"},
+    }}};
+    auto wildcardEntityNode = EntityNode{Entity{{
+      {"literalXYZ", "value"},
+    }}};
+
+    i.addNode(literalEntityNode);
+    i.addNode(wildcardEntityNode);
+
+    CHECK_THAT(
+      i.findNodes("literal*"),
+      UnorderedEquals(std::vector<Node*>{&literalEntityNode, &wildcardEntityNode}));
+    CHECK_THAT(
+      i.findNodes(NodeIndex::escapePattern("literal*?%\\")),
+      UnorderedEquals(std::vector<Node*>{&literalEntityNode}));
+  }
+
   SECTION("Indexing nodes")
   {
     SECTION("WorldNode")

--- a/lib/TbUiLib/src/EntityPropertyModel.cpp
+++ b/lib/TbUiLib/src/EntityPropertyModel.cpp
@@ -40,6 +40,7 @@
 #include "mdl/Map.h"
 #include "mdl/Map_Entities.h"
 #include "mdl/ModelUtils.h"
+#include "mdl/NodeIndex.h"
 #include "mdl/PropertyDefinition.h"
 #include "mdl/WorldNode.h"
 #include "ui/ImageUtils.h"
@@ -419,8 +420,8 @@ std::vector<std::string> getAllValuesForPropertyKeys(
   auto result = kdl::vector_set<std::string>();
   for (const auto& key : propertyKeys)
   {
-    for (const auto* entityNode :
-         map.findNodes<mdl::EntityNodeBase>(fmt::format("{}%*", key)))
+    for (const auto* entityNode : map.findNodes<mdl::EntityNodeBase>(
+           fmt::format("{}%*", mdl::NodeIndex::escapePattern(key))))
     {
       const auto values =
         entityNode->entity().numberedProperties(key)

--- a/lib/TbUiLib/test/src/tst_EntityPropertyModel.cpp
+++ b/lib/TbUiLib/test/src/tst_EntityPropertyModel.cpp
@@ -23,6 +23,7 @@
 #include "mdl/Map.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
+#include "mdl/NodeIndex.h"
 #include "ui/CatchConfig.h"
 #include "ui/EntityPropertyModel.h"
 #include "ui/MapDocument.h"
@@ -417,6 +418,34 @@ TEST_CASE("EntityPropertyModel")
             .tooltip = "",
           },
         });
+    }
+
+    SECTION("properties with special characters")
+    {
+      const auto specialKey = std::string{"name%with%specials"};
+
+      auto* literalKeyEntityNode = new mdl::EntityNode{mdl::Entity{{
+        {specialKey, "literal_value"},
+      }}};
+      auto* wildcardMatchedEntityNode = new mdl::EntityNode{mdl::Entity{{
+        {"name1with2specials", "wildcard_value"},
+      }}};
+
+      mdl::addNodes(
+        map,
+        {{
+          mdl::parentForNodes(map),
+          {literalKeyEntityNode, wildcardMatchedEntityNode},
+        }});
+
+      mdl::selectNodes(map, {literalKeyEntityNode, wildcardMatchedEntityNode});
+      model.updateFromMap();
+
+      const auto rowIndex = model.rowIndexForPropertyKey(specialKey);
+      REQUIRE(rowIndex != -1);
+
+      const auto rowKey = model.propertyKey(rowIndex);
+      CHECK(rowKey == specialKey);
     }
   }
 }


### PR DESCRIPTION
Closes #5189.

The crash stemmed from the entity linking logic interpreting that either `\`, `*`, `?`, or `%` in the name were special characters when running `find_matches`. When a user is typing in these characters for a `targetname` in an entity, they are intending these to be an actual string - not passing them for any sort of regex / special parsing logic.

This is what caused the "libc++abi: terminating due to uncaught exception of type std::invalid_argument: invalid escape sequence in pattern" error message.

We now just ensure these special characters are escaped properly before determining entity links.

**To test:**

Drag a light entity into the map, and change the targetname to `test_\` and hit enter. TrenchBroom should not crash like it did before.

