### PR TITLE
Fix for Generate Manual

### DIFF
--- a/app/TrenchBroom/cmake/GenerateManual.cmake
+++ b/app/TrenchBroom/cmake/GenerateManual.cmake
@@ -42,7 +42,11 @@ set(DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE "${DOC_MANUAL_TARGET_DIR}/shortcuts.
 add_custom_command(
       OUTPUT "${DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE}"
       COMMAND ${CMAKE_COMMAND} -E make_directory "${DOC_MANUAL_TARGET_DIR}"
-      COMMAND ${CMAKE_COMMAND} -E env "QT_QPA_PLATFORM=offscreen" "$<TARGET_FILE:DumpShortcuts>" "${DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE}"
+      COMMAND ${CMAKE_COMMAND} -E env 
+      "QT_QPA_PLATFORM=offscreen"
+      "QT_PLUGIN_PATH=${Qt6_DIR}/../../../plugins"
+      "QT_QPA_PLATFORM_PLUGIN_PATH=${Qt6_DIR}/../../../plugins/platforms"
+      "$<TARGET_FILE:DumpShortcuts>" "${DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE}"
       DEPENDS DumpShortcuts
       VERBATIM)
 


### PR DESCRIPTION
This is just a small fix to GenerateManual.cmake so that it sets QT_PLUGIN_PATH and QT_QPA_PLATFORM_PLUGIN_PATH when QT is not in system path (eg: when QTDIR is passed directly to CMAKE during project generation)
