### PR TITLE
Use style hints to set the Dark color scheme

### DIFF
--- a/app/TrenchBroom/src/Main.cpp
+++ b/app/TrenchBroom/src/Main.cpp
@@ -27,6 +27,7 @@
 #include <QProxyStyle>
 #include <QSettings>
 #include <QString>
+#include <QStyleHints>
 #include <QSurfaceFormat>
 #include <QtGlobal>
 
@@ -157,6 +158,7 @@ void loadStyle(QApplication& app)
   {
     app.setStyle(new TrenchBroomProxyStyle{"Fusion"});
     app.setPalette(darkPalette());
+    app.styleHints()->setColorScheme(Qt::ColorScheme::Dark);
   }
   else
   {


### PR DESCRIPTION
Closes #5203.

In additional to setting the dark palette, we can also be using style hints to set the expected color scheme for Qt. This bypasses the OS-level light appearance / theme which styles some elements beyond the defined palette and makes sure they look okay on a dark theme.

On Mac, you can see the toolbar and list item text adheres to the dark color scheme now:

<img width="166" height="303" alt="Screenshot 2026-04-19 at 7 33 11 PM" src="https://github.com/user-attachments/assets/a18e07e5-65a9-4520-9c71-49217d988e44" />
<img width="799" height="742" alt="Screenshot 2026-04-19 at 4 28 07 PM" src="https://github.com/user-attachments/assets/b359f88f-f6a7-479f-b608-be46d60930a1" />
