### PR TITLE
Prefer passing by reference

### DIFF
--- a/lib/TbMdlLib/include/mdl/ApplyAndSwap.h
+++ b/lib/TbMdlLib/include/mdl/ApplyAndSwap.h
@@ -65,12 +65,12 @@ std::optional<std::vector<std::pair<Node*, NodeContents>>> applyToNodeContents(
   using NodeContent = std::variant<Layer, Group, Entity, Brush, BezierPatch>;
   auto getNodeContents = [](const Node* node) -> NodeContent {
     return node->accept(kdl::overload(
-      [](const WorldNode* worldNode) -> NodeContent { return worldNode->entity(); },
-      [](const LayerNode* layerNode) -> NodeContent { return layerNode->layer(); },
-      [](const GroupNode* groupNode) -> NodeContent { return groupNode->group(); },
-      [](const EntityNode* entityNode) -> NodeContent { return entityNode->entity(); },
-      [](const BrushNode* brushNode) -> NodeContent { return brushNode->brush(); },
-      [](const PatchNode* patchNode) -> NodeContent { return patchNode->patch(); }));
+      [](const WorldNode& worldNode) -> NodeContent { return worldNode.entity(); },
+      [](const LayerNode& layerNode) -> NodeContent { return layerNode.layer(); },
+      [](const GroupNode& groupNode) -> NodeContent { return groupNode.group(); },
+      [](const EntityNode& entityNode) -> NodeContent { return entityNode.entity(); },
+      [](const BrushNode& brushNode) -> NodeContent { return brushNode.brush(); },
+      [](const PatchNode& patchNode) -> NodeContent { return patchNode.patch(); }));
   };
 
   auto newNodes = std::vector<std::pair<Node*, NodeContents>>{};

--- a/lib/TbMdlLib/include/mdl/ApplyAndSwap.h
+++ b/lib/TbMdlLib/include/mdl/ApplyAndSwap.h
@@ -190,10 +190,8 @@ bool applyAndSwap(
 
   auto changedLinkedGroups =
     collectContainingGroups(newNodes | std::views::keys | kdl::ranges::to<std::vector>());
-  updateNodeContents(
+  return updateNodeContents(
     map, commandName, std::move(newNodes), std::move(changedLinkedGroups));
-
-  return true;
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/BrushNode.h
+++ b/lib/TbMdlLib/include/mdl/BrushNode.h
@@ -82,8 +82,8 @@ public:
 
   void setFaceMaterial(size_t faceIndex, gl::Material* material);
 
-  bool contains(const Node* node) const;
-  bool intersects(const Node* node) const;
+  bool contains(const Node& node) const;
+  bool intersects(const Node& node) const;
 
 private:
   void clearSelectedFaces();
@@ -98,8 +98,8 @@ private: // implement Node interface
 
   Node* doClone(const vm::bbox3d& worldBounds) const override;
 
-  bool doCanAddChild(const Node* child) const override;
-  bool doCanRemoveChild(const Node* child) const override;
+  bool doCanAddChild(const Node& child) const override;
+  bool doCanRemoveChild(const Node& child) const override;
   bool doRemoveIfEmpty() const override;
 
   bool doShouldAddToSpacialIndex() const override;

--- a/lib/TbMdlLib/include/mdl/EntityDefinitionManager.h
+++ b/lib/TbMdlLib/include/mdl/EntityDefinitionManager.h
@@ -43,7 +43,7 @@ public:
   void setDefinitions(std::vector<EntityDefinition> newDefinitions);
   void clear();
 
-  const EntityDefinition* definition(const EntityNodeBase* node) const;
+  const EntityDefinition* definition(const EntityNodeBase& node) const;
   const EntityDefinition* definition(std::string_view classname) const;
   std::vector<const EntityDefinition*> definitions(
     EntityDefinitionType type, EntityDefinitionSortOrder order) const;

--- a/lib/TbMdlLib/include/mdl/EntityNode.h
+++ b/lib/TbMdlLib/include/mdl/EntityNode.h
@@ -67,14 +67,14 @@ private: // implement Node interface
 
   Node* doClone(const vm::bbox3d& worldBounds) const override;
 
-  bool doCanAddChild(const Node* child) const override;
-  bool doCanRemoveChild(const Node* child) const override;
+  bool doCanAddChild(const Node& child) const override;
+  bool doCanRemoveChild(const Node& child) const override;
   bool doRemoveIfEmpty() const override;
 
   bool doShouldAddToSpacialIndex() const override;
 
-  void doChildWasAdded(Node* node) override;
-  void doChildWasRemoved(Node* node) override;
+  void doChildWasAdded(Node& node) override;
+  void doChildWasRemoved(Node& node) override;
 
   void doNodePhysicalBoundsDidChange() override;
   void doChildPhysicalBoundsDidChange() override;

--- a/lib/TbMdlLib/include/mdl/GroupNode.h
+++ b/lib/TbMdlLib/include/mdl/GroupNode.h
@@ -101,14 +101,14 @@ private: // implement methods inherited from Node
 
   Node* doClone(const vm::bbox3d& worldBounds) const override;
 
-  bool doCanAddChild(const Node* child) const override;
-  bool doCanRemoveChild(const Node* child) const override;
+  bool doCanAddChild(const Node& child) const override;
+  bool doCanRemoveChild(const Node& child) const override;
   bool doRemoveIfEmpty() const override;
 
   bool doShouldAddToSpacialIndex() const override;
 
-  void doChildWasAdded(Node* node) override;
-  void doChildWasRemoved(Node* node) override;
+  void doChildWasAdded(Node& node) override;
+  void doChildWasRemoved(Node& node) override;
 
   void doNodePhysicalBoundsDidChange() override;
   void doChildPhysicalBoundsDidChange() override;

--- a/lib/TbMdlLib/include/mdl/LayerNode.h
+++ b/lib/TbMdlLib/include/mdl/LayerNode.h
@@ -73,8 +73,8 @@ private: // implement Node interface
   double doGetProjectedArea(vm::axis::type axis) const override;
 
   Node* doClone(const vm::bbox3d& worldBounds) const override;
-  bool doCanAddChild(const Node* child) const override;
-  bool doCanRemoveChild(const Node* child) const override;
+  bool doCanAddChild(const Node& child) const override;
+  bool doCanRemoveChild(const Node& child) const override;
   bool doRemoveIfEmpty() const override;
   bool doShouldAddToSpacialIndex() const override;
   void doNodePhysicalBoundsDidChange() override;

--- a/lib/TbMdlLib/include/mdl/LinkedGroupUtils.h
+++ b/lib/TbMdlLib/include/mdl/LinkedGroupUtils.h
@@ -52,10 +52,10 @@ template <typename N>
 std::vector<N*> collectLinkedNodes(const std::vector<Node*>& nodes, const N& node)
 {
   return kdl::vec_static_cast<N*>(node.accept(kdl::overload(
-    [](const WorldNode*) { return std::vector<Node*>{}; },
-    [](const LayerNode*) { return std::vector<Node*>{}; },
-    [&](const Object* object) {
-      return collectNodesWithLinkId(nodes, object->linkId());
+    [](const WorldNode&) { return std::vector<Node*>{}; },
+    [](const LayerNode&) { return std::vector<Node*>{}; },
+    [&](const Object& object) {
+      return collectNodesWithLinkId(nodes, object.linkId());
     })));
 }
 

--- a/lib/TbMdlLib/include/mdl/MapFileSerializer.h
+++ b/lib/TbMdlLib/include/mdl/MapFileSerializer.h
@@ -66,16 +66,16 @@ private:
     const std::vector<const Node*>& rootNodes, kdl::task_manager& taskManager) override;
   void doEndFile() override;
 
-  void doBeginEntity(const Node* node) override;
-  void doEndEntity(const Node* node) override;
+  void doBeginEntity(const Node& node) override;
+  void doEndEntity(const Node& node) override;
   void doEntityProperty(const EntityProperty& attribute) override;
-  void doBrush(const BrushNode* brush) override;
+  void doBrush(const BrushNode& brushNode) override;
   void doBrushFace(const BrushFace& face) override;
 
-  void doPatch(const PatchNode* patchNode) override;
+  void doPatch(const PatchNode& patchNode) override;
 
 private:
-  void setFilePosition(const Node* node);
+  void setFilePosition(const Node& node);
   size_t startLine();
 
 private: // threadsafe

--- a/lib/TbMdlLib/include/mdl/Node.h
+++ b/lib/TbMdlLib/include/mdl/Node.h
@@ -156,9 +156,9 @@ protected:
 public: // tree management
   size_t depth() const;
   Node* parent() const;
-  bool isAncestorOf(const Node* node) const;
+  bool isAncestorOf(const Node& node) const;
   bool isAncestorOf(const std::vector<Node*>& nodes) const;
-  bool isDescendantOf(const Node* node) const;
+  bool isDescendantOf(const Node& node) const;
   bool isDescendantOf(const std::vector<Node*>& nodes) const;
   std::vector<Node*> findDescendants(const std::vector<Node*>& nodes) const;
 
@@ -205,20 +205,20 @@ public:
 
   void removeChild(Node* child);
 
-  bool canAddChild(const Node* child) const;
-  bool canRemoveChild(const Node* child) const;
+  bool canAddChild(const Node& child) const;
+  bool canRemoveChild(const Node& child) const;
 
   template <typename I>
   bool canAddChildren(I cur, I end) const
   {
-    return std::all_of(cur, end, [&](const auto* child) { return canAddChild(child); });
+    return std::all_of(cur, end, [&](const auto* child) { return canAddChild(*child); });
   }
 
   template <typename I>
   bool canRemoveChildren(I cur, I end) const
   {
     return std::all_of(
-      cur, end, [&](const auto* child) { return canRemoveChild(child); });
+      cur, end, [&](const auto* child) { return canRemoveChild(*child); });
   }
 
 private:
@@ -226,15 +226,15 @@ private:
   void doRemoveChild(Node* child);
   void clearChildren();
 
-  void childWillBeAdded(Node* node);
-  void childWasAdded(Node* node);
-  void childWillBeRemoved(Node* node);
-  void childWasRemoved(Node* node);
+  void childWillBeAdded(Node& node);
+  void childWasAdded(Node& node);
+  void childWillBeRemoved(Node& node);
+  void childWasRemoved(Node& node);
 
-  void descendantWillBeAdded(Node* newParent, Node* node, size_t depth);
-  void descendantWasAdded(Node* node, size_t depth);
-  void descendantWillBeRemoved(Node* node, size_t depth);
-  void descendantWasRemoved(Node* oldParent, Node* node, size_t depth);
+  void descendantWillBeAdded(Node& newParent, Node& node, size_t depth);
+  void descendantWasAdded(Node& node, size_t depth);
+  void descendantWillBeRemoved(Node& node, size_t depth);
+  void descendantWasRemoved(Node& oldParent, Node& node, size_t depth);
 
   void incDescendantCount(size_t delta);
   void decDescendantCount(size_t delta);
@@ -273,13 +273,13 @@ protected: // notification for parents
   void nodePhysicalBoundsDidChange();
 
 private:
-  void childWillChange(Node* node);
-  void childDidChange(Node* node);
-  void descendantWillChange(Node* node);
-  void descendantDidChange(Node* node);
+  void childWillChange(Node& node);
+  void childDidChange(Node& node);
+  void descendantWillChange(Node& node);
+  void descendantDidChange(Node& node);
 
-  void childPhysicalBoundsDidChange(Node* node);
-  void descendantPhysicalBoundsDidChange(Node* node, size_t depth);
+  void childPhysicalBoundsDidChange(Node& node);
+  void descendantPhysicalBoundsDidChange(Node& node, size_t depth);
 
 public: // selection
   bool selected() const;
@@ -498,21 +498,21 @@ private: // subclassing interface
   virtual Node* doClone(const vm::bbox3d& worldBounds) const = 0;
   virtual Node* doCloneRecursively(const vm::bbox3d& worldBounds) const;
 
-  virtual bool doCanAddChild(const Node* child) const = 0;
-  virtual bool doCanRemoveChild(const Node* child) const = 0;
+  virtual bool doCanAddChild(const Node& child) const = 0;
+  virtual bool doCanRemoveChild(const Node& child) const = 0;
   virtual bool doRemoveIfEmpty() const = 0;
 
   virtual bool doShouldAddToSpacialIndex() const = 0;
 
-  virtual void doChildWillBeAdded(Node* node);
-  virtual void doChildWasAdded(Node* node);
-  virtual void doChildWillBeRemoved(Node* node);
-  virtual void doChildWasRemoved(Node* node);
+  virtual void doChildWillBeAdded(Node& node);
+  virtual void doChildWasAdded(Node& node);
+  virtual void doChildWillBeRemoved(Node& node);
+  virtual void doChildWasRemoved(Node& node);
 
-  virtual void doDescendantWillBeAdded(Node* newParent, Node* node, size_t depth);
-  virtual void doDescendantWasAdded(Node* node, size_t depth);
-  virtual void doDescendantWillBeRemoved(Node* node, size_t depth);
-  virtual void doDescendantWasRemoved(Node* oldParent, Node* node, size_t depth);
+  virtual void doDescendantWillBeAdded(Node& newParent, Node& node, size_t depth);
+  virtual void doDescendantWasAdded(Node& node, size_t depth);
+  virtual void doDescendantWillBeRemoved(Node& node, size_t depth);
+  virtual void doDescendantWasRemoved(Node& oldParent, Node& node, size_t depth);
 
   virtual void doParentWillChange();
   virtual void doParentDidChange();
@@ -521,12 +521,12 @@ private: // subclassing interface
 
   virtual void doNodePhysicalBoundsDidChange();
   virtual void doChildPhysicalBoundsDidChange();
-  virtual void doDescendantPhysicalBoundsDidChange(Node* node);
+  virtual void doDescendantPhysicalBoundsDidChange(Node& node);
 
-  virtual void doChildWillChange(Node* node);
-  virtual void doChildDidChange(Node* node);
-  virtual void doDescendantWillChange(Node* node);
-  virtual void doDescendantDidChange(Node* node);
+  virtual void doChildWillChange(Node& node);
+  virtual void doChildDidChange(Node& node);
+  virtual void doDescendantWillChange(Node& node);
+  virtual void doDescendantDidChange(Node& node);
 
   virtual bool doSelectable() const = 0;
 

--- a/lib/TbMdlLib/include/mdl/NodeQueries.h
+++ b/lib/TbMdlLib/include/mdl/NodeQueries.h
@@ -39,20 +39,20 @@ namespace tb::mdl
 
 struct TrueNodePredicate
 {
-  bool operator()(WorldNode*) const { return true; }
-  bool operator()(LayerNode*) const { return true; }
-  bool operator()(GroupNode*) const { return true; }
-  bool operator()(EntityNode*) const { return true; }
-  bool operator()(BrushNode*) const { return true; }
-  bool operator()(PatchNode*) const { return true; }
+  bool operator()(WorldNode&) const { return true; }
+  bool operator()(LayerNode&) const { return true; }
+  bool operator()(GroupNode&) const { return true; }
+  bool operator()(EntityNode&) const { return true; }
+  bool operator()(BrushNode&) const { return true; }
+  bool operator()(PatchNode&) const { return true; }
 };
 
 template <typename N, typename T = Node*>
-N* findNode(const std::vector<T>& nodes, const std::function<bool(const N*)>& predicate)
+N* findNode(const std::vector<T>& nodes, const std::function<bool(const N&)>& predicate)
 {
   for (auto* node : nodes)
   {
-    if (auto* tNode = dynamic_cast<N*>(node); tNode && predicate(tNode))
+    if (auto* tNode = dynamic_cast<N*>(node); tNode && predicate(*tNode))
     {
       return tNode;
     }
@@ -63,11 +63,11 @@ N* findNode(const std::vector<T>& nodes, const std::function<bool(const N*)>& pr
 
 template <typename N, typename T = Node*>
 N* findNodeOrDescendant(
-  const std::vector<T>& nodes, const std::function<bool(const N*)>& predicate)
+  const std::vector<T>& nodes, const std::function<bool(const N&)>& predicate)
 {
   for (auto* node : nodes)
   {
-    if (auto* tNode = dynamic_cast<N*>(node); tNode && predicate(tNode))
+    if (auto* tNode = dynamic_cast<N*>(node); tNode && predicate(*tNode))
     {
       return tNode;
     }
@@ -85,57 +85,57 @@ auto collectNodes(const std::vector<T>& nodes, const Predicate& predicate = Pred
 {
   auto result = std::vector<Node*>{};
   auto visitor = kdl::overload(
-    [&]([[maybe_unused]] WorldNode* worldNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode*>)
+    [&]([[maybe_unused]] WorldNode& worldNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode&>)
       {
         if (predicate(worldNode))
         {
-          result.push_back(worldNode);
+          result.push_back(&worldNode);
         }
       }
     },
-    [&]([[maybe_unused]] LayerNode* layerNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode*>)
+    [&]([[maybe_unused]] LayerNode& layerNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode&>)
       {
         if (predicate(layerNode))
         {
-          result.push_back(layerNode);
+          result.push_back(&layerNode);
         }
       }
     },
-    [&]([[maybe_unused]] GroupNode* groupNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode*>)
+    [&]([[maybe_unused]] GroupNode& groupNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode&>)
       {
         if (predicate(groupNode))
         {
-          result.push_back(groupNode);
+          result.push_back(&groupNode);
         }
       }
     },
-    [&]([[maybe_unused]] EntityNode* entityNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode*>)
+    [&]([[maybe_unused]] EntityNode& entityNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode&>)
       {
         if (predicate(entityNode))
         {
-          result.push_back(entityNode);
+          result.push_back(&entityNode);
         }
       }
     },
-    [&]([[maybe_unused]] BrushNode* brushNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode*>)
+    [&]([[maybe_unused]] BrushNode& brushNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode&>)
       {
         if (predicate(brushNode))
         {
-          result.push_back(brushNode);
+          result.push_back(&brushNode);
         }
       }
     },
-    [&]([[maybe_unused]] PatchNode* patchNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode*>)
+    [&]([[maybe_unused]] PatchNode& patchNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode&>)
       {
         if (predicate(patchNode))
         {
-          result.push_back(patchNode);
+          result.push_back(&patchNode);
         }
       }
     });
@@ -153,64 +153,64 @@ auto collectAncestors(
 {
   auto result = std::vector<Node*>{};
   auto visitor = kdl::overload(
-    [&]([[maybe_unused]] WorldNode* worldNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode*>)
+    [&]([[maybe_unused]] WorldNode& worldNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode&>)
       {
         if (predicate(worldNode))
         {
-          result.push_back(worldNode);
+          result.push_back(&worldNode);
         }
       }
     },
-    [&](auto&& thisLambda, [[maybe_unused]] LayerNode* layerNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] LayerNode& layerNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode&>)
       {
         if (predicate(layerNode))
         {
-          result.push_back(layerNode);
+          result.push_back(&layerNode);
         }
       }
-      layerNode->visitParent(thisLambda);
+      layerNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] GroupNode* groupNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] GroupNode& groupNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode&>)
       {
         if (predicate(groupNode))
         {
-          result.push_back(groupNode);
+          result.push_back(&groupNode);
         }
       }
-      groupNode->visitParent(thisLambda);
+      groupNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] EntityNode* entityNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] EntityNode& entityNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode&>)
       {
         if (predicate(entityNode))
         {
-          result.push_back(entityNode);
+          result.push_back(&entityNode);
         }
       }
-      entityNode->visitParent(thisLambda);
+      entityNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] BrushNode* brushNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] BrushNode& brushNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode&>)
       {
         if (predicate(brushNode))
         {
-          result.push_back(brushNode);
+          result.push_back(&brushNode);
         }
       }
-      brushNode->visitParent(thisLambda);
+      brushNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] PatchNode* patchNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] PatchNode& patchNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode&>)
       {
         if (predicate(patchNode))
         {
-          result.push_back(patchNode);
+          result.push_back(&patchNode);
         }
       }
-      patchNode->visitParent(thisLambda);
+      patchNode.visitParent(thisLambda);
     });
 
   for (auto* node : nodes)
@@ -226,64 +226,64 @@ auto collectNodesAndAncestors(
 {
   auto result = std::vector<Node*>{};
   auto visitor = kdl::overload(
-    [&]([[maybe_unused]] WorldNode* worldNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode*>)
+    [&]([[maybe_unused]] WorldNode& worldNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode&>)
       {
         if (predicate(worldNode))
         {
-          result.push_back(worldNode);
+          result.push_back(&worldNode);
         }
       }
     },
-    [&](auto&& thisLambda, [[maybe_unused]] LayerNode* layerNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] LayerNode& layerNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode&>)
       {
         if (predicate(layerNode))
         {
-          result.push_back(layerNode);
+          result.push_back(&layerNode);
         }
       }
-      layerNode->visitParent(thisLambda);
+      layerNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] GroupNode* groupNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] GroupNode& groupNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode&>)
       {
         if (predicate(groupNode))
         {
-          result.push_back(groupNode);
+          result.push_back(&groupNode);
         }
       }
-      groupNode->visitParent(thisLambda);
+      groupNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] EntityNode* entityNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] EntityNode& entityNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode&>)
       {
         if (predicate(entityNode))
         {
-          result.push_back(entityNode);
+          result.push_back(&entityNode);
         }
       }
-      entityNode->visitParent(thisLambda);
+      entityNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] BrushNode* brushNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] BrushNode& brushNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode&>)
       {
         if (predicate(brushNode))
         {
-          result.push_back(brushNode);
+          result.push_back(&brushNode);
         }
       }
-      brushNode->visitParent(thisLambda);
+      brushNode.visitParent(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] PatchNode* patchNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] PatchNode& patchNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode&>)
       {
         if (predicate(patchNode))
         {
-          result.push_back(patchNode);
+          result.push_back(&patchNode);
         }
       }
-      patchNode->visitParent(thisLambda);
+      patchNode.visitParent(thisLambda);
     });
 
   Node::visitAll(nodes, visitor);
@@ -296,65 +296,65 @@ auto collectDescendants(
 {
   auto result = std::vector<Node*>{};
   auto visitor = kdl::overload(
-    [&](auto&& thisLambda, [[maybe_unused]] WorldNode* worldNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] WorldNode& worldNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode&>)
       {
         if (predicate(worldNode))
         {
-          result.push_back(worldNode);
+          result.push_back(&worldNode);
         }
       }
-      worldNode->visitChildren(thisLambda);
+      worldNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] LayerNode* layerNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] LayerNode& layerNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode&>)
       {
         if (predicate(layerNode))
         {
-          result.push_back(layerNode);
+          result.push_back(&layerNode);
         }
       }
-      layerNode->visitChildren(thisLambda);
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] GroupNode* groupNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] GroupNode& groupNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode&>)
       {
         if (predicate(groupNode))
         {
-          result.push_back(groupNode);
+          result.push_back(&groupNode);
         }
       }
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] EntityNode* entityNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] EntityNode& entityNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode&>)
       {
         if (predicate(entityNode))
         {
-          result.push_back(entityNode);
+          result.push_back(&entityNode);
         }
       }
-      entityNode->visitChildren(thisLambda);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] BrushNode* brushNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] BrushNode& brushNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode&>)
       {
         if (predicate(brushNode))
         {
-          result.push_back(brushNode);
+          result.push_back(&brushNode);
         }
       }
-      brushNode->visitChildren(thisLambda);
+      brushNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] PatchNode* patchNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] PatchNode& patchNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode&>)
       {
         if (predicate(patchNode))
         {
-          result.push_back(patchNode);
+          result.push_back(&patchNode);
         }
       }
-      patchNode->visitChildren(thisLambda);
+      patchNode.visitChildren(thisLambda);
     });
 
   for (auto* node : nodes)
@@ -370,65 +370,65 @@ auto collectNodesAndDescendants(
 {
   auto result = std::vector<Node*>{};
   auto visitor = kdl::overload(
-    [&](auto&& thisLambda, [[maybe_unused]] WorldNode* worldNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] WorldNode& worldNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, WorldNode&>)
       {
         if (predicate(worldNode))
         {
-          result.push_back(worldNode);
+          result.push_back(&worldNode);
         }
       }
-      worldNode->visitChildren(thisLambda);
+      worldNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] LayerNode* layerNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] LayerNode& layerNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, LayerNode&>)
       {
         if (predicate(layerNode))
         {
-          result.push_back(layerNode);
+          result.push_back(&layerNode);
         }
       }
-      layerNode->visitChildren(thisLambda);
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] GroupNode* groupNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] GroupNode& groupNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, GroupNode&>)
       {
         if (predicate(groupNode))
         {
-          result.push_back(groupNode);
+          result.push_back(&groupNode);
         }
       }
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] EntityNode* entityNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] EntityNode& entityNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, EntityNode&>)
       {
         if (predicate(entityNode))
         {
-          result.push_back(entityNode);
+          result.push_back(&entityNode);
         }
       }
-      entityNode->visitChildren(thisLambda);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] BrushNode* brushNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] BrushNode& brushNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, BrushNode&>)
       {
         if (predicate(brushNode))
         {
-          result.push_back(brushNode);
+          result.push_back(&brushNode);
         }
       }
-      brushNode->visitChildren(thisLambda);
+      brushNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, [[maybe_unused]] PatchNode* patchNode) {
-      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode*>)
+    [&](auto&& thisLambda, [[maybe_unused]] PatchNode& patchNode) {
+      if constexpr (std::is_invocable_r_v<bool, Predicate, PatchNode&>)
       {
         if (predicate(patchNode))
         {
-          result.push_back(patchNode);
+          result.push_back(&patchNode);
         }
       }
-      patchNode->visitChildren(thisLambda);
+      patchNode.visitChildren(thisLambda);
     });
 
   Node::visitAll(nodes, visitor);
@@ -448,30 +448,30 @@ std::vector<BrushFaceHandle> collectBrushFaces(
   Node::visitAll(
     nodes,
     kdl::overload(
-      [&](auto&& thisLambda, const WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, const LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, const GroupNode* groupNode) {
-        groupNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const GroupNode& groupNode) {
+        groupNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, const EntityNode* entityNode) {
-        entityNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const EntityNode& entityNode) {
+        entityNode.visitChildren(thisLambda);
       },
-      [&](BrushNode* brushNode) {
-        const auto& brush = brushNode->brush();
+      [&](BrushNode& brushNode) {
+        const auto& brush = brushNode.brush();
         for (size_t i = 0; i < brush.faceCount(); ++i)
         {
           const auto& face = brush.face(i);
-          if (predicate(*brushNode, face))
+          if (predicate(brushNode, face))
           {
-            result.emplace_back(brushNode, i);
+            result.emplace_back(&brushNode, i);
           }
         }
       },
-      [&](const PatchNode*) {}));
+      [&](const PatchNode&) {}));
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 

--- a/lib/TbMdlLib/include/mdl/NodeQueries.h
+++ b/lib/TbMdlLib/include/mdl/NodeQueries.h
@@ -32,19 +32,42 @@
 #include "kd/overload.h"
 #include "kd/vector_utils.h"
 
+#include <concepts>
 #include <vector>
 
 namespace tb::mdl
 {
 
+// Concept: NodePredicate
+// True if Predicate is callable with any of the following:
+//   const WorldNode&, const LayerNode&, const GroupNode&,
+//   const EntityNode&, const BrushNode&, const PatchNode&
+// and returns bool.
+template <typename Predicate>
+concept NodePredicate = requires(Predicate pred, const WorldNode& w) {
+  { pred(w) } -> std::convertible_to<bool>;
+} || requires(Predicate pred, const LayerNode& l) {
+  { pred(l) } -> std::convertible_to<bool>;
+} || requires(Predicate pred, const GroupNode& g) {
+  { pred(g) } -> std::convertible_to<bool>;
+} || requires(Predicate pred, const EntityNode& e) {
+  { pred(e) } -> std::convertible_to<bool>;
+} || requires(Predicate pred, const BrushNode& b) {
+  { pred(b) } -> std::convertible_to<bool>;
+} || requires(Predicate pred, const PatchNode& p) {
+  { pred(p) } -> std::convertible_to<bool>;
+} || requires(Predicate pred, const Object& o) {
+  { pred(o) } -> std::convertible_to<bool>;
+};
+
 struct TrueNodePredicate
 {
-  bool operator()(WorldNode&) const { return true; }
-  bool operator()(LayerNode&) const { return true; }
-  bool operator()(GroupNode&) const { return true; }
-  bool operator()(EntityNode&) const { return true; }
-  bool operator()(BrushNode&) const { return true; }
-  bool operator()(PatchNode&) const { return true; }
+  bool operator()(const WorldNode&) const { return true; }
+  bool operator()(const LayerNode&) const { return true; }
+  bool operator()(const GroupNode&) const { return true; }
+  bool operator()(const EntityNode&) const { return true; }
+  bool operator()(const BrushNode&) const { return true; }
+  bool operator()(const PatchNode&) const { return true; }
 };
 
 template <typename N, typename T = Node*>
@@ -80,7 +103,7 @@ N* findNodeOrDescendant(
   return nullptr;
 }
 
-template <typename T = Node*, typename Predicate = TrueNodePredicate>
+template <typename T = Node*, NodePredicate Predicate = TrueNodePredicate>
 auto collectNodes(const std::vector<T>& nodes, const Predicate& predicate = Predicate{})
 {
   auto result = std::vector<Node*>{};
@@ -147,7 +170,7 @@ auto collectNodes(const std::vector<T>& nodes, const Predicate& predicate = Pred
   return result;
 }
 
-template <typename T = Node*, typename Predicate = TrueNodePredicate>
+template <typename T = Node*, NodePredicate Predicate = TrueNodePredicate>
 auto collectAncestors(
   const std::vector<T>& nodes, const Predicate& predicate = Predicate{})
 {
@@ -220,7 +243,7 @@ auto collectAncestors(
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 
-template <typename T = Node*, typename Predicate = TrueNodePredicate>
+template <typename T = Node*, NodePredicate Predicate = TrueNodePredicate>
 auto collectNodesAndAncestors(
   const std::vector<T>& nodes, const Predicate& predicate = Predicate{})
 {
@@ -290,7 +313,7 @@ auto collectNodesAndAncestors(
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 
-template <typename T = Node*, typename Predicate = TrueNodePredicate>
+template <typename T = Node*, NodePredicate Predicate = TrueNodePredicate>
 auto collectDescendants(
   const std::vector<T>& nodes, const Predicate& predicate = Predicate{})
 {
@@ -364,7 +387,7 @@ auto collectDescendants(
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 
-template <typename T = Node*, typename Predicate = TrueNodePredicate>
+template <typename T = Node*, NodePredicate Predicate = TrueNodePredicate>
 auto collectNodesAndDescendants(
   const std::vector<T>& nodes, const Predicate& predicate = Predicate{})
 {
@@ -435,12 +458,22 @@ auto collectNodesAndDescendants(
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 
+
+// Concept: BrushFacePredicate
+// True if Predicate is callable with (const BrushNode&, const BrushFace&) and returns
+// bool.
+template <typename Predicate>
+concept BrushFacePredicate =
+  requires(Predicate pred, const BrushNode& b, const BrushFace& f) {
+    { pred(b, f) } -> std::convertible_to<bool>;
+  };
+
 struct TrueBrushFacePredicate
 {
   bool operator()(const BrushNode&, const BrushFace&) const { return true; }
 };
 
-template <typename T = Node, typename Predicate = TrueBrushFacePredicate>
+template <typename T = Node, BrushFacePredicate Predicate = TrueBrushFacePredicate>
 std::vector<BrushFaceHandle> collectBrushFaces(
   const std::vector<T*>& nodes, const Predicate& predicate = Predicate{})
 {

--- a/lib/TbMdlLib/include/mdl/NodeSerializer.h
+++ b/lib/TbMdlLib/include/mdl/NodeSerializer.h
@@ -95,35 +95,35 @@ public:
 
 public:
   void defaultLayer(const WorldNode& world);
-  void customLayer(const LayerNode* layer);
-  void group(const GroupNode* group, const std::vector<EntityProperty>& parentProperties);
+  void customLayer(const LayerNode& layer);
+  void group(const GroupNode& group, const std::vector<EntityProperty>& parentProperties);
 
   void entity(
-    const Node* node,
+    const Node& node,
     const std::vector<EntityProperty>& properties,
     const std::vector<EntityProperty>& parentProperties,
-    const Node* brushParent);
+    const Node& brushParent);
   void entity(
-    const Node* node,
+    const Node& node,
     const std::vector<EntityProperty>& properties,
     const std::vector<EntityProperty>& parentProperties,
     const std::vector<BrushNode*>& entityBrushes);
 
 private:
   void beginEntity(
-    const Node* node,
+    const Node& node,
     const std::vector<EntityProperty>& properties,
     const std::vector<EntityProperty>& extraAttributes);
-  void beginEntity(const Node* node);
-  void endEntity(const Node* node);
+  void beginEntity(const Node& node);
+  void endEntity(const Node& node);
 
   void entityProperties(const std::vector<EntityProperty>& properties);
   void entityProperty(const EntityProperty& property);
 
   void brushes(const std::vector<BrushNode*>& brushNodes);
-  void brush(const BrushNode* brushNode);
+  void brush(const BrushNode& brushNode);
 
-  void patch(const PatchNode* patchNode);
+  void patch(const PatchNode& patchNode);
 
 public:
   void brushFaces(const std::vector<BrushFace>& faces);
@@ -135,8 +135,8 @@ public:
   std::vector<EntityProperty> parentProperties(const Node* groupNode);
 
 private:
-  std::vector<EntityProperty> layerProperties(const LayerNode* layerNode);
-  std::vector<EntityProperty> groupProperties(const GroupNode* groupNode);
+  std::vector<EntityProperty> layerProperties(const LayerNode& layerNode);
+  std::vector<EntityProperty> groupProperties(const GroupNode& groupNode);
 
 protected:
   std::string escapeEntityProperties(const std::string& str) const;
@@ -146,14 +146,14 @@ private:
     const std::vector<const Node*>& nodes, kdl::task_manager& taskManager) = 0;
   virtual void doEndFile() = 0;
 
-  virtual void doBeginEntity(const Node* node) = 0;
-  virtual void doEndEntity(const Node* node) = 0;
+  virtual void doBeginEntity(const Node& node) = 0;
+  virtual void doEndEntity(const Node& node) = 0;
   virtual void doEntityProperty(const EntityProperty& property) = 0;
 
-  virtual void doBrush(const BrushNode* brushNode) = 0;
+  virtual void doBrush(const BrushNode& brushNode) = 0;
   virtual void doBrushFace(const BrushFace& face) = 0;
 
-  virtual void doPatch(const PatchNode* patchNode) = 0;
+  virtual void doPatch(const PatchNode& patchNode) = 0;
 };
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/NodeVisitor.h
+++ b/lib/TbMdlLib/include/mdl/NodeVisitor.h
@@ -45,12 +45,12 @@ protected:
 public:
   virtual ~NodeVisitor();
 
-  virtual void visit(WorldNode* world) = 0;
-  virtual void visit(LayerNode* layer) = 0;
-  virtual void visit(GroupNode* group) = 0;
-  virtual void visit(EntityNode* entity) = 0;
-  virtual void visit(BrushNode* brush) = 0;
-  virtual void visit(PatchNode* patch) = 0;
+  virtual void visit(WorldNode& worldNode) = 0;
+  virtual void visit(LayerNode& layerNode) = 0;
+  virtual void visit(GroupNode& groupNode) = 0;
+  virtual void visit(EntityNode& entityNode) = 0;
+  virtual void visit(BrushNode& brushNode) = 0;
+  virtual void visit(PatchNode& patchNode) = 0;
 };
 
 class ConstNodeVisitor
@@ -61,12 +61,12 @@ protected:
 public:
   virtual ~ConstNodeVisitor();
 
-  virtual void visit(const WorldNode* world) = 0;
-  virtual void visit(const LayerNode* layer) = 0;
-  virtual void visit(const GroupNode* group) = 0;
-  virtual void visit(const EntityNode* entity) = 0;
-  virtual void visit(const BrushNode* brush) = 0;
-  virtual void visit(const PatchNode* patch) = 0;
+  virtual void visit(const WorldNode& worldNode) = 0;
+  virtual void visit(const LayerNode& layerNode) = 0;
+  virtual void visit(const GroupNode& groupNode) = 0;
+  virtual void visit(const EntityNode& entityNode) = 0;
+  virtual void visit(const BrushNode& brushNode) = 0;
+  virtual void visit(const PatchNode& patchNode) = 0;
 };
 
 template <typename L, typename N, typename Enable = void>
@@ -89,9 +89,9 @@ using NodeLambdaInvokeResult_t = typename NodeLambdaInvokeResult<L, N>::type;
 
 template <typename L>
 using NodeLambdaResultType = std::conditional_t<
-  std::is_same_v<NodeLambdaInvokeResult_t<L, WorldNode*>, void>,
+  std::is_same_v<NodeLambdaInvokeResult_t<L, WorldNode&>, void>,
   void,
-  NodeLambdaInvokeResult_t<L, WorldNode*>>;
+  NodeLambdaInvokeResult_t<L, WorldNode&>>;
 
 template <typename L>
 struct NodeLambdaHasResult : std::conditional_t<
@@ -143,25 +143,25 @@ public:
   }
 
 private:
-  void visit(WorldNode* world) override { doVisit(world); }
-  void visit(LayerNode* layer) override { doVisit(layer); }
-  void visit(GroupNode* group) override { doVisit(group); }
-  void visit(EntityNode* entity) override { doVisit(entity); }
-  void visit(BrushNode* brush) override { doVisit(brush); }
-  void visit(PatchNode* patch) override { doVisit(patch); }
+  void visit(WorldNode& worldNode) override { doVisit(worldNode); }
+  void visit(LayerNode& layerNode) override { doVisit(layerNode); }
+  void visit(GroupNode& groupNode) override { doVisit(groupNode); }
+  void visit(EntityNode& entityNode) override { doVisit(entityNode); }
+  void visit(BrushNode& brushNode) override { doVisit(brushNode); }
+  void visit(PatchNode& patchNode) override { doVisit(patchNode); }
 
   template <typename N>
-  void doVisit(N* node)
+  void doVisit(N& node)
   {
-    constexpr bool invokableWithAnyPointerType =
-      std::is_invocable_v<L, int*> || std::is_invocable_v<L, const L&, int*>;
+    constexpr bool invokableWithAnyReferenceType =
+      std::is_invocable_v<L, int&> || std::is_invocable_v<L, const L&, int&>;
     static_assert(
-      !invokableWithAnyPointerType,
-      "Don't use auto* to generate node visitors, this can lead to hard to detect "
+      !invokableWithAnyReferenceType,
+      "Don't use auto& to generate node visitors, this can lead to hard to detect "
       "errors.");
 
-    constexpr bool invokableWithLambdaAndNode = std::is_invocable_v<L, const L&, N*>;
-    constexpr bool invokableWithNode = std::is_invocable_v<L, N*>;
+    constexpr bool invokableWithLambdaAndNode = std::is_invocable_v<L, const L&, N&>;
+    constexpr bool invokableWithNode = std::is_invocable_v<L, N&>;
 
     static_assert(
       !(invokableWithNode && invokableWithLambdaAndNode),
@@ -209,26 +209,26 @@ public:
   }
 
 private:
-  void visit(const WorldNode* world) override { doVisit(world); }
-  void visit(const LayerNode* layer) override { doVisit(layer); }
-  void visit(const GroupNode* group) override { doVisit(group); }
-  void visit(const EntityNode* entity) override { doVisit(entity); }
-  void visit(const BrushNode* brush) override { doVisit(brush); }
-  void visit(const PatchNode* patch) override { doVisit(patch); }
+  void visit(const WorldNode& worldNode) override { doVisit(worldNode); }
+  void visit(const LayerNode& layerNode) override { doVisit(layerNode); }
+  void visit(const GroupNode& groupNode) override { doVisit(groupNode); }
+  void visit(const EntityNode& entityNode) override { doVisit(entityNode); }
+  void visit(const BrushNode& brushNode) override { doVisit(brushNode); }
+  void visit(const PatchNode& patchNode) override { doVisit(patchNode); }
 
   template <typename N>
-  void doVisit(const N* node)
+  void doVisit(const N& node)
   {
-    constexpr bool invokableWithAnyPointerType =
-      std::is_invocable_v<L, int*> || std::is_invocable_v<L, const L&, int*>;
+    constexpr bool invokableWithAnyReferenceType =
+      std::is_invocable_v<L, int&> || std::is_invocable_v<L, const L&, int&>;
     static_assert(
-      !invokableWithAnyPointerType,
-      "Don't use auto* to generate node visitors, this can lead to hard to detect "
+      !invokableWithAnyReferenceType,
+      "Don't use auto& to generate node visitors, this can lead to hard to detect "
       "errors.");
 
     constexpr bool invokableWithLambdaAndNode =
-      std::is_invocable_v<L, const L&, const N*>;
-    constexpr bool invokableWithNode = std::is_invocable_v<L, const N*>;
+      std::is_invocable_v<L, const L&, const N&>;
+    constexpr bool invokableWithNode = std::is_invocable_v<L, const N&>;
 
     static_assert(
       !(invokableWithNode && invokableWithLambdaAndNode),

--- a/lib/TbMdlLib/include/mdl/NodeWriter.h
+++ b/lib/TbMdlLib/include/mdl/NodeWriter.h
@@ -60,7 +60,7 @@ public:
 private:
   void writeDefaultLayer();
   void writeCustomLayers();
-  void writeCustomLayer(const LayerNode* layer);
+  void writeCustomLayer(const LayerNode& layer);
 
 public:
   void writeNodes(const std::vector<Node*>& nodes, kdl::task_manager& taskManager);

--- a/lib/TbMdlLib/include/mdl/ObjSerializer.h
+++ b/lib/TbMdlLib/include/mdl/ObjSerializer.h
@@ -146,14 +146,14 @@ private:
     const std::vector<const Node*>& rootNodes, kdl::task_manager& taskManager) override;
   void doEndFile() override;
 
-  void doBeginEntity(const Node* node) override;
-  void doEndEntity(const Node* node) override;
+  void doBeginEntity(const Node& node) override;
+  void doEndEntity(const Node& node) override;
   void doEntityProperty(const EntityProperty& property) override;
 
-  void doBrush(const BrushNode* brush) override;
+  void doBrush(const BrushNode& brushNode) override;
   void doBrushFace(const BrushFace& face) override;
 
-  void doPatch(const PatchNode* patchNode) override;
+  void doPatch(const PatchNode& patchNode) override;
 };
 
 } // namespace mdl

--- a/lib/TbMdlLib/include/mdl/PatchNode.h
+++ b/lib/TbMdlLib/include/mdl/PatchNode.h
@@ -104,8 +104,8 @@ private: // implement Node interface
 
   Node* doClone(const vm::bbox3d& worldBounds) const override;
 
-  bool doCanAddChild(const Node* child) const override;
-  bool doCanRemoveChild(const Node* child) const override;
+  bool doCanAddChild(const Node& child) const override;
+  bool doCanRemoveChild(const Node& child) const override;
   bool doRemoveIfEmpty() const override;
 
   bool doShouldAddToSpacialIndex() const override;

--- a/lib/TbMdlLib/include/mdl/VertexHandleManager.h
+++ b/lib/TbMdlLib/include/mdl/VertexHandleManager.h
@@ -55,14 +55,14 @@ public:
    * Adds all handles of the given range of brushes to this handle manager.
    *
    * @tparam R the type of the given range
-   * @param handles the handles to add
+   * @param brushNodes the brushes
    */
   template <std::ranges::range R>
-  void addHandles(const R& handles)
+  void addHandles(const R& brushNodes)
   {
-    for (const auto& handle : handles)
+    for (const auto* brushNode : brushNodes)
     {
-      addHandles(handle);
+      addHandles(*brushNode);
     }
   }
 
@@ -71,20 +71,20 @@ public:
    *
    * @param brushNode the brush whose handles to add
    */
-  virtual void addHandles(const BrushNode* brushNode) = 0;
+  virtual void addHandles(const BrushNode& brushNode) = 0;
 
   /**
    * Removes all handles of the given range of brushes from this handle manager.
    *
    * @tparam R the type of the given range
-   * @param handles the handles to remove
+   * @param brushNodes the brushes
    */
   template <std::ranges::range R>
-  void removeHandles(const R& handles)
+  void removeHandles(const R& brushNodes)
   {
-    for (const auto& handle : handles)
+    for (const auto* brushNode : brushNodes)
     {
-      removeHandles(handle);
+      removeHandles(*brushNode);
     }
   }
 
@@ -93,7 +93,7 @@ public:
    *
    * @param brushNode the brush whose handles to remove
    */
-  virtual void removeHandles(const BrushNode* brushNode) = 0;
+  virtual void removeHandles(const BrushNode& brushNode) = 0;
 };
 
 template <typename H>
@@ -541,10 +541,11 @@ public:
    * @param out an output iterator that accepts the incident brushes
    */
   template <std::ranges::range R, typename O>
-  void findIncidentBrushes(const Handle& handle, const R& brushes, O out) const
+  void findIncidentBrushes(const Handle& handle, const R& brushNodes, O out) const
   {
-    std::ranges::copy_if(
-      brushes, out, [&](const auto& brush) { return isIncident(handle, brush); });
+    std::ranges::copy_if(brushNodes, out, [&](const auto* brushNode) {
+      return isIncident(handle, *brushNode);
+    });
   }
 
 private:
@@ -555,7 +556,7 @@ private:
    * @param brushNode the brush to check
    * @return true if and only if the given brush is incident to the given handle
    */
-  virtual bool isIncident(const Handle& handle, const BrushNode* brushNode) const = 0;
+  virtual bool isIncident(const Handle& handle, const BrushNode& brushNode) const = 0;
 };
 
 /**
@@ -587,13 +588,13 @@ public:
     PickResult& pickResult) const;
 
 public:
-  void addHandles(const BrushNode* brushNode) override;
-  void removeHandles(const BrushNode* brushNode) override;
+  void addHandles(const BrushNode& brushNode) override;
+  void removeHandles(const BrushNode& brushNode) override;
 
   HitType::Type hitType() const override;
 
 private:
-  bool isIncident(const Handle& handle, const BrushNode* brushNode) const override;
+  bool isIncident(const Handle& handle, const BrushNode& brushNode) const override;
 };
 
 /**
@@ -649,13 +650,13 @@ public:
     PickResult& pickResult) const;
 
 public:
-  void addHandles(const BrushNode* brushNode) override;
-  void removeHandles(const BrushNode* brushNode) override;
+  void addHandles(const BrushNode& brushNode) override;
+  void removeHandles(const BrushNode& brushNode) override;
 
   HitType::Type hitType() const override;
 
 private:
-  bool isIncident(const Handle& handle, const BrushNode* brushNode) const override;
+  bool isIncident(const Handle& handle, const BrushNode& brushNode) const override;
 };
 
 /**
@@ -711,13 +712,13 @@ public:
     PickResult& pickResult) const;
 
 public:
-  void addHandles(const BrushNode* brushNode) override;
-  void removeHandles(const BrushNode* brushNode) override;
+  void addHandles(const BrushNode& brushNode) override;
+  void removeHandles(const BrushNode& brushNode) override;
 
   HitType::Type hitType() const override;
 
 private:
-  bool isIncident(const Handle& handle, const BrushNode* brushNode) const override;
+  bool isIncident(const Handle& handle, const BrushNode& brushNode) const override;
 };
 
 } // namespace mdl

--- a/lib/TbMdlLib/include/mdl/WorldNode.h
+++ b/lib/TbMdlLib/include/mdl/WorldNode.h
@@ -138,14 +138,14 @@ private: // implement Node interface
   double doGetProjectedArea(vm::axis::type axis) const override;
   Node* doClone(const vm::bbox3d& worldBounds) const override;
   Node* doCloneRecursively(const vm::bbox3d& worldBounds) const override;
-  bool doCanAddChild(const Node* child) const override;
-  bool doCanRemoveChild(const Node* child) const override;
+  bool doCanAddChild(const Node& child) const override;
+  bool doCanRemoveChild(const Node& child) const override;
   bool doRemoveIfEmpty() const override;
   bool doShouldAddToSpacialIndex() const override;
 
-  void doDescendantWasAdded(Node* node, size_t depth) override;
-  void doDescendantWillBeRemoved(Node* node, size_t depth) override;
-  void doDescendantPhysicalBoundsDidChange(Node* node) override;
+  void doDescendantWasAdded(Node& node, size_t depth) override;
+  void doDescendantWillBeRemoved(Node& node, size_t depth) override;
+  void doDescendantPhysicalBoundsDidChange(Node& node) override;
 
   bool doSelectable() const override;
   void doPick(

--- a/lib/TbMdlLib/src/BrushNode.cpp
+++ b/lib/TbMdlLib/src/BrushNode.cpp
@@ -63,19 +63,23 @@ const EntityNodeBase* BrushNode::entity() const
 {
   return visitParent(
            kdl::overload(
-             [](const WorldNode* world) -> const EntityNodeBase* { return world; },
-             [](const EntityNode* entity) -> const EntityNodeBase* { return entity; },
-             [](auto&& thisLambda, const LayerNode* layer) -> const EntityNodeBase* {
-               return layer->visitParent(thisLambda).value_or(nullptr);
+             [](const WorldNode& worldNode) -> const EntityNodeBase* {
+               return &worldNode;
              },
-             [](auto&& thisLambda, const GroupNode* group) -> const EntityNodeBase* {
-               return group->visitParent(thisLambda).value_or(nullptr);
+             [](const EntityNode& entityNode) -> const EntityNodeBase* {
+               return &entityNode;
              },
-             [](auto&& thisLambda, const BrushNode* brush) -> const EntityNodeBase* {
-               return brush->visitParent(thisLambda).value_or(nullptr);
+             [](auto&& thisLambda, const LayerNode& layerNode) -> const EntityNodeBase* {
+               return layerNode.visitParent(thisLambda).value_or(nullptr);
              },
-             [](auto&& thisLambda, const PatchNode* patch) -> const EntityNodeBase* {
-               return patch->visitParent(thisLambda).value_or(nullptr);
+             [](auto&& thisLambda, const GroupNode& groupNode) -> const EntityNodeBase* {
+               return groupNode.visitParent(thisLambda).value_or(nullptr);
+             },
+             [](auto&& thisLambda, const BrushNode& brushNode) -> const EntityNodeBase* {
+               return brushNode.visitParent(thisLambda).value_or(nullptr);
+             },
+             [](auto&& thisLambda, const PatchNode& patchNode) -> const EntityNodeBase* {
+               return patchNode.visitParent(thisLambda).value_or(nullptr);
              }))
     .value_or(nullptr);
 }
@@ -156,12 +160,12 @@ static bool containsPatch(const Brush& brush, const PatchGrid& grid)
 bool BrushNode::contains(const Node& node) const
 {
   return node.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [&](const GroupNode* group) { return m_brush.contains(group->logicalBounds()); },
-    [&](const EntityNode* entity) { return m_brush.contains(entity->logicalBounds()); },
-    [&](const BrushNode* brush) { return m_brush.contains(brush->brush()); },
-    [&](const PatchNode* patch) { return containsPatch(m_brush, patch->grid()); }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [&](const GroupNode& group) { return m_brush.contains(group.logicalBounds()); },
+    [&](const EntityNode& entity) { return m_brush.contains(entity.logicalBounds()); },
+    [&](const BrushNode& brush) { return m_brush.contains(brush.brush()); },
+    [&](const PatchNode& patch) { return containsPatch(m_brush, patch.grid()); }));
 }
 
 static bool faceIntersectsEdge(
@@ -230,12 +234,12 @@ static bool intersectsPatch(const Brush& brush, const PatchGrid& grid)
 bool BrushNode::intersects(const Node& node) const
 {
   return node.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [&](const GroupNode* group) { return m_brush.intersects(group->logicalBounds()); },
-    [&](const EntityNode* entity) { return m_brush.intersects(entity->logicalBounds()); },
-    [&](const BrushNode* brush) { return m_brush.intersects(brush->brush()); },
-    [&](const PatchNode* patch) { return intersectsPatch(m_brush, patch->grid()); }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [&](const GroupNode& group) { return m_brush.intersects(group.logicalBounds()); },
+    [&](const EntityNode& entity) { return m_brush.intersects(entity.logicalBounds()); },
+    [&](const BrushNode& brush) { return m_brush.intersects(brush.brush()); },
+    [&](const PatchNode& patch) { return intersectsPatch(m_brush, patch.grid()); }));
 }
 
 void BrushNode::clearSelectedFaces()
@@ -330,12 +334,12 @@ bool BrushNode::doSelectable() const
 
 void BrushNode::doAccept(NodeVisitor& visitor)
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void BrushNode::doAccept(ConstNodeVisitor& visitor) const
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void BrushNode::doPick(

--- a/lib/TbMdlLib/src/BrushNode.cpp
+++ b/lib/TbMdlLib/src/BrushNode.cpp
@@ -153,9 +153,9 @@ static bool containsPatch(const Brush& brush, const PatchGrid& grid)
   return true;
 }
 
-bool BrushNode::contains(const Node* node) const
+bool BrushNode::contains(const Node& node) const
 {
-  return node->accept(kdl::overload(
+  return node.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return false; },
     [&](const GroupNode* group) { return m_brush.contains(group->logicalBounds()); },
@@ -227,9 +227,9 @@ static bool intersectsPatch(const Brush& brush, const PatchGrid& grid)
   return false;
 }
 
-bool BrushNode::intersects(const Node* node) const
+bool BrushNode::intersects(const Node& node) const
 {
-  return node->accept(kdl::overload(
+  return node.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return false; },
     [&](const GroupNode* group) { return m_brush.intersects(group->logicalBounds()); },
@@ -303,12 +303,12 @@ Node* BrushNode::doClone(const vm::bbox3d& /* worldBounds */) const
   return result.release();
 }
 
-bool BrushNode::doCanAddChild(const Node* /* child */) const
+bool BrushNode::doCanAddChild(const Node&) const
 {
   return false;
 }
 
-bool BrushNode::doCanRemoveChild(const Node* /* child */) const
+bool BrushNode::doCanRemoveChild(const Node&) const
 {
   return false;
 }

--- a/lib/TbMdlLib/src/ColorRange.cpp
+++ b/lib/TbMdlLib/src/ColorRange.cpp
@@ -57,8 +57,8 @@ ColorRange::Type detectColorRange(
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [&](const EntityNodeBase* entityNode) {
-        if (const auto* value = entityNode->entity().property(propertyKey))
+      [&](const EntityNodeBase& entityNode) {
+        if (const auto* value = entityNode.entity().property(propertyKey))
         {
           setResult(detectColorRange(*value));
         }
@@ -82,10 +82,10 @@ ColorRange::Type detectColorRange(
             propDef->valueType);
         }
       },
-      [](const LayerNode*) {},
-      [](const GroupNode*) {},
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const LayerNode&) {},
+      [](const GroupNode&) {},
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
   }
   return result;
 }

--- a/lib/TbMdlLib/src/EditorContext.cpp
+++ b/lib/TbMdlLib/src/EditorContext.cpp
@@ -177,12 +177,12 @@ void EditorContext::setUVLock(const bool uvLock)
 bool EditorContext::visible(const Node& node) const
 {
   return node.accept(kdl::overload(
-    [&](const WorldNode* worldNode) { return visible(*worldNode); },
-    [&](const LayerNode* layerNode) { return visible(*layerNode); },
-    [&](const GroupNode* groupNode) { return visible(*groupNode); },
-    [&](const EntityNode* entityNode) { return visible(*entityNode); },
-    [&](const BrushNode* brushNode) { return visible(*brushNode); },
-    [&](const PatchNode* patchNode) { return visible(*patchNode); }));
+    [&](const WorldNode& worldNode) { return visible(worldNode); },
+    [&](const LayerNode& layerNode) { return visible(layerNode); },
+    [&](const GroupNode& groupNode) { return visible(groupNode); },
+    [&](const EntityNode& entityNode) { return visible(entityNode); },
+    [&](const BrushNode& brushNode) { return visible(brushNode); },
+    [&](const PatchNode& patchNode) { return visible(patchNode); }));
 }
 
 bool EditorContext::visible(const WorldNode& worldNode) const
@@ -309,12 +309,12 @@ bool EditorContext::editable(const BrushNode& brushNode, const BrushFace&) const
 bool EditorContext::selectable(const Node& node) const
 {
   return node.accept(kdl::overload(
-    [&](const WorldNode* worldNode) { return selectable(*worldNode); },
-    [&](const LayerNode* layerNode) { return selectable(*layerNode); },
-    [&](const GroupNode* groupNode) { return selectable(*groupNode); },
-    [&](const EntityNode* entityNode) { return selectable(*entityNode); },
-    [&](const BrushNode* brushNode) { return selectable(*brushNode); },
-    [&](const PatchNode* patchNode) { return selectable(*patchNode); }));
+    [&](const WorldNode& worldNode) { return selectable(worldNode); },
+    [&](const LayerNode& layerNode) { return selectable(layerNode); },
+    [&](const GroupNode& groupNode) { return selectable(groupNode); },
+    [&](const EntityNode& entityNode) { return selectable(entityNode); },
+    [&](const BrushNode& brushNode) { return selectable(brushNode); },
+    [&](const PatchNode& patchNode) { return selectable(patchNode); }));
 }
 
 bool EditorContext::selectable(const WorldNode&) const

--- a/lib/TbMdlLib/src/EntityDefinitionManager.cpp
+++ b/lib/TbMdlLib/src/EntityDefinitionManager.cpp
@@ -23,8 +23,6 @@
 #include "mdl/EntityDefinitionUtils.h"
 #include "mdl/EntityNodeBase.h"
 
-#include "kd/contracts.h"
-
 #include <algorithm>
 #include <string>
 #include <unordered_map>
@@ -55,11 +53,9 @@ void EntityDefinitionManager::clear()
 }
 
 const EntityDefinition* EntityDefinitionManager::definition(
-  const EntityNodeBase* node) const
+  const EntityNodeBase& node) const
 {
-  contract_pre(node != nullptr);
-
-  return definition(node->entity().classname());
+  return definition(node.entity().classname());
 }
 
 const EntityDefinition* EntityDefinitionManager::definition(

--- a/lib/TbMdlLib/src/EntityNode.cpp
+++ b/lib/TbMdlLib/src/EntityNode.cpp
@@ -103,12 +103,12 @@ Node* EntityNode::doClone(const vm::bbox3d& /* worldBounds */) const
 bool EntityNode::doCanAddChild(const Node& child) const
 {
   return child.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [](const GroupNode*) { return false; },
-    [](const EntityNode*) { return false; },
-    [](const BrushNode*) { return true; },
-    [](const PatchNode*) { return true; }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [](const GroupNode&) { return false; },
+    [](const EntityNode&) { return false; },
+    [](const BrushNode&) { return true; },
+    [](const PatchNode&) { return true; }));
 }
 
 bool EntityNode::doCanRemoveChild(const Node&) const
@@ -213,12 +213,12 @@ void EntityNode::doFindNodesContaining(const vm::vec3d& point, std::vector<Node*
 
 void EntityNode::doAccept(NodeVisitor& visitor)
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void EntityNode::doAccept(ConstNodeVisitor& visitor) const
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 std::vector<Node*> EntityNode::nodesRequiredForViewSelection()

--- a/lib/TbMdlLib/src/EntityNode.cpp
+++ b/lib/TbMdlLib/src/EntityNode.cpp
@@ -100,9 +100,9 @@ Node* EntityNode::doClone(const vm::bbox3d& /* worldBounds */) const
   return result.release();
 }
 
-bool EntityNode::doCanAddChild(const Node* child) const
+bool EntityNode::doCanAddChild(const Node& child) const
 {
-  return child->accept(kdl::overload(
+  return child.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return false; },
     [](const GroupNode*) { return false; },
@@ -111,7 +111,7 @@ bool EntityNode::doCanAddChild(const Node* child) const
     [](const PatchNode*) { return true; }));
 }
 
-bool EntityNode::doCanRemoveChild(const Node* /* child */) const
+bool EntityNode::doCanRemoveChild(const Node&) const
 {
   return true;
 }
@@ -126,13 +126,13 @@ bool EntityNode::doShouldAddToSpacialIndex() const
   return true;
 }
 
-void EntityNode::doChildWasAdded(Node* /* node */)
+void EntityNode::doChildWasAdded(Node&)
 {
   m_entity.setPointEntity(!hasChildren());
   nodePhysicalBoundsDidChange();
 }
 
-void EntityNode::doChildWasRemoved(Node* /* node */)
+void EntityNode::doChildWasRemoved(Node&)
 {
   m_entity.setPointEntity(!hasChildren());
   nodePhysicalBoundsDidChange();

--- a/lib/TbMdlLib/src/GroupNode.cpp
+++ b/lib/TbMdlLib/src/GroupNode.cpp
@@ -121,17 +121,25 @@ void GroupNode::setEditState(const EditState editState)
 void GroupNode::setAncestorEditState(const EditState editState)
 {
   visitParent(kdl::overload(
-    [=](auto&& thisLambda, WorldNode* world) -> void { world->visitParent(thisLambda); },
-    [=](auto&& thisLambda, LayerNode* layer) -> void { layer->visitParent(thisLambda); },
-    [=](auto&& thisLambda, GroupNode* group) -> void {
-      group->setEditState(editState);
-      group->visitParent(thisLambda);
+    [=](auto&& thisLambda, WorldNode& worldNode) -> void {
+      worldNode.visitParent(thisLambda);
     },
-    [=](
-      auto&& thisLambda, EntityNode* entity) -> void { entity->visitParent(thisLambda); },
-    [=](auto&& thisLambda, BrushNode* brush) -> void { brush->visitParent(thisLambda); },
-    [=](
-      auto&& thisLambda, PatchNode* patch) -> void { patch->visitParent(thisLambda); }));
+    [=](auto&& thisLambda, LayerNode& layerNode) -> void {
+      layerNode.visitParent(thisLambda);
+    },
+    [=](auto&& thisLambda, GroupNode& groupNode) -> void {
+      groupNode.setEditState(editState);
+      groupNode.visitParent(thisLambda);
+    },
+    [=](auto&& thisLambda, EntityNode& entityNode) -> void {
+      entityNode.visitParent(thisLambda);
+    },
+    [=](auto&& thisLambda, BrushNode& brushNode) -> void {
+      brushNode.visitParent(thisLambda);
+    },
+    [=](auto&& thisLambda, PatchNode& patchNode) -> void {
+      patchNode.visitParent(thisLambda);
+    }));
 }
 
 void GroupNode::openAncestors()
@@ -198,14 +206,14 @@ bool checkRecursiveLinkedGroups(const Node& parentNode, const GroupNode& groupNo
 bool GroupNode::doCanAddChild(const Node& child) const
 {
   return child.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [&](const GroupNode* groupNode) {
-      return !checkRecursiveLinkedGroups(*this, *groupNode);
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [&](const GroupNode& groupNode) {
+      return !checkRecursiveLinkedGroups(*this, groupNode);
     },
-    [](const EntityNode*) { return true; },
-    [](const BrushNode*) { return true; },
-    [](const PatchNode*) { return true; }));
+    [](const EntityNode&) { return true; },
+    [](const BrushNode&) { return true; },
+    [](const PatchNode&) { return true; }));
 }
 
 bool GroupNode::doCanRemoveChild(const Node&) const
@@ -274,12 +282,12 @@ void GroupNode::doFindNodesContaining(const vm::vec3d& point, std::vector<Node*>
 
 void GroupNode::doAccept(NodeVisitor& visitor)
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void GroupNode::doAccept(ConstNodeVisitor& visitor) const
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 Node* GroupNode::doGetContainer()

--- a/lib/TbMdlLib/src/GroupNode.cpp
+++ b/lib/TbMdlLib/src/GroupNode.cpp
@@ -195,9 +195,9 @@ bool checkRecursiveLinkedGroups(const Node& parentNode, const GroupNode& groupNo
 }
 } // namespace
 
-bool GroupNode::doCanAddChild(const Node* child) const
+bool GroupNode::doCanAddChild(const Node& child) const
 {
-  return child->accept(kdl::overload(
+  return child.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return false; },
     [&](const GroupNode* groupNode) {
@@ -208,7 +208,7 @@ bool GroupNode::doCanAddChild(const Node* child) const
     [](const PatchNode*) { return true; }));
 }
 
-bool GroupNode::doCanRemoveChild(const Node* /* child */) const
+bool GroupNode::doCanRemoveChild(const Node&) const
 {
   return true;
 }
@@ -223,12 +223,12 @@ bool GroupNode::doShouldAddToSpacialIndex() const
   return false;
 }
 
-void GroupNode::doChildWasAdded(Node* /* node */)
+void GroupNode::doChildWasAdded(Node&)
 {
   nodePhysicalBoundsDidChange();
 }
 
-void GroupNode::doChildWasRemoved(Node* /* node */)
+void GroupNode::doChildWasRemoved(Node&)
 {
   nodePhysicalBoundsDidChange();
 }

--- a/lib/TbMdlLib/src/Issue.cpp
+++ b/lib/TbMdlLib/src/Issue.cpp
@@ -78,21 +78,21 @@ bool Issue::addSelectableNodes(std::vector<Node*>& nodes) const
   }
 
   m_node.accept(kdl::overload(
-    [](WorldNode*) {},
-    [](LayerNode*) {},
-    [&](GroupNode* group) { nodes.push_back(group); },
-    [&](auto&& thisLambda, EntityNode* entity) {
-      if (!entity->hasChildren())
+    [](WorldNode&) {},
+    [](LayerNode&) {},
+    [&](GroupNode& groupNode) { nodes.push_back(&groupNode); },
+    [&](auto&& thisLambda, EntityNode& entityNode) {
+      if (!entityNode.hasChildren())
       {
-        nodes.push_back(entity);
+        nodes.push_back(&entityNode);
       }
       else
       {
-        entity->visitChildren(thisLambda);
+        entityNode.visitChildren(thisLambda);
       }
     },
-    [&](BrushNode* brush) { nodes.push_back(brush); },
-    [&](PatchNode* patch) { nodes.push_back(patch); }));
+    [&](BrushNode& brushNode) { nodes.push_back(&brushNode); },
+    [&](PatchNode& patchNode) { nodes.push_back(&patchNode); }));
 
   return true;
 }

--- a/lib/TbMdlLib/src/LayerNode.cpp
+++ b/lib/TbMdlLib/src/LayerNode.cpp
@@ -123,12 +123,12 @@ Node* LayerNode::doClone(const vm::bbox3d&) const
 bool LayerNode::doCanAddChild(const Node& child) const
 {
   return child.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [](const GroupNode*) { return true; },
-    [](const EntityNode*) { return true; },
-    [](const BrushNode*) { return true; },
-    [](const PatchNode*) { return true; }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [](const GroupNode&) { return true; },
+    [](const EntityNode&) { return true; },
+    [](const BrushNode&) { return true; },
+    [](const PatchNode&) { return true; }));
 }
 
 bool LayerNode::doCanRemoveChild(const Node&) const
@@ -168,12 +168,12 @@ void LayerNode::doFindNodesContaining(const vm::vec3d& point, std::vector<Node*>
 
 void LayerNode::doAccept(NodeVisitor& visitor)
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void LayerNode::doAccept(ConstNodeVisitor& visitor) const
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void LayerNode::invalidateBounds()

--- a/lib/TbMdlLib/src/LayerNode.cpp
+++ b/lib/TbMdlLib/src/LayerNode.cpp
@@ -120,9 +120,9 @@ Node* LayerNode::doClone(const vm::bbox3d&) const
   return result.release();
 }
 
-bool LayerNode::doCanAddChild(const Node* child) const
+bool LayerNode::doCanAddChild(const Node& child) const
 {
-  return child->accept(kdl::overload(
+  return child.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return false; },
     [](const GroupNode*) { return true; },
@@ -131,7 +131,7 @@ bool LayerNode::doCanAddChild(const Node* child) const
     [](const PatchNode*) { return true; }));
 }
 
-bool LayerNode::doCanRemoveChild(const Node* /* child */) const
+bool LayerNode::doCanRemoveChild(const Node&) const
 {
   return true;
 }

--- a/lib/TbMdlLib/src/LinkedGroupUtils.cpp
+++ b/lib/TbMdlLib/src/LinkedGroupUtils.cpp
@@ -47,19 +47,17 @@ std::vector<Node*> collectNodesWithLinkId(
   return collectNodesAndDescendants(
     nodes,
     kdl::overload(
-      [&](const GroupNode* groupNode) { return groupNode->linkId() == linkId; },
-      [&](const EntityNode* entityNode) { return entityNode->linkId() == linkId; },
-      [&](const BrushNode* brushNode) { return brushNode->linkId() == linkId; },
-      [&](const PatchNode* patchNode) { return patchNode->linkId() == linkId; }));
+      [&](const GroupNode& groupNode) { return groupNode.linkId() == linkId; },
+      [&](const EntityNode& entityNode) { return entityNode.linkId() == linkId; },
+      [&](const BrushNode& brushNode) { return brushNode.linkId() == linkId; },
+      [&](const PatchNode& patchNode) { return patchNode.linkId() == linkId; }));
 }
 
 std::vector<GroupNode*> collectGroupsWithLinkId(
   const std::vector<Node*>& nodes, const std::string& linkId)
 {
-  return kdl::vec_static_cast<GroupNode*>(
-    collectNodesAndDescendants(nodes, kdl::overload([&](const GroupNode* groupNode) {
-                                 return groupNode->linkId() == linkId;
-                               })));
+  return kdl::vec_static_cast<GroupNode*>(collectNodesAndDescendants(
+    nodes, [&](const GroupNode& groupNode) { return groupNode.linkId() == linkId; }));
 }
 
 std::vector<std::string> collectLinkedGroupIds(const std::vector<Node*>& nodes)
@@ -69,19 +67,19 @@ std::vector<std::string> collectLinkedGroupIds(const std::vector<Node*>& nodes)
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](auto&& thisLambda, const WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, const GroupNode* groupNode) {
-        result.push_back(groupNode->linkId());
-        groupNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const GroupNode& groupNode) {
+        result.push_back(groupNode.linkId());
+        groupNode.visitChildren(thisLambda);
       },
-      [](const EntityNode*) {},
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const EntityNode&) {},
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 
@@ -212,31 +210,32 @@ Result<std::unique_ptr<Node>> cloneAndTransformRecursive(
   // First, clone `n`, and move in the new (transformed) content which was
   // prepared for it above
   auto clone = nodeToClone->accept(kdl::overload(
-    [](const WorldNode*) -> std::unique_ptr<Node> { contract_assert(false); },
-    [](const LayerNode*) -> std::unique_ptr<Node> { contract_assert(false); },
-    [&](const GroupNode* groupNode) -> std::unique_ptr<Node> {
-      auto& group = std::get<Group>(origNodeToTransformedContents.at(groupNode).get());
+    [](const WorldNode&) -> std::unique_ptr<Node> { contract_assert(false); },
+    [](const LayerNode&) -> std::unique_ptr<Node> { contract_assert(false); },
+    [&](const GroupNode& groupNode) -> std::unique_ptr<Node> {
+      auto& group = std::get<Group>(origNodeToTransformedContents.at(&groupNode).get());
       auto newGroupNode = std::make_unique<GroupNode>(std::move(group));
-      newGroupNode->setLinkId(groupNode->linkId());
+      newGroupNode->setLinkId(groupNode.linkId());
       return newGroupNode;
     },
-    [&](const EntityNode* entityNode) -> std::unique_ptr<Node> {
-      auto& entity = std::get<Entity>(origNodeToTransformedContents.at(entityNode).get());
+    [&](const EntityNode& entityNode) -> std::unique_ptr<Node> {
+      auto& entity =
+        std::get<Entity>(origNodeToTransformedContents.at(&entityNode).get());
       auto newEntityNode = std::make_unique<EntityNode>(std::move(entity));
-      newEntityNode->setLinkId(entityNode->linkId());
+      newEntityNode->setLinkId(entityNode.linkId());
       return newEntityNode;
     },
-    [&](const BrushNode* brushNode) -> std::unique_ptr<Node> {
-      auto& brush = std::get<Brush>(origNodeToTransformedContents.at(brushNode).get());
+    [&](const BrushNode& brushNode) -> std::unique_ptr<Node> {
+      auto& brush = std::get<Brush>(origNodeToTransformedContents.at(&brushNode).get());
       auto newBrushNode = std::make_unique<BrushNode>(std::move(brush));
-      newBrushNode->setLinkId(brushNode->linkId());
+      newBrushNode->setLinkId(brushNode.linkId());
       return newBrushNode;
     },
-    [&](const PatchNode* patchNode) -> std::unique_ptr<Node> {
+    [&](const PatchNode& patchNode) -> std::unique_ptr<Node> {
       auto& patch =
-        std::get<BezierPatch>(origNodeToTransformedContents.at(patchNode).get());
+        std::get<BezierPatch>(origNodeToTransformedContents.at(&patchNode).get());
       auto newPatchNode = std::make_unique<PatchNode>(std::move(patch));
-      newPatchNode->setLinkId(patchNode->linkId());
+      newPatchNode->setLinkId(patchNode.linkId());
       return newPatchNode;
     }));
 
@@ -280,30 +279,30 @@ Result<std::vector<std::unique_ptr<Node>>> cloneAndTransformChildren(
     nodesToClone | std::views::transform([&](const auto& nodeToTransform) {
       return std::function{[&]() {
         return nodeToTransform->accept(kdl::overload(
-          [](const WorldNode*) -> TransformResult { contract_assert(false); },
-          [](const LayerNode*) -> TransformResult { contract_assert(false); },
-          [&](const GroupNode* groupNode) -> TransformResult {
-            auto group = groupNode->group();
+          [](const WorldNode&) -> TransformResult { contract_assert(false); },
+          [](const LayerNode&) -> TransformResult { contract_assert(false); },
+          [&](const GroupNode& groupNode) -> TransformResult {
+            auto group = groupNode.group();
             group.transform(transformation);
             return std::make_pair(nodeToTransform, NodeContents{std::move(group)});
           },
-          [&](const EntityNode* entityNode) -> TransformResult {
+          [&](const EntityNode& entityNode) -> TransformResult {
             const auto updateAngleProperty =
-              entityNode->entityPropertyConfig().updateAnglePropertyAfterTransform;
-            auto entity = entityNode->entity();
+              entityNode.entityPropertyConfig().updateAnglePropertyAfterTransform;
+            auto entity = entityNode.entity();
             entity.transform(transformation, updateAngleProperty);
             return std::make_pair(nodeToTransform, NodeContents{std::move(entity)});
           },
-          [&](const BrushNode* brushNode) -> TransformResult {
-            auto brush = brushNode->brush();
+          [&](const BrushNode& brushNode) -> TransformResult {
+            auto brush = brushNode.brush();
             return brush.transform(worldBounds, transformation, true)
                    | kdl::and_then([&]() -> TransformResult {
                        return std::make_pair(
                          nodeToTransform, NodeContents{std::move(brush)});
                      });
           },
-          [&](const PatchNode* patchNode) -> TransformResult {
-            auto patch = patchNode->patch();
+          [&](const PatchNode& patchNode) -> TransformResult {
+            auto patch = patchNode.patch();
             patch.transform(transformation);
             return std::make_pair(nodeToTransform, NodeContents{std::move(patch)});
           }));
@@ -341,22 +340,22 @@ auto makeLinkIdToNodeMap(const std::vector<Node*>& nodes)
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](auto&& thisLambda, const WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, const GroupNode* groupNode) {
-        result[groupNode->linkId()] = groupNode;
-        groupNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const GroupNode& groupNode) {
+        result[groupNode.linkId()] = &groupNode;
+        groupNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, const EntityNode* entityNode) {
-        result[entityNode->linkId()] = entityNode;
-        entityNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, const EntityNode& entityNode) {
+        result[entityNode.linkId()] = &entityNode;
+        entityNode.visitChildren(thisLambda);
       },
-      [&](const BrushNode* brushNode) { result[brushNode->linkId()] = brushNode; },
-      [&](const PatchNode* patchNode) { result[patchNode->linkId()] = patchNode; }));
+      [&](const BrushNode& brushNode) { result[brushNode.linkId()] = &brushNode; },
+      [&](const PatchNode& patchNode) { result[patchNode.linkId()] = &patchNode; }));
   return result;
 }
 
@@ -377,26 +376,26 @@ void preserveGroupNames(
   return Node::visitAll(
     clonedNodes,
     kdl::overload(
-      [](auto&& thisLambda, const WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, GroupNode* groupNode) {
+      [&](auto&& thisLambda, GroupNode& groupNode) {
         if (
           const auto* correspondingNode =
-            getCorrespondingNode<GroupNode>(correspondingNodes, groupNode->linkId()))
+            getCorrespondingNode<GroupNode>(correspondingNodes, groupNode.linkId()))
         {
-          auto group = groupNode->group();
+          auto group = groupNode.group();
           group.setName(correspondingNode->group().name());
-          groupNode->setGroup(std::move(group));
+          groupNode.setGroup(std::move(group));
         }
-        groupNode->visitChildren(thisLambda);
+        groupNode.visitChildren(thisLambda);
       },
-      [](const EntityNode*) {},
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const EntityNode&) {},
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
 }
 
 void preserveEntityProperties(
@@ -438,25 +437,25 @@ void preserveEntityProperties(
   return Node::visitAll(
     clonedNodes,
     kdl::overload(
-      [](auto&& thisLambda, const WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const GroupNode* groupNode) {
-        groupNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const GroupNode& groupNode) {
+        groupNode.visitChildren(thisLambda);
       },
-      [&](EntityNode* entityNode) {
+      [&](EntityNode& entityNode) {
         if (
           const auto* correspondingNode =
-            getCorrespondingNode<EntityNode>(correspondingNodes, entityNode->linkId()))
+            getCorrespondingNode<EntityNode>(correspondingNodes, entityNode.linkId()))
         {
-          preserveEntityProperties(*entityNode, *correspondingNode);
+          preserveEntityProperties(entityNode, *correspondingNode);
         }
       },
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
 }
 } // namespace
 
@@ -518,31 +517,31 @@ Result<void> visitNodesPerPosition(
   const size_t depth = 0)
 {
   return sourceNode.accept(kdl::overload(
-    [&](const WorldNode* sourceWorldNode) {
+    [&](const WorldNode& sourceWorldNode) {
       return tryCast<WorldNode>(targetNode)
              | kdl::transform(
-               [&](WorldNode* targetWorldNode) { f(*sourceWorldNode, *targetWorldNode); })
+               [&](WorldNode* targetWorldNode) { f(sourceWorldNode, *targetWorldNode); })
              | kdl::and_then([&]() {
                  return visitChildrenPerPosition(
                    sourceNode, targetNode, f, recursionMode, depth);
                });
       ;
     },
-    [&](const LayerNode* sourceLayerNode) {
+    [&](const LayerNode& sourceLayerNode) {
       return tryCast<LayerNode>(targetNode)
              | kdl::transform(
-               [&](LayerNode* targetLayerNode) { f(*sourceLayerNode, *targetLayerNode); })
+               [&](LayerNode* targetLayerNode) { f(sourceLayerNode, *targetLayerNode); })
              | kdl::and_then([&]() {
                  return visitChildrenPerPosition(
                    sourceNode, targetNode, f, recursionMode, depth);
                });
       ;
     },
-    [&](const GroupNode* sourceGroupNode) {
+    [&](const GroupNode& sourceGroupNode) {
       return depth == 0 || recursionMode == GroupRecursionMode::Deep
                ? tryCast<GroupNode>(targetNode)
                    | kdl::transform([&](GroupNode* targetGroupNode) {
-                       f(*sourceGroupNode, *targetGroupNode);
+                       f(sourceGroupNode, *targetGroupNode);
                      })
                    | kdl::and_then([&]() {
                        return visitChildrenPerPosition(
@@ -551,10 +550,10 @@ Result<void> visitNodesPerPosition(
                : Result<void>{};
       ;
     },
-    [&](const EntityNode* sourceEntityNode) {
+    [&](const EntityNode& sourceEntityNode) {
       return tryCast<EntityNode>(targetNode)
              | kdl::transform([&](EntityNode* targetEntityNode) {
-                 f(*sourceEntityNode, *targetEntityNode);
+                 f(sourceEntityNode, *targetEntityNode);
                })
              | kdl::and_then([&]() {
                  return visitChildrenPerPosition(
@@ -562,17 +561,15 @@ Result<void> visitNodesPerPosition(
                });
       ;
     },
-    [&](const BrushNode* sourceBrushNode) {
+    [&](const BrushNode& sourceBrushNode) {
       return tryCast<BrushNode>(targetNode)
-             | kdl::transform([&](BrushNode* targetBrushNode) {
-                 f(*sourceBrushNode, *targetBrushNode);
-               });
+             | kdl::transform(
+               [&](BrushNode* targetBrushNode) { f(sourceBrushNode, *targetBrushNode); });
     },
-    [&](const PatchNode* sourcePatchNode) {
+    [&](const PatchNode& sourcePatchNode) {
       return tryCast<PatchNode>(targetNode)
-             | kdl::transform([&](PatchNode* targetPatchNode) {
-                 f(*sourcePatchNode, *targetPatchNode);
-               });
+             | kdl::transform(
+               [&](PatchNode* targetPatchNode) { f(sourcePatchNode, *targetPatchNode); });
     }));
 }
 
@@ -662,9 +659,9 @@ void setLinkIds(
     for (auto& [node, linkId] : linkIds)
     {
       node->accept(kdl::overload(
-        [](const WorldNode*) {},
-        [](const LayerNode*) {},
-        [&](Object* object) { object->setLinkId(std::move(linkId)); }));
+        [](const WorldNode&) {},
+        [](const LayerNode&) {},
+        [&](Object& object) { object.setLinkId(std::move(linkId)); }));
     }
   }) | kdl::transform_error([&](auto e) {
     for (auto* linkedGroupNode : groups)
@@ -682,15 +679,15 @@ void resetLinkIds(GroupNode& rootNode)
 {
   rootNode.setLinkId(generateUuid());
   rootNode.visitChildren(kdl::overload(
-    [](const WorldNode*) {},
-    [](const LayerNode*) {},
-    [](const GroupNode*) {},
-    [](auto&& thisLambda, EntityNode* entityNode) {
-      entityNode->setLinkId(generateUuid());
-      entityNode->visitChildren(thisLambda);
+    [](const WorldNode&) {},
+    [](const LayerNode&) {},
+    [](const GroupNode&) {},
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.setLinkId(generateUuid());
+      entityNode.visitChildren(thisLambda);
     },
-    [](BrushNode* brushNode) { brushNode->setLinkId(generateUuid()); },
-    [](PatchNode* patchNode) { patchNode->setLinkId(generateUuid()); }));
+    [](BrushNode& brushNode) { brushNode.setLinkId(generateUuid()); },
+    [](PatchNode& patchNode) { patchNode.setLinkId(generateUuid()); }));
 }
 
 } // namespace

--- a/lib/TbMdlLib/src/Map.cpp
+++ b/lib/TbMdlLib/src/Map.cpp
@@ -287,153 +287,153 @@ auto findEntityDefinitionFile(
 auto makeInitializeNodeTagsVisitor(TagManager& tagManager)
 {
   return kdl::overload(
-    [&](auto&& thisLambda, WorldNode* world) {
-      world->initializeTags(tagManager);
-      world->visitChildren(thisLambda);
+    [&](auto&& thisLambda, WorldNode& worldNode) {
+      worldNode.initializeTags(tagManager);
+      worldNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, LayerNode* layer) {
-      layer->initializeTags(tagManager);
-      layer->visitChildren(thisLambda);
+    [&](auto&& thisLambda, LayerNode& layerNode) {
+      layerNode.initializeTags(tagManager);
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, GroupNode* group) {
-      group->initializeTags(tagManager);
-      group->visitChildren(thisLambda);
+    [&](auto&& thisLambda, GroupNode& groupNode) {
+      groupNode.initializeTags(tagManager);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, EntityNode* entity) {
-      entity->initializeTags(tagManager);
-      entity->visitChildren(thisLambda);
+    [&](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.initializeTags(tagManager);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](BrushNode* brush) { brush->initializeTags(tagManager); },
-    [&](PatchNode* patch) { patch->initializeTags(tagManager); });
+    [&](BrushNode& brushNode) { brushNode.initializeTags(tagManager); },
+    [&](PatchNode& patchNode) { patchNode.initializeTags(tagManager); });
 }
 
 auto makeClearNodeTagsVisitor()
 {
   return kdl::overload(
-    [](auto&& thisLambda, WorldNode* world) {
-      world->clearTags();
-      world->visitChildren(thisLambda);
+    [](auto&& thisLambda, WorldNode& worldNode) {
+      worldNode.clearTags();
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, LayerNode* layer) {
-      layer->clearTags();
-      layer->visitChildren(thisLambda);
+    [](auto&& thisLambda, LayerNode& layerNode) {
+      layerNode.clearTags();
+      layerNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, GroupNode* group) {
-      group->clearTags();
-      group->visitChildren(thisLambda);
+    [](auto&& thisLambda, GroupNode& groupNode) {
+      groupNode.clearTags();
+      groupNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, EntityNode* entity) {
-      entity->clearTags();
-      entity->visitChildren(thisLambda);
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.clearTags();
+      entityNode.visitChildren(thisLambda);
     },
-    [](BrushNode* brush) { brush->clearTags(); },
-    [](PatchNode* patch) { patch->clearTags(); });
+    [](BrushNode& brushNode) { brushNode.clearTags(); },
+    [](PatchNode& patchNode) { patchNode.clearTags(); });
 }
 
 auto makeSetMaterialsVisitor(gl::MaterialManager& manager)
 {
   return kdl::overload(
-    [](auto&& thisLambda, WorldNode* worldNode) { worldNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layerNode) { layerNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* groupNode) { groupNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, EntityNode* entityNode) {
-      entityNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.visitChildren(thisLambda);
     },
-    [&](BrushNode* brushNode) {
-      const auto& brush = brushNode->brush();
+    [&](BrushNode& brushNode) {
+      const auto& brush = brushNode.brush();
       for (size_t i = 0u; i < brush.faceCount(); ++i)
       {
         const auto& face = brush.face(i);
         auto* material = manager.material(face.attributes().materialName());
-        brushNode->setFaceMaterial(i, material);
+        brushNode.setFaceMaterial(i, material);
       }
     },
-    [&](PatchNode* patchNode) {
-      auto* material = manager.material(patchNode->patch().materialName());
-      patchNode->setMaterial(material);
+    [&](PatchNode& patchNode) {
+      auto* material = manager.material(patchNode.patch().materialName());
+      patchNode.setMaterial(material);
     });
 }
 
 auto makeUnsetMaterialsVisitor()
 {
   return kdl::overload(
-    [](auto&& thisLambda, WorldNode* worldNode) { worldNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layerNode) { layerNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* groupNode) { groupNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, EntityNode* entityNode) {
-      entityNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.visitChildren(thisLambda);
     },
-    [](BrushNode* brushNode) {
-      const auto& brush = brushNode->brush();
+    [](BrushNode& brushNode) {
+      const auto& brush = brushNode.brush();
       for (size_t i = 0u; i < brush.faceCount(); ++i)
       {
-        brushNode->setFaceMaterial(i, nullptr);
+        brushNode.setFaceMaterial(i, nullptr);
       }
     },
-    [](PatchNode* patchNode) { patchNode->setMaterial(nullptr); });
+    [](PatchNode& patchNode) { patchNode.setMaterial(nullptr); });
 }
 
 auto makeSetEntityDefinitionsVisitor(EntityDefinitionManager& manager)
 {
   // this helper lambda must be captured by value
-  const auto setEntityDefinition = [&](auto* node) {
-    const auto* definition = manager.definition(*node);
-    node->setDefinition(definition);
+  const auto setEntityDefinition = [&](auto& node) {
+    const auto* definition = manager.definition(node);
+    node.setDefinition(definition);
   };
 
   return kdl::overload(
-    [=](auto&& thisLambda, WorldNode* worldNode) {
+    [=](auto&& thisLambda, WorldNode& worldNode) {
       setEntityDefinition(worldNode);
-      worldNode->visitChildren(thisLambda);
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, LayerNode* layerNode) { layerNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* groupNode) { groupNode->visitChildren(thisLambda); },
-    [=](EntityNode* entityNode) { setEntityDefinition(entityNode); },
-    [](BrushNode*) {},
-    [](PatchNode*) {});
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [=](EntityNode& entityNode) { setEntityDefinition(entityNode); },
+    [](BrushNode&) {},
+    [](PatchNode&) {});
 }
 
 auto makeUnsetEntityDefinitionsVisitor()
 {
   return kdl::overload(
-    [](auto&& thisLambda, WorldNode* worldNode) {
-      worldNode->setDefinition(nullptr);
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, WorldNode& worldNode) {
+      worldNode.setDefinition(nullptr);
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, LayerNode* layerNode) { layerNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* groupNode) { groupNode->visitChildren(thisLambda); },
-    [](EntityNode* entityNode) { entityNode->setDefinition(nullptr); },
-    [](BrushNode*) {},
-    [](PatchNode*) {});
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](EntityNode& entityNode) { entityNode.setDefinition(nullptr); },
+    [](BrushNode&) {},
+    [](PatchNode&) {});
 }
 
 auto makeSetEntityModelsVisitor(EntityModelManager& manager, Logger& logger)
 {
   return kdl::overload(
-    [](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
-    [&](EntityNode* entityNode) {
+    [](auto&& thisLambda, WorldNode& world) { world.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layer) { layer.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& group) { group.visitChildren(thisLambda); },
+    [&](EntityNode& entityNode) {
       const auto modelSpec =
-        safeGetModelSpecification(logger, entityNode->entity().classname(), [&]() {
-          return entityNode->entity().modelSpecification();
+        safeGetModelSpecification(logger, entityNode.entity().classname(), [&]() {
+          return entityNode.entity().modelSpecification();
         });
       const auto* model = manager.model(modelSpec.path);
-      entityNode->setModel(model);
+      entityNode.setModel(model);
     },
-    [](BrushNode*) {},
-    [](PatchNode*) {});
+    [](BrushNode&) {},
+    [](PatchNode&) {});
 }
 
 auto makeUnsetEntityModelsVisitor()
 {
   return kdl::overload(
-    [](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
-    [](EntityNode* entity) { entity->setModel(nullptr); },
-    [](BrushNode*) {},
-    [](PatchNode*) {});
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](EntityNode& entityNode) { entityNode.setModel(nullptr); },
+    [](BrushNode&) {},
+    [](PatchNode&) {});
 }
 
 std::vector<GroupNode*> collectGroupsWithPendingChanges(Node& node)
@@ -441,22 +441,22 @@ std::vector<GroupNode*> collectGroupsWithPendingChanges(Node& node)
   auto result = std::vector<GroupNode*>{};
 
   node.accept(kdl::overload(
-    [](auto&& thisLambda, const WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, GroupNode* groupNode) {
-      if (groupNode->hasPendingChanges())
+    [&](auto&& thisLambda, GroupNode& groupNode) {
+      if (groupNode.hasPendingChanges())
       {
-        result.push_back(groupNode);
+        result.push_back(&groupNode);
       }
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [](const EntityNode*) {},
-    [](const BrushNode*) {},
-    [](const PatchNode*) {}));
+    [](const EntityNode&) {},
+    [](const BrushNode&) {},
+    [](const PatchNode&) {}));
 
   return result;
 }
@@ -1069,12 +1069,14 @@ void Map::updateFaceTags(const std::vector<BrushFaceHandle>& faceHandles)
 void Map::updateAllFaceTags()
 {
   m_worldNode->accept(kdl::overload(
-    [](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
-    [](auto&& thisLambda, EntityNode* entity) { entity->visitChildren(thisLambda); },
-    [&](BrushNode* brush) { brush->initializeTags(*m_tagManager); },
-    [](PatchNode*) {}));
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.visitChildren(thisLambda);
+    },
+    [&](BrushNode& brushNode) { brushNode.initializeTags(*m_tagManager); },
+    [](PatchNode&) {}));
 }
 
 void Map::updateFaceTagsAfterResourcesWhereProcessed(
@@ -1088,24 +1090,26 @@ void Map::updateFaceTagsAfterResourcesWhereProcessed(
     std::unordered_set<const gl::Material*>{materials.begin(), materials.end()};
 
   worldNode().accept(kdl::overload(
-    [](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-    [](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
-    [](auto&& thisLambda, EntityNode* entity) { entity->visitChildren(thisLambda); },
-    [&](BrushNode* brushNode) {
-      const auto& faces = brushNode->brush().faces();
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.visitChildren(thisLambda);
+    },
+    [&](BrushNode& brushNode) {
+      const auto& faces = brushNode.brush().faces();
       for (size_t i = 0; i < faces.size(); ++i)
       {
         {
           const auto& face = faces[i];
           if (materialSet.contains(face.material()))
           {
-            brushNode->updateFaceTags(i, *m_tagManager);
+            brushNode.updateFaceTags(i, *m_tagManager);
           }
         }
       }
     },
-    [](PatchNode*) {}));
+    [](PatchNode&) {}));
 }
 
 void Map::registerValidators()
@@ -1403,12 +1407,12 @@ void Map::addEntityLinks(const std::vector<Node*>& nodes, const bool recurse)
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [&](WorldNode* worldNode) { m_entityLinkManager->addEntityNode(*worldNode); },
-      [](LayerNode*) {},
-      [](GroupNode*) {},
-      [&](EntityNode* entityNode) { m_entityLinkManager->addEntityNode(*entityNode); },
-      [](BrushNode*) {},
-      [](PatchNode*) {}));
+      [&](WorldNode& worldNode) { m_entityLinkManager->addEntityNode(worldNode); },
+      [](LayerNode&) {},
+      [](GroupNode&) {},
+      [&](EntityNode& entityNode) { m_entityLinkManager->addEntityNode(entityNode); },
+      [](BrushNode&) {},
+      [](PatchNode&) {}));
 
     if (recurse)
     {
@@ -1422,12 +1426,12 @@ void Map::removeEntityLinks(const std::vector<Node*>& nodes, const bool recurse)
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [&](WorldNode* worldNode) { m_entityLinkManager->removeEntityNode(*worldNode); },
-      [](LayerNode*) {},
-      [](GroupNode*) {},
-      [&](EntityNode* entityNode) { m_entityLinkManager->removeEntityNode(*entityNode); },
-      [](BrushNode*) {},
-      [](PatchNode*) {}));
+      [&](WorldNode& worldNode) { m_entityLinkManager->removeEntityNode(worldNode); },
+      [](LayerNode&) {},
+      [](GroupNode&) {},
+      [&](EntityNode& entityNode) { m_entityLinkManager->removeEntityNode(entityNode); },
+      [](BrushNode&) {},
+      [](PatchNode&) {}));
 
 
     if (recurse)

--- a/lib/TbMdlLib/src/Map.cpp
+++ b/lib/TbMdlLib/src/Map.cpp
@@ -377,7 +377,7 @@ auto makeSetEntityDefinitionsVisitor(EntityDefinitionManager& manager)
 {
   // this helper lambda must be captured by value
   const auto setEntityDefinition = [&](auto* node) {
-    const auto* definition = manager.definition(node);
+    const auto* definition = manager.definition(*node);
     node->setDefinition(definition);
   };
 

--- a/lib/TbMdlLib/src/MapFileSerializer.cpp
+++ b/lib/TbMdlLib/src/MapFileSerializer.cpp
@@ -318,14 +318,20 @@ void MapFileSerializer::doBeginFile(
   Node::visitAll(
     rootNodes,
     kdl::overload(
-      [](auto&& thisLambda, const WorldNode* world) { world->visitChildren(thisLambda); },
-      [](auto&& thisLambda, const LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [](auto&& thisLambda, const GroupNode* group) { group->visitChildren(thisLambda); },
-      [](auto&& thisLambda, const EntityNode* entity) {
-        entity->visitChildren(thisLambda);
+      [](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [&](const BrushNode* brush) { nodesToSerialize.emplace_back(brush); },
-      [&](const PatchNode* patchNode) { nodesToSerialize.emplace_back(patchNode); }));
+      [](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
+      },
+      [](auto&& thisLambda, const GroupNode& groupNode) {
+        groupNode.visitChildren(thisLambda);
+      },
+      [](auto&& thisLambda, const EntityNode& entityNode) {
+        entityNode.visitChildren(thisLambda);
+      },
+      [&](const BrushNode& brushNode) { nodesToSerialize.emplace_back(&brushNode); },
+      [&](const PatchNode& patchNode) { nodesToSerialize.emplace_back(&patchNode); }));
 
   // serialize brushes to strings in parallel
   using Entry = std::pair<const Node*, PrecomputedString>;

--- a/lib/TbMdlLib/src/MapFileSerializer.cpp
+++ b/lib/TbMdlLib/src/MapFileSerializer.cpp
@@ -352,7 +352,7 @@ void MapFileSerializer::doBeginFile(
 
 void MapFileSerializer::doEndFile() {}
 
-void MapFileSerializer::doBeginEntity(const Node* /* node */)
+void MapFileSerializer::doBeginEntity(const Node& /* node */)
 {
   fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "// entity {}\n", entityNo());
   ++m_line;
@@ -361,7 +361,7 @@ void MapFileSerializer::doBeginEntity(const Node* /* node */)
   ++m_line;
 }
 
-void MapFileSerializer::doEndEntity(const Node* node)
+void MapFileSerializer::doEndEntity(const Node& node)
 {
   fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "}}\n");
   ++m_line;
@@ -378,7 +378,7 @@ void MapFileSerializer::doEntityProperty(const EntityProperty& attribute)
   ++m_line;
 }
 
-void MapFileSerializer::doBrush(const BrushNode* brush)
+void MapFileSerializer::doBrush(const BrushNode& brushNode)
 {
   fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "// brush {}\n", brushNo());
   ++m_line;
@@ -387,7 +387,7 @@ void MapFileSerializer::doBrush(const BrushNode* brush)
   ++m_line;
 
   // write pre-serialized brush faces
-  auto it = m_nodeToPrecomputedString.find(brush);
+  auto it = m_nodeToPrecomputedString.find(&brushNode);
   contract_assert(it != std::end(m_nodeToPrecomputedString));
 
   const auto& precomputedString = it->second;
@@ -396,7 +396,7 @@ void MapFileSerializer::doBrush(const BrushNode* brush)
 
   fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "}}\n");
   ++m_line;
-  setFilePosition(brush);
+  setFilePosition(brushNode);
 }
 
 void MapFileSerializer::doBrushFace(const BrushFace& face)
@@ -407,14 +407,14 @@ void MapFileSerializer::doBrushFace(const BrushFace& face)
   m_line += lines;
 }
 
-void MapFileSerializer::doPatch(const PatchNode* patchNode)
+void MapFileSerializer::doPatch(const PatchNode& patchNode)
 {
   fmt::format_to(std::ostreambuf_iterator<char>{m_stream}, "// brush {}\n", brushNo());
   ++m_line;
   m_startLineStack.push_back(m_line);
 
   // write pre-serialized patch
-  auto it = m_nodeToPrecomputedString.find(patchNode);
+  auto it = m_nodeToPrecomputedString.find(&patchNode);
   contract_assert(it != std::end(m_nodeToPrecomputedString));
 
   const auto& precomputedString = it->second;
@@ -424,10 +424,10 @@ void MapFileSerializer::doPatch(const PatchNode* patchNode)
   setFilePosition(patchNode);
 }
 
-void MapFileSerializer::setFilePosition(const Node* node)
+void MapFileSerializer::setFilePosition(const Node& node)
 {
   const auto start = startLine();
-  node->setFilePosition(start, m_line - start);
+  node.setFilePosition(start, m_line - start);
 }
 
 size_t MapFileSerializer::startLine()

--- a/lib/TbMdlLib/src/MapReader.cpp
+++ b/lib/TbMdlLib/src/MapReader.cpp
@@ -690,30 +690,30 @@ void validateDuplicateLayersAndGroups(
     if (nodeInfo)
     {
       nodeInfo->node->accept(kdl::overload(
-        [](WorldNode*) {},
-        [&](LayerNode* layerNode) {
-          const auto persistentId = *layerNode->persistentId();
+        [](WorldNode&) {},
+        [&](LayerNode& layerNode) {
+          const auto persistentId = *layerNode.persistentId();
           if (!layerIds.emplace(persistentId).second)
           {
             status.error(
-              FileLocation{layerNode->lineNumber()},
+              FileLocation{layerNode.lineNumber()},
               fmt::format("Skipping duplicate layer with ID '{}'", persistentId));
             nodeInfo.reset();
           }
         },
-        [&](GroupNode* groupNode) {
-          const auto persistentId = *groupNode->persistentId();
+        [&](GroupNode& groupNode) {
+          const auto persistentId = *groupNode.persistentId();
           if (!groupIds.emplace(persistentId).second)
           {
             status.error(
-              FileLocation{groupNode->lineNumber()},
+              FileLocation{groupNode.lineNumber()},
               fmt::format("Skipping duplicate group with ID '{}'", persistentId));
             nodeInfo.reset();
           }
         },
-        [](EntityNode*) {},
-        [](BrushNode*) {},
-        [](PatchNode*) {}));
+        [](EntityNode&) {},
+        [](BrushNode&) {},
+        [](PatchNode&) {}));
     }
   }
 }
@@ -825,18 +825,18 @@ std::unordered_map<Node*, Node*> buildNodeToParentMap(
     if (nodeInfo)
     {
       nodeInfo->node->accept(kdl::overload(
-        [](WorldNode*) {},
-        [&](LayerNode* layerNode) {
-          const auto persistentId = *layerNode->persistentId();
-          assertResult(layerIdMap.emplace(persistentId, layerNode).second);
+        [](WorldNode&) {},
+        [&](LayerNode& layerNode) {
+          const auto persistentId = *layerNode.persistentId();
+          assertResult(layerIdMap.emplace(persistentId, &layerNode).second);
         },
-        [&](GroupNode* groupNode) {
-          const auto persistentId = *groupNode->persistentId();
-          assertResult(groupIdMap.emplace(persistentId, groupNode).second);
+        [&](GroupNode& groupNode) {
+          const auto persistentId = *groupNode.persistentId();
+          assertResult(groupIdMap.emplace(persistentId, &groupNode).second);
         },
-        [](EntityNode*) {},
-        [](BrushNode*) {},
-        [](PatchNode*) {}));
+        [](EntityNode&) {},
+        [](BrushNode&) {},
+        [](PatchNode&) {}));
     }
   }
 
@@ -978,14 +978,14 @@ void MapReader::createNodes(ParserStatus& status, kdl::task_manager& taskManager
         parentNodeIt != std::end(nodeToParentMap) ? parentNodeIt->second : defaultParent;
 
       node->accept(kdl::overload(
-        [&](WorldNode*) {
+        [&](WorldNode&) {
           // this should not happen since we already cleared out any world nodes
         },
-        [&](LayerNode*) { onLayerNode(std::move(node), status); },
-        [&](GroupNode*) { onNode(parentNode, std::move(node), status); },
-        [&](EntityNode*) { onNode(parentNode, std::move(node), status); },
-        [&](BrushNode*) { onNode(parentNode, std::move(node), status); },
-        [&](PatchNode*) { onNode(parentNode, std::move(node), status); }));
+        [&](LayerNode&) { onLayerNode(std::move(node), status); },
+        [&](GroupNode&) { onNode(parentNode, std::move(node), status); },
+        [&](EntityNode&) { onNode(parentNode, std::move(node), status); },
+        [&](BrushNode&) { onNode(parentNode, std::move(node), status); },
+        [&](PatchNode&) { onNode(parentNode, std::move(node), status); }));
     }
   }
 }

--- a/lib/TbMdlLib/src/Map_CopyPaste.cpp
+++ b/lib/TbMdlLib/src/Map_CopyPaste.cpp
@@ -64,39 +64,39 @@ auto extractNodesToPaste(const std::vector<Node*>& nodes, Node* parent)
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* world) {
-        world->visitChildren(thisLambda);
-        nodesToDelete.push_back(world);
+      [&](auto&& thisLambda, WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
+        nodesToDelete.push_back(&worldNode);
       },
-      [&](auto&& thisLambda, LayerNode* layer) {
-        layer->visitChildren(thisLambda);
-        nodesToDetach.push_back(layer);
-        nodesToDelete.push_back(layer);
+      [&](auto&& thisLambda, LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
+        nodesToDetach.push_back(&layerNode);
+        nodesToDelete.push_back(&layerNode);
       },
-      [&](GroupNode* group) {
-        nodesToDetach.push_back(group);
-        nodesToAdd[parent].push_back(group);
+      [&](GroupNode& groupNode) {
+        nodesToDetach.push_back(&groupNode);
+        nodesToAdd[parent].push_back(&groupNode);
       },
-      [&](auto&& thisLambda, EntityNode* entityNode) {
-        if (isWorldspawn(entityNode->entity().classname()))
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        if (isWorldspawn(entityNode.entity().classname()))
         {
-          entityNode->visitChildren(thisLambda);
-          nodesToDetach.push_back(entityNode);
-          nodesToDelete.push_back(entityNode);
+          entityNode.visitChildren(thisLambda);
+          nodesToDetach.push_back(&entityNode);
+          nodesToDelete.push_back(&entityNode);
         }
         else
         {
-          nodesToDetach.push_back(entityNode);
-          nodesToAdd[parent].push_back(entityNode);
+          nodesToDetach.push_back(&entityNode);
+          nodesToAdd[parent].push_back(&entityNode);
         }
       },
-      [&](BrushNode* brush) {
-        nodesToDetach.push_back(brush);
-        nodesToAdd[parent].push_back(brush);
+      [&](BrushNode& brushNode) {
+        nodesToDetach.push_back(&brushNode);
+        nodesToAdd[parent].push_back(&brushNode);
       },
-      [&](PatchNode* patch) {
-        nodesToDetach.push_back(patch);
-        nodesToAdd[parent].push_back(patch);
+      [&](PatchNode& patchNode) {
+        nodesToDetach.push_back(&patchNode);
+        nodesToAdd[parent].push_back(&patchNode);
       }));
   }
 
@@ -116,22 +116,22 @@ std::vector<IdType> allPersistentGroupIds(const Node& root)
 {
   auto result = std::vector<IdType>{};
   root.accept(kdl::overload(
-    [](auto&& thisLambda, const WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, const GroupNode* groupNode) {
-      if (const auto persistentId = groupNode->persistentId())
+    [&](auto&& thisLambda, const GroupNode& groupNode) {
+      if (const auto persistentId = groupNode.persistentId())
       {
         result.push_back(*persistentId);
       }
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [](const EntityNode*) {},
-    [](const BrushNode*) {},
-    [](const PatchNode*) {}));
+    [](const EntityNode&) {},
+    [](const BrushNode&) {},
+    [](const PatchNode&) {}));
   return result;
 }
 
@@ -145,26 +145,26 @@ void fixRedundantPersistentIds(
     for (auto* node : nodesToAddToParent)
     {
       node->accept(kdl::overload(
-        [&](auto&& thisLambda, WorldNode* worldNode) {
-          worldNode->visitChildren(thisLambda);
+        [&](auto&& thisLambda, WorldNode& worldNode) {
+          worldNode.visitChildren(thisLambda);
         },
-        [&](auto&& thisLambda, LayerNode* layerNode) {
-          layerNode->visitChildren(thisLambda);
+        [&](auto&& thisLambda, LayerNode& layerNode) {
+          layerNode.visitChildren(thisLambda);
         },
-        [&](auto&& thisLambda, GroupNode* groupNode) {
-          if (const auto persistentGroupId = groupNode->persistentId())
+        [&](auto&& thisLambda, GroupNode& groupNode) {
+          if (const auto persistentGroupId = groupNode.persistentId())
           {
             if (!persistentGroupIds.insert(*persistentGroupId).second)
             {
               // a group with this ID is already in the map or being pasted
-              groupNode->resetPersistentId();
+              groupNode.resetPersistentId();
             }
           }
-          groupNode->visitChildren(thisLambda);
+          groupNode.visitChildren(thisLambda);
         },
-        [](EntityNode*) {},
-        [](BrushNode*) {},
-        [](PatchNode*) {}));
+        [](EntityNode&) {},
+        [](BrushNode&) {},
+        [](PatchNode&) {}));
     }
   }
 }
@@ -178,29 +178,29 @@ void fixRecursiveLinkedGroups(
     for (auto* node : nodesToAddToParent)
     {
       node->accept(kdl::overload(
-        [&](auto&& thisLambda, WorldNode* worldNode) {
-          worldNode->visitChildren(thisLambda);
+        [&](auto&& thisLambda, WorldNode& worldNode) {
+          worldNode.visitChildren(thisLambda);
         },
-        [&](auto&& thisLambda, LayerNode* layerNode) {
-          layerNode->visitChildren(thisLambda);
+        [&](auto&& thisLambda, LayerNode& layerNode) {
+          layerNode.visitChildren(thisLambda);
         },
-        [&](auto&& thisLambda, GroupNode* groupNode) {
-          const auto& linkId = groupNode->linkId();
+        [&](auto&& thisLambda, GroupNode& groupNode) {
+          const auto& linkId = groupNode.linkId();
           if (std::ranges::binary_search(linkedGroupIds, linkId))
           {
             logger.warn() << "Unlinking recursive linked group with ID '" << linkId
                           << "'";
 
-            auto group = groupNode->group();
+            auto group = groupNode.group();
             group.setTransformation(vm::mat4x4d::identity());
-            groupNode->setGroup(std::move(group));
-            groupNode->setLinkId(generateUuid());
+            groupNode.setGroup(std::move(group));
+            groupNode.setLinkId(generateUuid());
           }
-          groupNode->visitChildren(thisLambda);
+          groupNode.visitChildren(thisLambda);
         },
-        [](EntityNode*) {},
-        [](BrushNode*) {},
-        [](PatchNode*) {}));
+        [](EntityNode&) {},
+        [](BrushNode&) {},
+        [](PatchNode&) {}));
     }
   }
 }

--- a/lib/TbMdlLib/src/Map_Geometry.cpp
+++ b/lib/TbMdlLib/src/Map_Geometry.cpp
@@ -78,33 +78,31 @@ bool transformSelection(
   for (auto* node : map.selection().nodes)
   {
     node->accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [&](
+        auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+      [&](
+        auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        nodesToTransform.push_back(&groupNode);
+        groupNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
-      },
-      [&](auto&& thisLambda, GroupNode* groupNode) {
-        nodesToTransform.push_back(groupNode);
-        groupNode->visitChildren(thisLambda);
-      },
-      [&](auto&& thisLambda, EntityNode* entityNode) {
-        if (!entityNode->hasChildren())
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        if (!entityNode.hasChildren())
         {
-          nodesToTransform.push_back(entityNode);
+          nodesToTransform.push_back(&entityNode);
         }
         else
         {
-          entityNode->visitChildren(thisLambda);
+          entityNode.visitChildren(thisLambda);
         }
       },
-      [&](BrushNode* brushNode) {
-        nodesToTransform.push_back(brushNode);
-        entitiesToTransform[brushNode->entity()]++;
+      [&](BrushNode& brushNode) {
+        nodesToTransform.push_back(&brushNode);
+        entitiesToTransform[brushNode.entity()]++;
       },
-      [&](PatchNode* patchNode) {
-        nodesToTransform.push_back(patchNode);
-        entitiesToTransform[patchNode->entity()]++;
+      [&](PatchNode& patchNode) {
+        nodesToTransform.push_back(&patchNode);
+        entitiesToTransform[patchNode.entity()]++;
       }));
   }
 
@@ -129,34 +127,34 @@ bool transformSelection(
     nodesToTransform | std::views::transform([&](auto& node) {
       return std::function{[&]() {
         return node->accept(kdl::overload(
-          [&](WorldNode*) -> TransformResult { contract_assert(false); },
-          [&](LayerNode*) -> TransformResult { contract_assert(false); },
-          [&](GroupNode* groupNode) -> TransformResult {
-            auto group = groupNode->group();
+          [&](WorldNode&) -> TransformResult { contract_assert(false); },
+          [&](LayerNode&) -> TransformResult { contract_assert(false); },
+          [&](GroupNode& groupNode) -> TransformResult {
+            auto group = groupNode.group();
             group.transform(transformation);
-            return std::make_pair(groupNode, NodeContents{std::move(group)});
+            return std::make_pair(&groupNode, NodeContents{std::move(group)});
           },
-          [&](EntityNode* entityNode) -> TransformResult {
-            auto entity = entityNode->entity();
+          [&](EntityNode& entityNode) -> TransformResult {
+            auto entity = entityNode.entity();
             entity.transform(transformation, updateAngleProperty);
-            return std::make_pair(entityNode, NodeContents{std::move(entity)});
+            return std::make_pair(&entityNode, NodeContents{std::move(entity)});
           },
-          [&](BrushNode* brushNode) -> TransformResult {
-            const auto* containingGroup = brushNode->containingGroup();
+          [&](BrushNode& brushNode) -> TransformResult {
+            const auto* containingGroup = brushNode.containingGroup();
             const bool lockAlignment =
             alignmentLock
-            || (containingGroup && containingGroup->closed() && collectLinkedNodes({&map.worldNode()}, *brushNode).size() > 1);
+            || (containingGroup && containingGroup->closed() && collectLinkedNodes({&map.worldNode()}, brushNode).size() > 1);
 
-            auto brush = brushNode->brush();
+            auto brush = brushNode.brush();
             return brush.transform(map.worldBounds(), transformation, lockAlignment)
                    | kdl::and_then([&]() -> TransformResult {
-                       return std::make_pair(brushNode, NodeContents{std::move(brush)});
+                       return std::make_pair(&brushNode, NodeContents{std::move(brush)});
                      });
           },
-          [&](PatchNode* patchNode) -> TransformResult {
-            auto patch = patchNode->patch();
+          [&](PatchNode& patchNode) -> TransformResult {
+            auto patch = patchNode.patch();
             patch.transform(transformation);
-            return std::make_pair(patchNode, NodeContents{std::move(patch)});
+            return std::make_pair(&patchNode, NodeContents{std::move(patch)});
           }));
       }};
     });

--- a/lib/TbMdlLib/src/Map_Groups.cpp
+++ b/lib/TbMdlLib/src/Map_Groups.cpp
@@ -56,26 +56,26 @@ std::vector<Node*> collectGroupableNodes(
   const std::vector<Node*>& selectedNodes, const EntityNodeBase& world)
 {
   std::vector<Node*> result;
-  const auto addNode = [&](auto&& thisLambda, auto* node) {
-    if (node->entity() == &world)
+  const auto addNode = [&](auto&& thisLambda, auto& node) {
+    if (node.entity() == &world)
     {
-      result.push_back(node);
+      result.push_back(&node);
     }
     else
     {
-      node->visitParent(thisLambda);
+      node.visitParent(thisLambda);
     }
   };
 
   Node::visitAll(
     selectedNodes,
     kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [&](GroupNode* group) { result.push_back(group); },
-      [&](EntityNode* entity) { result.push_back(entity); },
-      [&](auto&& thisLambda, BrushNode* brush) { addNode(thisLambda, brush); },
-      [&](auto&& thisLambda, PatchNode* patch) { addNode(thisLambda, patch); }));
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [&](GroupNode& groupNode) { result.push_back(&groupNode); },
+      [&](EntityNode& entityNode) { result.push_back(&entityNode); },
+      [&](auto&& thisLambda, BrushNode& brushNode) { addNode(thisLambda, brushNode); },
+      [&](auto&& thisLambda, PatchNode& patchNode) { addNode(thisLambda, patchNode); }));
   return kdl::col_stable_remove_duplicates(std::move(result));
 }
 
@@ -86,12 +86,12 @@ std::vector<Node*> collectNodesToUnlink(const std::vector<GroupNode*>& groupNode
   {
     result.push_back(groupNode);
     groupNode->visitChildren(kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [](const GroupNode*) {},
-      [&](EntityNode* entityNode) { result.push_back(entityNode); },
-      [&](BrushNode* brushNode) { result.push_back(brushNode); },
-      [&](PatchNode* patchNode) { result.push_back(patchNode); }));
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [](const GroupNode&) {},
+      [&](EntityNode& entityNode) { result.push_back(&entityNode); },
+      [&](BrushNode& brushNode) { result.push_back(&brushNode); },
+      [&](PatchNode& patchNode) { result.push_back(&patchNode); }));
   }
   return result;
 }
@@ -138,12 +138,12 @@ auto getLinkIds(const std::vector<Node*> nodes)
   for (const auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](const GroupNode* groupNode) { result.insert(groupNode->linkId()); },
-      [&](const EntityNode* entityNode) { result.insert(entityNode->linkId()); },
-      [&](const BrushNode* brushNode) { result.insert(brushNode->linkId()); },
-      [&](const PatchNode* patchNode) { result.insert(patchNode->linkId()); }));
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](const GroupNode& groupNode) { result.insert(groupNode.linkId()); },
+      [&](const EntityNode& entityNode) { result.insert(entityNode.linkId()); },
+      [&](const BrushNode& brushNode) { result.insert(brushNode.linkId()); },
+      [&](const PatchNode& patchNode) { result.insert(patchNode.linkId()); }));
   }
   return result;
 }
@@ -151,12 +151,12 @@ auto getLinkIds(const std::vector<Node*> nodes)
 bool hasLinkIdOf(const Node& node, const std::unordered_set<std::string>& linkIds)
 {
   return node.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [&](const GroupNode* groupNode) { return linkIds.contains(groupNode->linkId()); },
-    [&](const EntityNode* entityNode) { return linkIds.contains(entityNode->linkId()); },
-    [&](const BrushNode* brushNode) { return linkIds.contains(brushNode->linkId()); },
-    [&](const PatchNode* patchNode) { return linkIds.contains(patchNode->linkId()); }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [&](const GroupNode& groupNode) { return linkIds.contains(groupNode.linkId()); },
+    [&](const EntityNode& entityNode) { return linkIds.contains(entityNode.linkId()); },
+    [&](const BrushNode& brushNode) { return linkIds.contains(brushNode.linkId()); },
+    [&](const PatchNode& patchNode) { return linkIds.contains(patchNode.linkId()); }));
 }
 
 bool recursivelyHasLinkIdOf(
@@ -195,22 +195,22 @@ auto getNodesToRemoveAfterExtraction(
   for (auto* node : rootNode.children())
   {
     node->accept(kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](auto&& thisLambda, GroupNode* groupNode) {
-        if (addNodeToRemove(groupNode))
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        if (addNodeToRemove(&groupNode))
         {
-          groupNode->visitChildren(thisLambda);
+          groupNode.visitChildren(thisLambda);
         }
       },
-      [&](auto&& thisLambda, EntityNode* entityNode) {
-        if (addNodeToRemove(entityNode))
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        if (addNodeToRemove(&entityNode))
         {
-          entityNode->visitChildren(thisLambda);
+          entityNode.visitChildren(thisLambda);
         }
       },
-      [&](BrushNode* brushNode) { addNodeToRemove(brushNode); },
-      [&](PatchNode* patchNode) { addNodeToRemove(patchNode); }));
+      [&](BrushNode& brushNode) { addNodeToRemove(&brushNode); },
+      [&](PatchNode& patchNode) { addNodeToRemove(&patchNode); }));
   }
 
   return nodesToRemove;
@@ -321,17 +321,17 @@ void ungroupSelectedNodes(Map& map)
   Node::visitAll(
     selectedNodes,
     kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [&](GroupNode* group) {
-        auto* parent = group->parent();
-        const auto children = group->children();
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [&](GroupNode& groupNode) {
+        auto* parent = groupNode.parent();
+        const auto children = groupNode.children();
         success = success && reparentNodes(map, {{parent, children}});
         nodesToReselect = kdl::vec_concat(std::move(nodesToReselect), children);
       },
-      [&](EntityNode* entity) { nodesToReselect.push_back(entity); },
-      [&](BrushNode* brush) { nodesToReselect.push_back(brush); },
-      [&](PatchNode* patch) { nodesToReselect.push_back(patch); }));
+      [&](EntityNode& entityNode) { nodesToReselect.push_back(&entityNode); },
+      [&](BrushNode& brushNode) { nodesToReselect.push_back(&brushNode); },
+      [&](PatchNode& patchNode) { nodesToReselect.push_back(&patchNode); }));
 
   if (!success)
   {

--- a/lib/TbMdlLib/src/Map_Layers.cpp
+++ b/lib/TbMdlLib/src/Map_Layers.cpp
@@ -204,28 +204,28 @@ void moveSelectedNodesToLayer(Map& map, LayerNode* layerNode)
   for (auto* node : selectedNodes)
   {
     node->accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [&](GroupNode* groupNode) {
-        contract_pre(groupNode->selected());
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [&](GroupNode& groupNode) {
+        contract_pre(groupNode.selected());
 
-        if (!groupNode->containedInGroup())
+        if (!groupNode.containedInGroup())
         {
-          nodesToMove.push_back(groupNode);
-          nodesToSelect.push_back(groupNode);
+          nodesToMove.push_back(&groupNode);
+          nodesToSelect.push_back(&groupNode);
         }
       },
-      [&](EntityNode* entityNode) {
-        contract_pre(entityNode->selected());
+      [&](EntityNode& entityNode) {
+        contract_pre(entityNode.selected());
 
-        if (!entityNode->containedInGroup())
+        if (!entityNode.containedInGroup())
         {
-          nodesToMove.push_back(entityNode);
-          nodesToSelect.push_back(entityNode);
+          nodesToMove.push_back(&entityNode);
+          nodesToSelect.push_back(&entityNode);
         }
       },
-      [&](BrushNode* brushNode) { addBrushOrPatchNode(brushNode); },
-      [&](PatchNode* patchNode) { addBrushOrPatchNode(patchNode); }));
+      [&](BrushNode& brushNode) { addBrushOrPatchNode(&brushNode); },
+      [&](PatchNode& patchNode) { addBrushOrPatchNode(&patchNode); }));
   }
 
   if (!nodesToMove.empty())

--- a/lib/TbMdlLib/src/Map_NodeVisibility.cpp
+++ b/lib/TbMdlLib/src/Map_NodeVisibility.cpp
@@ -45,30 +45,30 @@ void isolateSelectedNodes(Map& map)
   auto selectedNodes = std::vector<Node*>{};
   auto unselectedNodes = std::vector<Node*>{};
 
-  const auto collectNode = [&](auto* node) {
-    if (node->transitivelySelected() || node->descendantSelected())
+  const auto collectNode = [&](auto& node) {
+    if (node.transitivelySelected() || node.descendantSelected())
     {
-      selectedNodes.push_back(node);
+      selectedNodes.push_back(&node);
     }
     else
     {
-      unselectedNodes.push_back(node);
+      unselectedNodes.push_back(&node);
     }
   };
 
   map.worldNode().accept(kdl::overload(
-    [](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-    [&](auto&& thisLambda, GroupNode* group) {
-      collectNode(group);
-      group->visitChildren(thisLambda);
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [&](auto&& thisLambda, GroupNode& groupNode) {
+      collectNode(groupNode);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, EntityNode* entity) {
-      collectNode(entity);
-      entity->visitChildren(thisLambda);
+    [&](auto&& thisLambda, EntityNode& entityNode) {
+      collectNode(entityNode);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](BrushNode* brush) { collectNode(brush); },
-    [&](PatchNode* patch) { collectNode(patch); }));
+    [&](BrushNode& brushNode) { collectNode(brushNode); },
+    [&](PatchNode& patchNode) { collectNode(patchNode); }));
 
   auto transaction = Transaction{map, "Isolate Objects"};
   map.executeAndStore(SetVisibilityCommand::hide(unselectedNodes));

--- a/lib/TbMdlLib/src/Map_Nodes.cpp
+++ b/lib/TbMdlLib/src/Map_Nodes.cpp
@@ -59,23 +59,23 @@ std::vector<GroupNode*> collectGroupsOrContainers(const std::vector<Node*>& node
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](GroupNode* groupNode) { result.push_back(groupNode); },
-      [&](EntityNode* entityNode) {
-        if (auto* containingGroup = entityNode->containingGroup())
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](GroupNode& groupNode) { result.push_back(&groupNode); },
+      [&](EntityNode& entityNode) {
+        if (auto* containingGroup = entityNode.containingGroup())
         {
           result.push_back(containingGroup);
         }
       },
-      [&](BrushNode* brushNode) {
-        if (auto* containingGroup = brushNode->containingGroup())
+      [&](BrushNode& brushNode) {
+        if (auto* containingGroup = brushNode.containingGroup())
         {
           result.push_back(containingGroup);
         }
       },
-      [&](PatchNode* patchNode) {
-        if (auto* containingGroup = patchNode->containingGroup())
+      [&](PatchNode& patchNode) {
+        if (auto* containingGroup = patchNode.containingGroup())
         {
           result.push_back(containingGroup);
         }
@@ -104,12 +104,12 @@ void copyAndSetLinkIds(
 bool shouldCloneParentWhenCloningNode(const Node* node)
 {
   return node->parent()->accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return false; },
-    [](const GroupNode*) { return false; },
-    [&](const EntityNode*) { return true; },
-    [](const BrushNode*) { return false; },
-    [](const PatchNode*) { return false; }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [](const GroupNode&) { return false; },
+    [&](const EntityNode&) { return true; },
+    [](const BrushNode&) { return false; },
+    [](const PatchNode&) { return false; }));
 }
 
 void resetLinkIdsOfNonGroupedNodes(const std::map<Node*, std::vector<Node*>>& nodes)
@@ -119,15 +119,15 @@ void resetLinkIdsOfNonGroupedNodes(const std::map<Node*, std::vector<Node*>>& no
     Node::visitAll(
       children,
       kdl::overload(
-        [](const WorldNode*) {},
-        [](const LayerNode*) {},
-        [](const GroupNode*) {},
-        [](auto&& thisLambda, EntityNode* entityNode) {
-          entityNode->setLinkId(generateUuid());
-          entityNode->visitChildren(thisLambda);
+        [](const WorldNode&) {},
+        [](const LayerNode&) {},
+        [](const GroupNode&) {},
+        [](auto&& thisLambda, EntityNode& entityNode) {
+          entityNode.setLinkId(generateUuid());
+          entityNode.visitChildren(thisLambda);
         },
-        [](BrushNode* brushNode) { brushNode->setLinkId(generateUuid()); },
-        [](PatchNode* patchNode) { patchNode->setLinkId(generateUuid()); }));
+        [](BrushNode& brushNode) { brushNode.setLinkId(generateUuid()); },
+        [](PatchNode& patchNode) { patchNode.setLinkId(generateUuid()); }));
   }
 }
 
@@ -152,28 +152,28 @@ auto setLinkIdsForReparentingNodes(
     Node::visitAll(
       nodes,
       kdl::overload(
-        [](const WorldNode*) {},
-        [](const LayerNode*) {},
-        [](const GroupNode*) {
+        [](const WorldNode&) {},
+        [](const LayerNode&) {},
+        [](const GroupNode&) {
           // group nodes can keep their ID because they should remain in their link set
         },
-        [&, newParent = newParent_](auto&& thisLambda, EntityNode* entityNode) {
-          if (newParent->isAncestorOf(*entityNode->parent()))
+        [&, newParent = newParent_](auto&& thisLambda, EntityNode& entityNode) {
+          if (newParent->isAncestorOf(*entityNode.parent()))
           {
-            result.emplace_back(entityNode, generateUuid());
-            entityNode->visitChildren(thisLambda);
+            result.emplace_back(&entityNode, generateUuid());
+            entityNode.visitChildren(thisLambda);
           }
         },
-        [&, newParent = newParent_](BrushNode* brushNode) {
-          if (newParent->isAncestorOf(*brushNode->parent()))
+        [&, newParent = newParent_](BrushNode& brushNode) {
+          if (newParent->isAncestorOf(*brushNode.parent()))
           {
-            result.emplace_back(brushNode, generateUuid());
+            result.emplace_back(&brushNode, generateUuid());
           }
         },
-        [&, newParent = newParent_](PatchNode* patchNode) {
-          if (newParent->isAncestorOf(*patchNode->parent()))
+        [&, newParent = newParent_](PatchNode& patchNode) {
+          if (newParent->isAncestorOf(*patchNode.parent()))
           {
-            result.emplace_back(patchNode, generateUuid());
+            result.emplace_back(&patchNode, generateUuid());
           }
         }));
   }
@@ -394,7 +394,7 @@ bool reparentNodes(Map& map, const std::map<Node*, std::vector<Node*>>& nodesToA
 
     const auto nodesToDowngrade = mdl::collectNodesAndDescendants(
       nodes,
-      [&](mdl::Object* node) { return node->containingLayer() != newParentLayer; });
+      [&](const mdl::Object& node) { return node.containingLayer() != newParentLayer; });
 
     downgradeUnlockedToInherit(map, nodesToDowngrade);
     downgradeShownToInherit(map, nodesToDowngrade);

--- a/lib/TbMdlLib/src/Map_Nodes.cpp
+++ b/lib/TbMdlLib/src/Map_Nodes.cpp
@@ -158,20 +158,20 @@ auto setLinkIdsForReparentingNodes(
           // group nodes can keep their ID because they should remain in their link set
         },
         [&, newParent = newParent_](auto&& thisLambda, EntityNode* entityNode) {
-          if (newParent->isAncestorOf(entityNode->parent()))
+          if (newParent->isAncestorOf(*entityNode->parent()))
           {
             result.emplace_back(entityNode, generateUuid());
             entityNode->visitChildren(thisLambda);
           }
         },
         [&, newParent = newParent_](BrushNode* brushNode) {
-          if (newParent->isAncestorOf(brushNode->parent()))
+          if (newParent->isAncestorOf(*brushNode->parent()))
           {
             result.emplace_back(brushNode, generateUuid());
           }
         },
         [&, newParent = newParent_](PatchNode* patchNode) {
-          if (newParent->isAncestorOf(patchNode->parent()))
+          if (newParent->isAncestorOf(*patchNode->parent()))
           {
             result.emplace_back(patchNode, generateUuid());
           }
@@ -188,7 +188,7 @@ std::vector<Node*> removeImplicitelyRemovedNodes(std::vector<Node*> nodes)
   }
 
   nodes = kdl::vec_sort(std::move(nodes), [](const auto* lhs, const auto* rhs) {
-    return lhs->isAncestorOf(rhs);
+    return lhs->isAncestorOf(*rhs);
   });
 
   auto result = std::vector<Node*>{};
@@ -270,7 +270,7 @@ std::vector<Node*> addNodes(Map& map, const std::map<Node*, std::vector<Node*>>&
 {
   contract_assert(std::ranges::all_of(nodes, [&](const auto& parentAndChildren) {
     const auto& [parent, children] = parentAndChildren;
-    return parent == &map.worldNode() || parent->isDescendantOf(&map.worldNode());
+    return parent == &map.worldNode() || parent->isDescendantOf(map.worldNode());
   }));
 
   auto transaction = Transaction{map, "Add Objects"};

--- a/lib/TbMdlLib/src/Map_Selection.cpp
+++ b/lib/TbMdlLib/src/Map_Selection.cpp
@@ -194,60 +194,58 @@ void selectContainedNodes(Map& map, const bool del)
 void selectNodesWithFilePosition(Map& map, const std::vector<size_t>& positions)
 {
   auto nodesToSelect = std::vector<Node*>{};
-  const auto hasFilePosition = [&](const auto* node) {
+  const auto hasFilePosition = [&](const auto& node) {
     return std::ranges::any_of(
-      positions, [&](const auto position) { return node->containsLine(position); });
+      positions, [&](const auto position) { return node.containsLine(position); });
   };
 
   map.worldNode().accept(kdl::overload(
-    [&](
-      auto&& thisLambda, WorldNode* worldNode) { worldNode->visitChildren(thisLambda); },
-    [&](
-      auto&& thisLambda, LayerNode* layerNode) { layerNode->visitChildren(thisLambda); },
-    [&](auto&& thisLambda, GroupNode* groupNode) {
+    [&](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [&](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [&](auto&& thisLambda, GroupNode& groupNode) {
       if (hasFilePosition(groupNode))
       {
-        if (map.editorContext().selectable(*groupNode))
+        if (map.editorContext().selectable(groupNode))
         {
-          nodesToSelect.push_back(groupNode);
+          nodesToSelect.push_back(&groupNode);
         }
         else
         {
-          groupNode->visitChildren(thisLambda);
+          groupNode.visitChildren(thisLambda);
         }
       }
     },
-    [&](auto&& thisLambda, EntityNode* entityNode) {
+    [&](auto&& thisLambda, EntityNode& entityNode) {
       if (hasFilePosition(entityNode))
       {
-        if (map.editorContext().selectable(*entityNode))
+        if (map.editorContext().selectable(entityNode))
         {
-          nodesToSelect.push_back(entityNode);
+          nodesToSelect.push_back(&entityNode);
         }
         else
         {
           const auto previousCount = nodesToSelect.size();
-          entityNode->visitChildren(thisLambda);
+          entityNode.visitChildren(thisLambda);
           if (previousCount == nodesToSelect.size())
           {
             // no child was selected, select all children
             nodesToSelect = kdl::vec_concat(
               std::move(nodesToSelect),
-              collectSelectableNodes(entityNode->children(), map.editorContext()));
+              collectSelectableNodes(entityNode.children(), map.editorContext()));
           }
         }
       }
     },
-    [&](BrushNode* brushNode) {
-      if (hasFilePosition(brushNode) && map.editorContext().selectable(*brushNode))
+    [&](BrushNode& brushNode) {
+      if (hasFilePosition(brushNode) && map.editorContext().selectable(brushNode))
       {
-        nodesToSelect.push_back(brushNode);
+        nodesToSelect.push_back(&brushNode);
       }
     },
-    [&](PatchNode* patchNode) {
-      if (hasFilePosition(patchNode) && map.editorContext().selectable(*patchNode))
+    [&](PatchNode& patchNode) {
+      if (hasFilePosition(patchNode) && map.editorContext().selectable(patchNode))
       {
-        nodesToSelect.push_back(patchNode);
+        nodesToSelect.push_back(&patchNode);
       }
     }));
 
@@ -284,28 +282,28 @@ void invertNodeSelection(Map& map)
   // selection is inverted, which would reselect both children.
 
   auto nodesToSelect = std::vector<Node*>{};
-  const auto collectNode = [&](auto* node) {
+  const auto collectNode = [&](auto& node) {
     if (
-      !node->transitivelySelected() && !node->descendantSelected()
-      && map.editorContext().selectable(*node))
+      !node.transitivelySelected() && !node.descendantSelected()
+      && map.editorContext().selectable(node))
     {
-      nodesToSelect.push_back(node);
+      nodesToSelect.push_back(&node);
     }
   };
 
   currentGroupOrWorld(map)->accept(kdl::overload(
-    [](auto&& thisLambda, WorldNode* worldNode) { worldNode->visitChildren(thisLambda); },
-    [](auto&& thisLambda, LayerNode* layerNode) { layerNode->visitChildren(thisLambda); },
-    [&](auto&& thisLambda, GroupNode* groupNode) {
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [&](auto&& thisLambda, GroupNode& groupNode) {
       collectNode(groupNode);
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, EntityNode* entityNode) {
+    [&](auto&& thisLambda, EntityNode& entityNode) {
       collectNode(entityNode);
-      entityNode->visitChildren(thisLambda);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](BrushNode* brushNode) { collectNode(brushNode); },
-    [&](PatchNode* patchNode) { collectNode(patchNode); }));
+    [&](BrushNode& brushNode) { collectNode(brushNode); },
+    [&](PatchNode& patchNode) { collectNode(patchNode); }));
 
   auto transaction = Transaction{map, "Select Inverse"};
   deselectAll(map);

--- a/lib/TbMdlLib/src/ModelUtils.cpp
+++ b/lib/TbMdlLib/src/ModelUtils.cpp
@@ -43,19 +43,19 @@ HitType::Type nodeHitType()
 LayerNode* findContainingLayer(Node* node)
 {
   return node->accept(kdl::overload(
-    [](WorldNode*) -> LayerNode* { return nullptr; },
-    [](LayerNode* layer) -> LayerNode* { return layer; },
-    [](auto&& thisLambda, GroupNode* group) -> LayerNode* {
-      return group->visitParent(thisLambda).value_or(nullptr);
+    [](WorldNode&) -> LayerNode* { return nullptr; },
+    [](LayerNode& layerNode) -> LayerNode* { return &layerNode; },
+    [](auto&& thisLambda, GroupNode& groupNode) -> LayerNode* {
+      return groupNode.visitParent(thisLambda).value_or(nullptr);
     },
-    [](auto&& thisLambda, EntityNode* entity) -> LayerNode* {
-      return entity->visitParent(thisLambda).value_or(nullptr);
+    [](auto&& thisLambda, EntityNode& entityNode) -> LayerNode* {
+      return entityNode.visitParent(thisLambda).value_or(nullptr);
     },
-    [](auto&& thisLambda, BrushNode* brush) -> LayerNode* {
-      return brush->visitParent(thisLambda).value_or(nullptr);
+    [](auto&& thisLambda, BrushNode& brushNode) -> LayerNode* {
+      return brushNode.visitParent(thisLambda).value_or(nullptr);
     },
-    [](auto&& thisLambda, PatchNode* patch) -> LayerNode* {
-      return patch->visitParent(thisLambda).value_or(nullptr);
+    [](auto&& thisLambda, PatchNode& patchNode) -> LayerNode* {
+      return patchNode.visitParent(thisLambda).value_or(nullptr);
     }));
 }
 
@@ -76,17 +76,17 @@ GroupNode* findContainingGroup(Node* node)
 {
   return node
     ->visitParent(kdl::overload(
-      [](WorldNode*) -> GroupNode* { return nullptr; },
-      [](LayerNode*) -> GroupNode* { return nullptr; },
-      [](GroupNode* group) -> GroupNode* { return group; },
-      [](auto&& thisLambda, EntityNode* entity) -> GroupNode* {
-        return entity->visitParent(thisLambda).value_or(nullptr);
+      [](WorldNode&) -> GroupNode* { return nullptr; },
+      [](LayerNode&) -> GroupNode* { return nullptr; },
+      [](GroupNode& groupNode) -> GroupNode* { return &groupNode; },
+      [](auto&& thisLambda, EntityNode& entityNode) -> GroupNode* {
+        return entityNode.visitParent(thisLambda).value_or(nullptr);
       },
-      [](auto&& thisLambda, BrushNode* brush) -> GroupNode* {
-        return brush->visitParent(thisLambda).value_or(nullptr);
+      [](auto&& thisLambda, BrushNode& brushNode) -> GroupNode* {
+        return brushNode.visitParent(thisLambda).value_or(nullptr);
       },
-      [](auto&& thisLambda, PatchNode* patch) -> GroupNode* {
-        return patch->visitParent(thisLambda).value_or(nullptr);
+      [](auto&& thisLambda, PatchNode& patchNode) -> GroupNode* {
+        return patchNode.visitParent(thisLambda).value_or(nullptr);
       }))
     .value_or(nullptr);
 }
@@ -100,25 +100,25 @@ GroupNode* findOutermostClosedGroup(Node* node)
 {
   return node
     ->visitParent(kdl::overload(
-      [](WorldNode*) -> GroupNode* { return nullptr; },
-      [](LayerNode*) -> GroupNode* { return nullptr; },
-      [](auto&& thisLambda, GroupNode* group) -> GroupNode* {
-        if (GroupNode* parentResult = group->visitParent(thisLambda).value_or(nullptr))
+      [](WorldNode&) -> GroupNode* { return nullptr; },
+      [](LayerNode&) -> GroupNode* { return nullptr; },
+      [](auto&& thisLambda, GroupNode& groupNode) -> GroupNode* {
+        if (auto* parentResult = groupNode.visitParent(thisLambda).value_or(nullptr))
         {
           return parentResult;
         }
         // we didn't find a result searching the parent chain, so either return
         // this group (if it's closed) or nullptr to indicate no result
-        return group->closed() ? group : nullptr;
+        return groupNode.closed() ? &groupNode : nullptr;
       },
-      [](auto&& thisLambda, EntityNode* entity) -> GroupNode* {
-        return entity->visitParent(thisLambda).value_or(nullptr);
+      [](auto&& thisLambda, EntityNode& entityNode) -> GroupNode* {
+        return entityNode.visitParent(thisLambda).value_or(nullptr);
       },
-      [](auto&& thisLambda, BrushNode* brush) -> GroupNode* {
-        return brush->visitParent(thisLambda).value_or(nullptr);
+      [](auto&& thisLambda, BrushNode& brushNode) -> GroupNode* {
+        return brushNode.visitParent(thisLambda).value_or(nullptr);
       },
-      [](auto&& thisLambda, PatchNode* patch) -> GroupNode* {
-        return patch->visitParent(thisLambda).value_or(nullptr);
+      [](auto&& thisLambda, PatchNode& patchNode) -> GroupNode* {
+        return patchNode.visitParent(thisLambda).value_or(nullptr);
       }))
     .value_or(nullptr);
 }
@@ -158,19 +158,19 @@ std::vector<GroupNode*> collectGroups(const std::vector<Node*>& nodes)
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](auto&& thisLambda, const WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
+      [](auto&& thisLambda, const LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, GroupNode* groupNode) {
-        result.push_back(groupNode);
-        groupNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        result.push_back(&groupNode);
+        groupNode.visitChildren(thisLambda);
       },
-      [](const EntityNode*) {},
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const EntityNode&) {},
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
   return result;
 }
 
@@ -181,28 +181,28 @@ std::vector<GroupNode*> collectContainingGroups(const std::vector<Node*>& nodes)
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](GroupNode* groupNode) {
-        if (auto* containingGroupNode = groupNode->containingGroup())
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](GroupNode& groupNode) {
+        if (auto* containingGroupNode = groupNode.containingGroup())
         {
           result.push_back(containingGroupNode);
         }
       },
-      [&](EntityNode* entityNode) {
-        if (auto* containingGroupNode = entityNode->containingGroup())
+      [&](EntityNode& entityNode) {
+        if (auto* containingGroupNode = entityNode.containingGroup())
         {
           result.push_back(containingGroupNode);
         }
       },
-      [&](BrushNode* brushNode) {
-        if (auto* containingGroupNode = brushNode->containingGroup())
+      [&](BrushNode& brushNode) {
+        if (auto* containingGroupNode = brushNode.containingGroup())
         {
           result.push_back(containingGroupNode);
         }
       },
-      [&](PatchNode* patchNode) {
-        if (auto* containingGroupNode = patchNode->containingGroup())
+      [&](PatchNode& patchNode) {
+        if (auto* containingGroupNode = patchNode.containingGroup())
         {
           result.push_back(containingGroupNode);
         }
@@ -243,12 +243,12 @@ static std::vector<Node*> collectMatchingNodes(
 {
   auto result = std::vector<Node*>{};
 
-  const auto collectIfMatching = [&](auto* node) {
+  const auto collectIfMatching = [&](auto& node) {
     for (const auto* brush : brushes)
     {
       if (predicate(node, brush))
       {
-        result.push_back(node);
+        result.push_back(&node);
         return;
       }
     }
@@ -257,38 +257,40 @@ static std::vector<Node*> collectMatchingNodes(
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-      [](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, GroupNode* group) {
-        if (group->opened() || group->hasOpenedDescendant())
+      [](
+        auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+      [](
+        auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        if (groupNode.opened() || groupNode.hasOpenedDescendant())
         {
-          group->visitChildren(thisLambda);
+          groupNode.visitChildren(thisLambda);
         }
         else
         {
-          collectIfMatching(group);
+          collectIfMatching(groupNode);
         }
       },
-      [&](auto&& thisLambda, EntityNode* entity) {
-        if (entity->hasChildren())
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        if (entityNode.hasChildren())
         {
-          entity->visitChildren(thisLambda);
+          entityNode.visitChildren(thisLambda);
         }
         else
         {
-          collectIfMatching(entity);
+          collectIfMatching(entityNode);
         }
       },
-      [&](BrushNode* brush) {
+      [&](BrushNode& brushNode) {
         // if `brush` is one of the search query nodes, don't count it as touching
-        if (!kdl::vec_contains(brushes, brush))
+        if (!kdl::vec_contains(brushes, &brushNode))
         {
-          collectIfMatching(brush);
+          collectIfMatching(brushNode);
         }
       },
-      [&](PatchNode* patch) {
+      [&](PatchNode& patchNode) {
         // if `patch` is one of the search query nodes, don't count it as touching
-        collectIfMatching(patch);
+        collectIfMatching(patchNode);
       }));
   }
 
@@ -296,25 +298,27 @@ static std::vector<Node*> collectMatchingNodes(
 }
 
 std::vector<Node*> collectTouchingNodes(
-  const std::vector<Node*>& nodes, const std::vector<BrushNode*>& brushes)
+  const std::vector<Node*>& nodes, const std::vector<BrushNode*>& brushNodes)
 {
-  return collectMatchingNodes(nodes, brushes, [](const auto* node, const auto* brush) {
-    return brush->intersects(*node);
-  });
+  return collectMatchingNodes(
+    nodes, brushNodes, [](const auto& node, const auto& brushNode) {
+      return brushNode->intersects(node);
+    });
 }
 
 std::vector<Node*> collectContainedNodes(
-  const std::vector<Node*>& nodes, const std::vector<BrushNode*>& brushes)
+  const std::vector<Node*>& nodes, const std::vector<BrushNode*>& brushNodes)
 {
-  return collectMatchingNodes(nodes, brushes, [](const auto* node, const auto* brush) {
-    return brush->contains(*node);
-  });
+  return collectMatchingNodes(
+    nodes, brushNodes, [](const auto& node, const auto& brushNode) {
+      return brushNode->contains(node);
+    });
 }
 
 std::vector<Node*> collectSelectedNodes(const std::vector<Node*>& nodes)
 {
   return collectNodesAndDescendants(
-    nodes, [](const auto* node) { return node->selected(); });
+    nodes, [](const auto& node) { return node.selected(); });
 }
 
 std::vector<Node*> collectSelectableNodes(
@@ -325,41 +329,39 @@ std::vector<Node*> collectSelectableNodes(
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* worldNode) {
-        worldNode->visitChildren(thisLambda);
-      },
-      [&](auto&& thisLambda, LayerNode* layerNode) {
-        layerNode->visitChildren(thisLambda);
-      },
-      [&](auto&& thisLambda, GroupNode* groupNode) {
-        if (editorContext.selectable(*groupNode))
+      [&](
+        auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+      [&](
+        auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        if (editorContext.selectable(groupNode))
         {
           // implies that any containing group is opened and that group itself is closed
           // therefore we don't need to visit the group's children
-          result.push_back(groupNode);
+          result.push_back(&groupNode);
         }
         else
         {
-          groupNode->visitChildren(thisLambda);
+          groupNode.visitChildren(thisLambda);
         }
       },
-      [&](auto&& thisLambda, EntityNode* entityNode) {
-        if (editorContext.selectable(*entityNode))
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        if (editorContext.selectable(entityNode))
         {
-          result.push_back(entityNode);
+          result.push_back(&entityNode);
         }
-        entityNode->visitChildren(thisLambda);
+        entityNode.visitChildren(thisLambda);
       },
-      [&](BrushNode* brushNode) {
-        if (editorContext.selectable(*brushNode))
+      [&](BrushNode& brushNode) {
+        if (editorContext.selectable(brushNode))
         {
-          result.push_back(brushNode);
+          result.push_back(&brushNode);
         }
       },
-      [&](PatchNode* patchNode) {
-        if (editorContext.selectable(*patchNode))
+      [&](PatchNode& patchNode) {
+        if (editorContext.selectable(patchNode))
         {
-          result.push_back(patchNode);
+          result.push_back(&patchNode);
         }
       }));
   }
@@ -390,12 +392,12 @@ vm::bbox3d computeLogicalBounds(
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](const GroupNode* group) { builder.add(group->logicalBounds()); },
-      [&](const EntityNode* entity) { builder.add(entity->logicalBounds()); },
-      [&](const BrushNode* brush) { builder.add(brush->logicalBounds()); },
-      [&](const PatchNode* patch) { builder.add(patch->logicalBounds()); }));
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](const GroupNode& groupNode) { builder.add(groupNode.logicalBounds()); },
+      [&](const EntityNode& entityNode) { builder.add(entityNode.logicalBounds()); },
+      [&](const BrushNode& brushNode) { builder.add(brushNode.logicalBounds()); },
+      [&](const PatchNode& patchNode) { builder.add(patchNode.logicalBounds()); }));
   return builder.initialized() ? builder.bounds() : defaultBounds;
 }
 
@@ -406,12 +408,12 @@ vm::bbox3d computePhysicalBounds(
   Node::visitAll(
     nodes,
     kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](const GroupNode* group) { builder.add(group->physicalBounds()); },
-      [&](const EntityNode* entity) { builder.add(entity->physicalBounds()); },
-      [&](const BrushNode* brush) { builder.add(brush->physicalBounds()); },
-      [&](const PatchNode* patch) { builder.add(patch->physicalBounds()); }));
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](const GroupNode& groupNode) { builder.add(groupNode.physicalBounds()); },
+      [&](const EntityNode& entityNode) { builder.add(entityNode.physicalBounds()); },
+      [&](const BrushNode& brushNode) { builder.add(brushNode.physicalBounds()); },
+      [&](const PatchNode& patchNode) { builder.add(patchNode.physicalBounds()); }));
   return builder.initialized() ? builder.bounds() : defaultBounds;
 }
 
@@ -422,12 +424,12 @@ std::vector<BrushNode*> filterBrushNodes(const std::vector<Node*>& nodes)
   for (Node* node : nodes)
   {
     node->accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [](GroupNode*) {},
-      [](EntityNode*) {},
-      [&](BrushNode* brushNode) { result.push_back(brushNode); },
-      [](PatchNode*) {}));
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [](GroupNode&) {},
+      [](EntityNode&) {},
+      [&](BrushNode& brushNode) { result.push_back(&brushNode); },
+      [](PatchNode&) {}));
   }
   return result;
 }
@@ -439,12 +441,12 @@ std::vector<EntityNode*> filterEntityNodes(const std::vector<Node*>& nodes)
   for (Node* node : nodes)
   {
     node->accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [](GroupNode*) {},
-      [&](EntityNode* entityNode) { result.push_back(entityNode); },
-      [](BrushNode*) {},
-      [](PatchNode*) {}));
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [](GroupNode&) {},
+      [&](EntityNode& entityNode) { result.push_back(&entityNode); },
+      [](BrushNode&) {},
+      [](PatchNode&) {}));
   }
   return result;
 }

--- a/lib/TbMdlLib/src/ModelUtils.cpp
+++ b/lib/TbMdlLib/src/ModelUtils.cpp
@@ -299,7 +299,7 @@ std::vector<Node*> collectTouchingNodes(
   const std::vector<Node*>& nodes, const std::vector<BrushNode*>& brushes)
 {
   return collectMatchingNodes(nodes, brushes, [](const auto* node, const auto* brush) {
-    return brush->intersects(node);
+    return brush->intersects(*node);
   });
 }
 
@@ -307,7 +307,7 @@ std::vector<Node*> collectContainedNodes(
   const std::vector<Node*>& nodes, const std::vector<BrushNode*>& brushes)
 {
   return collectMatchingNodes(nodes, brushes, [](const auto* node, const auto* brush) {
-    return brush->contains(node);
+    return brush->contains(*node);
   });
 }
 

--- a/lib/TbMdlLib/src/Node.cpp
+++ b/lib/TbMdlLib/src/Node.cpp
@@ -156,23 +156,23 @@ Node* Node::parent() const
   return m_parent;
 }
 
-bool Node::isAncestorOf(const Node* node) const
+bool Node::isAncestorOf(const Node& node) const
 {
-  return node->isDescendantOf(this);
+  return node.isDescendantOf(*this);
 }
 
 bool Node::isAncestorOf(const std::vector<Node*>& nodes) const
 {
   return std::ranges::any_of(
-    nodes, [this](const Node* node) { return isAncestorOf(node); });
+    nodes, [this](const Node* node) { return isAncestorOf(*node); });
 }
 
-bool Node::isDescendantOf(const Node* node) const
+bool Node::isDescendantOf(const Node& node) const
 {
-  Node* parent = m_parent;
+  auto* parent = m_parent;
   while (parent)
   {
-    if (parent == node)
+    if (parent == &node)
     {
       return true;
     }
@@ -184,7 +184,7 @@ bool Node::isDescendantOf(const Node* node) const
 bool Node::isDescendantOf(const std::vector<Node*>& nodes) const
 {
   return std::ranges::any_of(
-    nodes, [this](const Node* node) { return isDescendantOf(node); });
+    nodes, [this](const Node* node) { return isDescendantOf(*node); });
 }
 
 std::vector<Node*> Node::findDescendants(const std::vector<Node*>& nodes) const
@@ -192,7 +192,7 @@ std::vector<Node*> Node::findDescendants(const std::vector<Node*>& nodes) const
   auto result = std::vector<Node*>{};
   for (auto* node : nodes)
   {
-    if (node->isDescendantOf(this))
+    if (node->isDescendantOf(*this))
     {
       result.push_back(node);
     }
@@ -258,9 +258,9 @@ std::vector<std::unique_ptr<Node>> Node::replaceChildren(
   {
     contract_assert(child != nullptr);
     contract_assert(child->parent() == this);
-    contract_assert(canRemoveChild(child));
+    contract_assert(canRemoveChild(*child));
 
-    childWillBeRemoved(child);
+    childWillBeRemoved(*child);
     child->setParent(nullptr);
   }
 
@@ -272,7 +272,7 @@ std::vector<std::unique_ptr<Node>> Node::replaceChildren(
 
   for (auto& child : oldChildren)
   {
-    childWasRemoved(child.get());
+    childWasRemoved(*child);
   }
 
   decDescendantCount(descendantCount());
@@ -294,12 +294,12 @@ void Node::removeChild(Node* child)
   decDescendantSelectionCount(child->descendantSelectionCount());
 }
 
-bool Node::canAddChild(const Node* child) const
+bool Node::canAddChild(const Node& child) const
 {
-  return child != this && !isDescendantOf(child) && doCanAddChild(child);
+  return &child != this && !isDescendantOf(child) && doCanAddChild(child);
 }
 
-bool Node::canRemoveChild(const Node* child) const
+bool Node::canRemoveChild(const Node& child) const
 {
   return doCanRemoveChild(child);
 }
@@ -309,13 +309,13 @@ void Node::doAddChild(Node* child)
   contract_pre(child != nullptr);
   contract_pre(child->parent() == nullptr);
   contract_pre(!kdl::vec_contains(m_children, child));
-  contract_pre(canAddChild(child));
+  contract_pre(canAddChild(*child));
 
-  childWillBeAdded(child);
+  childWillBeAdded(*child);
   // nodeWillChange();
   m_children.push_back(child);
   child->setParent(this);
-  childWasAdded(child);
+  childWasAdded(*child);
   // nodeDidChange();
 }
 
@@ -323,13 +323,13 @@ void Node::doRemoveChild(Node* child)
 {
   contract_pre(child != nullptr);
   contract_pre(child->parent() == this);
-  contract_pre(canRemoveChild(child));
+  contract_pre(canRemoveChild(*child));
 
-  childWillBeRemoved(child);
+  childWillBeRemoved(*child);
   // nodeWillChange();
   child->setParent(nullptr);
   m_children = kdl::vec_erase(std::move(m_children), child);
-  childWasRemoved(child);
+  childWasRemoved(*child);
   // nodeDidChange();
 }
 
@@ -338,31 +338,31 @@ void Node::clearChildren()
   kdl::vec_clear_and_delete(m_children);
 }
 
-void Node::childWillBeAdded(Node* node)
+void Node::childWillBeAdded(Node& node)
 {
   doChildWillBeAdded(node);
-  descendantWillBeAdded(this, node, 1);
+  descendantWillBeAdded(*this, node, 1);
 }
 
-void Node::childWasAdded(Node* node)
+void Node::childWasAdded(Node& node)
 {
   doChildWasAdded(node);
   descendantWasAdded(node, 1);
 }
 
-void Node::childWillBeRemoved(Node* node)
+void Node::childWillBeRemoved(Node& node)
 {
   doChildWillBeRemoved(node);
   descendantWillBeRemoved(node, 1);
 }
 
-void Node::childWasRemoved(Node* node)
+void Node::childWasRemoved(Node& node)
 {
   doChildWasRemoved(node);
-  descendantWasRemoved(this, node, 1);
+  descendantWasRemoved(*this, node, 1);
 }
 
-void Node::descendantWillBeAdded(Node* newParent, Node* node, const size_t depth)
+void Node::descendantWillBeAdded(Node& newParent, Node& node, const size_t depth)
 {
   doDescendantWillBeAdded(newParent, node, depth);
   if (m_parent)
@@ -371,7 +371,7 @@ void Node::descendantWillBeAdded(Node* newParent, Node* node, const size_t depth
   }
 }
 
-void Node::descendantWasAdded(Node* node, const size_t depth)
+void Node::descendantWasAdded(Node& node, const size_t depth)
 {
   doDescendantWasAdded(node, depth);
   if (m_parent)
@@ -381,7 +381,7 @@ void Node::descendantWasAdded(Node* node, const size_t depth)
   invalidateIssues();
 }
 
-void Node::descendantWillBeRemoved(Node* node, const size_t depth)
+void Node::descendantWillBeRemoved(Node& node, const size_t depth)
 {
   doDescendantWillBeRemoved(node, depth);
   if (m_parent)
@@ -390,7 +390,7 @@ void Node::descendantWillBeRemoved(Node* node, const size_t depth)
   }
 }
 
-void Node::descendantWasRemoved(Node* oldParent, Node* node, const size_t depth)
+void Node::descendantWasRemoved(Node& oldParent, Node& node, const size_t depth)
 {
   doDescendantWasRemoved(oldParent, node, depth);
   if (m_parent)
@@ -475,7 +475,7 @@ void Node::nodeWillChange()
 {
   if (m_parent)
   {
-    m_parent->childWillChange(this);
+    m_parent->childWillChange(*this);
   }
   invalidateIssues();
 }
@@ -484,7 +484,7 @@ void Node::nodeDidChange()
 {
   if (m_parent)
   {
-    m_parent->childDidChange(this);
+    m_parent->childDidChange(*this);
   }
   invalidateIssues();
 }
@@ -515,23 +515,23 @@ void Node::nodePhysicalBoundsDidChange()
   doNodePhysicalBoundsDidChange();
   if (m_parent)
   {
-    m_parent->childPhysicalBoundsDidChange(this);
+    m_parent->childPhysicalBoundsDidChange(*this);
   }
 }
 
-void Node::childWillChange(Node* node)
+void Node::childWillChange(Node& node)
 {
   doChildWillChange(node);
   descendantWillChange(node);
 }
 
-void Node::childDidChange(Node* node)
+void Node::childDidChange(Node& node)
 {
   doChildDidChange(node);
   descendantDidChange(node);
 }
 
-void Node::descendantWillChange(Node* node)
+void Node::descendantWillChange(Node& node)
 {
   doDescendantWillChange(node);
   if (m_parent)
@@ -541,7 +541,7 @@ void Node::descendantWillChange(Node* node)
   invalidateIssues();
 }
 
-void Node::descendantDidChange(Node* node)
+void Node::descendantDidChange(Node& node)
 {
   doDescendantDidChange(node);
   if (m_parent)
@@ -551,14 +551,14 @@ void Node::descendantDidChange(Node* node)
   invalidateIssues();
 }
 
-void Node::childPhysicalBoundsDidChange(Node* node)
+void Node::childPhysicalBoundsDidChange(Node& node)
 {
   nodePhysicalBoundsDidChange();
   doChildPhysicalBoundsDidChange();
   descendantPhysicalBoundsDidChange(node, 1);
 }
 
-void Node::descendantPhysicalBoundsDidChange(Node* node, const size_t depth)
+void Node::descendantPhysicalBoundsDidChange(Node& node, const size_t depth)
 {
   doDescendantPhysicalBoundsDidChange(node);
   if (m_parent)
@@ -871,19 +871,17 @@ Node* Node::doCloneRecursively(const vm::bbox3d& worldBounds) const
   return clone;
 }
 
-void Node::doChildWillBeAdded(Node* /* node */) {}
-void Node::doChildWasAdded(Node* /* node */) {}
-void Node::doChildWillBeRemoved(Node* /* node */) {}
-void Node::doChildWasRemoved(Node* /* node */) {}
+void Node::doChildWillBeAdded(Node&) {}
+void Node::doChildWasAdded(Node&) {}
+void Node::doChildWillBeRemoved(Node&) {}
+void Node::doChildWasRemoved(Node&) {}
 
-void Node::doDescendantWillBeAdded(
-  Node* /* newParent */, Node* /* node */, const size_t /* depth */)
+void Node::doDescendantWillBeAdded(Node& /* newParent */, Node&, const size_t /* depth */)
 {
 }
-void Node::doDescendantWasAdded(Node* /* node */, const size_t /* depth */) {}
-void Node::doDescendantWillBeRemoved(Node* /* node */, const size_t /* depth */) {}
-void Node::doDescendantWasRemoved(
-  Node* /* oldParent */, Node* /* node */, const size_t /* depth */)
+void Node::doDescendantWasAdded(Node&, const size_t /* depth */) {}
+void Node::doDescendantWillBeRemoved(Node&, const size_t /* depth */) {}
+void Node::doDescendantWasRemoved(Node& /* oldParent */, Node&, const size_t /* depth */)
 {
 }
 
@@ -894,12 +892,12 @@ void Node::doAncestorDidChange() {}
 
 void Node::doNodePhysicalBoundsDidChange() {}
 void Node::doChildPhysicalBoundsDidChange() {}
-void Node::doDescendantPhysicalBoundsDidChange(Node* /* node */) {}
+void Node::doDescendantPhysicalBoundsDidChange(Node&) {}
 
-void Node::doChildWillChange(Node* /* node */) {}
-void Node::doChildDidChange(Node* /* node */) {}
-void Node::doDescendantWillChange(Node* /* node */) {}
-void Node::doDescendantDidChange(Node* /* node */) {}
+void Node::doChildWillChange(Node&) {}
+void Node::doChildDidChange(Node&) {}
+void Node::doDescendantWillChange(Node&) {}
+void Node::doDescendantDidChange(Node&) {}
 
 const EntityPropertyConfig& Node::doGetEntityPropertyConfig() const
 {

--- a/lib/TbMdlLib/src/NodeIndex.cpp
+++ b/lib/TbMdlLib/src/NodeIndex.cpp
@@ -93,12 +93,12 @@ void NodeIndex::addNode(Node& node)
   };
 
   node.accept(kdl::overload(
-    [&](WorldNode* worldNode) { withEntityNode(*worldNode, addToIndex); },
-    [](LayerNode*) {},
-    [&](GroupNode* groupNode) { withGroupNode(*groupNode, addToIndex); },
-    [&](EntityNode* entityNode) { withEntityNode(*entityNode, addToIndex); },
-    [&](BrushNode* brushNode) { withBrushNode(*brushNode, addToIndex); },
-    [&](PatchNode* patchNode) { withPatchNode(*patchNode, addToIndex); }));
+    [&](WorldNode& worldNode) { withEntityNode(worldNode, addToIndex); },
+    [](LayerNode&) {},
+    [&](GroupNode& groupNode) { withGroupNode(groupNode, addToIndex); },
+    [&](EntityNode& entityNode) { withEntityNode(entityNode, addToIndex); },
+    [&](BrushNode& brushNode) { withBrushNode(brushNode, addToIndex); },
+    [&](PatchNode& patchNode) { withPatchNode(patchNode, addToIndex); }));
 }
 
 void NodeIndex::removeNode(Node& node)
@@ -108,12 +108,12 @@ void NodeIndex::removeNode(Node& node)
   };
 
   node.accept(kdl::overload(
-    [&](WorldNode* worldNode) { withEntityNode(*worldNode, removeFromIndex); },
-    [](LayerNode*) {},
-    [&](GroupNode* groupNode) { withGroupNode(*groupNode, removeFromIndex); },
-    [&](EntityNode* entityNode) { withEntityNode(*entityNode, removeFromIndex); },
-    [&](BrushNode* brushNode) { withBrushNode(*brushNode, removeFromIndex); },
-    [&](PatchNode* patchNode) { withPatchNode(*patchNode, removeFromIndex); }));
+    [&](WorldNode& worldNode) { withEntityNode(worldNode, removeFromIndex); },
+    [](LayerNode&) {},
+    [&](GroupNode& groupNode) { withGroupNode(groupNode, removeFromIndex); },
+    [&](EntityNode& entityNode) { withEntityNode(entityNode, removeFromIndex); },
+    [&](BrushNode& brushNode) { withBrushNode(brushNode, removeFromIndex); },
+    [&](PatchNode& patchNode) { withPatchNode(patchNode, removeFromIndex); }));
 }
 
 void NodeIndex::clear()

--- a/lib/TbMdlLib/src/NodeSerializer.cpp
+++ b/lib/TbMdlLib/src/NodeSerializer.cpp
@@ -172,12 +172,12 @@ void NodeSerializer::entity(
   beginEntity(node, properties, extraProperties);
 
   brushParent.visitChildren(kdl::overload(
-    [](const WorldNode*) {},
-    [](const LayerNode*) {},
-    [](const GroupNode*) {},
-    [](const EntityNode*) {},
-    [&](const BrushNode* b) { brush(*b); },
-    [&](const PatchNode* p) { patch(*p); }));
+    [](const WorldNode&) {},
+    [](const LayerNode&) {},
+    [](const GroupNode&) {},
+    [](const EntityNode&) {},
+    [&](const BrushNode& brushNode) { brush(brushNode); },
+    [&](const PatchNode& patchNode) { patch(patchNode); }));
 
   endEntity(node);
 }
@@ -275,18 +275,18 @@ std::vector<EntityProperty> NodeSerializer::parentProperties(const Node* node)
 
   auto properties = std::vector<EntityProperty>{};
   node->accept(kdl::overload(
-    [](const WorldNode*) {},
-    [&](const LayerNode* layerNode) {
+    [](const WorldNode&) {},
+    [&](const LayerNode& layerNode) {
       properties.emplace_back(
-        EntityPropertyKeys::TbLayer, kdl::str_to_string(*layerNode->persistentId()));
+        EntityPropertyKeys::TbLayer, kdl::str_to_string(*layerNode.persistentId()));
     },
-    [&](const GroupNode* groupNode) {
+    [&](const GroupNode& groupNode) {
       properties.emplace_back(
-        EntityPropertyKeys::TbGroup, kdl::str_to_string(*groupNode->persistentId()));
+        EntityPropertyKeys::TbGroup, kdl::str_to_string(*groupNode.persistentId()));
     },
-    [](const EntityNode*) {},
-    [](const BrushNode*) {},
-    [](const PatchNode*) {}));
+    [](const EntityNode&) {},
+    [](const BrushNode&) {},
+    [](const PatchNode&) {}));
 
   return properties;
 }

--- a/lib/TbMdlLib/src/NodeSerializer.cpp
+++ b/lib/TbMdlLib/src/NodeSerializer.cpp
@@ -90,13 +90,13 @@ void NodeSerializer::endFile()
 /**
  * Writes the worldspawn entity.
  */
-void NodeSerializer::defaultLayer(const WorldNode& world)
+void NodeSerializer::defaultLayer(const WorldNode& worldNode)
 {
-  auto worldEntity = world.entity();
+  auto worldEntity = worldNode.entity();
 
   // Transfer the color, locked state, and hidden state from the default layer Layer
   // object to worldspawn
-  const auto* defaultLayerNode = world.defaultLayer();
+  const auto* defaultLayerNode = worldNode.defaultLayer();
   const auto& defaultLayer = defaultLayerNode->layer();
   if (const auto color = defaultLayer.color())
   {
@@ -140,50 +140,50 @@ void NodeSerializer::defaultLayer(const WorldNode& world)
 
   if (m_exporting && defaultLayer.omitFromExport())
   {
-    beginEntity(&world, worldEntity.properties(), {});
-    endEntity(&world);
+    beginEntity(worldNode, worldEntity.properties(), {});
+    endEntity(worldNode);
   }
   else
   {
-    entity(&world, worldEntity.properties(), {}, world.defaultLayer());
+    entity(worldNode, worldEntity.properties(), {}, *worldNode.defaultLayer());
   }
 }
 
-void NodeSerializer::customLayer(const LayerNode* layer)
+void NodeSerializer::customLayer(const LayerNode& layerNode)
 {
-  if (!(m_exporting && layer->layer().omitFromExport()))
+  if (!(m_exporting && layerNode.layer().omitFromExport()))
   {
-    entity(layer, layerProperties(layer), {}, layer);
+    entity(layerNode, layerProperties(layerNode), {}, layerNode);
   }
 }
 
 void NodeSerializer::group(
-  const GroupNode* group, const std::vector<EntityProperty>& extraProperties)
+  const GroupNode& groupNode, const std::vector<EntityProperty>& extraProperties)
 {
-  entity(group, groupProperties(group), extraProperties, group);
+  entity(groupNode, groupProperties(groupNode), extraProperties, groupNode);
 }
 
 void NodeSerializer::entity(
-  const Node* node,
+  const Node& node,
   const std::vector<EntityProperty>& properties,
   const std::vector<EntityProperty>& extraProperties,
-  const Node* brushParent)
+  const Node& brushParent)
 {
   beginEntity(node, properties, extraProperties);
 
-  brushParent->visitChildren(kdl::overload(
+  brushParent.visitChildren(kdl::overload(
     [](const WorldNode*) {},
     [](const LayerNode*) {},
     [](const GroupNode*) {},
     [](const EntityNode*) {},
-    [&](const BrushNode* b) { brush(b); },
-    [&](const PatchNode* p) { patch(p); }));
+    [&](const BrushNode* b) { brush(*b); },
+    [&](const PatchNode* p) { patch(*p); }));
 
   endEntity(node);
 }
 
 void NodeSerializer::entity(
-  const Node* node,
+  const Node& node,
   const std::vector<EntityProperty>& properties,
   const std::vector<EntityProperty>& extraProperties,
   const std::vector<BrushNode*>& entityBrushes)
@@ -194,7 +194,7 @@ void NodeSerializer::entity(
 }
 
 void NodeSerializer::beginEntity(
-  const Node* node,
+  const Node& node,
   const std::vector<EntityProperty>& properties,
   const std::vector<EntityProperty>& extraAttributes)
 {
@@ -203,13 +203,13 @@ void NodeSerializer::beginEntity(
   entityProperties(extraAttributes);
 }
 
-void NodeSerializer::beginEntity(const Node* node)
+void NodeSerializer::beginEntity(const Node& node)
 {
   m_brushNo = 0;
   doBeginEntity(node);
 }
 
-void NodeSerializer::endEntity(const Node* node)
+void NodeSerializer::endEntity(const Node& node)
 {
   doEndEntity(node);
   ++m_entityNo;
@@ -235,19 +235,19 @@ void NodeSerializer::entityProperty(const EntityProperty& property)
 
 void NodeSerializer::brushes(const std::vector<BrushNode*>& brushNodes)
 {
-  for (auto* brush : brushNodes)
+  for (auto* brushNode : brushNodes)
   {
-    this->brush(brush);
+    brush(*brushNode);
   }
 }
 
-void NodeSerializer::brush(const BrushNode* brushNode)
+void NodeSerializer::brush(const BrushNode& brushNode)
 {
   doBrush(brushNode);
   ++m_brushNo;
 }
 
-void NodeSerializer::patch(const PatchNode* patchNode)
+void NodeSerializer::patch(const PatchNode& patchNode)
 {
   doPatch(patchNode);
   ++m_brushNo;
@@ -291,27 +291,27 @@ std::vector<EntityProperty> NodeSerializer::parentProperties(const Node* node)
   return properties;
 }
 
-std::vector<EntityProperty> NodeSerializer::layerProperties(const LayerNode* layerNode)
+std::vector<EntityProperty> NodeSerializer::layerProperties(const LayerNode& layerNode)
 {
   std::vector<EntityProperty> result = {
     {EntityPropertyKeys::Classname, EntityPropertyValues::LayerClassname},
     {EntityPropertyKeys::TbGroupType, EntityPropertyValues::GroupTypeLayer},
-    {EntityPropertyKeys::TbLayerName, layerNode->name()},
-    {EntityPropertyKeys::TbLayerId, kdl::str_to_string(*layerNode->persistentId())},
+    {EntityPropertyKeys::TbLayerName, layerNode.name()},
+    {EntityPropertyKeys::TbLayerId, kdl::str_to_string(*layerNode.persistentId())},
   };
 
-  const auto& layer = layerNode->layer();
+  const auto& layer = layerNode.layer();
   if (layer.hasSortIndex())
   {
     result.emplace_back(
       EntityPropertyKeys::TbLayerSortIndex, kdl::str_to_string(layer.sortIndex()));
   }
-  if (layerNode->lockState() == LockState::Locked)
+  if (layerNode.lockState() == LockState::Locked)
   {
     result.emplace_back(
       EntityPropertyKeys::TbLayerLocked, EntityPropertyValues::LayerLockedValue);
   }
-  if (layerNode->hidden())
+  if (layerNode.hidden())
   {
     result.emplace_back(
       EntityPropertyKeys::TbLayerHidden, EntityPropertyValues::LayerHiddenValue);
@@ -325,20 +325,20 @@ std::vector<EntityProperty> NodeSerializer::layerProperties(const LayerNode* lay
   return result;
 }
 
-std::vector<EntityProperty> NodeSerializer::groupProperties(const GroupNode* groupNode)
+std::vector<EntityProperty> NodeSerializer::groupProperties(const GroupNode& groupNode)
 {
   auto result = std::vector<EntityProperty>{
     {EntityPropertyKeys::Classname, EntityPropertyValues::GroupClassname},
     {EntityPropertyKeys::TbGroupType, EntityPropertyValues::GroupTypeGroup},
-    {EntityPropertyKeys::TbGroupName, groupNode->name()},
-    {EntityPropertyKeys::TbGroupId, kdl::str_to_string(*groupNode->persistentId())},
+    {EntityPropertyKeys::TbGroupName, groupNode.name()},
+    {EntityPropertyKeys::TbGroupId, kdl::str_to_string(*groupNode.persistentId())},
   };
 
-  const auto& linkId = groupNode->linkId();
+  const auto& linkId = groupNode.linkId();
   result.emplace_back(EntityPropertyKeys::TbLinkId, kdl::str_to_string(linkId));
 
   // write transformation matrix in column major format
-  const auto& transformation = groupNode->group().transformation();
+  const auto& transformation = groupNode.group().transformation();
   if (transformation != vm::mat4x4d::identity())
   {
     const auto transformationStr = fmt::format(

--- a/lib/TbMdlLib/src/NodeWriter.cpp
+++ b/lib/TbMdlLib/src/NodeWriter.cpp
@@ -59,18 +59,18 @@ void doWriteNodes(
   for (const auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [](const WorldNode*) {},
-      [](const LayerNode*) {},
-      [&](auto&& thisLambda, const GroupNode* groupNode) {
-        serializer.group(*groupNode, parentProperties());
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [&](auto&& thisLambda, const GroupNode& groupNode) {
+        serializer.group(groupNode, parentProperties());
 
-        parentStack.push_back(groupNode);
-        groupNode->visitChildren(thisLambda);
+        parentStack.push_back(&groupNode);
+        groupNode.visitChildren(thisLambda);
         parentStack.pop_back();
       },
-      [&](const EntityNode* entityNode) {
+      [&](const EntityNode& entityNode) {
         auto extraProperties = parentProperties();
-        const auto& protectedProperties = entityNode->entity().protectedProperties();
+        const auto& protectedProperties = entityNode.entity().protectedProperties();
         if (!protectedProperties.empty())
         {
           const auto escapedProperties = protectedProperties
@@ -83,10 +83,10 @@ void doWriteNodes(
             kdl::str_join(escapedProperties, ";"));
         }
         serializer.entity(
-          *entityNode, entityNode->entity().properties(), extraProperties, *entityNode);
+          entityNode, entityNode.entity().properties(), extraProperties, entityNode);
       },
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
   }
 }
 
@@ -165,21 +165,21 @@ void NodeWriter::writeNodes(
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [&](GroupNode* groupNode) { groups.push_back(groupNode); },
-      [&](EntityNode* entityNode) { entities.push_back(entityNode); },
-      [&](BrushNode* brushNode) {
-        if (auto* entity = dynamic_cast<EntityNode*>(brushNode->parent()))
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [&](GroupNode& groupNode) { groups.push_back(&groupNode); },
+      [&](EntityNode& entityNode) { entities.push_back(&entityNode); },
+      [&](BrushNode& brushNode) {
+        if (auto* entityNode = dynamic_cast<EntityNode*>(brushNode.parent()))
         {
-          entityBrushes[entity].push_back(brushNode);
+          entityBrushes[entityNode].push_back(&brushNode);
         }
         else
         {
-          worldBrushes.push_back(brushNode);
+          worldBrushes.push_back(&brushNode);
         }
       },
-      [](PatchNode*) {}));
+      [](PatchNode&) {}));
   }
 
   writeWorldBrushes(worldBrushes);

--- a/lib/TbMdlLib/src/NodeWriter.cpp
+++ b/lib/TbMdlLib/src/NodeWriter.cpp
@@ -61,11 +61,11 @@ void doWriteNodes(
     node->accept(kdl::overload(
       [](const WorldNode*) {},
       [](const LayerNode*) {},
-      [&](auto&& thisLambda, const GroupNode* group) {
-        serializer.group(group, parentProperties());
+      [&](auto&& thisLambda, const GroupNode* groupNode) {
+        serializer.group(*groupNode, parentProperties());
 
-        parentStack.push_back(group);
-        group->visitChildren(thisLambda);
+        parentStack.push_back(groupNode);
+        groupNode->visitChildren(thisLambda);
         parentStack.pop_back();
       },
       [&](const EntityNode* entityNode) {
@@ -83,7 +83,7 @@ void doWriteNodes(
             kdl::str_join(escapedProperties, ";"));
         }
         serializer.entity(
-          entityNode, entityNode->entity().properties(), extraProperties, entityNode);
+          *entityNode, entityNode->entity().properties(), extraProperties, *entityNode);
       },
       [](const BrushNode*) {},
       [](const PatchNode*) {}));
@@ -135,19 +135,18 @@ void NodeWriter::writeDefaultLayer()
 
 void NodeWriter::writeCustomLayers()
 {
-  const std::vector<const LayerNode*> customLayers = m_world.customLayers();
-  for (auto* layer : customLayers)
+  for (auto* layerNode : m_world.customLayers())
   {
-    writeCustomLayer(layer);
+    writeCustomLayer(*layerNode);
   }
 }
 
-void NodeWriter::writeCustomLayer(const LayerNode* layerNode)
+void NodeWriter::writeCustomLayer(const LayerNode& layerNode)
 {
-  if (!(m_serializer->exporting() && layerNode->layer().omitFromExport()))
+  if (!(m_serializer->exporting() && layerNode.layer().omitFromExport()))
   {
     m_serializer->customLayer(layerNode);
-    doWriteNodes(*m_serializer, layerNode->children(), layerNode);
+    doWriteNodes(*m_serializer, layerNode.children(), &layerNode);
   }
 }
 
@@ -168,16 +167,16 @@ void NodeWriter::writeNodes(
     node->accept(kdl::overload(
       [](WorldNode*) {},
       [](LayerNode*) {},
-      [&](GroupNode* group) { groups.push_back(group); },
-      [&](EntityNode* entity) { entities.push_back(entity); },
-      [&](BrushNode* brush) {
-        if (auto* entity = dynamic_cast<EntityNode*>(brush->parent()))
+      [&](GroupNode* groupNode) { groups.push_back(groupNode); },
+      [&](EntityNode* entityNode) { entities.push_back(entityNode); },
+      [&](BrushNode* brushNode) {
+        if (auto* entity = dynamic_cast<EntityNode*>(brushNode->parent()))
         {
-          entityBrushes[entity].push_back(brush);
+          entityBrushes[entity].push_back(brushNode);
         }
         else
         {
-          worldBrushes.push_back(brush);
+          worldBrushes.push_back(brushNode);
         }
       },
       [](PatchNode*) {}));
@@ -196,7 +195,7 @@ void NodeWriter::writeWorldBrushes(const std::vector<BrushNode*>& brushes)
 {
   if (!brushes.empty())
   {
-    m_serializer->entity(&m_world, m_world.entity().properties(), {}, brushes);
+    m_serializer->entity(m_world, m_world.entity().properties(), {}, brushes);
   }
 }
 
@@ -204,7 +203,7 @@ void NodeWriter::writeEntityBrushes(const EntityBrushesMap& entityBrushes)
 {
   for (const auto& [entityNode, brushes] : entityBrushes)
   {
-    m_serializer->entity(entityNode, entityNode->entity().properties(), {}, brushes);
+    m_serializer->entity(*entityNode, entityNode->entity().properties(), {}, brushes);
   }
 }
 

--- a/lib/TbMdlLib/src/ObjSerializer.cpp
+++ b/lib/TbMdlLib/src/ObjSerializer.cpp
@@ -227,19 +227,19 @@ void ObjSerializer::doEndFile()
     m_objects);
 }
 
-void ObjSerializer::doBeginEntity(const Node*) {}
-void ObjSerializer::doEndEntity(const Node*) {}
+void ObjSerializer::doBeginEntity(const Node&) {}
+void ObjSerializer::doEndEntity(const Node&) {}
 void ObjSerializer::doEntityProperty(const EntityProperty&) {}
 
-void ObjSerializer::doBrush(const BrushNode* brush)
+void ObjSerializer::doBrush(const BrushNode& brushNode)
 {
   m_currentBrush = BrushObject{entityNo(), brushNo(), {}};
-  m_currentBrush->faces.reserve(brush->brush().faceCount());
+  m_currentBrush->faces.reserve(brushNode.brush().faceCount());
 
   // Vertex positions inserted from now on should get new indices
   m_vertices.clearIndices();
 
-  for (const auto& face : brush->brush().faces())
+  for (const auto& face : brushNode.brush().faces())
   {
     doBrushFace(face);
   }
@@ -274,13 +274,13 @@ void ObjSerializer::doBrushFace(const BrushFace& face)
   });
 }
 
-void ObjSerializer::doPatch(const PatchNode* patchNode)
+void ObjSerializer::doPatch(const PatchNode& patchNode)
 {
-  const auto& patch = patchNode->patch();
+  const auto& patch = patchNode.patch();
   auto patchObject =
     PatchObject{entityNo(), brushNo(), {}, patch.materialName(), patch.material()};
 
-  const auto& patchGrid = patchNode->grid();
+  const auto& patchGrid = patchNode.grid();
   patchObject.quads.reserve(patchGrid.quadRowCount() * patchGrid.quadColumnCount());
 
   // Vertex positions inserted from now on should get new indices

--- a/lib/TbMdlLib/src/PatchNode.cpp
+++ b/lib/TbMdlLib/src/PatchNode.cpp
@@ -311,19 +311,23 @@ const EntityNodeBase* PatchNode::entity() const
 {
   return visitParent(
            kdl::overload(
-             [](const WorldNode* world) -> const EntityNodeBase* { return world; },
-             [](const EntityNode* entity) -> const EntityNodeBase* { return entity; },
-             [](auto&& thisLambda, const LayerNode* layer) -> const EntityNodeBase* {
-               return layer->visitParent(thisLambda).value_or(nullptr);
+             [](const WorldNode& worldNode) -> const EntityNodeBase* {
+               return &worldNode;
              },
-             [](auto&& thisLambda, const GroupNode* group) -> const EntityNodeBase* {
-               return group->visitParent(thisLambda).value_or(nullptr);
+             [](const EntityNode& entityNode) -> const EntityNodeBase* {
+               return &entityNode;
              },
-             [](auto&& thisLambda, const BrushNode* brush) -> const EntityNodeBase* {
-               return brush->visitParent(thisLambda).value_or(nullptr);
+             [](auto&& thisLambda, const LayerNode& layerNode) -> const EntityNodeBase* {
+               return layerNode.visitParent(thisLambda).value_or(nullptr);
              },
-             [](auto&& thisLambda, const PatchNode* patch) -> const EntityNodeBase* {
-               return patch->visitParent(thisLambda).value_or(nullptr);
+             [](auto&& thisLambda, const GroupNode& groupNode) -> const EntityNodeBase* {
+               return groupNode.visitParent(thisLambda).value_or(nullptr);
+             },
+             [](auto&& thisLambda, const BrushNode& brushNode) -> const EntityNodeBase* {
+               return brushNode.visitParent(thisLambda).value_or(nullptr);
+             },
+             [](auto&& thisLambda, const PatchNode& patchNode) -> const EntityNodeBase* {
+               return patchNode.visitParent(thisLambda).value_or(nullptr);
              }))
     .value_or(nullptr);
 }
@@ -461,12 +465,12 @@ void PatchNode::doFindNodesContaining(const vm::vec3d&, std::vector<Node*>&) {}
 
 void PatchNode::doAccept(NodeVisitor& visitor)
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void PatchNode::doAccept(ConstNodeVisitor& visitor) const
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 Node* PatchNode::doGetContainer()

--- a/lib/TbMdlLib/src/PatchNode.cpp
+++ b/lib/TbMdlLib/src/PatchNode.cpp
@@ -398,12 +398,12 @@ Node* PatchNode::doClone(const vm::bbox3d&) const
   return result.release();
 }
 
-bool PatchNode::doCanAddChild(const Node*) const
+bool PatchNode::doCanAddChild(const Node&) const
 {
   return false;
 }
 
-bool PatchNode::doCanRemoveChild(const Node*) const
+bool PatchNode::doCanRemoveChild(const Node&) const
 {
   return false;
 }

--- a/lib/TbMdlLib/src/Selection.cpp
+++ b/lib/TbMdlLib/src/Selection.cpp
@@ -55,14 +55,13 @@ std::vector<EntityNodeBase*> computeAllEntities(
   for (auto* node : selection.nodes)
   {
     node->accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [](auto&& thisLambda, GroupNode* groupNode) {
-        groupNode->visitChildren(thisLambda);
-      },
-      [&](EntityNode* entityNode) { result.push_back(entityNode); },
-      [&](BrushNode* brushNode) { result.push_back(brushNode->entity()); },
-      [&](PatchNode* patchNode) { result.push_back(patchNode->entity()); }));
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [](
+        auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+      [&](EntityNode& entityNode) { result.push_back(&entityNode); },
+      [&](BrushNode& brushNode) { result.push_back(brushNode.entity()); },
+      [&](PatchNode& patchNode) { result.push_back(patchNode.entity()); }));
   }
 
   if (result.empty())
@@ -91,16 +90,15 @@ std::vector<BrushNode*> computeAllBrushes(const Selection& selection)
   for (auto* node : selection.nodes)
   {
     node->accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [](auto&& thisLambda, GroupNode* groupNode) {
-        groupNode->visitChildren(thisLambda);
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [](
+        auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+      [](auto&& thisLambda, EntityNode& entityNode) {
+        entityNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, EntityNode* entityNode) {
-        entityNode->visitChildren(thisLambda);
-      },
-      [&](BrushNode* brushNode) { result.push_back(brushNode); },
-      [&](PatchNode*) {}));
+      [&](BrushNode& brushNode) { result.push_back(&brushNode); },
+      [&](PatchNode&) {}));
   }
 
   return result;

--- a/lib/TbMdlLib/src/SelectionCommand.cpp
+++ b/lib/TbMdlLib/src/SelectionCommand.cpp
@@ -128,7 +128,7 @@ void doDeselectAll(Map& map)
 void doSelectNodes(const std::vector<Node*>& nodes, Map& map)
 {
   contract_pre(std::ranges::all_of(nodes, [&](const auto* node) {
-    return node->isDescendantOf(&map.worldNode()) || node == &map.worldNode();
+    return node->isDescendantOf(map.worldNode()) || node == &map.worldNode();
   }));
 
   map.selectionWillChangeNotifier();

--- a/lib/TbMdlLib/src/SetLinkIdsCommand.cpp
+++ b/lib/TbMdlLib/src/SetLinkIdsCommand.cpp
@@ -44,15 +44,15 @@ auto setLinkIds(const std::vector<std::tuple<Node*, std::string>>& linkIds)
            auto* node = std::get<Node*>(nodeAndLinkId);
            const auto& linkId = std::get<std::string>(nodeAndLinkId);
            return node->accept(kdl::overload(
-             [&](const WorldNode*) -> std::tuple<Node*, std::string> {
+             [&](const WorldNode&) -> std::tuple<Node*, std::string> {
                contract_assert(false);
              },
-             [](const LayerNode*) -> std::tuple<Node*, std::string> {
+             [](const LayerNode&) -> std::tuple<Node*, std::string> {
                contract_assert(false);
              },
-             [&](Object* object) -> std::tuple<Node*, std::string> {
-               auto oldLinkId = object->linkId();
-               object->setLinkId(std::move(linkId));
+             [&](Object& object) -> std::tuple<Node*, std::string> {
+               auto oldLinkId = object.linkId();
+               object.setLinkId(std::move(linkId));
                return {node, std::move(oldLinkId)};
              }));
          })

--- a/lib/TbMdlLib/src/SetLockStateCommand.cpp
+++ b/lib/TbMdlLib/src/SetLockStateCommand.cpp
@@ -99,12 +99,12 @@ static bool shouldUpdateModificationCount(const std::vector<Node*>& nodes)
 {
   return std::ranges::any_of(nodes, [](const auto* node) {
     return node->accept(kdl::overload(
-      [](const WorldNode*) { return false; },
-      [](const LayerNode*) { return true; },
-      [](const GroupNode*) { return false; },
-      [](const EntityNode*) { return false; },
-      [](const BrushNode*) { return false; },
-      [](const PatchNode*) { return false; }));
+      [](const WorldNode&) { return false; },
+      [](const LayerNode&) { return true; },
+      [](const GroupNode&) { return false; },
+      [](const EntityNode&) { return false; },
+      [](const BrushNode&) { return false; },
+      [](const PatchNode&) { return false; }));
   });
 }
 

--- a/lib/TbMdlLib/src/SwapNodeContentsCommand.cpp
+++ b/lib/TbMdlLib/src/SwapNodeContentsCommand.cpp
@@ -99,24 +99,24 @@ void doSwapNodeContents(
     auto& contents = pair.second.get();
 
     pair.second = node->accept(kdl::overload(
-      [&](WorldNode* worldNode) {
-        return NodeContents{worldNode->setEntity(std::get<Entity>(std::move(contents)))};
+      [&](WorldNode& worldNode) {
+        return NodeContents{worldNode.setEntity(std::get<Entity>(std::move(contents)))};
       },
-      [&](LayerNode* layerNode) {
-        return NodeContents(layerNode->setLayer(std::get<Layer>(std::move(contents))));
+      [&](LayerNode& layerNode) {
+        return NodeContents(layerNode.setLayer(std::get<Layer>(std::move(contents))));
       },
-      [&](GroupNode* groupNode) {
-        return NodeContents{groupNode->setGroup(std::get<Group>(std::move(contents)))};
+      [&](GroupNode& groupNode) {
+        return NodeContents{groupNode.setGroup(std::get<Group>(std::move(contents)))};
       },
-      [&](EntityNode* entityNode) {
-        return NodeContents{entityNode->setEntity(std::get<Entity>(std::move(contents)))};
+      [&](EntityNode& entityNode) {
+        return NodeContents{entityNode.setEntity(std::get<Entity>(std::move(contents)))};
       },
-      [&](BrushNode* brushNode) {
-        return NodeContents{brushNode->setBrush(std::get<Brush>(std::move(contents)))};
+      [&](BrushNode& brushNode) {
+        return NodeContents{brushNode.setBrush(std::get<Brush>(std::move(contents)))};
       },
-      [&](PatchNode* patchNode) {
+      [&](PatchNode& patchNode) {
         return NodeContents{
-          patchNode->setPatch(std::get<BezierPatch>(std::move(contents)))};
+          patchNode.setPatch(std::get<BezierPatch>(std::move(contents)))};
       }));
   }
 }

--- a/lib/TbMdlLib/src/UpdateLinkedGroupsHelper.cpp
+++ b/lib/TbMdlLib/src/UpdateLinkedGroupsHelper.cpp
@@ -45,7 +45,7 @@ namespace
 // Order groups so that descendants will be updated before their ancestors
 auto compareByAncestry(const GroupNode* lhs, const GroupNode* rhs)
 {
-  return rhs->isAncestorOf(lhs);
+  return rhs->isAncestorOf(*lhs);
 }
 
 std::vector<Node*> collectOldChildren(

--- a/lib/TbMdlLib/src/Validator.cpp
+++ b/lib/TbMdlLib/src/Validator.cpp
@@ -56,12 +56,12 @@ std::vector<const IssueQuickFix*> Validator::quickFixes() const
 void Validator::validate(Node& node, std::vector<std::unique_ptr<Issue>>& issues) const
 {
   node.accept(kdl::overload(
-    [&](WorldNode* worldNode) { doValidate(*worldNode, issues); },
-    [&](LayerNode* layerNode) { doValidate(*layerNode, issues); },
-    [&](GroupNode* groupNode) { doValidate(*groupNode, issues); },
-    [&](EntityNode* entityNode) { doValidate(*entityNode, issues); },
-    [&](BrushNode* brushNode) { doValidate(*brushNode, issues); },
-    [&](PatchNode* patchNode) { doValidate(*patchNode, issues); }));
+    [&](WorldNode& worldNode) { doValidate(worldNode, issues); },
+    [&](LayerNode& layerNode) { doValidate(layerNode, issues); },
+    [&](GroupNode& groupNode) { doValidate(groupNode, issues); },
+    [&](EntityNode& entityNode) { doValidate(entityNode, issues); },
+    [&](BrushNode& brushNode) { doValidate(brushNode, issues); },
+    [&](PatchNode& patchNode) { doValidate(patchNode, issues); }));
 }
 
 Validator::Validator(const IssueType type, std::string description)

--- a/lib/TbMdlLib/src/VertexHandleManager.cpp
+++ b/lib/TbMdlLib/src/VertexHandleManager.cpp
@@ -52,18 +52,18 @@ void VertexHandleManager::pick(
   }
 }
 
-void VertexHandleManager::addHandles(const BrushNode* brushNode)
+void VertexHandleManager::addHandles(const BrushNode& brushNode)
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   for (const auto* vertex : brush.vertices())
   {
     add(vertex->position());
   }
 }
 
-void VertexHandleManager::removeHandles(const BrushNode* brushNode)
+void VertexHandleManager::removeHandles(const BrushNode& brushNode)
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   for (const auto* vertex : brush.vertices())
   {
     assertResult(remove(vertex->position()));
@@ -76,9 +76,9 @@ HitType::Type VertexHandleManager::hitType() const
 }
 
 bool VertexHandleManager::isIncident(
-  const Handle& handle, const BrushNode* brushNode) const
+  const Handle& handle, const BrushNode& brushNode) const
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   return brush.hasVertex(handle);
 }
 
@@ -131,18 +131,18 @@ void EdgeHandleManager::pickCenterHandle(
   }
 }
 
-void EdgeHandleManager::addHandles(const BrushNode* brushNode)
+void EdgeHandleManager::addHandles(const BrushNode& brushNode)
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   for (const auto* edge : brush.edges())
   {
     add(vm::segment3d{edge->firstVertex()->position(), edge->secondVertex()->position()});
   }
 }
 
-void EdgeHandleManager::removeHandles(const BrushNode* brushNode)
+void EdgeHandleManager::removeHandles(const BrushNode& brushNode)
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   for (const auto* edge : brush.edges())
   {
     assertResult(remove(
@@ -155,9 +155,9 @@ HitType::Type EdgeHandleManager::hitType() const
   return HandleHitType;
 }
 
-bool EdgeHandleManager::isIncident(const Handle& handle, const BrushNode* brushNode) const
+bool EdgeHandleManager::isIncident(const Handle& handle, const BrushNode& brushNode) const
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   return brush.hasEdge(handle);
 }
 
@@ -214,18 +214,18 @@ void FaceHandleManager::pickCenterHandle(
   }
 }
 
-void FaceHandleManager::addHandles(const BrushNode* brushNode)
+void FaceHandleManager::addHandles(const BrushNode& brushNode)
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   for (const auto& face : brush.faces())
   {
     add(face.polygon());
   }
 }
 
-void FaceHandleManager::removeHandles(const BrushNode* brushNode)
+void FaceHandleManager::removeHandles(const BrushNode& brushNode)
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   for (const auto& face : brush.faces())
   {
     assertResult(remove(face.polygon()));
@@ -237,9 +237,9 @@ HitType::Type FaceHandleManager::hitType() const
   return HandleHitType;
 }
 
-bool FaceHandleManager::isIncident(const Handle& handle, const BrushNode* brushNode) const
+bool FaceHandleManager::isIncident(const Handle& handle, const BrushNode& brushNode) const
 {
-  const auto& brush = brushNode->brush();
+  const auto& brush = brushNode.brush();
   return brush.hasFace(handle);
 }
 

--- a/lib/TbMdlLib/src/WorldNode.cpp
+++ b/lib/TbMdlLib/src/WorldNode.cpp
@@ -107,12 +107,12 @@ std::vector<const LayerNode*> WorldNode::allLayers() const
 {
   auto layers = std::vector<const LayerNode*>{};
   visitChildren(kdl::overload(
-    [](const WorldNode*) {},
-    [&](const LayerNode* layer) { layers.push_back(layer); },
-    [](const GroupNode*) {},
-    [](const EntityNode*) {},
-    [](const BrushNode*) {},
-    [](const PatchNode*) {}));
+    [](const WorldNode&) {},
+    [&](const LayerNode& layerNode) { layers.push_back(&layerNode); },
+    [](const GroupNode&) {},
+    [](const EntityNode&) {},
+    [](const BrushNode&) {},
+    [](const PatchNode&) {}));
   return layers;
 }
 
@@ -129,12 +129,12 @@ std::vector<const LayerNode*> WorldNode::customLayers() const
   for (auto it = std::next(std::begin(children)); it != std::end(children); ++it)
   {
     (*it)->accept(kdl::overload(
-      [](const WorldNode*) {},
-      [&](const LayerNode* layer) { layers.push_back(layer); },
-      [](const GroupNode*) {},
-      [](const EntityNode*) {},
-      [](const BrushNode*) {},
-      [](const PatchNode*) {}));
+      [](const WorldNode&) {},
+      [&](const LayerNode& layerNode) { layers.push_back(&layerNode); },
+      [](const GroupNode&) {},
+      [](const EntityNode&) {},
+      [](const BrushNode&) {},
+      [](const PatchNode&) {}));
   }
 
   return layers;
@@ -207,32 +207,32 @@ void WorldNode::enableNodeTreeUpdates()
 void WorldNode::rebuildNodeTree()
 {
   auto nodes = std::vector<Node*>{};
-  const auto addNode = [&](auto* node) {
-    if (node->shouldAddToSpacialIndex())
+  const auto addNode = [&](auto& node) {
+    if (node.shouldAddToSpacialIndex())
     {
-      nodes.push_back(node);
+      nodes.push_back(&node);
     }
   };
 
   accept(kdl::overload(
-    [&](auto&& thisLambda, WorldNode* world) {
-      addNode(world);
-      world->visitChildren(thisLambda);
+    [&](auto&& thisLambda, WorldNode& worldNode) {
+      addNode(worldNode);
+      worldNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, LayerNode* layer) {
-      addNode(layer);
-      layer->visitChildren(thisLambda);
+    [&](auto&& thisLambda, LayerNode& layerNode) {
+      addNode(layerNode);
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, GroupNode* group) {
-      addNode(group);
-      group->visitChildren(thisLambda);
+    [&](auto&& thisLambda, GroupNode& groupNode) {
+      addNode(groupNode);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, EntityNode* entity) {
-      addNode(entity);
-      entity->visitChildren(thisLambda);
+    [&](auto&& thisLambda, EntityNode& entityNode) {
+      addNode(entityNode);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](BrushNode* brush) { addNode(brush); },
-    [&](PatchNode* patch) { addNode(patch); }));
+    [&](BrushNode& brushNode) { addNode(brushNode); },
+    [&](PatchNode& patchNode) { addNode(patchNode); }));
 
   m_nodeTree->clear();
   for (auto* node : nodes)
@@ -243,9 +243,9 @@ void WorldNode::rebuildNodeTree()
 
 void WorldNode::invalidateAllIssues()
 {
-  accept([](auto&& thisLambda, Node* node) {
-    node->invalidateIssues();
-    node->visitChildren(thisLambda);
+  accept([](auto&& thisLambda, Node& node) {
+    node.invalidateIssues();
+    node.visitChildren(thisLambda);
   });
 }
 
@@ -302,23 +302,23 @@ Node* WorldNode::doCloneRecursively(const vm::bbox3d& worldBounds) const
 bool WorldNode::doCanAddChild(const Node& child) const
 {
   return child.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [](const LayerNode*) { return true; },
-    [](const GroupNode*) { return false; },
-    [](const EntityNode*) { return false; },
-    [](const BrushNode*) { return false; },
-    [](const PatchNode*) { return false; }));
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return true; },
+    [](const GroupNode&) { return false; },
+    [](const EntityNode&) { return false; },
+    [](const BrushNode&) { return false; },
+    [](const PatchNode&) { return false; }));
 }
 
 bool WorldNode::doCanRemoveChild(const Node& child) const
 {
   return child.accept(kdl::overload(
-    [](const WorldNode*) { return false; },
-    [&](const LayerNode* layer) { return (layer != defaultLayer()); },
-    [](const GroupNode*) { return false; },
-    [](const EntityNode*) { return false; },
-    [](const BrushNode*) { return false; },
-    [](const PatchNode*) { return false; }));
+    [](const WorldNode&) { return false; },
+    [&](const LayerNode& layerNode) { return (&layerNode != defaultLayer()); },
+    [](const GroupNode&) { return false; },
+    [](const EntityNode&) { return false; },
+    [](const BrushNode&) { return false; },
+    [](const PatchNode&) { return false; }));
 }
 
 bool WorldNode::doRemoveIfEmpty() const
@@ -340,49 +340,52 @@ void WorldNode::doDescendantWasAdded(Node& node, const size_t /* depth */)
   if (m_updateNodeTree)
   {
     node.accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, EntityNode* entity) {
-        contract_assert(m_nodeTree->insert(entity->physicalBounds(), entity));
-        entity->visitChildren(thisLambda);
+      [&](
+        auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+      [&](
+        auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+      [&](
+        auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        contract_assert(m_nodeTree->insert(entityNode.physicalBounds(), &entityNode));
+        entityNode.visitChildren(thisLambda);
       },
-      [&](BrushNode* brush) {
-        contract_assert(m_nodeTree->insert(brush->physicalBounds(), brush));
+      [&](BrushNode& brushNode) {
+        contract_assert(m_nodeTree->insert(brushNode.physicalBounds(), &brushNode));
       },
-      [&](PatchNode* patch) {
-        contract_assert(m_nodeTree->insert(patch->physicalBounds(), patch));
+      [&](PatchNode& patchNode) {
+        contract_assert(m_nodeTree->insert(patchNode.physicalBounds(), &patchNode));
       }));
   }
 
-  const auto updatePersistentId = [&](auto* persistentNode) {
-    if (const auto persistentNodeId = persistentNode->persistentId())
+  const auto updatePersistentId = [&](auto& persistentNode) {
+    if (const auto persistentNodeId = persistentNode.persistentId())
     {
       contract_assert(*persistentNodeId < std::numeric_limits<IdType>::max());
       m_nextPersistentId = std::max(m_nextPersistentId, *persistentNodeId + 1u);
     }
     else
     {
-      persistentNode->setPersistentId(m_nextPersistentId++);
+      persistentNode.setPersistentId(m_nextPersistentId++);
     }
   };
 
   node.accept(kdl::overload(
-    [&](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-    [&](auto&& thisLambda, LayerNode* layer) {
-      layer->visitChildren(thisLambda);
-      if (layer != defaultLayer())
+    [&](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [&](auto&& thisLambda, LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
+      if (&layerNode != defaultLayer())
       {
-        updatePersistentId(layer);
+        updatePersistentId(layerNode);
       }
     },
-    [&](auto&& thisLambda, GroupNode* group) {
-      group->visitChildren(thisLambda);
-      updatePersistentId(group);
+    [&](auto&& thisLambda, GroupNode& groupNode) {
+      groupNode.visitChildren(thisLambda);
+      updatePersistentId(groupNode);
     },
-    [&](EntityNode*) {},
-    [&](BrushNode*) {},
-    [&](PatchNode*) {}));
+    [&](EntityNode&) {},
+    [&](BrushNode&) {},
+    [&](PatchNode&) {}));
 }
 
 void WorldNode::doDescendantWillBeRemoved(Node& node, const size_t /* depth */)
@@ -390,15 +393,18 @@ void WorldNode::doDescendantWillBeRemoved(Node& node, const size_t /* depth */)
   if (m_updateNodeTree)
   {
     node.accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, EntityNode* entity) {
-        contract_assert(m_nodeTree->remove(entity));
-        entity->visitChildren(thisLambda);
+      [&](
+        auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+      [&](
+        auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+      [&](
+        auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+      [&](auto&& thisLambda, EntityNode& entityNode) {
+        contract_assert(m_nodeTree->remove(&entityNode));
+        entityNode.visitChildren(thisLambda);
       },
-      [&](BrushNode* brush) { contract_assert(m_nodeTree->remove(brush)); },
-      [&](PatchNode* patch) { contract_assert(m_nodeTree->remove(patch)); }));
+      [&](BrushNode& brushNode) { contract_assert(m_nodeTree->remove(&brushNode)); },
+      [&](PatchNode& patchNode) { contract_assert(m_nodeTree->remove(&patchNode)); }));
   }
 }
 
@@ -407,12 +413,18 @@ void WorldNode::doDescendantPhysicalBoundsDidChange(Node& node)
   if (m_updateNodeTree)
   {
     node.accept(kdl::overload(
-      [](WorldNode*) {},
-      [](LayerNode*) {},
-      [](GroupNode*) {},
-      [&](EntityNode* entity) { m_nodeTree->update(entity->physicalBounds(), entity); },
-      [&](BrushNode* brush) { m_nodeTree->update(brush->physicalBounds(), brush); },
-      [&](PatchNode* patch) { m_nodeTree->update(patch->physicalBounds(), patch); }));
+      [](WorldNode&) {},
+      [](LayerNode&) {},
+      [](GroupNode&) {},
+      [&](EntityNode& entityNode) {
+        m_nodeTree->update(entityNode.physicalBounds(), &entityNode);
+      },
+      [&](BrushNode& brushNode) {
+        m_nodeTree->update(brushNode.physicalBounds(), &brushNode);
+      },
+      [&](PatchNode& patchNode) {
+        m_nodeTree->update(patchNode.physicalBounds(), &patchNode);
+      }));
   }
 }
 
@@ -440,12 +452,12 @@ void WorldNode::doFindNodesContaining(const vm::vec3d& point, std::vector<Node*>
 
 void WorldNode::doAccept(NodeVisitor& visitor)
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 void WorldNode::doAccept(ConstNodeVisitor& visitor) const
 {
-  visitor.visit(this);
+  visitor.visit(*this);
 }
 
 const EntityPropertyConfig& WorldNode::doGetEntityPropertyConfig() const

--- a/lib/TbMdlLib/src/WorldNode.cpp
+++ b/lib/TbMdlLib/src/WorldNode.cpp
@@ -299,9 +299,9 @@ Node* WorldNode::doCloneRecursively(const vm::bbox3d& worldBounds) const
   return worldNode;
 }
 
-bool WorldNode::doCanAddChild(const Node* child) const
+bool WorldNode::doCanAddChild(const Node& child) const
 {
-  return child->accept(kdl::overload(
+  return child.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [](const LayerNode*) { return true; },
     [](const GroupNode*) { return false; },
@@ -310,9 +310,9 @@ bool WorldNode::doCanAddChild(const Node* child) const
     [](const PatchNode*) { return false; }));
 }
 
-bool WorldNode::doCanRemoveChild(const Node* child) const
+bool WorldNode::doCanRemoveChild(const Node& child) const
 {
-  return child->accept(kdl::overload(
+  return child.accept(kdl::overload(
     [](const WorldNode*) { return false; },
     [&](const LayerNode* layer) { return (layer != defaultLayer()); },
     [](const GroupNode*) { return false; },
@@ -331,7 +331,7 @@ bool WorldNode::doShouldAddToSpacialIndex() const
   return false;
 }
 
-void WorldNode::doDescendantWasAdded(Node* node, const size_t /* depth */)
+void WorldNode::doDescendantWasAdded(Node& node, const size_t /* depth */)
 {
   // NOTE: `node` is just the root of a subtree that is being connected to this World.
   // In some cases, (e.g. if `node` is a Group), `node` will not be added to the spatial
@@ -339,7 +339,7 @@ void WorldNode::doDescendantWasAdded(Node* node, const size_t /* depth */)
   // being connected and add it or any descendants that need to be added.
   if (m_updateNodeTree)
   {
-    node->accept(kdl::overload(
+    node.accept(kdl::overload(
       [&](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
       [&](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
       [&](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
@@ -367,7 +367,7 @@ void WorldNode::doDescendantWasAdded(Node* node, const size_t /* depth */)
     }
   };
 
-  node->accept(kdl::overload(
+  node.accept(kdl::overload(
     [&](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
     [&](auto&& thisLambda, LayerNode* layer) {
       layer->visitChildren(thisLambda);
@@ -385,11 +385,11 @@ void WorldNode::doDescendantWasAdded(Node* node, const size_t /* depth */)
     [&](PatchNode*) {}));
 }
 
-void WorldNode::doDescendantWillBeRemoved(Node* node, const size_t /* depth */)
+void WorldNode::doDescendantWillBeRemoved(Node& node, const size_t /* depth */)
 {
   if (m_updateNodeTree)
   {
-    node->accept(kdl::overload(
+    node.accept(kdl::overload(
       [&](auto&& thisLambda, WorldNode* world) { world->visitChildren(thisLambda); },
       [&](auto&& thisLambda, LayerNode* layer) { layer->visitChildren(thisLambda); },
       [&](auto&& thisLambda, GroupNode* group) { group->visitChildren(thisLambda); },
@@ -402,11 +402,11 @@ void WorldNode::doDescendantWillBeRemoved(Node* node, const size_t /* depth */)
   }
 }
 
-void WorldNode::doDescendantPhysicalBoundsDidChange(Node* node)
+void WorldNode::doDescendantPhysicalBoundsDidChange(Node& node)
 {
   if (m_updateNodeTree)
   {
-    node->accept(kdl::overload(
+    node.accept(kdl::overload(
       [](WorldNode*) {},
       [](LayerNode*) {},
       [](GroupNode*) {},

--- a/lib/TbMdlLib/test-utils/src/Matchers.cpp
+++ b/lib/TbMdlLib/test-utils/src/Matchers.cpp
@@ -55,37 +55,37 @@ bool nodesMatch(const Node& lhs, const Node& rhs)
   }
 
   return lhs.accept(kdl::overload(
-    [&](const WorldNode* expectedWorldNode) {
+    [&](const WorldNode& expectedWorldNode) {
       const auto* inWorldNode = dynamic_cast<const WorldNode*>(&rhs);
-      return inWorldNode && inWorldNode->entity() == expectedWorldNode->entity()
-             && nodesMatch(inWorldNode->children(), expectedWorldNode->children());
+      return inWorldNode && inWorldNode->entity() == expectedWorldNode.entity()
+             && nodesMatch(inWorldNode->children(), expectedWorldNode.children());
     },
-    [&](const LayerNode* expectedLayerNode) {
+    [&](const LayerNode& expectedLayerNode) {
       const auto* inLayerNode = dynamic_cast<const LayerNode*>(&rhs);
-      return inLayerNode && inLayerNode->layer() == expectedLayerNode->layer()
-             && nodesMatch(inLayerNode->children(), expectedLayerNode->children());
+      return inLayerNode && inLayerNode->layer() == expectedLayerNode.layer()
+             && nodesMatch(inLayerNode->children(), expectedLayerNode.children());
     },
-    [&](const GroupNode* expectedGroupNode) {
+    [&](const GroupNode& expectedGroupNode) {
       const auto* inGroupNode = dynamic_cast<const GroupNode*>(&rhs);
-      return inGroupNode && inGroupNode->group() == expectedGroupNode->group()
-             && inGroupNode->linkId() == expectedGroupNode->linkId()
-             && nodesMatch(inGroupNode->children(), expectedGroupNode->children());
+      return inGroupNode && inGroupNode->group() == expectedGroupNode.group()
+             && inGroupNode->linkId() == expectedGroupNode.linkId()
+             && nodesMatch(inGroupNode->children(), expectedGroupNode.children());
     },
-    [&](const EntityNode* expectedEntityNode) {
+    [&](const EntityNode& expectedEntityNode) {
       const auto* inEntityNode = dynamic_cast<const EntityNode*>(&rhs);
-      return inEntityNode && inEntityNode->entity() == expectedEntityNode->entity()
-             && inEntityNode->linkId() == expectedEntityNode->linkId()
-             && nodesMatch(inEntityNode->children(), expectedEntityNode->children());
+      return inEntityNode && inEntityNode->entity() == expectedEntityNode.entity()
+             && inEntityNode->linkId() == expectedEntityNode.linkId()
+             && nodesMatch(inEntityNode->children(), expectedEntityNode.children());
     },
-    [&](const BrushNode* expectedBrushNode) {
+    [&](const BrushNode& expectedBrushNode) {
       const auto* inBrushNode = dynamic_cast<const BrushNode*>(&rhs);
-      return inBrushNode && inBrushNode->brush() == expectedBrushNode->brush()
-             && inBrushNode->linkId() == expectedBrushNode->linkId();
+      return inBrushNode && inBrushNode->brush() == expectedBrushNode.brush()
+             && inBrushNode->linkId() == expectedBrushNode.linkId();
     },
-    [&](const PatchNode* expectedPatchNode) {
+    [&](const PatchNode& expectedPatchNode) {
       const auto* inPatchNode = dynamic_cast<const PatchNode*>(&rhs);
-      return inPatchNode && inPatchNode->patch() == expectedPatchNode->patch()
-             && inPatchNode->linkId() == expectedPatchNode->linkId();
+      return inPatchNode && inPatchNode->patch() == expectedPatchNode.patch()
+             && inPatchNode->linkId() == expectedPatchNode.linkId();
     }));
 }
 

--- a/lib/TbMdlLib/test-utils/src/StringMakers.cpp
+++ b/lib/TbMdlLib/test-utils/src/StringMakers.cpp
@@ -125,12 +125,12 @@ void printPatchNode(
 void printNode(const Node& node, const std::string& indent, std::ostream& str)
 {
   node.accept(kdl::overload(
-    [&](const WorldNode* worldNode) { printWorldNode(*worldNode, indent, str); },
-    [&](const LayerNode* layerNode) { printLayerNode(*layerNode, indent, str); },
-    [&](const GroupNode* groupNode) { printGroupNode(*groupNode, indent, str); },
-    [&](const EntityNode* entityNode) { printEntityNode(*entityNode, indent, str); },
-    [&](const BrushNode* brushNode) { printBrushNode(*brushNode, indent, str); },
-    [&](const PatchNode* patchNode) { printPatchNode(*patchNode, indent, str); }));
+    [&](const WorldNode& worldNode) { printWorldNode(worldNode, indent, str); },
+    [&](const LayerNode& layerNode) { printLayerNode(layerNode, indent, str); },
+    [&](const GroupNode& groupNode) { printGroupNode(groupNode, indent, str); },
+    [&](const EntityNode& entityNode) { printEntityNode(entityNode, indent, str); },
+    [&](const BrushNode& brushNode) { printBrushNode(brushNode, indent, str); },
+    [&](const PatchNode& patchNode) { printPatchNode(patchNode, indent, str); }));
 }
 
 void printNodes(

--- a/lib/TbMdlLib/test-utils/src/TestUtils.cpp
+++ b/lib/TbMdlLib/test-utils/src/TestUtils.cpp
@@ -284,34 +284,34 @@ void transformNode(
   Node& node, const vm::mat4x4d& transformation, const vm::bbox3d& worldBounds)
 {
   node.accept(kdl::overload(
-    [](const WorldNode*) {},
-    [](const LayerNode*) {},
-    [&](auto&& thisLambda, GroupNode* groupNode) {
-      auto group = groupNode->group();
+    [](const WorldNode&) {},
+    [](const LayerNode&) {},
+    [&](auto&& thisLambda, GroupNode& groupNode) {
+      auto group = groupNode.group();
       group.transform(transformation);
-      groupNode->setGroup(std::move(group));
+      groupNode.setGroup(std::move(group));
 
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, EntityNode* entityNode) {
+    [&](auto&& thisLambda, EntityNode& entityNode) {
       const auto updateAngleProperty =
-        entityNode->entityPropertyConfig().updateAnglePropertyAfterTransform;
+        entityNode.entityPropertyConfig().updateAnglePropertyAfterTransform;
 
-      auto entity = entityNode->entity();
+      auto entity = entityNode.entity();
       entity.transform(transformation, updateAngleProperty);
-      entityNode->setEntity(std::move(entity));
+      entityNode.setEntity(std::move(entity));
 
-      entityNode->visitChildren(thisLambda);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](BrushNode* brushNode) {
-      auto brush = brushNode->brush();
+    [&](BrushNode& brushNode) {
+      auto brush = brushNode.brush();
       REQUIRE(brush.transform(worldBounds, transformation, false));
-      brushNode->setBrush(std::move(brush));
+      brushNode.setBrush(std::move(brush));
     },
-    [&](PatchNode* patchNode) {
-      auto patch = patchNode->patch();
+    [&](PatchNode& patchNode) {
+      auto patch = patchNode.patch();
       patch.transform(transformation);
-      patchNode->setPatch(std::move(patch));
+      patchNode.setPatch(std::move(patch));
     }));
 }
 
@@ -356,9 +356,9 @@ void checkBrushUVCoordSystem(const mdl::BrushNode* brushNode, const bool expectP
 void setLinkId(Node& node, std::string linkId)
 {
   node.accept(kdl::overload(
-    [](const WorldNode*) {},
-    [](const LayerNode*) {},
-    [&](Object* object) { object->setLinkId(std::move(linkId)); }));
+    [](const WorldNode&) {},
+    [](const LayerNode&) {},
+    [&](Object& object) { object.setLinkId(std::move(linkId)); }));
 }
 
 Selection makeSelection(Map& map, const std::vector<Node*>& nodes)
@@ -368,23 +368,23 @@ Selection makeSelection(Map& map, const std::vector<Node*>& nodes)
   mdl::Node::visitAll(
     nodes,
     kdl::overload(
-      [](mdl::WorldNode*) {},
-      [](mdl::LayerNode*) {},
-      [&](mdl::GroupNode* group) {
-        selection.nodes.push_back(group);
-        selection.groups.push_back(group);
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [&](mdl::GroupNode& groupNode) {
+        selection.nodes.push_back(&groupNode);
+        selection.groups.push_back(&groupNode);
       },
-      [&](mdl::EntityNode* entity) {
-        selection.nodes.push_back(entity);
-        selection.entities.push_back(entity);
+      [&](mdl::EntityNode& entityNode) {
+        selection.nodes.push_back(&entityNode);
+        selection.entities.push_back(&entityNode);
       },
-      [&](mdl::BrushNode* brush) {
-        selection.nodes.push_back(brush);
-        selection.brushes.push_back(brush);
+      [&](mdl::BrushNode& brushNode) {
+        selection.nodes.push_back(&brushNode);
+        selection.brushes.push_back(&brushNode);
       },
-      [&](mdl::PatchNode* patch) {
-        selection.nodes.push_back(patch);
-        selection.patches.push_back(patch);
+      [&](mdl::PatchNode& patchNode) {
+        selection.nodes.push_back(&patchNode);
+        selection.patches.push_back(&patchNode);
       }));
 
   return selection;

--- a/lib/TbMdlLib/test/src/tst_BrushNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushNode.cpp
@@ -176,13 +176,13 @@ TEST_CASE("BrushNode")
     }, "some_material"}};
       // clang-format on
 
-      CHECK_FALSE(brushNode.contains(&patchNode));
+      CHECK_FALSE(brushNode.contains(patchNode));
 
       transformNode(patchNode, vm::translation_matrix(vm::vec3d{0, -8, 0}), worldBounds);
-      CHECK(brushNode.contains(&patchNode));
+      CHECK(brushNode.contains(patchNode));
 
       transformNode(patchNode, vm::translation_matrix(vm::vec3d{0, 0, 32}), worldBounds);
-      CHECK_FALSE(brushNode.contains(&patchNode));
+      CHECK_FALSE(brushNode.contains(patchNode));
     }
   }
 
@@ -208,34 +208,34 @@ TEST_CASE("BrushNode")
       }, "some_material"}};
       // clang-format on
 
-      CHECK(brushNode.intersects(&patchNode));
+      CHECK(brushNode.intersects(patchNode));
 
       SECTION("Brush contains patch")
       {
         transformNode(
           patchNode, vm::translation_matrix(vm::vec3d{0, -8, 0}), worldBounds);
-        CHECK(brushNode.intersects(&patchNode));
+        CHECK(brushNode.intersects(patchNode));
       }
 
       SECTION("Patch sticks out of top of brush")
       {
         transformNode(
           patchNode, vm::translation_matrix(vm::vec3d{0, -8, 32}), worldBounds);
-        CHECK(brushNode.intersects(&patchNode));
+        CHECK(brushNode.intersects(patchNode));
       }
 
       SECTION("Patch is above brush")
       {
         transformNode(
           patchNode, vm::translation_matrix(vm::vec3d{0, -8, 64}), worldBounds);
-        CHECK_FALSE(brushNode.intersects(&patchNode));
+        CHECK_FALSE(brushNode.intersects(patchNode));
       }
 
       SECTION("Patch doesn't touch brush, but bounds intersect")
       {
         transformNode(
           patchNode, vm::translation_matrix(vm::vec3d{0, 32, 0}), worldBounds);
-        CHECK_FALSE(brushNode.intersects(&patchNode));
+        CHECK_FALSE(brushNode.intersects(patchNode));
       }
 
       SECTION("Brush does not contain any grid points, but patch intersects")
@@ -247,7 +247,7 @@ TEST_CASE("BrushNode")
         {
           REQUIRE_FALSE(thinBrushNode.brush().containsPoint(point.position));
         }
-        CHECK(thinBrushNode.intersects(&patchNode));
+        CHECK(thinBrushNode.intersects(patchNode));
       }
     }
   }
@@ -852,8 +852,8 @@ TEST_CASE("BrushNode (Regression)", "[regression]")
     auto* pipe = static_cast<BrushNode*>(nodes.value().at(0)->children().at(0));
     auto* cube = static_cast<BrushNode*>(nodes.value().at(0)->children().at(1));
 
-    CHECK(pipe->intersects(cube));
-    CHECK(cube->intersects(pipe));
+    CHECK(pipe->intersects(*cube));
+    CHECK(cube->intersects(*pipe));
 
     kdl::col_delete_all(nodes.value());
   }

--- a/lib/TbMdlLib/test/src/tst_EntityNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_EntityNode.cpp
@@ -67,12 +67,12 @@ TEST_CASE("EntityNodeTest.canAddChild")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
   // clang-format on
 
-  CHECK_FALSE(entityNode.canAddChild(&worldNode));
-  CHECK_FALSE(entityNode.canAddChild(&layerNode));
-  CHECK_FALSE(entityNode.canAddChild(&groupNode));
-  CHECK_FALSE(entityNode.canAddChild(&entityNode));
-  CHECK(entityNode.canAddChild(&brushNode));
-  CHECK(entityNode.canAddChild(&patchNode));
+  CHECK_FALSE(entityNode.canAddChild(worldNode));
+  CHECK_FALSE(entityNode.canAddChild(layerNode));
+  CHECK_FALSE(entityNode.canAddChild(groupNode));
+  CHECK_FALSE(entityNode.canAddChild(entityNode));
+  CHECK(entityNode.canAddChild(brushNode));
+  CHECK(entityNode.canAddChild(patchNode));
 }
 
 TEST_CASE("EntityNodeTest.canRemoveChild")
@@ -94,12 +94,12 @@ TEST_CASE("EntityNodeTest.canRemoveChild")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
   // clang-format on
 
-  CHECK(entityNode.canRemoveChild(&worldNode));
-  CHECK(worldNode.canRemoveChild(&layerNode));
-  CHECK(entityNode.canRemoveChild(&groupNode));
-  CHECK(entityNode.canRemoveChild(&entityNode));
-  CHECK(entityNode.canRemoveChild(&brushNode));
-  CHECK(entityNode.canRemoveChild(&patchNode));
+  CHECK(entityNode.canRemoveChild(worldNode));
+  CHECK(worldNode.canRemoveChild(layerNode));
+  CHECK(entityNode.canRemoveChild(groupNode));
+  CHECK(entityNode.canRemoveChild(entityNode));
+  CHECK(entityNode.canRemoveChild(brushNode));
+  CHECK(entityNode.canRemoveChild(patchNode));
 }
 
 TEST_CASE("EntityNodeTest.setPointEntity")

--- a/lib/TbMdlLib/test/src/tst_GroupNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_GroupNode.cpp
@@ -117,23 +117,23 @@ TEST_CASE("GroupNode.canAddChild")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
   // clang-format on
 
-  CHECK_FALSE(groupNode.canAddChild(&worldNode));
-  CHECK_FALSE(groupNode.canAddChild(&layerNode));
-  CHECK_FALSE(groupNode.canAddChild(&groupNode));
-  CHECK(groupNode.canAddChild(&entityNode));
-  CHECK(groupNode.canAddChild(&brushNode));
-  CHECK(groupNode.canAddChild(&patchNode));
+  CHECK_FALSE(groupNode.canAddChild(worldNode));
+  CHECK_FALSE(groupNode.canAddChild(layerNode));
+  CHECK_FALSE(groupNode.canAddChild(groupNode));
+  CHECK(groupNode.canAddChild(entityNode));
+  CHECK(groupNode.canAddChild(brushNode));
+  CHECK(groupNode.canAddChild(patchNode));
 
   SECTION("Recursive linked groups")
   {
     auto linkedGroupNode = std::make_unique<GroupNode>(Group{"group"});
     setLinkId(groupNode, "linked_group_id");
     setLinkId(*linkedGroupNode, groupNode.linkId());
-    CHECK_FALSE(groupNode.canAddChild(linkedGroupNode.get()));
+    CHECK_FALSE(groupNode.canAddChild(*linkedGroupNode));
 
     auto outerGroupNode = GroupNode{Group{"outer_group"}};
     outerGroupNode.addChild(linkedGroupNode.release());
-    CHECK_FALSE(groupNode.canAddChild(&outerGroupNode));
+    CHECK_FALSE(groupNode.canAddChild(outerGroupNode));
   }
 }
 
@@ -156,12 +156,12 @@ TEST_CASE("GroupNode.canRemoveChild")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
   // clang-format on
 
-  CHECK(groupNode.canRemoveChild(&worldNode));
-  CHECK(groupNode.canRemoveChild(&layerNode));
-  CHECK(groupNode.canRemoveChild(&groupNode));
-  CHECK(groupNode.canRemoveChild(&entityNode));
-  CHECK(groupNode.canRemoveChild(&brushNode));
-  CHECK(groupNode.canRemoveChild(&patchNode));
+  CHECK(groupNode.canRemoveChild(worldNode));
+  CHECK(groupNode.canRemoveChild(layerNode));
+  CHECK(groupNode.canRemoveChild(groupNode));
+  CHECK(groupNode.canRemoveChild(entityNode));
+  CHECK(groupNode.canRemoveChild(brushNode));
+  CHECK(groupNode.canRemoveChild(patchNode));
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_LayerNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_LayerNode.cpp
@@ -60,12 +60,12 @@ TEST_CASE("LayerNode")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
     // clang-format on
 
-    CHECK_FALSE(layerNode.canAddChild(&worldNode));
-    CHECK_FALSE(layerNode.canAddChild(&layerNode));
-    CHECK(layerNode.canAddChild(&groupNode));
-    CHECK(layerNode.canAddChild(&entityNode));
-    CHECK(layerNode.canAddChild(&brushNode));
-    CHECK(layerNode.canAddChild(&patchNode));
+    CHECK_FALSE(layerNode.canAddChild(worldNode));
+    CHECK_FALSE(layerNode.canAddChild(layerNode));
+    CHECK(layerNode.canAddChild(groupNode));
+    CHECK(layerNode.canAddChild(entityNode));
+    CHECK(layerNode.canAddChild(brushNode));
+    CHECK(layerNode.canAddChild(patchNode));
   }
 
   SECTION("canRemoveChild")
@@ -87,12 +87,12 @@ TEST_CASE("LayerNode")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
     // clang-format on
 
-    CHECK(layerNode.canRemoveChild(&worldNode));
-    CHECK(layerNode.canRemoveChild(&layerNode));
-    CHECK(layerNode.canRemoveChild(&groupNode));
-    CHECK(layerNode.canRemoveChild(&entityNode));
-    CHECK(layerNode.canRemoveChild(&brushNode));
-    CHECK(layerNode.canRemoveChild(&patchNode));
+    CHECK(layerNode.canRemoveChild(worldNode));
+    CHECK(layerNode.canRemoveChild(layerNode));
+    CHECK(layerNode.canRemoveChild(groupNode));
+    CHECK(layerNode.canRemoveChild(entityNode));
+    CHECK(layerNode.canRemoveChild(brushNode));
+    CHECK(layerNode.canRemoveChild(patchNode));
   }
 }
 

--- a/lib/TbMdlLib/test/src/tst_LinkedGroupUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_LinkedGroupUtils.cpp
@@ -83,22 +83,22 @@ std::unordered_map<const Node*, std::string> getLinkIds(const Node& node)
 {
   auto result = std::unordered_map<const Node*, std::string>{};
   node.accept(kdl::overload(
-    [](auto&& thisLambda, const WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, const GroupNode* groupNode) {
-      result[groupNode] = groupNode->linkId();
-      groupNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, const GroupNode& groupNode) {
+      result[&groupNode] = groupNode.linkId();
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, const EntityNode* entityNode) {
-      result[entityNode] = entityNode->linkId();
-      entityNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, const EntityNode& entityNode) {
+      result[&entityNode] = entityNode.linkId();
+      entityNode.visitChildren(thisLambda);
     },
-    [&](const BrushNode* brushNode) { result[brushNode] = brushNode->linkId(); },
-    [&](const PatchNode* patchNode) { result[patchNode] = patchNode->linkId(); }));
+    [&](const BrushNode& brushNode) { result[&brushNode] = brushNode.linkId(); },
+    [&](const PatchNode& patchNode) { result[&patchNode] = patchNode.linkId(); }));
   return result;
 }
 

--- a/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
@@ -389,7 +389,7 @@ TEST_CASE("Map_Brushes")
       {
         selectNodes(map, {groupNode, linkedGroupNode});
 
-        CHECK(setBrushFaceAttributes(map, {.materialName = "abc"}));
+        REQUIRE(setBrushFaceAttributes(map, {.materialName = "abc"}));
 
         // check that the brushes in both linked groups got a material
         for (auto* g : std::vector<GroupNode*>{groupNode, linkedGroupNode})

--- a/lib/TbMdlLib/test/src/tst_Map_Geometry.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Geometry.cpp
@@ -399,7 +399,7 @@ TEST_CASE("Map_Geometry")
       selectNodes(map, {brushNode});
 
       auto& vertexHandles = map.vertexHandles();
-      vertexHandles.addHandles(brushNode);
+      vertexHandles.addHandles(*brushNode);
       vertexHandles.select(std::vector<vm::vec3d>{
         {-32, -32, 32},
         {-32, 32, 32},

--- a/lib/TbMdlLib/test/src/tst_Map_Groups.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Groups.cpp
@@ -980,8 +980,8 @@ TEST_CASE("Map_Groups")
         const auto [newProtectedGroupNode, newUnprotectedGroupNode] =
           findNodeOrDescendant<EntityNode>(
             {newGroupNodes[0]->children()},
-            [](const auto* entityNode) {
-              return !entityNode->entity().protectedProperties().empty();
+            [](const auto& entityNode) {
+              return !entityNode.entity().protectedProperties().empty();
             })
             ? std::tuple{newGroupNodes[0], newGroupNodes[1]}
             : std::tuple{newGroupNodes[1], newGroupNodes[0]};
@@ -1083,13 +1083,13 @@ TEST_CASE("Map_Groups")
         REQUIRE(newGroupNodes[1]->childCount() == 1);
 
         const auto newEntityNode =
-          findNodeOrDescendant<EntityNode>(newGroupNodes, [&](const auto* entityNode) {
-            return entityNode->entity().origin() == originalEntityPosition;
+          findNodeOrDescendant<EntityNode>(newGroupNodes, [&](const auto& entityNode) {
+            return entityNode.entity().origin() == originalEntityPosition;
           });
 
         const auto newTranslatedEntityNode =
-          findNodeOrDescendant<EntityNode>(newGroupNodes, [&](const auto* entityNode) {
-            return entityNode->entity().origin() == originalLinkedEntityPosition;
+          findNodeOrDescendant<EntityNode>(newGroupNodes, [&](const auto& entityNode) {
+            return entityNode.entity().origin() == originalLinkedEntityPosition;
           });
 
         CHECK(newEntityNode);

--- a/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
@@ -196,23 +196,23 @@ TEST_CASE("Map_Nodes")
 
         auto* linkedNode = linkedGroupNode->children().back();
         linkedNode->accept(kdl::overload(
-          [](const WorldNode*) {},
-          [](const LayerNode*) {},
-          [](const GroupNode*) {},
-          [&](const EntityNode* linkedEntityNode) {
+          [](const WorldNode&) {},
+          [](const LayerNode&) {},
+          [](const GroupNode&) {},
+          [&](const EntityNode& linkedEntityNode) {
             const auto* originalEntityNode = dynamic_cast<EntityNode*>(nodeToAdd);
             REQUIRE(originalEntityNode);
-            CHECK(originalEntityNode->entity() == linkedEntityNode->entity());
+            CHECK(originalEntityNode->entity() == linkedEntityNode.entity());
           },
-          [&](const BrushNode* linkedBrushNode) {
+          [&](const BrushNode& linkedBrushNode) {
             const auto* originalBrushNode = dynamic_cast<BrushNode*>(nodeToAdd);
             REQUIRE(originalBrushNode);
-            CHECK(originalBrushNode->brush() == linkedBrushNode->brush());
+            CHECK(originalBrushNode->brush() == linkedBrushNode.brush());
           },
-          [&](const PatchNode* linkedPatchNode) {
+          [&](const PatchNode& linkedPatchNode) {
             const auto* originalPatchNode = dynamic_cast<PatchNode*>(nodeToAdd);
             REQUIRE(originalPatchNode);
-            CHECK(originalPatchNode->patch() == linkedPatchNode->patch());
+            CHECK(originalPatchNode->patch() == linkedPatchNode.patch());
           }));
 
         map.undoCommand();

--- a/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
@@ -251,11 +251,11 @@ TEST_CASE("Map_Selection")
 
       addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
 
-      REQUIRE(brushNode1->intersects(brushNode2));
-      REQUIRE(brushNode2->intersects(brushNode1));
+      REQUIRE(brushNode1->intersects(*brushNode2));
+      REQUIRE(brushNode2->intersects(*brushNode1));
 
-      REQUIRE(!brushNode1->intersects(brushNode3));
-      REQUIRE(!brushNode3->intersects(brushNode1));
+      REQUIRE(!brushNode1->intersects(*brushNode3));
+      REQUIRE(!brushNode3->intersects(*brushNode1));
 
       selectNodes(map, {brushNode1});
       selectTouchingNodes(map, false);
@@ -369,8 +369,8 @@ TEST_CASE("Map_Selection")
         vm::translation_matrix(vm::vec3d{100.0, 0.0, 0.0}),
         map.worldBounds());
 
-      REQUIRE(!brushNode1->intersects(brushNode2));
-      REQUIRE(!brushNode1->intersects(brushNode3));
+      REQUIRE(!brushNode1->intersects(*brushNode2));
+      REQUIRE(!brushNode1->intersects(*brushNode3));
 
       addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
       selectNodes(map, {brushNode1});

--- a/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
@@ -210,31 +210,31 @@ TEST_CASE("ModelUtils.collectTouchingNodes")
 
   auto touchesAll = BrushNode{
     BrushBuilder{mapFormat, worldBounds}.createCube(24.0, "material") | kdl::value()};
-  REQUIRE_FALSE(touchesAll.intersects(&worldNode));
-  REQUIRE_FALSE(touchesAll.intersects(&layerNode));
-  REQUIRE(touchesAll.intersects(&groupNode));
-  REQUIRE(touchesAll.intersects(&entityNode));
-  REQUIRE(touchesAll.intersects(&brushNode));
-  REQUIRE(touchesAll.intersects(&patchNode));
+  REQUIRE_FALSE(touchesAll.intersects(worldNode));
+  REQUIRE_FALSE(touchesAll.intersects(layerNode));
+  REQUIRE(touchesAll.intersects(groupNode));
+  REQUIRE(touchesAll.intersects(entityNode));
+  REQUIRE(touchesAll.intersects(brushNode));
+  REQUIRE(touchesAll.intersects(patchNode));
 
   auto touchesNothing = BrushNode{touchesAll.brush()};
   transformNode(
     touchesNothing, vm::translation_matrix(vm::vec3d{128, 0, 0}), worldBounds);
-  REQUIRE_FALSE(touchesNothing.intersects(&worldNode));
-  REQUIRE_FALSE(touchesNothing.intersects(&layerNode));
-  REQUIRE_FALSE(touchesNothing.intersects(&groupNode));
-  REQUIRE_FALSE(touchesNothing.intersects(&entityNode));
-  REQUIRE_FALSE(touchesNothing.intersects(&brushNode));
-  REQUIRE_FALSE(touchesNothing.intersects(&patchNode));
+  REQUIRE_FALSE(touchesNothing.intersects(worldNode));
+  REQUIRE_FALSE(touchesNothing.intersects(layerNode));
+  REQUIRE_FALSE(touchesNothing.intersects(groupNode));
+  REQUIRE_FALSE(touchesNothing.intersects(entityNode));
+  REQUIRE_FALSE(touchesNothing.intersects(brushNode));
+  REQUIRE_FALSE(touchesNothing.intersects(patchNode));
 
   auto touchesBrush = BrushNode{touchesAll.brush()};
   transformNode(touchesBrush, vm::translation_matrix(vm::vec3d{24, 0, 0}), worldBounds);
-  REQUIRE_FALSE(touchesBrush.intersects(&worldNode));
-  REQUIRE_FALSE(touchesBrush.intersects(&layerNode));
-  REQUIRE_FALSE(touchesBrush.intersects(&groupNode));
-  REQUIRE_FALSE(touchesBrush.intersects(&entityNode));
-  REQUIRE(touchesBrush.intersects(&brushNode));
-  REQUIRE_FALSE(touchesBrush.intersects(&patchNode));
+  REQUIRE_FALSE(touchesBrush.intersects(worldNode));
+  REQUIRE_FALSE(touchesBrush.intersects(layerNode));
+  REQUIRE_FALSE(touchesBrush.intersects(groupNode));
+  REQUIRE_FALSE(touchesBrush.intersects(entityNode));
+  REQUIRE(touchesBrush.intersects(brushNode));
+  REQUIRE_FALSE(touchesBrush.intersects(patchNode));
 
   const auto allNodes = std::vector<Node*>{
     &worldNode, &layerNode, &groupNode, &entityNode, &brushNode, &patchNode};
@@ -285,31 +285,31 @@ TEST_CASE("ModelUtils.collectContainedNodes")
 
   auto containsAll = BrushNode{
     BrushBuilder{mapFormat, worldBounds}.createCube(128.0, "material") | kdl::value()};
-  REQUIRE_FALSE(containsAll.contains(&worldNode));
-  REQUIRE_FALSE(containsAll.contains(&layerNode));
-  REQUIRE(containsAll.contains(&groupNode));
-  REQUIRE(containsAll.contains(&entityNode));
-  REQUIRE(containsAll.contains(&brushNode));
-  REQUIRE(containsAll.contains(&patchNode));
+  REQUIRE_FALSE(containsAll.contains(worldNode));
+  REQUIRE_FALSE(containsAll.contains(layerNode));
+  REQUIRE(containsAll.contains(groupNode));
+  REQUIRE(containsAll.contains(entityNode));
+  REQUIRE(containsAll.contains(brushNode));
+  REQUIRE(containsAll.contains(patchNode));
 
   auto containsNothing = BrushNode{containsAll.brush()};
   transformNode(
     containsNothing, vm::translation_matrix(vm::vec3d{-64, 0, 0}), worldBounds);
-  REQUIRE_FALSE(containsNothing.contains(&worldNode));
-  REQUIRE_FALSE(containsNothing.contains(&layerNode));
-  REQUIRE_FALSE(containsNothing.contains(&groupNode));
-  REQUIRE_FALSE(containsNothing.contains(&entityNode));
-  REQUIRE_FALSE(containsNothing.contains(&brushNode));
-  REQUIRE_FALSE(containsNothing.contains(&patchNode));
+  REQUIRE_FALSE(containsNothing.contains(worldNode));
+  REQUIRE_FALSE(containsNothing.contains(layerNode));
+  REQUIRE_FALSE(containsNothing.contains(groupNode));
+  REQUIRE_FALSE(containsNothing.contains(entityNode));
+  REQUIRE_FALSE(containsNothing.contains(brushNode));
+  REQUIRE_FALSE(containsNothing.contains(patchNode));
 
   auto containsPatch = BrushNode{
     BrushBuilder{mapFormat, worldBounds}.createCube(8.0, "material") | kdl::value()};
-  REQUIRE_FALSE(containsPatch.contains(&worldNode));
-  REQUIRE_FALSE(containsPatch.contains(&layerNode));
-  REQUIRE_FALSE(containsPatch.contains(&groupNode));
-  REQUIRE_FALSE(containsPatch.contains(&entityNode));
-  REQUIRE_FALSE(containsPatch.contains(&brushNode));
-  REQUIRE(containsPatch.contains(&patchNode));
+  REQUIRE_FALSE(containsPatch.contains(worldNode));
+  REQUIRE_FALSE(containsPatch.contains(layerNode));
+  REQUIRE_FALSE(containsPatch.contains(groupNode));
+  REQUIRE_FALSE(containsPatch.contains(entityNode));
+  REQUIRE_FALSE(containsPatch.contains(brushNode));
+  REQUIRE(containsPatch.contains(patchNode));
 
   const auto allNodes = std::vector<Node*>{
     &worldNode, &layerNode, &groupNode, &entityNode, &brushNode, &patchNode};

--- a/lib/TbMdlLib/test/src/tst_Node.cpp
+++ b/lib/TbMdlLib/test/src/tst_Node.cpp
@@ -575,20 +575,20 @@ enum class Visited
 }
 
 const auto nodeTestVisitor = kdl::overload(
-  [](WorldNode*) { return Visited::World; },
-  [](LayerNode*) { return Visited::Layer; },
-  [](GroupNode*) { return Visited::Group; },
-  [](EntityNode*) { return Visited::Entity; },
-  [](BrushNode*) { return Visited::Brush; },
-  [](PatchNode*) { return Visited::Patch; });
+  [](WorldNode&) { return Visited::World; },
+  [](LayerNode&) { return Visited::Layer; },
+  [](GroupNode&) { return Visited::Group; },
+  [](EntityNode&) { return Visited::Entity; },
+  [](BrushNode&) { return Visited::Brush; },
+  [](PatchNode&) { return Visited::Patch; });
 
 const auto constNodeTestVisitor = kdl::overload(
-  [](const WorldNode*) { return Visited::World; },
-  [](const LayerNode*) { return Visited::Layer; },
-  [](const GroupNode*) { return Visited::Group; },
-  [](const EntityNode*) { return Visited::Entity; },
-  [](const BrushNode*) { return Visited::Brush; },
-  [](const PatchNode*) { return Visited::Patch; });
+  [](const WorldNode&) { return Visited::World; },
+  [](const LayerNode&) { return Visited::Layer; },
+  [](const GroupNode&) { return Visited::Group; },
+  [](const EntityNode&) { return Visited::Entity; },
+  [](const BrushNode&) { return Visited::Brush; },
+  [](const PatchNode&) { return Visited::Patch; });
 
 } // namespace
 
@@ -674,24 +674,24 @@ TEST_CASE("NodeTest.acceptAndVisitChildren")
   const auto collectRecursively = [](auto& node) {
     auto result = std::vector<Node*>{};
     node.accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* w) {
-        result.push_back(w);
-        w->visitChildren(thisLambda);
+      [&](auto&& thisLambda, WorldNode& w) {
+        result.push_back(&w);
+        w.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, LayerNode* l) {
-        result.push_back(l);
-        l->visitChildren(thisLambda);
+      [&](auto&& thisLambda, LayerNode& l) {
+        result.push_back(&l);
+        l.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, GroupNode* g) {
-        result.push_back(g);
-        g->visitChildren(thisLambda);
+      [&](auto&& thisLambda, GroupNode& g) {
+        result.push_back(&g);
+        g.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, EntityNode* e) {
-        result.push_back(e);
-        e->visitChildren(thisLambda);
+      [&](auto&& thisLambda, EntityNode& e) {
+        result.push_back(&e);
+        e.visitChildren(thisLambda);
       },
-      [&](BrushNode* b) { result.push_back(b); },
-      [&](PatchNode* p) { result.push_back(p); }));
+      [&](BrushNode& b) { result.push_back(&b); },
+      [&](PatchNode& p) { result.push_back(&p); }));
     return result;
   };
 
@@ -726,12 +726,12 @@ namespace
 auto makeCollectVisitedNodesVisitor(std::vector<Node*>& visited)
 {
   return kdl::overload(
-    [&](WorldNode* worldNode) { visited.push_back(worldNode); },
-    [&](LayerNode* layerNode) { visited.push_back(layerNode); },
-    [&](GroupNode* groupNode) { visited.push_back(groupNode); },
-    [&](EntityNode* entityNode) { visited.push_back(entityNode); },
-    [&](BrushNode* brushNode) { visited.push_back(brushNode); },
-    [&](PatchNode* patchNode) { visited.push_back(patchNode); });
+    [&](WorldNode& worldNode) { visited.push_back(&worldNode); },
+    [&](LayerNode& layerNode) { visited.push_back(&layerNode); },
+    [&](GroupNode& groupNode) { visited.push_back(&groupNode); },
+    [&](EntityNode& entityNode) { visited.push_back(&entityNode); },
+    [&](BrushNode& brushNode) { visited.push_back(&brushNode); },
+    [&](PatchNode& patchNode) { visited.push_back(&patchNode); });
 }
 
 } // namespace

--- a/lib/TbMdlLib/test/src/tst_Node.cpp
+++ b/lib/TbMdlLib/test/src/tst_Node.cpp
@@ -148,17 +148,17 @@ private: // implement Node interface
 
   double doGetProjectedArea(const vm::axis::type) const override { return double(0); }
 
-  bool doCanAddChild(const Node* child) const override
+  bool doCanAddChild(const Node& child) const override
   {
     auto call = popCall<DoCanAddChild>();
-    CHECK(child == call.expectedChild);
+    CHECK(&child == call.expectedChild);
     return call.valueToReturn;
   }
 
-  bool doCanRemoveChild(const Node* child) const override
+  bool doCanRemoveChild(const Node& child) const override
   {
     auto call = popCall<DoCanRemoveChild>();
-    CHECK(child == call.expectedChild);
+    CHECK(&child == call.expectedChild);
     return call.valueToReturn;
   }
 
@@ -222,9 +222,9 @@ private: // implement Node interface
 
   double doGetProjectedArea(const vm::axis::type) const override { return double(0); }
 
-  bool doCanAddChild(const Node* /* child */) const override { return true; }
+  bool doCanAddChild(const Node&) const override { return true; }
 
-  bool doCanRemoveChild(const Node* /* child */) const override { return true; }
+  bool doCanRemoveChild(const Node&) const override { return true; }
 
   bool doRemoveIfEmpty() const override { return false; }
 
@@ -445,35 +445,35 @@ TEST_CASE("NodeTest.isAncestorOf")
   childNode1->addChild(grandChildNode1_1);
   childNode1->addChild(grandChildNode1_2);
 
-  CHECK_FALSE(rootNode.isAncestorOf(&rootNode));
-  CHECK(rootNode.isAncestorOf(childNode1));
-  CHECK(rootNode.isAncestorOf(childNode2));
-  CHECK(rootNode.isAncestorOf(grandChildNode1_1));
-  CHECK(rootNode.isAncestorOf(grandChildNode1_2));
+  CHECK_FALSE(rootNode.isAncestorOf(rootNode));
+  CHECK(rootNode.isAncestorOf(*childNode1));
+  CHECK(rootNode.isAncestorOf(*childNode2));
+  CHECK(rootNode.isAncestorOf(*grandChildNode1_1));
+  CHECK(rootNode.isAncestorOf(*grandChildNode1_2));
 
-  CHECK_FALSE(childNode1->isAncestorOf(&rootNode));
-  CHECK_FALSE(childNode1->isAncestorOf(childNode1));
-  CHECK_FALSE(childNode1->isAncestorOf(childNode2));
-  CHECK(childNode1->isAncestorOf(grandChildNode1_1));
-  CHECK(childNode1->isAncestorOf(grandChildNode1_2));
+  CHECK_FALSE(childNode1->isAncestorOf(rootNode));
+  CHECK_FALSE(childNode1->isAncestorOf(*childNode1));
+  CHECK_FALSE(childNode1->isAncestorOf(*childNode2));
+  CHECK(childNode1->isAncestorOf(*grandChildNode1_1));
+  CHECK(childNode1->isAncestorOf(*grandChildNode1_2));
 
-  CHECK_FALSE(childNode2->isAncestorOf(&rootNode));
-  CHECK_FALSE(childNode2->isAncestorOf(childNode1));
-  CHECK_FALSE(childNode2->isAncestorOf(childNode2));
-  CHECK_FALSE(childNode2->isAncestorOf(grandChildNode1_1));
-  CHECK_FALSE(childNode2->isAncestorOf(grandChildNode1_2));
+  CHECK_FALSE(childNode2->isAncestorOf(rootNode));
+  CHECK_FALSE(childNode2->isAncestorOf(*childNode1));
+  CHECK_FALSE(childNode2->isAncestorOf(*childNode2));
+  CHECK_FALSE(childNode2->isAncestorOf(*grandChildNode1_1));
+  CHECK_FALSE(childNode2->isAncestorOf(*grandChildNode1_2));
 
-  CHECK_FALSE(grandChildNode1_1->isAncestorOf(&rootNode));
-  CHECK_FALSE(grandChildNode1_1->isAncestorOf(childNode1));
-  CHECK_FALSE(grandChildNode1_1->isAncestorOf(childNode2));
-  CHECK_FALSE(grandChildNode1_1->isAncestorOf(grandChildNode1_1));
-  CHECK_FALSE(grandChildNode1_1->isAncestorOf(grandChildNode1_2));
+  CHECK_FALSE(grandChildNode1_1->isAncestorOf(rootNode));
+  CHECK_FALSE(grandChildNode1_1->isAncestorOf(*childNode1));
+  CHECK_FALSE(grandChildNode1_1->isAncestorOf(*childNode2));
+  CHECK_FALSE(grandChildNode1_1->isAncestorOf(*grandChildNode1_1));
+  CHECK_FALSE(grandChildNode1_1->isAncestorOf(*grandChildNode1_2));
 
-  CHECK_FALSE(grandChildNode1_2->isAncestorOf(&rootNode));
-  CHECK_FALSE(grandChildNode1_2->isAncestorOf(childNode1));
-  CHECK_FALSE(grandChildNode1_2->isAncestorOf(childNode2));
-  CHECK_FALSE(grandChildNode1_2->isAncestorOf(grandChildNode1_1));
-  CHECK_FALSE(grandChildNode1_2->isAncestorOf(grandChildNode1_2));
+  CHECK_FALSE(grandChildNode1_2->isAncestorOf(rootNode));
+  CHECK_FALSE(grandChildNode1_2->isAncestorOf(*childNode1));
+  CHECK_FALSE(grandChildNode1_2->isAncestorOf(*childNode2));
+  CHECK_FALSE(grandChildNode1_2->isAncestorOf(*grandChildNode1_1));
+  CHECK_FALSE(grandChildNode1_2->isAncestorOf(*grandChildNode1_2));
 
   CHECK(rootNode.isAncestorOf(std::vector<Node*>{
     &rootNode, childNode1, childNode2, grandChildNode1_1, grandChildNode1_2}));
@@ -500,35 +500,35 @@ TEST_CASE("NodeTest.isDescendantOf")
   childNode1->addChild(grandChildNode1_1);
   childNode1->addChild(grandChildNode1_2);
 
-  CHECK_FALSE(rootNode.isDescendantOf(&rootNode));
-  CHECK_FALSE(rootNode.isDescendantOf(childNode1));
-  CHECK_FALSE(rootNode.isDescendantOf(childNode2));
-  CHECK_FALSE(rootNode.isDescendantOf(grandChildNode1_1));
-  CHECK_FALSE(rootNode.isDescendantOf(grandChildNode1_2));
+  CHECK_FALSE(rootNode.isDescendantOf(rootNode));
+  CHECK_FALSE(rootNode.isDescendantOf(*childNode1));
+  CHECK_FALSE(rootNode.isDescendantOf(*childNode2));
+  CHECK_FALSE(rootNode.isDescendantOf(*grandChildNode1_1));
+  CHECK_FALSE(rootNode.isDescendantOf(*grandChildNode1_2));
 
-  CHECK(childNode1->isDescendantOf(&rootNode));
-  CHECK_FALSE(childNode1->isDescendantOf(childNode1));
-  CHECK_FALSE(childNode1->isDescendantOf(childNode2));
-  CHECK_FALSE(childNode1->isDescendantOf(grandChildNode1_1));
-  CHECK_FALSE(childNode1->isDescendantOf(grandChildNode1_2));
+  CHECK(childNode1->isDescendantOf(rootNode));
+  CHECK_FALSE(childNode1->isDescendantOf(*childNode1));
+  CHECK_FALSE(childNode1->isDescendantOf(*childNode2));
+  CHECK_FALSE(childNode1->isDescendantOf(*grandChildNode1_1));
+  CHECK_FALSE(childNode1->isDescendantOf(*grandChildNode1_2));
 
-  CHECK(childNode2->isDescendantOf(&rootNode));
-  CHECK_FALSE(childNode2->isDescendantOf(childNode1));
-  CHECK_FALSE(childNode2->isDescendantOf(childNode2));
-  CHECK_FALSE(childNode2->isDescendantOf(grandChildNode1_1));
-  CHECK_FALSE(childNode2->isDescendantOf(grandChildNode1_2));
+  CHECK(childNode2->isDescendantOf(rootNode));
+  CHECK_FALSE(childNode2->isDescendantOf(*childNode1));
+  CHECK_FALSE(childNode2->isDescendantOf(*childNode2));
+  CHECK_FALSE(childNode2->isDescendantOf(*grandChildNode1_1));
+  CHECK_FALSE(childNode2->isDescendantOf(*grandChildNode1_2));
 
-  CHECK(grandChildNode1_1->isDescendantOf(&rootNode));
-  CHECK(grandChildNode1_1->isDescendantOf(childNode1));
-  CHECK_FALSE(grandChildNode1_1->isDescendantOf(childNode2));
-  CHECK_FALSE(grandChildNode1_1->isDescendantOf(grandChildNode1_1));
-  CHECK_FALSE(grandChildNode1_1->isDescendantOf(grandChildNode1_2));
+  CHECK(grandChildNode1_1->isDescendantOf(rootNode));
+  CHECK(grandChildNode1_1->isDescendantOf(*childNode1));
+  CHECK_FALSE(grandChildNode1_1->isDescendantOf(*childNode2));
+  CHECK_FALSE(grandChildNode1_1->isDescendantOf(*grandChildNode1_1));
+  CHECK_FALSE(grandChildNode1_1->isDescendantOf(*grandChildNode1_2));
 
-  CHECK(grandChildNode1_2->isDescendantOf(&rootNode));
-  CHECK(grandChildNode1_2->isDescendantOf(childNode1));
-  CHECK_FALSE(grandChildNode1_2->isDescendantOf(childNode2));
-  CHECK_FALSE(grandChildNode1_2->isDescendantOf(grandChildNode1_1));
-  CHECK_FALSE(grandChildNode1_2->isDescendantOf(grandChildNode1_2));
+  CHECK(grandChildNode1_2->isDescendantOf(rootNode));
+  CHECK(grandChildNode1_2->isDescendantOf(*childNode1));
+  CHECK_FALSE(grandChildNode1_2->isDescendantOf(*childNode2));
+  CHECK_FALSE(grandChildNode1_2->isDescendantOf(*grandChildNode1_1));
+  CHECK_FALSE(grandChildNode1_2->isDescendantOf(*grandChildNode1_2));
 
   CHECK_FALSE(rootNode.isDescendantOf(std::vector<Node*>{
     &rootNode, childNode1, childNode2, grandChildNode1_1, grandChildNode1_2}));

--- a/lib/TbMdlLib/test/src/tst_NodeQueries.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeQueries.cpp
@@ -80,36 +80,36 @@ TEST_CASE("NodeQueries")
 
   SECTION("findNode")
   {
-    CHECK(findNode<WorldNode>({}, [](const WorldNode*) { return false; }) == nullptr);
-    CHECK(findNode<WorldNode>({}, [](const WorldNode*) { return true; }) == nullptr);
+    CHECK(findNode<WorldNode>({}, [](const WorldNode&) { return false; }) == nullptr);
+    CHECK(findNode<WorldNode>({}, [](const WorldNode&) { return true; }) == nullptr);
     CHECK(
-      findNode<WorldNode>({&worldNode}, [](const WorldNode*) { return true; })
+      findNode<WorldNode>({&worldNode}, [](const WorldNode&) { return true; })
       == &worldNode);
     CHECK(
-      findNode<WorldNode>({&worldNode}, [](const WorldNode*) { return false; })
+      findNode<WorldNode>({&worldNode}, [](const WorldNode&) { return false; })
       == nullptr);
     CHECK(
-      findNode<GroupNode>({&worldNode}, [](const GroupNode*) { return true; })
+      findNode<GroupNode>({&worldNode}, [](const GroupNode&) { return true; })
       == nullptr);
   }
 
   SECTION("findNodeOrDescendant")
   {
     CHECK(
-      findNodeOrDescendant<WorldNode>({}, [](const WorldNode*) { return false; })
+      findNodeOrDescendant<WorldNode>({}, [](const WorldNode&) { return false; })
       == nullptr);
     CHECK(
-      findNodeOrDescendant<WorldNode>({}, [](const WorldNode*) { return true; })
+      findNodeOrDescendant<WorldNode>({}, [](const WorldNode&) { return true; })
       == nullptr);
     CHECK(
-      findNodeOrDescendant<WorldNode>({&worldNode}, [](const WorldNode*) { return true; })
+      findNodeOrDescendant<WorldNode>({&worldNode}, [](const WorldNode&) { return true; })
       == &worldNode);
     CHECK(
       findNodeOrDescendant<WorldNode>(
-        {&worldNode}, [](const WorldNode*) { return false; })
+        {&worldNode}, [](const WorldNode&) { return false; })
       == nullptr);
     CHECK(
-      findNodeOrDescendant<GroupNode>({&worldNode}, [](const GroupNode*) { return true; })
+      findNodeOrDescendant<GroupNode>({&worldNode}, [](const GroupNode&) { return true; })
       == outerGroupNode);
   }
 
@@ -121,7 +121,7 @@ TEST_CASE("NodeQueries")
       collectNodes({outerGroupNode, entityNode})
       == std::vector<Node*>{outerGroupNode, entityNode});
     CHECK(
-      collectNodes({outerGroupNode, entityNode}, [&](const EntityNode*) { return true; })
+      collectNodes({outerGroupNode, entityNode}, [&](const EntityNode&) { return true; })
       == std::vector<Node*>{entityNode});
   }
 
@@ -152,7 +152,7 @@ TEST_CASE("NodeQueries")
       UnorderedEquals(
         std::vector<Node*>{&worldNode, layerNode, outerGroupNode, innerGroupNode}));
     CHECK_THAT(
-      collectAncestors({brushNode, patchNode}, [](const LayerNode*) { return true; }),
+      collectAncestors({brushNode, patchNode}, [](const LayerNode&) { return true; }),
       UnorderedEquals(std::vector<Node*>{layerNode}));
   }
 
@@ -167,7 +167,7 @@ TEST_CASE("NodeQueries")
         &worldNode, layerNode, outerGroupNode, innerGroupNode, brushNode, patchNode}));
     CHECK_THAT(
       collectNodesAndAncestors(
-        {brushNode, patchNode}, [](const GroupNode*) { return true; }),
+        {brushNode, patchNode}, [](const GroupNode&) { return true; }),
       UnorderedEquals(std::vector<Node*>{outerGroupNode, innerGroupNode}));
   }
 
@@ -200,7 +200,7 @@ TEST_CASE("NodeQueries")
       UnorderedEquals(
         std::vector<Node*>{innerGroupNode, entityNode, brushNode, patchNode}));
     CHECK_THAT(
-      collectDescendants({&worldNode}, [](const GroupNode*) { return true; }),
+      collectDescendants({&worldNode}, [](const GroupNode&) { return true; }),
       UnorderedEquals(std::vector<Node*>{outerGroupNode, innerGroupNode}));
   }
 
@@ -218,7 +218,7 @@ TEST_CASE("NodeQueries")
         outerGroupNode, innerGroupNode, entityNode, brushNode, patchNode}));
     CHECK_THAT(
       collectNodesAndDescendants(
-        {innerGroupNode, outerGroupNode}, [](const GroupNode*) { return true; }),
+        {innerGroupNode, outerGroupNode}, [](const GroupNode&) { return true; }),
       UnorderedEquals(std::vector<Node*>{outerGroupNode, innerGroupNode}));
   }
 }

--- a/lib/TbMdlLib/test/src/tst_UpdateLinkedGroupsHelper.cpp
+++ b/lib/TbMdlLib/test/src/tst_UpdateLinkedGroupsHelper.cpp
@@ -73,8 +73,8 @@ void setGroupName(GroupNode& groupNode, const std::string& name)
 
 GroupNode* findGroupByName(Node& node, const std::string& name)
 {
-  const auto visitChildren = [&](auto&& lambda, Node* n) -> GroupNode* {
-    for (auto* child : n->children())
+  const auto visitChildren = [&](auto&& lambda, Node& n) -> GroupNode* {
+    for (auto* child : n.children())
     {
       if (auto* result = child->accept(lambda))
       {
@@ -84,22 +84,22 @@ GroupNode* findGroupByName(Node& node, const std::string& name)
     return nullptr;
   };
   return node.accept(kdl::overload(
-    [&](auto&& thisLambda, WorldNode* worldNode) -> GroupNode* {
+    [&](auto&& thisLambda, WorldNode& worldNode) -> GroupNode* {
       return visitChildren(thisLambda, worldNode);
     },
-    [&](auto&& thisLambda, LayerNode* layerNode) -> GroupNode* {
+    [&](auto&& thisLambda, LayerNode& layerNode) -> GroupNode* {
       return visitChildren(thisLambda, layerNode);
     },
-    [&](auto&& thisLambda, GroupNode* groupNode) -> GroupNode* {
-      if (groupNode->name() == name)
+    [&](auto&& thisLambda, GroupNode& groupNode) -> GroupNode* {
+      if (groupNode.name() == name)
       {
-        return groupNode;
+        return &groupNode;
       }
       return visitChildren(thisLambda, groupNode);
     },
-    [](EntityNode*) -> GroupNode* { return nullptr; },
-    [](BrushNode*) -> GroupNode* { return nullptr; },
-    [](PatchNode*) -> GroupNode* { return nullptr; }));
+    [](EntityNode&) -> GroupNode* { return nullptr; },
+    [](BrushNode&) -> GroupNode* { return nullptr; },
+    [](PatchNode&) -> GroupNode* { return nullptr; }));
 }
 
 } // namespace
@@ -123,6 +123,7 @@ TEST_CASE("checkLinkedGroupsToUpdate")
 
 TEST_CASE("UpdateLinkedGroupsHelper")
 {
+  // NOLINTNEXTLINE(misc-const-correctness)
   bool deleted = false;
 
   auto fixture = MapFixture{};

--- a/lib/TbMdlLib/test/src/tst_Validation.cpp
+++ b/lib/TbMdlLib/test/src/tst_Validation.cpp
@@ -85,27 +85,27 @@ TEST_CASE("Validation")
 
     auto issues = std::vector<const Issue*>{};
     map.worldNode().accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* worldNode) {
-        issues = kdl::vec_concat(std::move(issues), worldNode->issues(validators));
-        worldNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, WorldNode& worldNode) {
+        issues = kdl::vec_concat(std::move(issues), worldNode.issues(validators));
+        worldNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, LayerNode* layerNode) {
-        issues = kdl::vec_concat(std::move(issues), layerNode->issues(validators));
-        layerNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, LayerNode& layerNode) {
+        issues = kdl::vec_concat(std::move(issues), layerNode.issues(validators));
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, GroupNode* groupNode) {
-        issues = kdl::vec_concat(std::move(issues), groupNode->issues(validators));
-        groupNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        issues = kdl::vec_concat(std::move(issues), groupNode.issues(validators));
+        groupNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, EntityNode* entityNode_) {
-        issues = kdl::vec_concat(std::move(issues), entityNode_->issues(validators));
-        entityNode_->visitChildren(thisLambda);
+      [&](auto&& thisLambda, EntityNode& entityNode_) {
+        issues = kdl::vec_concat(std::move(issues), entityNode_.issues(validators));
+        entityNode_.visitChildren(thisLambda);
       },
-      [&](BrushNode* brushNode) {
-        issues = kdl::vec_concat(std::move(issues), brushNode->issues(validators));
+      [&](BrushNode& brushNode) {
+        issues = kdl::vec_concat(std::move(issues), brushNode.issues(validators));
       },
-      [&](PatchNode* patchNode) {
-        issues = kdl::vec_concat(std::move(issues), patchNode->issues(validators));
+      [&](PatchNode& patchNode) {
+        issues = kdl::vec_concat(std::move(issues), patchNode.issues(validators));
       }));
 
     REQUIRE(issues.size() == 1);
@@ -136,27 +136,27 @@ TEST_CASE("Validation")
 
     auto issues = std::vector<const Issue*>{};
     map.worldNode().accept(kdl::overload(
-      [&](auto&& thisLambda, WorldNode* worldNode) {
-        issues = kdl::vec_concat(std::move(issues), worldNode->issues(validators));
-        worldNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, WorldNode& worldNode) {
+        issues = kdl::vec_concat(std::move(issues), worldNode.issues(validators));
+        worldNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, LayerNode* layerNode) {
-        issues = kdl::vec_concat(std::move(issues), layerNode->issues(validators));
-        layerNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, LayerNode& layerNode) {
+        issues = kdl::vec_concat(std::move(issues), layerNode.issues(validators));
+        layerNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, GroupNode* groupNode) {
-        issues = kdl::vec_concat(std::move(issues), groupNode->issues(validators));
-        groupNode->visitChildren(thisLambda);
+      [&](auto&& thisLambda, GroupNode& groupNode) {
+        issues = kdl::vec_concat(std::move(issues), groupNode.issues(validators));
+        groupNode.visitChildren(thisLambda);
       },
-      [&](auto&& thisLambda, EntityNode* entityNode_) {
-        issues = kdl::vec_concat(std::move(issues), entityNode_->issues(validators));
-        entityNode_->visitChildren(thisLambda);
+      [&](auto&& thisLambda, EntityNode& entityNode_) {
+        issues = kdl::vec_concat(std::move(issues), entityNode_.issues(validators));
+        entityNode_.visitChildren(thisLambda);
       },
-      [&](BrushNode* brushNode) {
-        issues = kdl::vec_concat(std::move(issues), brushNode->issues(validators));
+      [&](BrushNode& brushNode) {
+        issues = kdl::vec_concat(std::move(issues), brushNode.issues(validators));
       },
-      [&](PatchNode* patchNode) {
-        issues = kdl::vec_concat(std::move(issues), patchNode->issues(validators));
+      [&](PatchNode& patchNode) {
+        issues = kdl::vec_concat(std::move(issues), patchNode.issues(validators));
       }));
 
     REQUIRE(issues.size() == 1);

--- a/lib/TbMdlLib/test/src/tst_WorldNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_WorldNode.cpp
@@ -62,12 +62,12 @@ TEST_CASE("WorldNodeTest.canAddChild")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
   // clang-format on
 
-  CHECK_FALSE(worldNode.canAddChild(&worldNode));
-  CHECK(worldNode.canAddChild(&layerNode));
-  CHECK_FALSE(worldNode.canAddChild(&groupNode));
-  CHECK_FALSE(worldNode.canAddChild(&entityNode));
-  CHECK_FALSE(worldNode.canAddChild(&brushNode));
-  CHECK_FALSE(worldNode.canAddChild(&patchNode));
+  CHECK_FALSE(worldNode.canAddChild(worldNode));
+  CHECK(worldNode.canAddChild(layerNode));
+  CHECK_FALSE(worldNode.canAddChild(groupNode));
+  CHECK_FALSE(worldNode.canAddChild(entityNode));
+  CHECK_FALSE(worldNode.canAddChild(brushNode));
+  CHECK_FALSE(worldNode.canAddChild(patchNode));
 }
 
 TEST_CASE("WorldNodeTest.canRemoveChild")
@@ -89,13 +89,13 @@ TEST_CASE("WorldNodeTest.canRemoveChild")
     {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
   // clang-format on
 
-  CHECK_FALSE(worldNode.canRemoveChild(&worldNode));
-  CHECK(worldNode.canRemoveChild(&layerNode));
-  CHECK_FALSE(worldNode.canRemoveChild(worldNode.defaultLayer()));
-  CHECK_FALSE(worldNode.canRemoveChild(&groupNode));
-  CHECK_FALSE(worldNode.canRemoveChild(&entityNode));
-  CHECK_FALSE(worldNode.canRemoveChild(&brushNode));
-  CHECK_FALSE(worldNode.canRemoveChild(&patchNode));
+  CHECK_FALSE(worldNode.canRemoveChild(worldNode));
+  CHECK(worldNode.canRemoveChild(layerNode));
+  CHECK_FALSE(worldNode.canRemoveChild(*worldNode.defaultLayer()));
+  CHECK_FALSE(worldNode.canRemoveChild(groupNode));
+  CHECK_FALSE(worldNode.canRemoveChild(entityNode));
+  CHECK_FALSE(worldNode.canRemoveChild(brushNode));
+  CHECK_FALSE(worldNode.canRemoveChild(patchNode));
 }
 
 TEST_CASE("WorldNodeTest.nodeTreeUpdates")

--- a/lib/TbRenderLib/include/render/BrushRenderer.h
+++ b/lib/TbRenderLib/include/render/BrushRenderer.h
@@ -206,7 +206,7 @@ public:
    */
   void invalidate();
   void invalidateMaterials(const std::vector<const gl::Material*>& materials);
-  void invalidateBrush(const mdl::BrushNode* brush);
+  void invalidateBrush(const mdl::BrushNode& brush);
   void invalidateMaterial(const gl::Material& material);
   bool valid() const;
 
@@ -303,11 +303,11 @@ public:
    * Adds a brush. Calling with an already-added brush is allowed, but ignored (not
    * guaranteed to invalidate it).
    */
-  void addBrush(const mdl::BrushNode* brushNode);
+  void addBrush(const mdl::BrushNode& brushNode);
   /**
    * Removes a brush. Calling with an unknown brush is allowed, but ignored.
    */
-  void removeBrush(const mdl::BrushNode* brushNode);
+  void removeBrush(const mdl::BrushNode& brushNode);
 
 private:
   /**

--- a/lib/TbRenderLib/include/render/EntityModelRenderer.h
+++ b/lib/TbRenderLib/include/render/EntityModelRenderer.h
@@ -89,14 +89,14 @@ public:
   {
     while (cur != end)
     {
-      updateEntity(*cur);
+      updateEntity(**cur);
       ++cur;
     }
   }
 
-  void addEntity(const mdl::EntityNode* entityNode);
-  void removeEntity(const mdl::EntityNode* entityNode);
-  void updateEntity(const mdl::EntityNode* entityNode);
+  void addEntity(const mdl::EntityNode& entityNode);
+  void removeEntity(const mdl::EntityNode& entityNode);
+  void updateEntity(const mdl::EntityNode& entityNode);
   void clear();
 
   bool applyTinting() const;

--- a/lib/TbRenderLib/include/render/EntityRenderer.h
+++ b/lib/TbRenderLib/include/render/EntityRenderer.h
@@ -93,16 +93,16 @@ public:
    * Adds an entity. Calling with an already-added entity is allowed, but ignored (not
    * guaranteed to invalidate it).
    */
-  void addEntity(const mdl::EntityNode* entity);
+  void addEntity(const mdl::EntityNode& entityNode);
   /**
    * Removes an entity. Calling with an unknown entity is allowed, but ignored.
    */
-  void removeEntity(const mdl::EntityNode* entity);
+  void removeEntity(const mdl::EntityNode& entityNode);
   /**
    * Causes cached renderer data to be rebuilt for the given entity (on the next render()
    * call).
    */
-  void invalidateEntity(const mdl::EntityNode* entity);
+  void invalidateEntity(const mdl::EntityNode& entityNode);
 
   /**
    * Invalidates cached renderer data to be result for any entity that references any of
@@ -145,8 +145,8 @@ private:
   void invalidateBounds();
   void validateBounds();
 
-  gl::AttrString entityString(const mdl::EntityNode* entityNode) const;
-  const Color& boundsColor(const mdl::EntityNode* entityNode) const;
+  gl::AttrString entityString(const mdl::EntityNode& entityNode) const;
+  const Color& boundsColor(const mdl::EntityNode& entityNode) const;
 };
 
 } // namespace render

--- a/lib/TbRenderLib/include/render/GroupRenderer.h
+++ b/lib/TbRenderLib/include/render/GroupRenderer.h
@@ -74,16 +74,16 @@ public:
    * Adds a group. Calling with an already-added group is allowed, but ignored (not
    * guaranteed to invalidate it).
    */
-  void addGroup(const mdl::GroupNode* group);
+  void addGroup(const mdl::GroupNode& groupNode);
   /**
    * Removes a group. Calling with an unknown group is allowed, but ignored.
    */
-  void removeGroup(const mdl::GroupNode* group);
+  void removeGroup(const mdl::GroupNode& groupNode);
   /**
    * Causes cached renderer data to be rebuilt for the given group (on the next render()
    * call).
    */
-  void invalidateGroup(const mdl::GroupNode* group);
+  void invalidateGroup(const mdl::GroupNode& groupNode);
 
   void setOverrideColors(bool overrideColors);
 

--- a/lib/TbRenderLib/include/render/PatchRenderer.h
+++ b/lib/TbRenderLib/include/render/PatchRenderer.h
@@ -108,16 +108,16 @@ public:
    * Adds a patch. Calling with an already-added patch is allowed, but ignored (not
    * guaranteed to invalidate it).
    */
-  void addPatch(const mdl::PatchNode* patchNode);
+  void addPatch(const mdl::PatchNode& patchNode);
   /**
    * Removes a patch. Calling with an unknown patch is allowed, but ignored.
    */
-  void removePatch(const mdl::PatchNode* patchNode);
+  void removePatch(const mdl::PatchNode& patchNode);
   /**
    * Causes cached renderer data to be rebuilt for the given patch (on the next render()
    * call).
    */
-  void invalidatePatch(const mdl::PatchNode* patchNode);
+  void invalidatePatch(const mdl::PatchNode& patchNode);
 
   void render(RenderContext& renderContext, RenderBatch& renderBatch);
 

--- a/lib/TbRenderLib/src/BrushRenderer.cpp
+++ b/lib/TbRenderLib/src/BrushRenderer.cpp
@@ -192,32 +192,32 @@ void BrushRenderer::invalidateMaterials(const std::vector<const gl::Material*>& 
 {
   const auto materialSet =
     std::unordered_set<const gl::Material*>{materials.begin(), materials.end()};
-  for (auto* brush : m_allBrushes)
+  for (auto* brushNode : m_allBrushes)
   {
-    for (const auto& face : brush->brush().faces())
+    for (const auto& face : brushNode->brush().faces())
     {
       if (materialSet.count(face.material()) > 0)
       {
-        brush->brushRendererBrushCache().invalidateVertexCache();
-        invalidateBrush(brush);
+        brushNode->brushRendererBrushCache().invalidateVertexCache();
+        invalidateBrush(*brushNode);
       }
     }
   }
 }
 
-void BrushRenderer::invalidateBrush(const mdl::BrushNode* brushNode)
+void BrushRenderer::invalidateBrush(const mdl::BrushNode& brushNode)
 {
   // skip brushes that are not in the renderer
-  if (m_allBrushes.find(brushNode) == std::end(m_allBrushes))
+  if (m_allBrushes.find(&brushNode) == std::end(m_allBrushes))
   {
-    contract_assert(m_brushInfo.find(brushNode) == std::end(m_brushInfo));
-    contract_assert(m_invalidBrushes.find(brushNode) == std::end(m_invalidBrushes));
+    contract_assert(m_brushInfo.find(&brushNode) == std::end(m_brushInfo));
+    contract_assert(m_invalidBrushes.find(&brushNode) == std::end(m_invalidBrushes));
     return;
   }
   // if it's not in the invalid set, put it in
-  if (m_invalidBrushes.insert(brushNode).second)
+  if (m_invalidBrushes.insert(&brushNode).second)
   {
-    removeBrushFromVbo(*brushNode);
+    removeBrushFromVbo(brushNode);
   }
 }
 
@@ -676,32 +676,32 @@ void BrushRenderer::validateBrush(const mdl::BrushNode& brushNode)
   }
 }
 
-void BrushRenderer::addBrush(const mdl::BrushNode* brushNode)
+void BrushRenderer::addBrush(const mdl::BrushNode& brushNode)
 {
   // i.e. insert the brush as "invalid" if it's not already present.
   // if it is present, its validity is unchanged.
-  if (m_allBrushes.insert(brushNode).second)
+  if (m_allBrushes.insert(&brushNode).second)
   {
-    contract_assert(m_brushInfo.find(brushNode) == std::end(m_brushInfo));
+    contract_assert(m_brushInfo.find(&brushNode) == std::end(m_brushInfo));
 
-    assertResult(m_invalidBrushes.insert(brushNode).second);
+    assertResult(m_invalidBrushes.insert(&brushNode).second);
   }
 }
 
-void BrushRenderer::removeBrush(const mdl::BrushNode* brushNode)
+void BrushRenderer::removeBrush(const mdl::BrushNode& brushNode)
 {
   // update m_brushValid
-  m_allBrushes.erase(brushNode);
+  m_allBrushes.erase(&brushNode);
 
-  if (m_invalidBrushes.erase(brushNode) > 0u)
+  if (m_invalidBrushes.erase(&brushNode) > 0u)
   {
     // invalid brushes are not in the VBO, so we can return  now.
-    contract_assert(m_brushInfo.find(brushNode) == std::end(m_brushInfo));
+    contract_assert(m_brushInfo.find(&brushNode) == std::end(m_brushInfo));
 
     return;
   }
 
-  removeBrushFromVbo(*brushNode);
+  removeBrushFromVbo(brushNode);
 }
 
 void BrushRenderer::removeBrushFromVbo(const mdl::BrushNode& brushNode)

--- a/lib/TbRenderLib/src/EntityDecalRenderer.cpp
+++ b/lib/TbRenderLib/src/EntityDecalRenderer.cpp
@@ -174,23 +174,23 @@ void EntityDecalRenderer::clear()
 void EntityDecalRenderer::updateNode(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](mdl::WorldNode*) {},
-    [](mdl::LayerNode*) {},
-    [](mdl::GroupNode*) {},
-    [&](const mdl::EntityNode* entity) { updateEntity(*entity); },
-    [&](const mdl::BrushNode* brush) { updateBrush(*brush); },
-    [](mdl::PatchNode*) {}));
+    [](mdl::WorldNode&) {},
+    [](mdl::LayerNode&) {},
+    [](mdl::GroupNode&) {},
+    [&](const mdl::EntityNode& entityNode) { updateEntity(entityNode); },
+    [&](const mdl::BrushNode& brushNode) { updateBrush(brushNode); },
+    [](mdl::PatchNode&) {}));
 }
 
 void EntityDecalRenderer::removeNode(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](mdl::WorldNode*) {},
-    [](mdl::LayerNode*) {},
-    [](mdl::GroupNode*) {},
-    [&](const mdl::EntityNode* entity) { removeEntity(*entity); },
-    [&](const mdl::BrushNode* brush) { removeBrush(*brush); },
-    [](mdl::PatchNode*) {}));
+    [](mdl::WorldNode&) {},
+    [](mdl::LayerNode&) {},
+    [](mdl::GroupNode&) {},
+    [&](const mdl::EntityNode& entityNode) { removeEntity(entityNode); },
+    [&](const mdl::BrushNode& brushNode) { removeBrush(brushNode); },
+    [](mdl::PatchNode&) {}));
 }
 
 void EntityDecalRenderer::updateEntity(const mdl::EntityNode& entityNode)

--- a/lib/TbRenderLib/src/EntityDecalRenderer.cpp
+++ b/lib/TbRenderLib/src/EntityDecalRenderer.cpp
@@ -245,7 +245,8 @@ void EntityDecalRenderer::updateBrush(const mdl::BrushNode& brushNode)
 
     // if the brush is not visible, then it doesn't (currently) intersect
     const auto& editorContext = m_map.editorContext();
-    const auto intersects = editorContext.visible(brushNode) && brushNode.intersects(ent);
+    const auto intersects =
+      editorContext.visible(brushNode) && brushNode.intersects(*ent);
     const auto tracked =
       std::ranges::find(data.brushes, &brushNode) != data.brushes.end();
 

--- a/lib/TbRenderLib/src/EntityLinkRenderer.cpp
+++ b/lib/TbRenderLib/src/EntityLinkRenderer.cpp
@@ -217,15 +217,15 @@ auto collectSelectedLinks(const mdl::Selection& selection, Visitor visitor)
   for (auto* node : selection.nodes)
   {
     node->accept(kdl::overload(
-      [](const mdl::WorldNode*) {},
-      [](const mdl::LayerNode*) {},
-      [](const mdl::GroupNode*) {},
-      [&](const mdl::EntityNode* entityNode) { visitor.visit(*entityNode, links); },
-      [](auto&& thisLambda, const mdl::BrushNode* brushNode) {
-        brushNode->visitParent(thisLambda);
+      [](const mdl::WorldNode&) {},
+      [](const mdl::LayerNode&) {},
+      [](const mdl::GroupNode&) {},
+      [&](const mdl::EntityNode& entityNode) { visitor.visit(entityNode, links); },
+      [](auto&& thisLambda, const mdl::BrushNode& brushNode) {
+        brushNode.visitParent(thisLambda);
       },
-      [](auto&& thisLambda, const mdl::PatchNode* patchNode) {
-        patchNode->visitParent(thisLambda);
+      [](auto&& thisLambda, const mdl::PatchNode& patchNode) {
+        patchNode.visitParent(thisLambda);
       }));
   }
 
@@ -241,18 +241,18 @@ auto getAllLinks(
     map.entityLinkManager(), map.editorContext(), defaultColor, selectedColor};
 
   map.worldNode().accept(kdl::overload(
-    [](auto&& thisLambda, const mdl::WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const mdl::LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const mdl::GroupNode* groupNode) {
-      groupNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::GroupNode& groupNode) {
+      groupNode.visitChildren(thisLambda);
     },
-    [&](const mdl::EntityNode* entityNode) { visitor.visit(*entityNode, links); },
-    [](const mdl::BrushNode*) {},
-    [](const mdl::PatchNode*) {}));
+    [&](const mdl::EntityNode& entityNode) { visitor.visit(entityNode, links); },
+    [](const mdl::BrushNode&) {},
+    [](const mdl::PatchNode&) {}));
 
   return links;
 }

--- a/lib/TbRenderLib/src/EntityModelRenderer.cpp
+++ b/lib/TbRenderLib/src/EntityModelRenderer.cpp
@@ -60,34 +60,34 @@ EntityModelRenderer::~EntityModelRenderer()
   clear();
 }
 
-void EntityModelRenderer::addEntity(const mdl::EntityNode* entityNode)
+void EntityModelRenderer::addEntity(const mdl::EntityNode& entityNode)
 {
   const auto modelSpec =
-    mdl::safeGetModelSpecification(m_logger, entityNode->entity().classname(), [&]() {
-      return entityNode->entity().modelSpecification();
+    mdl::safeGetModelSpecification(m_logger, entityNode.entity().classname(), [&]() {
+      return entityNode.entity().modelSpecification();
     });
 
   auto* renderer = m_entityModelManager.renderer(modelSpec);
   if (renderer != nullptr)
   {
-    m_entities.emplace(entityNode, renderer);
+    m_entities.emplace(&entityNode, renderer);
   }
 }
 
-void EntityModelRenderer::removeEntity(const mdl::EntityNode* entityNode)
+void EntityModelRenderer::removeEntity(const mdl::EntityNode& entityNode)
 {
-  m_entities.erase(entityNode);
+  m_entities.erase(&entityNode);
 }
 
-void EntityModelRenderer::updateEntity(const mdl::EntityNode* entityNode)
+void EntityModelRenderer::updateEntity(const mdl::EntityNode& entityNode)
 {
   const auto modelSpec =
-    mdl::safeGetModelSpecification(m_logger, entityNode->entity().classname(), [&]() {
-      return entityNode->entity().modelSpecification();
+    mdl::safeGetModelSpecification(m_logger, entityNode.entity().classname(), [&]() {
+      return entityNode.entity().modelSpecification();
     });
 
   auto* renderer = m_entityModelManager.renderer(modelSpec);
-  auto it = m_entities.find(entityNode);
+  auto it = m_entities.find(&entityNode);
 
   if (renderer == nullptr && it == std::end(m_entities))
   {
@@ -96,7 +96,7 @@ void EntityModelRenderer::updateEntity(const mdl::EntityNode* entityNode)
 
   if (it == std::end(m_entities))
   {
-    m_entities.emplace(entityNode, renderer);
+    m_entities.emplace(&entityNode, renderer);
   }
   else
   {

--- a/lib/TbRenderLib/src/EntityRenderer.cpp
+++ b/lib/TbRenderLib/src/EntityRenderer.cpp
@@ -49,11 +49,11 @@ namespace
 class EntityClassnameAnchor : public TextAnchor3D
 {
 private:
-  const mdl::EntityNode* m_entity;
+  const mdl::EntityNode& m_entityNode;
 
 public:
-  explicit EntityClassnameAnchor(const mdl::EntityNode* entity)
-    : m_entity{entity}
+  explicit EntityClassnameAnchor(const mdl::EntityNode& entityNode)
+    : m_entityNode{entityNode}
   {
   }
 
@@ -61,7 +61,8 @@ private:
   vm::vec3f basePosition() const override
   {
     return vm::vec3f{
-      m_entity->logicalBounds().center().xy(), m_entity->logicalBounds().max.z() + 2.0};
+      m_entityNode.logicalBounds().center().xy(),
+      m_entityNode.logicalBounds().max.z() + 2.0};
   }
 
   TextAlignment::Type alignment() const override { return TextAlignment::Bottom; }
@@ -99,28 +100,28 @@ void EntityRenderer::reloadModels()
   m_modelRenderer.updateEntities(std::begin(m_entities), std::end(m_entities));
 }
 
-void EntityRenderer::addEntity(const mdl::EntityNode* entity)
+void EntityRenderer::addEntity(const mdl::EntityNode& entityNode)
 {
-  if (m_entities.insert(entity).second)
+  if (m_entities.insert(&entityNode).second)
   {
-    m_modelRenderer.addEntity(entity);
+    m_modelRenderer.addEntity(entityNode);
     invalidateBounds();
   }
 }
 
-void EntityRenderer::removeEntity(const mdl::EntityNode* entity)
+void EntityRenderer::removeEntity(const mdl::EntityNode& entityNode)
 {
-  if (auto it = m_entities.find(entity); it != std::end(m_entities))
+  if (auto it = m_entities.find(&entityNode); it != std::end(m_entities))
   {
     m_entities.erase(it);
-    m_modelRenderer.removeEntity(entity);
+    m_modelRenderer.removeEntity(entityNode);
     invalidateBounds();
   }
 }
 
-void EntityRenderer::invalidateEntity(const mdl::EntityNode* entity)
+void EntityRenderer::invalidateEntity(const mdl::EntityNode& entityNode)
 {
-  m_modelRenderer.updateEntity(entity);
+  m_modelRenderer.updateEntity(entityNode);
   invalidateBounds();
 }
 
@@ -129,11 +130,11 @@ void EntityRenderer::invalidateEntityModels(
 {
   const auto entityModelSet =
     std::unordered_set<const mdl::EntityModel*>{entityModels.begin(), entityModels.end()};
-  for (const auto* entity : m_entities)
+  for (const auto* entityNode : m_entities)
   {
-    if (entityModelSet.contains(entity->entity().model()))
+    if (entityModelSet.contains(entityNode->entity().model()))
     {
-      invalidateEntity(entity);
+      invalidateEntity(*entityNode);
     }
   }
 }
@@ -308,7 +309,7 @@ void EntityRenderer::renderClassnames(
           }
 
           renderService.renderString(
-            entityString(entityNode), EntityClassnameAnchor{entityNode});
+            entityString(*entityNode), EntityClassnameAnchor{*entityNode});
         }
       }
     }
@@ -490,21 +491,21 @@ void EntityRenderer::validateBounds()
         {
           entityNode->logicalBounds().for_each_edge(
             makeColoredWireFrameBoundsVertexBuilder(
-              pointEntityWireframeVertices, boundsColor(entityNode)));
+              pointEntityWireframeVertices, boundsColor(*entityNode)));
 
           const auto hasModel =
             entityNode->entity().model() && entityNode->entity().model()->data();
           if (!hasModel)
           {
             entityNode->logicalBounds().for_each_face(makeColoredSolidBoundsVertexBuilder(
-              solidVertices, boundsColor(entityNode)));
+              solidVertices, boundsColor(*entityNode)));
           }
         }
         else
         {
           entityNode->logicalBounds().for_each_edge(
             makeColoredWireFrameBoundsVertexBuilder(
-              brushEntityWireframeVertices, boundsColor(entityNode)));
+              brushEntityWireframeVertices, boundsColor(*entityNode)));
         }
       }
     }
@@ -522,9 +523,9 @@ void EntityRenderer::validateBounds()
   m_boundsValid = true;
 }
 
-gl::AttrString EntityRenderer::entityString(const mdl::EntityNode* entityNode) const
+gl::AttrString EntityRenderer::entityString(const mdl::EntityNode& entityNode) const
 {
-  const auto& classname = entityNode->entity().classname();
+  const auto& classname = entityNode.entity().classname();
   // const mdl::AttributeValue& targetname =
   // entity->attribute(mdl::AttributeNames::Targetname);
 
@@ -535,9 +536,9 @@ gl::AttrString EntityRenderer::entityString(const mdl::EntityNode* entityNode) c
   return str;
 }
 
-const Color& EntityRenderer::boundsColor(const mdl::EntityNode* entityNode) const
+const Color& EntityRenderer::boundsColor(const mdl::EntityNode& entityNode) const
 {
-  if (const auto* definition = entityNode->entity().definition())
+  if (const auto* definition = entityNode.entity().definition())
   {
     return definition->color;
   }

--- a/lib/TbRenderLib/src/GroupRenderer.cpp
+++ b/lib/TbRenderLib/src/GroupRenderer.cpp
@@ -73,24 +73,24 @@ void GroupRenderer::clear()
   m_boundsRenderer = DirectEdgeRenderer();
 }
 
-void GroupRenderer::addGroup(const mdl::GroupNode* group)
+void GroupRenderer::addGroup(const mdl::GroupNode& groupNode)
 {
-  if (m_groups.insert(group).second)
+  if (m_groups.insert(&groupNode).second)
   {
     invalidate();
   }
 }
 
-void GroupRenderer::removeGroup(const mdl::GroupNode* group)
+void GroupRenderer::removeGroup(const mdl::GroupNode& groupNode)
 {
-  if (auto it = m_groups.find(group); it != std::end(m_groups))
+  if (auto it = m_groups.find(&groupNode); it != std::end(m_groups))
   {
     m_groups.erase(it);
     invalidate();
   }
 }
 
-void GroupRenderer::invalidateGroup(const mdl::GroupNode*)
+void GroupRenderer::invalidateGroup(const mdl::GroupNode&)
 {
   invalidate();
 }

--- a/lib/TbRenderLib/src/MapRenderer.cpp
+++ b/lib/TbRenderLib/src/MapRenderer.cpp
@@ -401,9 +401,9 @@ void MapRenderer::setupLockedRenderer(ObjectRenderer& renderer)
   renderer.setBrushEdgeColor(pref(Preferences::LockedEdgeColor));
 }
 
-static bool selected(const mdl::Node* node)
+static bool selected(const mdl::Node& node)
 {
-  return node->selected() || node->descendantSelected() || node->parentSelected();
+  return node.selected() || node.descendantSelected() || node.parentSelected();
 }
 
 int MapRenderer::determineDesiredRenderers(mdl::Node& node)
@@ -411,14 +411,14 @@ int MapRenderer::determineDesiredRenderers(mdl::Node& node)
   int result = 0;
 
   node.accept(kdl::overload(
-    [](mdl::WorldNode*) {},
-    [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* group) {
-      if (group->locked())
+    [](mdl::WorldNode&) {},
+    [](mdl::LayerNode&) {},
+    [&](mdl::GroupNode& groupNode) {
+      if (groupNode.locked())
       {
         result = int(Renderer::Locked);
       }
-      else if (selected(group) || group->opened())
+      else if (selected(groupNode) || groupNode.opened())
       {
         result = int(Renderer::Selection);
       }
@@ -427,12 +427,12 @@ int MapRenderer::determineDesiredRenderers(mdl::Node& node)
         result = int(Renderer::Default);
       }
     },
-    [&](mdl::EntityNode* entity) {
-      if (entity->locked())
+    [&](mdl::EntityNode& entityNode) {
+      if (entityNode.locked())
       {
         result = int(Renderer::Locked);
       }
-      else if (selected(entity))
+      else if (selected(entityNode))
       {
         result = int(Renderer::Selection);
       }
@@ -441,22 +441,22 @@ int MapRenderer::determineDesiredRenderers(mdl::Node& node)
         result = int(Renderer::Default);
       }
     },
-    [&](mdl::BrushNode* brush) {
-      if (brush->locked())
+    [&](mdl::BrushNode& brushNode) {
+      if (brushNode.locked())
       {
         result = int(Renderer::Locked);
       }
-      else if (selected(brush) || brush->hasSelectedFaces())
+      else if (selected(brushNode) || brushNode.hasSelectedFaces())
       {
         result = int(Renderer::Selection);
       }
-      if (!brush->selected() && !brush->parentSelected() && !brush->locked())
+      if (!brushNode.selected() && !brushNode.parentSelected() && !brushNode.locked())
       {
         result |= int(Renderer::Default);
       }
     },
-    [&](mdl::PatchNode* patchNode) {
-      if (patchNode->locked())
+    [&](mdl::PatchNode& patchNode) {
+      if (patchNode.locked())
       {
         result = int(Renderer::Locked);
       }
@@ -464,7 +464,7 @@ int MapRenderer::determineDesiredRenderers(mdl::Node& node)
       {
         result = int(Renderer::Selection);
       }
-      if (!patchNode->selected() && !patchNode->parentSelected() && !patchNode->locked())
+      if (!patchNode.selected() && !patchNode.parentSelected() && !patchNode.locked())
       {
         result |= int(Renderer::Default);
       }
@@ -519,22 +519,22 @@ void MapRenderer::updateAndInvalidateNode(mdl::Node& node)
 void MapRenderer::updateAndInvalidateNodeRecursive(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](auto&& thisLambda, mdl::WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, mdl::WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, mdl::LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, mdl::LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::GroupNode* groupNode) {
-      updateAndInvalidateNode(*groupNode);
-      groupNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, mdl::GroupNode& groupNode) {
+      updateAndInvalidateNode(groupNode);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::EntityNode* entityNode) {
-      updateAndInvalidateNode(*entityNode);
-      entityNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, mdl::EntityNode& entityNode) {
+      updateAndInvalidateNode(entityNode);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](mdl::BrushNode* brushNode) { updateAndInvalidateNode(*brushNode); },
-    [&](mdl::PatchNode* patchNode) { updateAndInvalidateNode(*patchNode); }));
+    [&](mdl::BrushNode& brushNode) { updateAndInvalidateNode(brushNode); },
+    [&](mdl::PatchNode& patchNode) { updateAndInvalidateNode(patchNode); }));
 
   // Due to the definition of `selected()` above, we also need to update the parent.
   // (not recursively, though, so this has little performance impact.)
@@ -578,22 +578,22 @@ void MapRenderer::removeNode(mdl::Node& node)
 void MapRenderer::removeNodeRecursive(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](auto&& thisLambda, mdl::WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, mdl::WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, mdl::LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, mdl::LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::GroupNode* groupNode) {
-      removeNode(*groupNode);
-      groupNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, mdl::GroupNode& groupNode) {
+      removeNode(groupNode);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::EntityNode* entityNode) {
-      removeNode(*entityNode);
-      entityNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, mdl::EntityNode& entityNode) {
+      removeNode(entityNode);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](mdl::BrushNode* brushNode) { removeNode(*brushNode); },
-    [&](mdl::PatchNode* patchNode) { removeNode(*patchNode); }));
+    [&](mdl::BrushNode& brushNode) { removeNode(brushNode); },
+    [&](mdl::PatchNode& patchNode) { removeNode(patchNode); }));
 }
 
 /**

--- a/lib/TbRenderLib/src/ObjectRenderer.cpp
+++ b/lib/TbRenderLib/src/ObjectRenderer.cpp
@@ -29,23 +29,23 @@ namespace tb::render
 void ObjectRenderer::addNode(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](mdl::WorldNode*) {},
-    [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* groupNode) { m_groupRenderer.addGroup(*groupNode); },
-    [&](mdl::EntityNode* entityNode) { m_entityRenderer.addEntity(*entityNode); },
-    [&](mdl::BrushNode* brushNode) { m_brushRenderer.addBrush(*brushNode); },
-    [&](mdl::PatchNode* patchNode) { m_patchRenderer.addPatch(*patchNode); }));
+    [](mdl::WorldNode&) {},
+    [](mdl::LayerNode&) {},
+    [&](mdl::GroupNode& groupNode) { m_groupRenderer.addGroup(groupNode); },
+    [&](mdl::EntityNode& entityNode) { m_entityRenderer.addEntity(entityNode); },
+    [&](mdl::BrushNode& brushNode) { m_brushRenderer.addBrush(brushNode); },
+    [&](mdl::PatchNode& patchNode) { m_patchRenderer.addPatch(patchNode); }));
 }
 
 void ObjectRenderer::removeNode(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](mdl::WorldNode*) {},
-    [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* groupNode) { m_groupRenderer.removeGroup(*groupNode); },
-    [&](mdl::EntityNode* entityNode) { m_entityRenderer.removeEntity(*entityNode); },
-    [&](mdl::BrushNode* brushNode) { m_brushRenderer.removeBrush(*brushNode); },
-    [&](mdl::PatchNode* patchNode) { m_patchRenderer.removePatch(*patchNode); }));
+    [](mdl::WorldNode&) {},
+    [](mdl::LayerNode&) {},
+    [&](mdl::GroupNode& groupNode) { m_groupRenderer.removeGroup(groupNode); },
+    [&](mdl::EntityNode& entityNode) { m_entityRenderer.removeEntity(entityNode); },
+    [&](mdl::BrushNode& brushNode) { m_brushRenderer.removeBrush(brushNode); },
+    [&](mdl::PatchNode& patchNode) { m_patchRenderer.removePatch(patchNode); }));
 }
 
 void ObjectRenderer::invalidateMaterials(
@@ -64,12 +64,12 @@ void ObjectRenderer::invalidateEntityModels(
 void ObjectRenderer::invalidateNode(mdl::Node& node)
 {
   node.accept(kdl::overload(
-    [](mdl::WorldNode*) {},
-    [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* groupNode) { m_groupRenderer.invalidateGroup(*groupNode); },
-    [&](mdl::EntityNode* entityNode) { m_entityRenderer.invalidateEntity(*entityNode); },
-    [&](mdl::BrushNode* brushNode) { m_brushRenderer.invalidateBrush(*brushNode); },
-    [&](mdl::PatchNode* patchNode) { m_patchRenderer.invalidatePatch(*patchNode); }));
+    [](mdl::WorldNode&) {},
+    [](mdl::LayerNode&) {},
+    [&](mdl::GroupNode& groupNode) { m_groupRenderer.invalidateGroup(groupNode); },
+    [&](mdl::EntityNode& entityNode) { m_entityRenderer.invalidateEntity(entityNode); },
+    [&](mdl::BrushNode& brushNode) { m_brushRenderer.invalidateBrush(brushNode); },
+    [&](mdl::PatchNode& patchNode) { m_patchRenderer.invalidatePatch(patchNode); }));
 }
 
 void ObjectRenderer::invalidate()

--- a/lib/TbRenderLib/src/ObjectRenderer.cpp
+++ b/lib/TbRenderLib/src/ObjectRenderer.cpp
@@ -31,10 +31,10 @@ void ObjectRenderer::addNode(mdl::Node& node)
   node.accept(kdl::overload(
     [](mdl::WorldNode*) {},
     [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* group) { m_groupRenderer.addGroup(group); },
-    [&](mdl::EntityNode* entity) { m_entityRenderer.addEntity(entity); },
-    [&](mdl::BrushNode* brush) { m_brushRenderer.addBrush(brush); },
-    [&](mdl::PatchNode* patch) { m_patchRenderer.addPatch(patch); }));
+    [&](mdl::GroupNode* groupNode) { m_groupRenderer.addGroup(*groupNode); },
+    [&](mdl::EntityNode* entityNode) { m_entityRenderer.addEntity(*entityNode); },
+    [&](mdl::BrushNode* brushNode) { m_brushRenderer.addBrush(*brushNode); },
+    [&](mdl::PatchNode* patchNode) { m_patchRenderer.addPatch(*patchNode); }));
 }
 
 void ObjectRenderer::removeNode(mdl::Node& node)
@@ -42,10 +42,10 @@ void ObjectRenderer::removeNode(mdl::Node& node)
   node.accept(kdl::overload(
     [](mdl::WorldNode*) {},
     [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* group) { m_groupRenderer.removeGroup(group); },
-    [&](mdl::EntityNode* entity) { m_entityRenderer.removeEntity(entity); },
-    [&](mdl::BrushNode* brush) { m_brushRenderer.removeBrush(brush); },
-    [&](mdl::PatchNode* patch) { m_patchRenderer.removePatch(patch); }));
+    [&](mdl::GroupNode* groupNode) { m_groupRenderer.removeGroup(*groupNode); },
+    [&](mdl::EntityNode* entityNode) { m_entityRenderer.removeEntity(*entityNode); },
+    [&](mdl::BrushNode* brushNode) { m_brushRenderer.removeBrush(*brushNode); },
+    [&](mdl::PatchNode* patchNode) { m_patchRenderer.removePatch(*patchNode); }));
 }
 
 void ObjectRenderer::invalidateMaterials(
@@ -66,10 +66,10 @@ void ObjectRenderer::invalidateNode(mdl::Node& node)
   node.accept(kdl::overload(
     [](mdl::WorldNode*) {},
     [](mdl::LayerNode*) {},
-    [&](mdl::GroupNode* group) { m_groupRenderer.invalidateGroup(group); },
-    [&](mdl::EntityNode* entity) { m_entityRenderer.invalidateEntity(entity); },
-    [&](mdl::BrushNode* brush) { m_brushRenderer.invalidateBrush(brush); },
-    [&](mdl::PatchNode* patch) { m_patchRenderer.invalidatePatch(patch); }));
+    [&](mdl::GroupNode* groupNode) { m_groupRenderer.invalidateGroup(*groupNode); },
+    [&](mdl::EntityNode* entityNode) { m_entityRenderer.invalidateEntity(*entityNode); },
+    [&](mdl::BrushNode* brushNode) { m_brushRenderer.invalidateBrush(*brushNode); },
+    [&](mdl::PatchNode* patchNode) { m_patchRenderer.invalidatePatch(*patchNode); }));
 }
 
 void ObjectRenderer::invalidate()

--- a/lib/TbRenderLib/src/PatchRenderer.cpp
+++ b/lib/TbRenderLib/src/PatchRenderer.cpp
@@ -109,24 +109,24 @@ void PatchRenderer::clear()
   invalidate();
 }
 
-void PatchRenderer::addPatch(const mdl::PatchNode* patchNode)
+void PatchRenderer::addPatch(const mdl::PatchNode& patchNode)
 {
-  if (m_patchNodes.insert(patchNode).second)
+  if (m_patchNodes.insert(&patchNode).second)
   {
     invalidate();
   }
 }
 
-void PatchRenderer::removePatch(const mdl::PatchNode* patchNode)
+void PatchRenderer::removePatch(const mdl::PatchNode& patchNode)
 {
-  if (auto it = m_patchNodes.find(patchNode); it != std::end(m_patchNodes))
+  if (auto it = m_patchNodes.find(&patchNode); it != std::end(m_patchNodes))
   {
     m_patchNodes.erase(it);
     invalidate();
   }
 }
 
-void PatchRenderer::invalidatePatch(const mdl::PatchNode*)
+void PatchRenderer::invalidatePatch(const mdl::PatchNode&)
 {
   invalidate();
 }

--- a/lib/TbUiLib/include/ui/VertexToolBase.h
+++ b/lib/TbUiLib/include/ui/VertexToolBase.h
@@ -613,12 +613,12 @@ protected:
     for (const auto* node : nodes)
     {
       node->accept(kdl::overload(
-        [](const mdl::WorldNode*) {},
-        [](const mdl::LayerNode*) {},
-        [](const mdl::GroupNode*) {},
-        [](const mdl::EntityNode*) {},
-        [&](const mdl::BrushNode* brushNode) { handleManager.addHandles(*brushNode); },
-        [](const mdl::PatchNode*) {}));
+        [](const mdl::WorldNode&) {},
+        [](const mdl::LayerNode&) {},
+        [](const mdl::GroupNode&) {},
+        [](const mdl::EntityNode&) {},
+        [&](const mdl::BrushNode& brushNode) { handleManager.addHandles(brushNode); },
+        [](const mdl::PatchNode&) {}));
     }
   }
 
@@ -630,12 +630,12 @@ protected:
     for (const auto* node : nodes)
     {
       node->accept(kdl::overload(
-        [](const mdl::WorldNode*) {},
-        [](const mdl::LayerNode*) {},
-        [](const mdl::GroupNode*) {},
-        [](const mdl::EntityNode*) {},
-        [&](const mdl::BrushNode* brushNode) { handleManager.removeHandles(*brushNode); },
-        [](const mdl::PatchNode*) {}));
+        [](const mdl::WorldNode&) {},
+        [](const mdl::LayerNode&) {},
+        [](const mdl::GroupNode&) {},
+        [](const mdl::EntityNode&) {},
+        [&](const mdl::BrushNode& brushNode) { handleManager.removeHandles(brushNode); },
+        [](const mdl::PatchNode&) {}));
     }
   }
 

--- a/lib/TbUiLib/include/ui/VertexToolBase.h
+++ b/lib/TbUiLib/include/ui/VertexToolBase.h
@@ -617,7 +617,7 @@ protected:
         [](const mdl::LayerNode*) {},
         [](const mdl::GroupNode*) {},
         [](const mdl::EntityNode*) {},
-        [&](const mdl::BrushNode* brush) { handleManager.addHandles(brush); },
+        [&](const mdl::BrushNode* brushNode) { handleManager.addHandles(*brushNode); },
         [](const mdl::PatchNode*) {}));
     }
   }
@@ -634,7 +634,7 @@ protected:
         [](const mdl::LayerNode*) {},
         [](const mdl::GroupNode*) {},
         [](const mdl::EntityNode*) {},
-        [&](const mdl::BrushNode* brush) { handleManager.removeHandles(brush); },
+        [&](const mdl::BrushNode* brushNode) { handleManager.removeHandles(*brushNode); },
         [](const mdl::PatchNode*) {}));
     }
   }

--- a/lib/TbUiLib/src/ClipTool.cpp
+++ b/lib/TbUiLib/src/ClipTool.cpp
@@ -934,12 +934,12 @@ void ClipTool::addBrushesToRenderer(
     for (auto* node : nodes)
     {
       node->accept(kdl::overload(
-        [](const mdl::WorldNode*) {},
-        [](const mdl::LayerNode*) {},
-        [](const mdl::GroupNode*) {},
-        [](const mdl::EntityNode*) {},
-        [&](mdl::BrushNode* brushNode) { renderer.addBrush(*brushNode); },
-        [](mdl::PatchNode*) {}));
+        [](const mdl::WorldNode&) {},
+        [](const mdl::LayerNode&) {},
+        [](const mdl::GroupNode&) {},
+        [](const mdl::EntityNode&) {},
+        [&](mdl::BrushNode& brushNode) { renderer.addBrush(brushNode); },
+        [](mdl::PatchNode&) {}));
     }
   }
 }

--- a/lib/TbUiLib/src/ClipTool.cpp
+++ b/lib/TbUiLib/src/ClipTool.cpp
@@ -938,7 +938,7 @@ void ClipTool::addBrushesToRenderer(
         [](const mdl::LayerNode*) {},
         [](const mdl::GroupNode*) {},
         [](const mdl::EntityNode*) {},
-        [&](mdl::BrushNode* brush) { renderer.addBrush(brush); },
+        [&](mdl::BrushNode* brushNode) { renderer.addBrush(*brushNode); },
         [](mdl::PatchNode*) {}));
     }
   }

--- a/lib/TbUiLib/src/CreateBrushesToolBase.cpp
+++ b/lib/TbUiLib/src/CreateBrushesToolBase.cpp
@@ -106,7 +106,7 @@ void CreateBrushesToolBase::render(
     auto boundsBuilder = vm::bbox3d::builder{};
     for (const auto& brushNode : m_brushNodes)
     {
-      m_brushRenderer->addBrush(brushNode.get());
+      m_brushRenderer->addBrush(*brushNode);
       boundsBuilder.add(brushNode->logicalBounds());
     }
     m_brushRenderer->render(renderContext, renderBatch);

--- a/lib/TbUiLib/src/EntityPropertyModel.cpp
+++ b/lib/TbUiLib/src/EntityPropertyModel.cpp
@@ -386,19 +386,19 @@ std::vector<std::string> getAllPropertyKeys(const mdl::Map& map)
   };
 
   map.worldNode().accept(kdl::overload(
-    [&](auto&& thisLambda, const mdl::WorldNode* worldNode) {
-      addEntityKeys(*worldNode);
-      worldNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, const mdl::WorldNode& worldNode) {
+      addEntityKeys(worldNode);
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const mdl::LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const mdl::GroupNode* groupNode) {
-      groupNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::GroupNode& groupNode) {
+      groupNode.visitChildren(thisLambda);
     },
-    [&](const mdl::EntityNode* entityNode) { addEntityKeys(*entityNode); },
-    [](const mdl::BrushNode*) {},
-    [](const mdl::PatchNode*) {}));
+    [&](const mdl::EntityNode& entityNode) { addEntityKeys(entityNode); },
+    [](const mdl::BrushNode&) {},
+    [](const mdl::PatchNode&) {}));
 
   // also add keys from all loaded entity definitions
   for (const auto& entityDefinition : map.entityDefinitionManager().definitions())
@@ -458,17 +458,17 @@ std::vector<std::string> getAllValuesForPropertyValueTypes(const mdl::Map& map)
 {
   auto result = kdl::vector_set<std::string>();
   map.worldNode().accept(kdl::overload(
-    [](auto&& thisLambda, const mdl::WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const mdl::LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, const mdl::GroupNode* groupNode) {
-      groupNode->visitChildren(thisLambda);
+    [&](auto&& thisLambda, const mdl::GroupNode& groupNode) {
+      groupNode.visitChildren(thisLambda);
     },
-    [&](const mdl::EntityNode* entityNode) {
-      if (const auto* entityDefinition = entityNode->entity().definition())
+    [&](const mdl::EntityNode& entityNode) {
+      if (const auto* entityDefinition = entityNode.entity().definition())
       {
         auto propertyValues =
           entityDefinition->propertyDefinitions
@@ -477,7 +477,7 @@ std::vector<std::string> getAllValuesForPropertyValueTypes(const mdl::Map& map)
                 std::holds_alternative<ValueType>(propertyDefinition.valueType) || ...);
             })
           | std::views::transform([&](const auto& propertyDefinition) {
-              return entityNode->entity().property(propertyDefinition.key);
+              return entityNode.entity().property(propertyDefinition.key);
             })
           | std::views::filter(
             [](const auto* propertyValue) { return propertyValue != nullptr; })
@@ -487,8 +487,8 @@ std::vector<std::string> getAllValuesForPropertyValueTypes(const mdl::Map& map)
         result.insert(propertyValues.begin(), propertyValues.end());
       }
     },
-    [&](const mdl::BrushNode*) {},
-    [&](const mdl::PatchNode*) {}));
+    [&](const mdl::BrushNode&) {},
+    [&](const mdl::PatchNode&) {}));
 
   // remove the empty string
   result.erase("");

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -134,7 +134,7 @@ std::partial_ordering operator<=>(
 }
 
 std::optional<EdgeInfo> getEdgeInfo(
-  const mdl::BrushEdge* edge, mdl::BrushNode* brushNode, const vm::ray3d& pickRay)
+  const mdl::BrushEdge* edge, mdl::BrushNode& brushNode, const vm::ray3d& pickRay)
 {
 
   const auto segment = edge->segment();
@@ -144,8 +144,8 @@ std::optional<EdgeInfo> getEdgeInfo(
   const auto rightFaceIndex = edge->secondFace()->payload();
   contract_assert(leftFaceIndex && rightFaceIndex);
 
-  const auto& leftFace = brushNode->brush().face(*leftFaceIndex);
-  const auto& rightFace = brushNode->brush().face(*rightFaceIndex);
+  const auto& leftFace = brushNode.brush().face(*leftFaceIndex);
+  const auto& rightFace = brushNode.brush().face(*rightFaceIndex);
 
   const auto leftDot = vm::dot(leftFace.boundary().normal, pickRay.direction);
   const auto rightDot = vm::dot(rightFace.boundary().normal, pickRay.direction);
@@ -156,8 +156,8 @@ std::optional<EdgeInfo> getEdgeInfo(
     return std::nullopt;
   }
 
-  const auto leftFaceHandle = mdl::BrushFaceHandle{brushNode, *leftFaceIndex};
-  const auto rightFaceHandle = mdl::BrushFaceHandle{brushNode, *rightFaceIndex};
+  const auto leftFaceHandle = mdl::BrushFaceHandle{&brushNode, *leftFaceIndex};
+  const auto rightFaceHandle = mdl::BrushFaceHandle{&brushNode, *rightFaceIndex};
 
   return {{leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, dist}};
 }
@@ -169,17 +169,17 @@ std::optional<EdgeInfo> findClosestHorizonEdge(
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [](mdl::WorldNode*) {},
-      [](mdl::LayerNode*) {},
-      [](mdl::GroupNode*) {},
-      [](mdl::EntityNode*) {},
-      [&](mdl::BrushNode* brushNode) {
-        for (const auto* edge : brushNode->brush().edges())
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [](mdl::GroupNode&) {},
+      [](mdl::EntityNode&) {},
+      [&](mdl::BrushNode& brushNode) {
+        for (const auto* edge : brushNode.brush().edges())
         {
           result = std::min(result, getEdgeInfo(edge, brushNode, pickRay));
         }
       },
-      [](mdl::PatchNode*) {}));
+      [](mdl::PatchNode&) {}));
   }
   return result;
 }
@@ -286,12 +286,12 @@ std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [](mdl::WorldNode*) {},
-      [](mdl::LayerNode*) {},
-      [](mdl::GroupNode*) {},
-      [](mdl::EntityNode*) {},
-      [&](mdl::BrushNode* brushNode) {
-        const auto& brush = brushNode->brush();
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [](mdl::GroupNode&) {},
+      [](mdl::EntityNode&) {},
+      [&](mdl::BrushNode& brushNode) {
+        const auto& brush = brushNode.brush();
         for (size_t i = 0; i < brush.faceCount(); ++i)
         {
           const auto& face = brush.face(i);
@@ -300,10 +300,10 @@ std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
             continue;
           }
 
-          result.emplace_back(brushNode, i);
+          result.emplace_back(&brushNode, i);
         }
       },
-      [](mdl::PatchNode*) {}));
+      [](mdl::PatchNode&) {}));
   }
 
   return result;

--- a/lib/TbUiLib/src/IssueBrowserView.cpp
+++ b/lib/TbUiLib/src/IssueBrowserView.cpp
@@ -140,8 +140,8 @@ void IssueBrowserView::updateIssues()
   const auto validators = map.worldNode().registeredValidators();
 
   auto issues = std::vector<const mdl::Issue*>{};
-  const auto collectIssues = [&](auto* node) {
-    for (auto* issue : node->issues(validators))
+  const auto collectIssues = [&](auto& node) {
+    for (auto* issue : node.issues(validators))
     {
       if (
         m_showHiddenIssues
@@ -153,24 +153,24 @@ void IssueBrowserView::updateIssues()
   };
 
   map.worldNode().accept(kdl::overload(
-    [&](auto&& thisLambda, mdl::WorldNode* worldNode) {
+    [&](auto&& thisLambda, mdl::WorldNode& worldNode) {
       collectIssues(worldNode);
-      worldNode->visitChildren(thisLambda);
+      worldNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::LayerNode* layerNode) {
+    [&](auto&& thisLambda, mdl::LayerNode& layerNode) {
       collectIssues(layerNode);
-      layerNode->visitChildren(thisLambda);
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::GroupNode* groupNode) {
+    [&](auto&& thisLambda, mdl::GroupNode& groupNode) {
       collectIssues(groupNode);
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, mdl::EntityNode* entityNode) {
+    [&](auto&& thisLambda, mdl::EntityNode& entityNode) {
       collectIssues(entityNode);
-      entityNode->visitChildren(thisLambda);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](mdl::BrushNode* brushNode) { collectIssues(brushNode); },
-    [&](mdl::PatchNode* patchNode) { collectIssues(patchNode); }));
+    [&](mdl::BrushNode& brushNode) { collectIssues(brushNode); },
+    [&](mdl::PatchNode& patchNode) { collectIssues(patchNode); }));
 
   issues = kdl::vec_sort(std::move(issues), [](const auto* lhs, const auto* rhs) {
     return lhs->seqId() > rhs->seqId();

--- a/lib/TbUiLib/src/MapView3D.cpp
+++ b/lib/TbUiLib/src/MapView3D.cpp
@@ -300,27 +300,33 @@ vm::vec3f computeCameraTargetPosition(const std::vector<mdl::Node*>& nodes)
   mdl::Node::visitAll(
     nodes,
     kdl::overload(
-      [](auto&& thisLambda, mdl::WorldNode* world) { world->visitChildren(thisLambda); },
-      [](auto&& thisLambda, mdl::LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [](auto&& thisLambda, mdl::GroupNode* group) { group->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, mdl::EntityNode* entity) {
-        if (!entity->hasChildren())
+      [](auto&& thisLambda, mdl::WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
+      },
+      [](auto&& thisLambda, mdl::LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
+      },
+      [](auto&& thisLambda, mdl::GroupNode& groupNode) {
+        groupNode.visitChildren(thisLambda);
+      },
+      [&](auto&& thisLambda, mdl::EntityNode& entityNode) {
+        if (!entityNode.hasChildren())
         {
-          entity->logicalBounds().for_each_vertex(handlePoint);
+          entityNode.logicalBounds().for_each_vertex(handlePoint);
         }
         else
         {
-          entity->visitChildren(thisLambda);
+          entityNode.visitChildren(thisLambda);
         }
       },
-      [&](mdl::BrushNode* brush) {
-        for (const auto* vertex : brush->brush().vertices())
+      [&](mdl::BrushNode& brushNode) {
+        for (const auto* vertex : brushNode.brush().vertices())
         {
           handlePoint(vertex->position());
         }
       },
-      [&](mdl::PatchNode* patchNode) {
-        for (const auto& controlPoint : patchNode->patch().controlPoints())
+      [&](mdl::PatchNode& patchNode) {
+        for (const auto& controlPoint : patchNode.patch().controlPoints())
         {
           handlePoint(controlPoint.xyz());
         }
@@ -349,25 +355,31 @@ float computeCameraOffset(const gl::Camera& camera, const std::vector<mdl::Node*
   mdl::Node::visitAll(
     nodes,
     kdl::overload(
-      [](auto&& thisLambda, mdl::WorldNode* world) { world->visitChildren(thisLambda); },
-      [](auto&& thisLambda, mdl::LayerNode* layer) { layer->visitChildren(thisLambda); },
-      [](auto&& thisLambda, mdl::GroupNode* group) { group->visitChildren(thisLambda); },
-      [&](auto&& thisLambda, mdl::EntityNode* entity) {
-        if (!entity->hasChildren())
+      [](auto&& thisLambda, mdl::WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
+      },
+      [](auto&& thisLambda, mdl::LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
+      },
+      [](auto&& thisLambda, mdl::GroupNode& groupNode) {
+        groupNode.visitChildren(thisLambda);
+      },
+      [&](auto&& thisLambda, mdl::EntityNode& entityNode) {
+        if (!entityNode.hasChildren())
         {
           for (size_t i = 0u; i < 4u; ++i)
           {
-            entity->logicalBounds().for_each_vertex(
+            entityNode.logicalBounds().for_each_vertex(
               [&](const auto& point) { handlePoint(point, frustumPlanes[i]); });
           }
         }
         else
         {
-          entity->visitChildren(thisLambda);
+          entityNode.visitChildren(thisLambda);
         }
       },
-      [&](mdl::BrushNode* brush) {
-        for (const auto* vertex : brush->brush().vertices())
+      [&](mdl::BrushNode& brushNode) {
+        for (const auto* vertex : brushNode.brush().vertices())
         {
           for (size_t i = 0u; i < 4u; ++i)
           {
@@ -375,8 +387,8 @@ float computeCameraOffset(const gl::Camera& camera, const std::vector<mdl::Node*
           }
         }
       },
-      [&](mdl::PatchNode* patchNode) {
-        for (const auto& controlPoint : patchNode->patch().controlPoints())
+      [&](mdl::PatchNode& patchNode) {
+        for (const auto& controlPoint : patchNode.patch().controlPoints())
         {
           for (size_t i = 0u; i < 4u; ++i)
           {

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -1299,12 +1299,12 @@ void MapViewBase::showPopupMenuLater()
     moveToWorldAction->setEnabled(canMakeStructural());
 
     const auto isEntity = newBrushParent->accept(kdl::overload(
-      [](const mdl::WorldNode*) { return false; },
-      [](const mdl::LayerNode*) { return false; },
-      [](const mdl::GroupNode*) { return false; },
-      [](const mdl::EntityNode*) { return true; },
-      [](const mdl::BrushNode*) { return false; },
-      [](const mdl::PatchNode*) { return false; }));
+      [](const mdl::WorldNode&) { return false; },
+      [](const mdl::LayerNode&) { return false; },
+      [](const mdl::GroupNode&) { return false; },
+      [](const mdl::EntityNode&) { return true; },
+      [](const mdl::BrushNode&) { return false; },
+      [](const mdl::PatchNode&) { return false; }));
 
     if (isEntity)
     {
@@ -1622,26 +1622,29 @@ static std::vector<mdl::Node*> collectEntitiesForNodes(
   const std::vector<mdl::Node*>& selectedNodes, const mdl::WorldNode& worldNode)
 {
   auto result = std::vector<mdl::Node*>{};
-  const auto addNode = [&](auto&& thisLambda, auto* node) {
-    if (node->entity() == &worldNode)
+  const auto addNode = [&](auto&& thisLambda, auto& node) {
+    if (node.entity() == &worldNode)
     {
-      result.push_back(node);
+      result.push_back(&node);
     }
     else
     {
-      node->visitParent(thisLambda);
+      node.visitParent(thisLambda);
     }
   };
 
   mdl::Node::visitAll(
     selectedNodes,
     kdl::overload(
-      [](mdl::WorldNode*) {},
-      [](mdl::LayerNode*) {},
-      [&](mdl::GroupNode* group) { result.push_back(group); },
-      [&](mdl::EntityNode* entity) { result.push_back(entity); },
-      [&](auto&& thisLambda, mdl::BrushNode* brush) { addNode(thisLambda, brush); },
-      [&](auto&& thisLambda, mdl::PatchNode* patch) { addNode(thisLambda, patch); }));
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [&](mdl::GroupNode& groupNode) { result.push_back(&groupNode); },
+      [&](mdl::EntityNode& entityNode) { result.push_back(&entityNode); },
+      [&](
+        auto&& thisLambda, mdl::BrushNode& brushNode) { addNode(thisLambda, brushNode); },
+      [&](auto&& thisLambda, mdl::PatchNode& patchNode) {
+        addNode(thisLambda, patchNode);
+      }));
   return kdl::vec_sort_and_remove_duplicates(std::move(result));
 }
 

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -1551,7 +1551,8 @@ mdl::GroupNode* MapViewBase::findGroupToMergeGroupsInto(
 
 bool MapViewBase::canReparentNode(const mdl::Node* node, const mdl::Node* newParent) const
 {
-  return newParent != node && newParent != node->parent() && newParent->canAddChild(node);
+  return newParent != node && newParent != node->parent()
+         && newParent->canAddChild(*node);
 }
 
 void MapViewBase::moveSelectedBrushesToEntity()
@@ -1676,7 +1677,7 @@ std::vector<mdl::Node*> MapViewBase::collectReparentableNodes(
 {
   return nodes | std::views::filter([&](const auto* node) {
            return newParent != node && newParent != node->parent()
-                  && !newParent->isDescendantOf(node);
+                  && !newParent->isDescendantOf(*node);
          })
          | kdl::ranges::to<std::vector>();
 }

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -670,34 +670,34 @@ QString describeSelection(const mdl::Map& map)
   size_t hiddenPatches = 0u;
 
   map.worldNode().accept(kdl::overload(
-    [](auto&& thisLambda, const mdl::WorldNode* worldNode) {
-      worldNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::WorldNode& worldNode) {
+      worldNode.visitChildren(thisLambda);
     },
-    [](auto&& thisLambda, const mdl::LayerNode* layerNode) {
-      layerNode->visitChildren(thisLambda);
+    [](auto&& thisLambda, const mdl::LayerNode& layerNode) {
+      layerNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, const mdl::GroupNode* groupNode) {
-      if (!editorContext.visible(*groupNode))
+    [&](auto&& thisLambda, const mdl::GroupNode& groupNode) {
+      if (!editorContext.visible(groupNode))
       {
         ++hiddenGroups;
       }
-      groupNode->visitChildren(thisLambda);
+      groupNode.visitChildren(thisLambda);
     },
-    [&](auto&& thisLambda, const mdl::EntityNode* entityNode) {
-      if (!editorContext.visible(*entityNode))
+    [&](auto&& thisLambda, const mdl::EntityNode& entityNode) {
+      if (!editorContext.visible(entityNode))
       {
         ++hiddenEntities;
       }
-      entityNode->visitChildren(thisLambda);
+      entityNode.visitChildren(thisLambda);
     },
-    [&](const mdl::BrushNode* brushNode) {
-      if (!editorContext.visible(*brushNode))
+    [&](const mdl::BrushNode& brushNode) {
+      if (!editorContext.visible(brushNode))
       {
         ++hiddenBrushes;
       }
     },
-    [&](const mdl::PatchNode* patchNode) {
-      if (!editorContext.visible(*patchNode))
+    [&](const mdl::PatchNode& patchNode) {
+      if (!editorContext.visible(patchNode))
       {
         ++hiddenPatches;
       }

--- a/lib/TbUiLib/src/SelectionTool.cpp
+++ b/lib/TbUiLib/src/SelectionTool.cpp
@@ -407,7 +407,7 @@ bool SelectionTool::mouseDoubleClick(const InputState& inputState)
     if (hit.isMatch())
     {
       const auto hitInGroup =
-        inGroup && mdl::hitToNode(hit)->isDescendantOf(currentGroup);
+        inGroup && mdl::hitToNode(hit)->isDescendantOf(*currentGroup);
       if (!inGroup || hitInGroup)
       {
         // If the hit node is inside a closed group, treat it as a hit on the group insted

--- a/lib/TbUiLib/src/SetBrushFaceAttributesTool.cpp
+++ b/lib/TbUiLib/src/SetBrushFaceAttributesTool.cpp
@@ -173,7 +173,7 @@ std::optional<mdl::BrushFaceHandle> selectTargetFaceHandleForLinkedGroups(
   const auto& oldTargetBrushNode = *oldTargetFaceHandle.node();
 
   // The target is already in the same linked group as the source
-  if (containingSourceGroupNode.isAncestorOf(&oldTargetBrushNode))
+  if (containingSourceGroupNode.isAncestorOf(oldTargetBrushNode))
   {
     return oldTargetFaceHandle;
   }

--- a/lib/TbUiLib/src/SmartColorEditor.cpp
+++ b/lib/TbUiLib/src/SmartColorEditor.cpp
@@ -95,11 +95,11 @@ std::vector<QColor> collectColors(
   };
 
   auto colors = kdl::vector_set<QColor, decltype(cmp)>{cmp};
-  const auto visitEntityNode = [&](const auto* node) {
-    if (const auto* propertyValue = node->entity().property(propertyKey))
+  const auto visitEntityNode = [&](const auto& node) {
+    if (const auto* propertyValue = node.entity().property(propertyKey))
     {
       parseEntityColorPropertyValue(
-        node->entity().definition(), propertyKey, *propertyValue)
+        node.entity().definition(), propertyKey, *propertyValue)
         | kdl::transform([&](const auto entityColorProperty) {
             colors.insert(toQColor(entityColorProperty.color));
           })
@@ -110,19 +110,19 @@ std::vector<QColor> collectColors(
   for (const auto* node : nodes)
   {
     node->accept(kdl::overload(
-      [&](auto&& thisLambda, const mdl::WorldNode* world) {
-        world->visitChildren(thisLambda);
-        visitEntityNode(world);
+      [&](auto&& thisLambda, const mdl::WorldNode& worldNode) {
+        worldNode.visitChildren(thisLambda);
+        visitEntityNode(worldNode);
       },
-      [](auto&& thisLambda, const mdl::LayerNode* layer) {
-        layer->visitChildren(thisLambda);
+      [](auto&& thisLambda, const mdl::LayerNode& layerNode) {
+        layerNode.visitChildren(thisLambda);
       },
-      [](auto&& thisLambda, const mdl::GroupNode* group) {
-        group->visitChildren(thisLambda);
+      [](auto&& thisLambda, const mdl::GroupNode& groupNode) {
+        groupNode.visitChildren(thisLambda);
       },
-      [&](const mdl::EntityNode* entity) { visitEntityNode(entity); },
-      [](const mdl::BrushNode*) {},
-      [](const mdl::PatchNode*) {}));
+      [&](const mdl::EntityNode& entity) { visitEntityNode(entity); },
+      [](const mdl::BrushNode&) {},
+      [](const mdl::PatchNode&) {}));
   }
 
   return colors.get_data();


### PR DESCRIPTION
We should not pass objects by pointer unless they could be null. We change NodeVisitor
to take the visited notes by reference, and adapt a few other functions that take nodes
by pointer unnecessarily as well.