### PR TITLE
Clamp the row height of new cell layout rows

### DIFF
--- a/lib/TbUiLib/src/CellLayout.cpp
+++ b/lib/TbUiLib/src/CellLayout.cpp
@@ -313,13 +313,14 @@ void LayoutRow::addItem(
     m_maxCellHeight};
   width += cell.cellBounds().width;
 
-  const auto newItemRowHeight =
-    cell.cellBounds().height - cell.titleBounds().height - m_titleMargin;
+  const auto newItemRowHeight = std::clamp(
+    cell.cellBounds().height - cell.titleBounds().height - m_titleMargin,
+    m_minCellHeight,
+    m_maxCellHeight);
+
   if (newItemRowHeight > m_minCellHeight)
   {
     m_minCellHeight = newItemRowHeight;
-    contract_assert(m_minCellHeight <= m_maxCellHeight);
-
     readjustItems();
   }
 


### PR DESCRIPTION
Due to floating point inaccuracies, the new item row height could be slightly bigger than the maximum cell height, leading to a contract assertion. By clamping the row height to the min and max cell height, we avoid the problem.

Closes #5210 