### PR TITLE
Fix color editor behavior

### DIFF
--- a/lib/TbMdlLib/src/StandardMapParser.cpp
+++ b/lib/TbMdlLib/src/StandardMapParser.cpp
@@ -589,17 +589,20 @@ void StandardMapParser::parseDaikatanaFace(ParserStatus& status)
     attribs.setSurfaceValue(parseFloat());
 
     // Daikatana color triple is optional
-    if (m_tokenizer.peekToken().hasType(QuakeMapToken::Integer))
+    if (const auto firstColorToken = m_tokenizer.peekToken();
+        firstColorToken.hasType(QuakeMapToken::Integer))
     {
       // red, green, blue
-      const auto r = vm::clamp(parseInteger(), 0, 255);
-      const auto g = vm::clamp(parseInteger(), 0, 255);
-      const auto b = vm::clamp(parseInteger(), 0, 255);
-      attribs.setColor(RgbB{
-        static_cast<unsigned char>(r),
-        static_cast<unsigned char>(g),
-        static_cast<unsigned char>(b),
-      });
+      const auto r = parseInteger();
+      const auto g = parseInteger();
+      const auto b = parseInteger();
+      RgbB::fromValues(std::tuple{r, g, b})
+        | kdl::transform([&](const auto& color) { attribs.setColor(color); })
+        | kdl::transform_error([&](const auto& e) {
+            status.warn(
+              firstColorToken.location(),
+              fmt::format("Skipping invalid surface color: {}", e.msg));
+          });
     }
   }
 

--- a/lib/TbMdlLib/src/UpdateBrushFaceAttributes.cpp
+++ b/lib/TbMdlLib/src/UpdateBrushFaceAttributes.cpp
@@ -594,8 +594,7 @@ void evaluate(const UpdateBrushFaceAttributes& update, BrushFace& brushFace)
 
   if (update.color)
   {
-    attributes.setColor(
-      *update.color | kdl::optional_or_else([&]() { return brushFace.resolvedColor(); }));
+    attributes.setColor(*update.color);
   }
 
   brushFace.setAttributes(attributes);

--- a/lib/TbMdlLib/test/src/tst_WorldReader.cpp
+++ b/lib/TbMdlLib/test/src/tst_WorldReader.cpp
@@ -612,6 +612,42 @@ TEST_CASE("WorldReader")
     CHECK_FALSE(brush.face(*c_mf_v3cww_index).attributes().hasColor());
   }
 
