### PR TITLE
Load styles before app controller initialization

### DIFF
--- a/app/TrenchBroom/src/Main.cpp
+++ b/app/TrenchBroom/src/Main.cpp
@@ -323,12 +323,14 @@ int main(int argc, char* argv[])
   PreferenceManager::createInstance(
     std::make_unique<QPreferenceStore>(pathAsQString(SystemPaths::preferenceFilePath())));
 
+  // Style sheets must be loaded before creating the app controller, or they won't apply
+  // to the welcome window, which the app controller creates
+  loadStyleSheets();
+  loadStyle(app);
+
   auto appController = createAppController();
   auto crashReporter = CrashReporter{*appController};
   setContractViolationHandler(crashReporter);
-
-  loadStyleSheets();
-  loadStyle(app);
 
 #ifdef __APPLE__
   app.setQuitOnLastWindowClosed(false);


### PR DESCRIPTION
* This ensures that the styles are fully loaded to style the welcome window properly. This works because we're loading styles _before_ the app controller initialization now
* This fixes the dark text on the welcome window when running TrenchBroom using a system light theme with the TrenchBroom dark theme
  * Essentially, the welcome window was loading without our palette and style hints, so it was using the system default text style

**To test:**
* Load the build using a light system theme, with TrenchBroom being configured for a dark theme
* The text in the welcome window should be readable

**Drawbacks:**

The one drawback to this approach is the crash reporter is not initialized before loading styles. If you're not a fan of this we could theoretically hard code / force styles for the welcome window.