### PR TITLE
fix DumpShortcuts/CMakeLists.txt so it copies the offscreen plugin

### DIFF
--- a/app/DumpShortcuts/CMakeLists.txt
+++ b/app/DumpShortcuts/CMakeLists.txt
@@ -44,6 +44,7 @@ if(WIN32)
                 COMMAND "${TB_WINDEPLOYQT_PATH}"
                         --no-compiler-runtime
                         --no-translations
+						--include-plugins qoffscreen
                         "$<TARGET_FILE_DIR:DumpShortcuts>")
     else()
         message(STATUS "windeployqt skipped")


### PR DESCRIPTION
this seems to actually fix the generate manual problem. 
just forcing the DumpShortcuts windeploy to include the offscreen plugin.
so the other PR is unnecessary.