### PR TITLE
[cmake feature] options geared towards custom forks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 # 3.14 is required for generator expressions in install(CODE)
 cmake_minimum_required(VERSION 3.25)
 
+option(TB_TESTS "build all tests" ON)
+option(TB_NOUPDATER "disable the automatic updater" OFF)
 # Fix warning with Ninja and cotire (see https://github.com/sakra/cotire/issues/81)
 if(POLICY CMP0058)
   cmake_policy(SET CMP0058 NEW)
@@ -34,6 +36,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(TrenchBroom C CXX)
+if (TB_NOUPDATER)
+	add_compile_definitions(NO_UPDATER)
+endif()
 
 # Configure CCache if available and requested
 if(TB_ENABLE_CCACHE)

--- a/app/TrenchBroom/CMakeLists.txt
+++ b/app/TrenchBroom/CMakeLists.txt
@@ -303,7 +303,9 @@ if(WIN32 OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
     tb_add_post_build_copy_directory(TrenchBroom "${TB_RESOURCE_DIR}/stylesheets" "${APP_RESOURCE_DEST_DIR}/stylesheets")
 
     # Copy update scripts to resources directory
+    if (!TB_NOUPDATER)
     tb_add_post_build_copy_files(TrenchBroom "${APP_RESOURCE_DEST_DIR}/update" "${LIB_UPDATE_SCRIPT}")
+    endif()
 
     # Copy manual files to resource directory
     tb_add_post_build_copy_files(

--- a/app/TrenchBroom/src/Main.cpp
+++ b/app/TrenchBroom/src/Main.cpp
@@ -338,8 +338,10 @@ int main(int argc, char* argv[])
   installFileEventFilter(*appController);
 #endif
 
+#if !defined( NO_UPDATER )
   appController->askForAutoUpdates();
   appController->triggerAutoUpdateCheck();
+#endif
 
   if (!parseCommandLineAndOpenFiles(*appController))
   {

--- a/lib/KdLib/CMakeLists.txt
+++ b/lib/KdLib/CMakeLists.txt
@@ -39,4 +39,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   )
 endif()
 
+if(TB_TESTS)
 add_subdirectory(test)
+endif()
+

--- a/lib/TbBaseLib/CMakeLists.txt
+++ b/lib/TbBaseLib/CMakeLists.txt
@@ -32,5 +32,8 @@ target_link_libraries(TbBaseLib
     VmLib
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
 add_subdirectory(test-utils)
+endif()
+

--- a/lib/TbBaseLib/test-utils/CMakeLists.txt
+++ b/lib/TbBaseLib/test-utils/CMakeLists.txt
@@ -20,4 +20,7 @@ target_link_libraries(TbBaseTestUtilsLib
     TbBaseLib
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
+endif()
+

--- a/lib/TbElLib/CMakeLists.txt
+++ b/lib/TbElLib/CMakeLists.txt
@@ -26,5 +26,8 @@ target_link_libraries(TbElLib
     fmt::fmt-header-only
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
 add_subdirectory(test-utils)
+endif()
+

--- a/lib/TbFsLib/CMakeLists.txt
+++ b/lib/TbFsLib/CMakeLists.txt
@@ -33,5 +33,8 @@ target_link_libraries(TbFsLib
     fmt::fmt-header-only
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
 add_subdirectory(test-utils)
+endif()
+

--- a/lib/TbFsLib/test-utils/CMakeLists.txt
+++ b/lib/TbFsLib/test-utils/CMakeLists.txt
@@ -20,4 +20,7 @@ target_link_libraries(TbFsTestUtilsLib
     VmLib
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
+endif()
+

--- a/lib/TbGlLib/CMakeLists.txt
+++ b/lib/TbGlLib/CMakeLists.txt
@@ -62,5 +62,8 @@ target_link_libraries(TbGlLib
     VmLib
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
 add_subdirectory(test-utils)
+endif()
+

--- a/lib/TbMdlLib/CMakeLists.txt
+++ b/lib/TbMdlLib/CMakeLists.txt
@@ -217,5 +217,8 @@ target_link_libraries(TbMdlLib
     TbGlLib
   )
 
+if(TB_TESTS)
 add_subdirectory(test)
 add_subdirectory(test-utils)
+endif()
+

--- a/lib/TbMdlLib/test-utils/CMakeLists.txt
+++ b/lib/TbMdlLib/test-utils/CMakeLists.txt
@@ -24,4 +24,7 @@ target_link_libraries(TbMdlTestUtilsLib
     TbMdlLib
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
+endif()
+

--- a/lib/TbRenderLib/CMakeLists.txt
+++ b/lib/TbRenderLib/CMakeLists.txt
@@ -56,4 +56,7 @@ target_link_libraries(TbRenderLib
     VmLib
 )
 
+if(TB_TESTS)
 add_subdirectory(test)
+endif()
+

--- a/lib/TbUiLib/CMakeLists.txt
+++ b/lib/TbUiLib/CMakeLists.txt
@@ -501,5 +501,8 @@ if(APPLE)
     target_compile_definitions(TbUiLib PRIVATE GL_SILENCE_DEPRECATION)
 endif()
 
+if(TB_TESTS)
 add_subdirectory(test)
 add_subdirectory(test-utils)
+endif()
+

--- a/lib/TbUiLib/include/ui/AppController.h
+++ b/lib/TbUiLib/include/ui/AppController.h
@@ -81,8 +81,10 @@ private:
   QTimer* m_reloadRecentDocumentsTimer = nullptr;
   QTimer* m_processResourcesTimer = nullptr;
 
+#if !defined(NO_UPDATER)
   upd::HttpClient* m_httpClient = nullptr;
   upd::Updater* m_updater = nullptr;
+#endif
 
   MapWindowManager* m_mapWindowManager = nullptr;
   RecentDocuments* m_recentDocuments = nullptr;
@@ -115,7 +117,9 @@ public:
 
   mdl::GameManager& gameManager();
 
+#if !defined(NO_UPDATER)
   upd::Updater& updater();
+#endif
 
   MapWindowManager& mapWindowManager();
 

--- a/lib/TbUiLib/include/ui/AppInfoPanel.h
+++ b/lib/TbUiLib/include/ui/AppInfoPanel.h
@@ -30,7 +30,11 @@ class AppInfoPanel : public QWidget
   Q_OBJECT
 
 public:
+#if defined(NO_UPDATER)
+  explicit AppInfoPanel(QWidget* parent = nullptr);
+#else
   explicit AppInfoPanel(AppController& appController, QWidget* parent = nullptr);
+#endif
 
 private:
   void versionInfoClicked();

--- a/lib/TbUiLib/src/AboutDialog.cpp
+++ b/lib/TbUiLib/src/AboutDialog.cpp
@@ -86,7 +86,11 @@ Source Sans Pro (Font)<br />
 Font Awesome 5 Free (Icons)<br />)");
   setWindowIconTB(this);
 
+#if defined(NO_UPDATER)
+  auto* infoPanel = new AppInfoPanel();
+#else
   auto* infoPanel = new AppInfoPanel{m_appController};
+#endif
   auto* creditsText = new QLabel{creditsString};
   creditsText->setWordWrap(true);
   creditsText->setMaximumWidth(300);

--- a/lib/TbUiLib/src/AppController.cpp
+++ b/lib/TbUiLib/src/AppController.cpp
@@ -55,10 +55,13 @@
 #include "ui/QPathUtils.h"
 #include "ui/RecentDocuments.h"
 #include "ui/SystemPaths.h"
-#include "ui/UpdateConfig.h"
 #include "ui/WelcomeWindow.h"
+
+#if !defined( NO_UPDATER )
+#include "ui/UpdateConfig.h"
 #include "update/QtHttpClient.h"
 #include "update/Updater.h"
+#endif
 
 #include "kd/const_overload.h"
 #include "kd/task_manager.h"
@@ -169,8 +172,10 @@ AppController::AppController(
   , m_networkManager{new QNetworkAccessManager{this}}
   , m_reloadRecentDocumentsTimer{new QTimer{this}}
   , m_processResourcesTimer{new QTimer{this}}
+  #if !defined( NO_UPDATER )
   , m_httpClient{new upd::QtHttpClient{*m_networkManager}}
   , m_updater{new upd::Updater{*m_httpClient, makeUpdateConfig(), this}}
+#endif  
   , m_mapWindowManager{createMapWindowManager(*this)}
   , m_recentDocuments{createRecentDocuments(this)}
   , m_actionManager{std::make_unique<ActionManager>()}
@@ -223,11 +228,12 @@ mdl::GameManager& AppController::gameManager()
 {
   return *m_gameManager;
 }
-
+#if !defined( NO_UPDATER )
 upd::Updater& AppController::updater()
 {
   return *m_updater;
 }
+#endif
 
 MapWindowManager& AppController::mapWindowManager()
 {
@@ -251,6 +257,7 @@ ActionManager& AppController::actionManager()
 
 void AppController::askForAutoUpdates()
 {
+  #if !defined( NO_UPDATER )
   if (pref(Preferences::AskForAutoUpdates))
   {
     auto& prefs = PreferenceManager::instance();
@@ -268,14 +275,17 @@ void AppController::askForAutoUpdates()
     prefs.set(Preferences::AskForAutoUpdates, false);
     prefs.saveChanges();
   }
+  #endif
 }
 
 void AppController::triggerAutoUpdateCheck()
 {
+  #if !defined( NO_UPDATER )
   if (pref(Preferences::AutoCheckForUpdates))
   {
     m_updater->checkForUpdates();
   }
+  #endif
 }
 
 bool AppController::newDocument()

--- a/lib/TbUiLib/src/AppInfoPanel.cpp
+++ b/lib/TbUiLib/src/AppInfoPanel.cpp
@@ -37,8 +37,11 @@
 
 namespace tb::ui
 {
-
+#if defined(NO_UPDATER)
+AppInfoPanel::AppInfoPanel(QWidget* parent)
+#else
 AppInfoPanel::AppInfoPanel(AppController& appController, QWidget* parent)
+#endif
   : QWidget{parent}
 {
   auto appIconImage = loadPixmap("AppIcon.png");
@@ -70,14 +73,18 @@ AppInfoPanel::AppInfoPanel(AppController& appController, QWidget* parent)
   connect(build, &ClickableLabel::clicked, this, &AppInfoPanel::versionInfoClicked);
   connect(qtVersion, &ClickableLabel::clicked, this, &AppInfoPanel::versionInfoClicked);
 
+#if !defined(NO_UPDATER)
   auto* updateIndicator = appController.updater().createUpdateIndicator();
   setInfoStyle(updateIndicator);
+#endif
 
   auto* versionLayout = new QHBoxLayout{};
   versionLayout->setContentsMargins(0, 0, 0, 0);
   versionLayout->setSpacing(LayoutConstants::MediumHMargin);
   versionLayout->addWidget(version);
+#if !defined(NO_UPDATER)
   versionLayout->addWidget(updateIndicator);
+#endif
 
   auto* versionWidget = new QWidget{};
   versionWidget->setLayout(versionLayout);

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -511,7 +511,9 @@ void MapWindow::createStatusBar()
 {
   m_statusBarLabel = new QLabel{};
   statusBar()->addWidget(m_statusBarLabel, 1);
+#if !defined(NO_UPDATER)
   statusBar()->addWidget(m_appController.updater().createUpdateIndicator());
+#endif
 }
 
 namespace

--- a/lib/TbUiLib/src/PreferenceDialog.cpp
+++ b/lib/TbUiLib/src/PreferenceDialog.cpp
@@ -153,7 +153,9 @@ void PreferenceDialog::createGui()
   m_toolBar->addAction(mouseImage, "Mouse", [&]() { switchToPane(PrefPane::Mouse); });
   m_toolBar->addAction(
     keyboardImage, "Keyboard", [&]() { switchToPane(PrefPane::Keyboard); });
+#if !defined(NO_UPDATER)
   m_toolBar->addAction(updateImage, "Update", [&]() { switchToPane(PrefPane::Update); });
+#endif
 
   // Don't display tooltips for pane switcher buttons...
   for (auto* button : m_toolBar->findChildren<QToolButton*>())
@@ -167,7 +169,9 @@ void PreferenceDialog::createGui()
   m_stackedWidget->addWidget(new ColorsPreferencePane{});
   m_stackedWidget->addWidget(new MousePreferencePane{});
   m_stackedWidget->addWidget(new KeyboardPreferencePane{m_appController, m_document});
+#if !defined(NO_UPDATER)
   m_stackedWidget->addWidget(new UpdatePreferencePane{m_appController});
+#endif
 
   m_buttonBox = new QDialogButtonBox{
     PreferenceManager::instance().saveInstantly()

--- a/lib/TbUiLib/src/UpdatePreferencePane.cpp
+++ b/lib/TbUiLib/src/UpdatePreferencePane.cpp
@@ -76,8 +76,9 @@ To download and install an available update, click on the link labeled "Update a
       const auto value = state == Qt::Checked;
       auto& prefs = PreferenceManager::instance();
       prefs.set(Preferences::IncludePreReleaseUpdates, value);
-
+#if !defined(NO_UPDATER)
       m_appController.updater().reset();
+#endif
     });
 
   m_includeDraftReleaseUpdates = new QCheckBox{};
@@ -86,15 +87,18 @@ To download and install an available update, click on the link labeled "Update a
       const auto value = state == Qt::Checked;
       auto& prefs = PreferenceManager::instance();
       prefs.set(Preferences::IncludeDraftReleaseUpdates, value);
-
+#if !defined(NO_UPDATER)
       m_appController.updater().reset();
+#endif
     });
 
   auto* preReleaseInfo = new QLabel{tr(
     R"(Pre-releases are versions of TrenchBroom that are not yet considered stable. 
 They may contain new features or bug fixes that are not yet part of a stable release.)")};
 
+#if !defined(NO_UPDATER)
   auto* updateIndicator = m_appController.updater().createUpdateIndicator();
+#endif
 
   m_layout = new FormWithSectionsLayout{};
   m_layout->setContentsMargins(
@@ -106,7 +110,9 @@ They may contain new features or bug fixes that are not yet part of a stable rel
 
   m_layout->addSection("Automatic Updates");
   m_layout->addRow(updateInfo);
+#if !defined(NO_UPDATER)
   m_layout->addRow(updateIndicator);
+#endif
   m_layout->addSection("Update Preferences");
   m_layout->addRow("Check for updates on startup", m_autoCheckForUpdates);
   m_layout->addRow("Include pre-releases", m_includePreReleaseUpdates);

--- a/lib/TbUiLib/src/WelcomeWindow.cpp
+++ b/lib/TbUiLib/src/WelcomeWindow.cpp
@@ -87,7 +87,11 @@ void WelcomeWindow::createGui()
 QWidget* WelcomeWindow::createAppPanel()
 {
   auto* appPanel = new QWidget{};
+#if defined(NO_UPDATER)
+  auto* infoPanel = new AppInfoPanel{appPanel};
+#else
   auto* infoPanel = new AppInfoPanel{m_appController, appPanel};
+#endif
 
   m_createNewDocumentButton = new QPushButton{"New map..."};
   m_createNewDocumentButton->setToolTip("Create a new map document");

--- a/lib/UpdateLib/CMakeLists.txt
+++ b/lib/UpdateLib/CMakeLists.txt
@@ -54,4 +54,7 @@ elseif (APPLE)
   set(LIB_UPDATE_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/install_update.sh" CACHE INTERNAL "Path to the update script")
 endif()
 
+if(TB_TESTS)
 add_subdirectory(test)
+endif()
+

--- a/lib/VmLib/CMakeLists.txt
+++ b/lib/VmLib/CMakeLists.txt
@@ -19,4 +19,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   )
 endif()
 
+if (TB_TESTS)
 add_subdirectory(test)
+endif()


### PR DESCRIPTION
adds TB_TESTS ; which defaults ON, to compile all trenchbroom tests
adds TB_NOUPDATER; which defaults OFF, to disable the automatic updater.

when using a fork with a lot of unique features, it's not ideal to have the updater. 
it is also convenient to be able to disable building the tests when they aren't required.