+  SECTION("Invalid Daikatana surface color")
+  {
+    const auto data = R"(
+{
+"classname" "worldspawn"
+{
+( -712 1280 -448 ) ( -904 1280 -448 ) ( -904 992 -448 ) rtz/c_mf_v3cw 56 -32 0 1 1 0 0 0 5 6 300
+( -904 992 -416 ) ( -904 1280 -416 ) ( -712 1280 -416 ) rtz/b_rc_v16w 32 32 0 1 1 1 2 3
+( -832 968 -416 ) ( -832 1256 -416 ) ( -832 1256 -448 ) rtz/c_mf_v3cww 16 96 0 1 1
+( -920 1088 -448 ) ( -920 1088 -416 ) ( -680 1088 -416 ) rtz/c_mf_v3c 56 96 0 1 1 0 0 0
+( -968 1152 -448 ) ( -920 1152 -448 ) ( -944 1152 -416 ) rtz/c_mf_v3c 56 96 0 1 1 0 0 0
+( -896 1056 -416 ) ( -896 1056 -448 ) ( -896 1344 -448 ) rtz/c_mf_v3c 16 96 0 1 1 0 0 0
+}
+})";
+
+    auto reader = WorldReader{data, mdl::MapFormat::Daikatana, {}};
+
+    auto worldResult = reader.read(worldBounds, status, taskManager);
+    REQUIRE(worldResult);
+
+    const auto& world = worldResult.value();
+    CHECK(world->childCount() == 1u);
+    auto* defaultLayer = world->children().front();
+    CHECK(defaultLayer->childCount() == 1u);
+
+    const auto* brushNode =
+      static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    checkBrushUVCoordSystem(brushNode, false);
+    const auto& brush = brushNode->brush();
+
+    const auto c_mf_v3cw_index = brush.findFace("rtz/c_mf_v3cw");
+    REQUIRE(c_mf_v3cw_index);
+
+    CHECK(!brush.face(*c_mf_v3cw_index).attributes().hasColor());
+  }
+
   SECTION("Daikatana map header")
   {
     const auto data = R"(

--- a/lib/TbUiLib/include/ui/FaceAttribsEditor.h
+++ b/lib/TbUiLib/include/ui/FaceAttribsEditor.h
@@ -115,7 +115,7 @@ private:
   void surfaceFlagChanged(size_t index, int value, int setFlag, int mixedFlag);
   void contentFlagChanged(size_t index, int value, int setFlag, int mixedFlag);
   void surfaceValueChanged(double value);
-  void colorValueChanged(const QString& text);
+  void colorValueChanged();
   void surfaceFlagsUnset();
   void contentFlagsUnset();
   void surfaceValueUnset();

--- a/lib/TbUiLib/src/FaceAttribsEditor.cpp
+++ b/lib/TbUiLib/src/FaceAttribsEditor.cpp
@@ -50,17 +50,29 @@
 #include "ui/ViewConstants.h"
 #include "ui/ViewUtils.h"
 
-#include "kd/string_format.h"
-#include "kd/string_utils.h"
-
 #include "vm/vec_io.h" // IWYU pragma: keep
 
+#include <regex>
 #include <string>
 
 namespace tb::ui
 {
 namespace
 {
+
+class ColorValidator : public QValidator
+{
+public:
+  State validate(QString& input, int&) const override
+  {
+    static const auto Pattern = std::regex{R"(^\s*(?:\d+\s*){0,3}$)"};
+
+    const auto str = input.toStdString();
+    return str.empty() || RgbB::parse(str).is_success() ? State::Acceptable
+           : std::regex_match(str, Pattern)             ? State::Intermediate
+                                                        : State::Invalid;
+  };
+};
 
 std::tuple<QList<int>, QStringList, QStringList> getFlags(
   const std::vector<mdl::FlagConfig>& flags)
@@ -250,7 +262,7 @@ void FaceAttribsEditor::surfaceValueChanged(const double value)
   }
 }
 
-void FaceAttribsEditor::colorValueChanged(const QString& /* text */)
+void FaceAttribsEditor::colorValueChanged()
 {
   auto& map = m_document.map();
   if (!map.selection().hasAnyBrushFaces())
@@ -259,22 +271,11 @@ void FaceAttribsEditor::colorValueChanged(const QString& /* text */)
   }
 
   const auto str = m_colorEditor->text().toStdString();
-  if (!kdl::str_is_blank(str))
-  {
-    RgbB::parse(str) | kdl::transform([&](const auto& color) {
-      if (!setBrushFaceAttributes(map, {.color = {color}}))
-      {
-        updateControls();
-      }
-    }) | kdl::ignore();
-  }
-  else
-  {
-    if (!setBrushFaceAttributes(map, {.color = {std::nullopt}}))
-    {
-      updateControls();
-    }
-  }
+  const auto color = RgbB::parse(str)
+                     | kdl::transform([&](const auto& c) { return std::optional{c}; })
+                     | kdl::value_or(std::nullopt);
+
+  setBrushFaceAttributes(map, {.color = std::optional<std::optional<Color>>{color}});
 }
 
 void FaceAttribsEditor::surfaceFlagsUnset()
@@ -327,10 +328,8 @@ void FaceAttribsEditor::colorValueUnset()
     return;
   }
 
-  if (!setBrushFaceAttributes(map, {.color = std::nullopt}))
-  {
-    updateControls();
-  }
+  const auto color = std::optional<Color>{std::nullopt};
+  setBrushFaceAttributes(map, {.color = std::optional<std::optional<Color>>{color}});
 }
 
 void FaceAttribsEditor::updateIncrements()
@@ -536,8 +535,11 @@ QWidget* FaceAttribsEditor::createAttribsWidget()
   m_colorLabel = new QLabel{"Color"};
   setEmphasizedStyle(m_colorLabel);
   m_colorEditor = new QLineEdit{};
+  m_colorEditor->setProperty("error", false);
   m_colorUnsetButton = createBitmapButton("ResetUV.svg", tr("Unset color"));
   m_colorEditorLayout = createUnsetButtonLayout(m_colorEditor, m_colorUnsetButton);
+
+  m_colorEditor->setValidator(new ColorValidator{});
 
   const Qt::Alignment LabelFlags = Qt::AlignVCenter | Qt::AlignRight;
   const Qt::Alignment ValueFlags = Qt::AlignVCenter;
@@ -670,7 +672,10 @@ void FaceAttribsEditor::bindEvents()
     this,
     &FaceAttribsEditor::contentFlagChanged);
   connect(
-    m_colorEditor, &QLineEdit::textEdited, this, &FaceAttribsEditor::colorValueChanged);
+    m_colorEditor,
+    &QLineEdit::editingFinished,
+    this,
+    &FaceAttribsEditor::colorValueChanged);
   connect(
     m_surfaceValueUnsetButton,
     &QAbstractButton::clicked,


### PR DESCRIPTION
The behavior of the color editor in the face attribute inspector was completely broken. This commit should fix it and ensure that only valid input is possible.

Closes #5261 