### PR TITLE
Fix shortcuts with non-Latin keyboard layouts

### DIFF
--- a/lib/TbUiLib/CMakeLists.txt
+++ b/lib/TbUiLib/CMakeLists.txt
@@ -117,6 +117,7 @@ target_sources(TbUiLib
     ${CMAKE_CURRENT_SOURCE_DIR}/src/KeyboardPreferencePane.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/KeyboardShortcutItemDelegate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/KeyboardShortcutModel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/KeyboardShortcutUtils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Lasso.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LaunchGameEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LaunchGameEngineDialog.cpp
@@ -346,6 +347,7 @@ target_sources(TbUiLib
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/KeyboardPreferencePane.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/KeyboardShortcutItemDelegate.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/KeyboardShortcutModel.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/KeyboardShortcutUtils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/Lasso.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/LaunchGameEngine.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ui/LaunchGameEngineDialog.h

--- a/lib/TbUiLib/include/ui/KeyboardShortcutUtils.h
+++ b/lib/TbUiLib/include/ui/KeyboardShortcutUtils.h
@@ -1,0 +1,108 @@
+/*
+ Copyright (C) 2026 Artsiom Trubchyk
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QKeyEvent>
+
+#include "PreferenceManager.h"
+#include "ui/Action.h"
+
+#include "kd/reflection_decl.h"
+
+#include <algorithm>
+#include <ranges>
+#include <variant>
+
+class QKeySequence;
+
+namespace tb::ui
+{
+class ActionExecutionContext;
+
+bool eventMatchesPhysicalKey(const QKeyEvent& event, const QKeySequence& shortcut);
+
+bool shouldUsePhysicalShortcutFallback(const QKeyEvent& event);
+
+bool eventMatchesPhysicalShortcutFallback(
+  const QKeyEvent& event, const QKeySequence& shortcut);
+
+struct NoFallbackActionMatch
+{
+  kdl_reflect_decl_empty(NoFallbackActionMatch);
+};
+
+struct UniqueFallbackActionMatch
+{
+  const Action& action;
+
+  kdl_reflect_decl(UniqueFallbackActionMatch, action);
+};
+
+struct AmbiguousFallbackActionMatch
+{
+  const Action& action;
+
+  kdl_reflect_decl(AmbiguousFallbackActionMatch, action);
+};
+
+using FallbackActionMatch = std::
+  variant<NoFallbackActionMatch, UniqueFallbackActionMatch, AmbiguousFallbackActionMatch>;
+
+std::ostream& operator<<(std::ostream& lhs, const FallbackActionMatch& rhs);
+
+template <std::ranges::range R>
+FallbackActionMatch findFallbackAction(
+  const QKeyEvent& event, const ActionExecutionContext& context, R&& actions)
+{
+  const auto actionMatches = [&](const auto* action) {
+    return action->enabled(context)
+           && eventMatchesPhysicalShortcutFallback(event, pref(action->preference()));
+  };
+
+  const auto iFirstMatch = std::ranges::find_if(actions, actionMatches);
+  return iFirstMatch == actions.end() ? FallbackActionMatch{NoFallbackActionMatch{}}
+         : std::ranges::none_of(std::next(iFirstMatch), actions.end(), actionMatches)
+           ? FallbackActionMatch{UniqueFallbackActionMatch{**iFirstMatch}}
+           : FallbackActionMatch{AmbiguousFallbackActionMatch{**iFirstMatch}};
+}
+
+template <std::ranges::range R, typename F>
+bool triggerFallbackAction(
+  QKeyEvent& event,
+  ActionExecutionContext& context,
+  R&& actions,
+  const F& triggerAmbiguousAction)
+{
+  return std::visit(
+    kdl::overload(
+      [&](const NoFallbackActionMatch&) { return false; },
+      [&](const UniqueFallbackActionMatch& match) {
+        match.action.execute(context);
+        event.accept();
+        return true;
+      },
+      [&](const AmbiguousFallbackActionMatch& match) {
+        return triggerAmbiguousAction(match.action);
+      }),
+    findFallbackAction(event, context, actions));
+}
+
+} // namespace tb::ui

--- a/lib/TbUiLib/include/ui/MapViewBase.h
+++ b/lib/TbUiLib/include/ui/MapViewBase.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 class QMenu;
+class QKeyEvent;
 class QShortcut;
 class QString;
 class QAction;
@@ -164,6 +165,7 @@ private: // shortcut setup
   void updateActionBindings();
   void updateActionStates();
   void updateActionStatesDelayed();
+  bool tryTriggerShortcut(QKeyEvent* event);
 
 public:
   void triggerAction(const Action& action);

--- a/lib/TbUiLib/include/ui/MapWindow.h
+++ b/lib/TbUiLib/include/ui/MapWindow.h
@@ -36,6 +36,7 @@
 class QAction;
 class QComboBox;
 class QDropEvent;
+class QKeyEvent;
 class QMenuBar;
 class QLabel;
 class QSplitter;
@@ -155,6 +156,7 @@ private: // menu bar
   void updateActionState();
   void updateActionStateDelayed();
   void updateUndoRedoActions();
+  bool tryTriggerShortcut(QKeyEvent* event);
 
   void addRecentDocumentsMenu();
   void removeRecentDocumentsMenu();

--- a/lib/TbUiLib/src/FlyModeHelper.cpp
+++ b/lib/TbUiLib/src/FlyModeHelper.cpp
@@ -25,6 +25,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "gl/Camera.h"
+#include "ui/KeyboardShortcutUtils.h"
 
 #include "vm/vec.h"
 
@@ -49,9 +50,7 @@ bool eventMatchesShortcut(const QKeySequence& shortcut, QKeyEvent* event)
 
   // NOTE: For triggering fly mode we only support single keys.
   // e.g. you can't bind Shift+W to fly forward, only Shift or W.
-  const auto ourKey = shortcut[0].key();
-  const auto theirKey = event->key();
-  return ourKey == theirKey;
+  return eventMatchesPhysicalKey(*event, shortcut);
 }
 
 } // namespace

--- a/lib/TbUiLib/src/KeyboardShortcutUtils.cpp
+++ b/lib/TbUiLib/src/KeyboardShortcutUtils.cpp
@@ -1,0 +1,238 @@
+/*
+ Copyright (C) 2026 Artsiom Trubchyk
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ui/KeyboardShortcutUtils.h"
+
+#include <QCoreApplication>
+#include <QKeyEvent>
+#include <QKeySequence>
+#include <QtGlobal>
+
+#if defined(Q_OS_MACOS)
+#include <Carbon/Carbon.h>
+#endif
+
+#if defined(Q_OS_LINUX)
+#include <linux/input-event-codes.h>
+#endif
+
+#include "kd/reflection_impl.h"
+
+#include <cstddef>
+
+namespace tb::ui
+{
+namespace
+{
+
+constexpr auto ShortcutModifierMask =
+  Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier;
+
+bool isLatinLetterOrDigit(const Qt::Key key)
+{
+  return (key >= Qt::Key_A && key <= Qt::Key_Z) || (key >= Qt::Key_0 && key <= Qt::Key_9);
+}
+
+struct NativeKeyMap
+{
+  quint32 native;
+  Qt::Key key;
+};
+
+template <std::size_t N>
+Qt::Key lookupNativeKey(const quint32 native, const NativeKeyMap (&map)[N])
+{
+  for (const auto& item : map)
+  {
+    if (item.native == native)
+    {
+      return item.key;
+    }
+  }
+
+  return Qt::Key_unknown;
+}
+
+Qt::Key physicalLatinLetterOrDigitKey(const QKeyEvent& event)
+{
+#if defined(Q_OS_WIN)
+  const auto nativeVirtualKey = event.nativeVirtualKey();
+  if (nativeVirtualKey >= 'A' && nativeVirtualKey <= 'Z')
+  {
+    return static_cast<Qt::Key>(
+      static_cast<int>(Qt::Key_A) + static_cast<int>(nativeVirtualKey - 'A'));
+  }
+  if (nativeVirtualKey >= '0' && nativeVirtualKey <= '9')
+  {
+    return static_cast<Qt::Key>(
+      static_cast<int>(Qt::Key_0) + static_cast<int>(nativeVirtualKey - '0'));
+  }
+
+#elif defined(Q_OS_MACOS)
+#define MAC_KEY(x) {static_cast<quint32>(kVK_ANSI_##x), Qt::Key_##x}
+
+  static constexpr NativeKeyMap map[] = {
+    MAC_KEY(A), MAC_KEY(B), MAC_KEY(C), MAC_KEY(D), MAC_KEY(E), MAC_KEY(F), MAC_KEY(G),
+    MAC_KEY(H), MAC_KEY(I), MAC_KEY(J), MAC_KEY(K), MAC_KEY(L), MAC_KEY(M), MAC_KEY(N),
+    MAC_KEY(O), MAC_KEY(P), MAC_KEY(Q), MAC_KEY(R), MAC_KEY(S), MAC_KEY(T), MAC_KEY(U),
+    MAC_KEY(V), MAC_KEY(W), MAC_KEY(X), MAC_KEY(Y), MAC_KEY(Z),
+
+    MAC_KEY(0), MAC_KEY(1), MAC_KEY(2), MAC_KEY(3), MAC_KEY(4), MAC_KEY(5), MAC_KEY(6),
+    MAC_KEY(7), MAC_KEY(8), MAC_KEY(9),
+  };
+
+#undef MAC_KEY
+
+  const auto key = lookupNativeKey(event.nativeVirtualKey(), map);
+  if (key != Qt::Key_unknown)
+  {
+    return key;
+  }
+
+#elif defined(Q_OS_LINUX)
+  // Qt/X11 and Qt/Wayland expose XKB keycodes here.
+  // Linux evdev KEY_* -> XKB keycode = KEY_* + 8.
+  constexpr auto XkbOffset = quint32{8};
+
+#define LINUX_KEY(x) {static_cast<quint32>(KEY_##x + XkbOffset), Qt::Key_##x}
+
+  static constexpr NativeKeyMap map[] = {
+    LINUX_KEY(A), LINUX_KEY(B), LINUX_KEY(C), LINUX_KEY(D), LINUX_KEY(E), LINUX_KEY(F),
+    LINUX_KEY(G), LINUX_KEY(H), LINUX_KEY(I), LINUX_KEY(J), LINUX_KEY(K), LINUX_KEY(L),
+    LINUX_KEY(M), LINUX_KEY(N), LINUX_KEY(O), LINUX_KEY(P), LINUX_KEY(Q), LINUX_KEY(R),
+    LINUX_KEY(S), LINUX_KEY(T), LINUX_KEY(U), LINUX_KEY(V), LINUX_KEY(W), LINUX_KEY(X),
+    LINUX_KEY(Y), LINUX_KEY(Z),
+
+    LINUX_KEY(0), LINUX_KEY(1), LINUX_KEY(2), LINUX_KEY(3), LINUX_KEY(4), LINUX_KEY(5),
+    LINUX_KEY(6), LINUX_KEY(7), LINUX_KEY(8), LINUX_KEY(9),
+  };
+
+#undef LINUX_KEY
+
+  const auto key = lookupNativeKey(event.nativeScanCode(), map);
+  if (key != Qt::Key_unknown)
+  {
+    return key;
+  }
+#endif
+
+  return Qt::Key_unknown;
+}
+
+#if defined(Q_OS_MACOS)
+bool hasPhysicalCommandModifier(const QKeyEvent& event)
+{
+  const auto commandModifier =
+    QCoreApplication::testAttribute(Qt::AA_MacDontSwapCtrlAndMeta) ? Qt::MetaModifier
+                                                                   : Qt::ControlModifier;
+
+  return (event.modifiers() & commandModifier) != 0;
+}
+#endif
+
+bool matchesShortcut(
+  const QKeyEvent& event,
+  const QKeySequence& shortcut,
+  const bool compareModifiers,
+  const bool usePhysicalKey)
+{
+  if (shortcut.count() != 1)
+  {
+    return false;
+  }
+
+  const auto keyCombination = shortcut[0];
+  const auto shortcutKey = keyCombination.key();
+  const auto logicalEventKey = static_cast<Qt::Key>(event.key());
+  auto eventKey = logicalEventKey;
+  if (usePhysicalKey && isLatinLetterOrDigit(shortcutKey))
+  {
+    if (const auto physicalEventKey = physicalLatinLetterOrDigitKey(event);
+        physicalEventKey != Qt::Key_unknown)
+    {
+      eventKey = physicalEventKey;
+    }
+  }
+
+  if (shortcutKey != eventKey)
+  {
+    return false;
+  }
+
+  return !compareModifiers
+         || (keyCombination.keyboardModifiers() & ShortcutModifierMask)
+              == (event.modifiers() & ShortcutModifierMask);
+}
+
+} // namespace
+
+bool eventMatchesPhysicalKey(const QKeyEvent& event, const QKeySequence& shortcut)
+{
+  return matchesShortcut(event, shortcut, false, true);
+}
+
+bool shouldUsePhysicalShortcutFallback(const QKeyEvent& event)
+{
+  // Windows already handles QAction/QShortcut for these keys. On Linux it doesn't
+  // for non-Latin layouts. On macOS, Qt handles Command shortcuts but not
+  // single-key shortcuts in the same layout-independent way.
+#if defined(Q_OS_WIN)
+  (void)event;
+  return false;
+#elif defined(Q_OS_MACOS)
+  return !hasPhysicalCommandModifier(event);
+#elif defined(Q_OS_LINUX)
+  (void)event;
+  return true;
+#else
+  (void)event;
+  return false;
+#endif
+}
+
+bool eventMatchesPhysicalShortcutFallback(
+  const QKeyEvent& event, const QKeySequence& shortcut)
+{
+  return shouldUsePhysicalShortcutFallback(event)
+         && matchesShortcut(event, shortcut, true, true)
+         && !matchesShortcut(event, shortcut, true, false);
+}
+
+kdl_reflect_impl(NoFallbackActionMatch);
+
+std::ostream& operator<<(std::ostream& lhs, const UniqueFallbackActionMatch& rhs)
+{
+  return lhs << "UniqueFallbackActionMatch{action: " << rhs.action.label().toStdString()
+             << "}";
+}
+
+std::ostream& operator<<(std::ostream& lhs, const AmbiguousFallbackActionMatch& rhs)
+{
+  return lhs << "AmbiguousFallbackActionMatch{action: "
+             << rhs.action.label().toStdString() << "}";
+}
+
+std::ostream& operator<<(std::ostream& lhs, const FallbackActionMatch& rhs)
+{
+  std::visit([&](const auto& x) { lhs << x; }, rhs);
+  return lhs;
+}
+
+} // namespace tb::ui

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -22,6 +22,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QDebug>
+#include <QKeyEvent>
 #include <QMenu>
 #include <QMimeData>
 #include <QShortcut>
@@ -79,6 +80,7 @@
 #include "ui/AppController.h"
 #include "ui/EnableDisableTagCallback.h"
 #include "ui/FlashSelectionAnimation.h"
+#include "ui/KeyboardShortcutUtils.h"
 #include "ui/MapDocument.h"
 #include "ui/MapViewActivationTracker.h"
 #include "ui/MapViewToolBox.h"
@@ -341,6 +343,25 @@ void MapViewBase::updateActionStates()
 void MapViewBase::updateActionStatesDelayed()
 {
   m_updateActionStatesSignalDelayer->queueSignal();
+}
+
+bool MapViewBase::tryTriggerShortcut(QKeyEvent* event)
+{
+  // Skip auto-repeat to match Qt's native shortcut behavior.
+  if (event->isAutoRepeat())
+  {
+    return false;
+  }
+
+  auto* mapWindow = dynamic_cast<MapWindow*>(window());
+  auto context = ActionExecutionContext{m_appController, mapWindow, this};
+
+  return triggerFallbackAction(
+    *event, context, m_shortcuts | std::views::values, [&](const auto& action) {
+      triggerAmbiguousAction(action.label());
+      event->accept();
+      return true;
+    });
 }
 
 void MapViewBase::triggerAction(const Action& action)
@@ -874,6 +895,15 @@ bool MapViewBase::event(QEvent* event)
   if (event->type() == QEvent::WindowDeactivate)
   {
     cancelMouseDrag();
+  }
+  else if (event->type() == QEvent::KeyPress)
+  {
+    auto* ke = static_cast<QKeyEvent*>(event);
+    // Skip if the event was already handled by the window-level event filter fallback.
+    if (!ke->isAccepted() && tryTriggerShortcut(ke))
+    {
+      return true;
+    }
   }
 
   return RenderView::event(event);

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -19,24 +19,30 @@
 
 #include "ui/MapWindow.h"
 
+#include <QAbstractSpinBox>
 #include <QApplication>
 #include <QChildEvent>
 #include <QClipboard>
 #include <QComboBox>
 #include <QFileDialog>
 #include <QInputDialog>
+#include <QKeyEvent>
 #include <QLabel>
+#include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSettings>
 #include <QStatusBar>
 #include <QString>
 #include <QStringList>
 #include <QTableWidget>
+#include <QTextEdit>
 #include <QTimer>
 #include <QToolBar>
 #include <QVBoxLayout>
+#include <QWidget>
 #include <QtGlobal>
 
 #include "PreferenceManager.h"
@@ -88,6 +94,7 @@
 #include "ui/FaceTool.h"
 #include "ui/InfoPanel.h"
 #include "ui/Inspector.h"
+#include "ui/KeyboardShortcutUtils.h"
 #include "ui/LaunchGameEngineDialog.h"
 #include "ui/MapDocument.h"
 #include "ui/MapView2D.h"
@@ -152,6 +159,34 @@ bool widgetOrChildHasFocus(const QWidget* widget)
 
   const auto* focusWidget = QApplication::focusWidget();
   return widget == focusWidget || widget->isAncestorOf(focusWidget);
+}
+
+bool hasCommandLikeShortcutModifier(const QKeyEvent& event)
+{
+  return (event.modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))
+         != 0;
+}
+
+bool isTextInputWidget(const QWidget* widget)
+{
+  for (auto* current = widget; current != nullptr; current = current->parentWidget())
+  {
+    if (
+      dynamic_cast<const QLineEdit*>(current) || dynamic_cast<const QTextEdit*>(current)
+      || dynamic_cast<const QPlainTextEdit*>(current)
+      || dynamic_cast<const QAbstractSpinBox*>(current)
+      || dynamic_cast<const QComboBox*>(current))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool textInputWidgetHasFocus()
+{
+  return isTextInputWidget(QApplication::focusWidget());
 }
 
 QString lastCompilationProfileSettingsKey(const std::string& gameName)
@@ -379,6 +414,62 @@ void MapWindow::updateUndoRedoActions()
       m_redoAction->setEnabled(false);
     }
   }
+}
+
+bool MapWindow::tryTriggerShortcut(QKeyEvent* event)
+{
+  if (!shouldUsePhysicalShortcutFallback(*event))
+  {
+    return false;
+  }
+
+  // Qt's native shortcut system only triggers on the initial key press, not on
+  // auto-repeat. Skip auto-repeats so the fallback behaves the same way.
+  if (event->isAutoRepeat())
+  {
+    return false;
+  }
+
+  // The fallback runs from the window event filter before focused child widgets
+  // process the key event, so keep plain text input from triggering single-key actions.
+  if (!hasCommandLikeShortcutModifier(*event) && textInputWidgetHasFocus())
+  {
+    return false;
+  }
+
+  auto context = ActionExecutionContext{m_appController, this, currentMapViewBase()};
+
+  const auto match = findFallbackAction(*event, context, m_actionMap | std::views::keys);
+
+  return std::visit(
+    kdl::overload(
+      [&](const NoFallbackActionMatch&) { return false; },
+      [&](const UniqueFallbackActionMatch& m) {
+        // Find the corresponding QAction and trigger it so the toolbar updates.
+        if (const auto it = m_actionMap.find(&m.action); it != m_actionMap.end())
+        {
+          it->second->trigger();
+        }
+        else
+        {
+          m.action.execute(context);
+        }
+        event->accept();
+        return true;
+      },
+      [&](const AmbiguousFallbackActionMatch& m) {
+        if (const auto it = m_actionMap.find(&m.action); it != m_actionMap.end())
+        {
+          it->second->trigger();
+        }
+        else
+        {
+          m.action.execute(context);
+        }
+        event->accept();
+        return true;
+      }),
+    match);
 }
 
 void MapWindow::addRecentDocumentsMenu()
@@ -2447,9 +2538,7 @@ static void debugSegfault()
 void MapWindow::debugCrash()
 {
   auto items = QStringList{};
-  items << "Null pointer dereference"
-        << "Unhandled exception"
-        << "Contract failed";
+  items << "Null pointer dereference" << "Unhandled exception" << "Contract failed";
 
   bool ok;
   const auto item =
@@ -2629,6 +2718,12 @@ bool MapWindow::eventFilter(QObject* target, QEvent* event)
     || event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)
   {
     m_lastInputTime = std::chrono::system_clock::now();
+    if (
+      event->type() == QEvent::KeyPress
+      && tryTriggerShortcut(static_cast<QKeyEvent*>(event)))
+    {
+      return true;
+    }
   }
   else if (event->type() == QEvent::ChildAdded)
   {

--- a/lib/TbUiLib/test/CMakeLists.txt
+++ b/lib/TbUiLib/test/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(TbUiLibTest
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ExtrudeTool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_HandleDragTracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_InputEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_KeyboardShortcutUtils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_LaunchGameEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_MapDocument.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_MapWindow.cpp

--- a/lib/TbUiLib/test/src/tst_KeyboardShortcutUtils.cpp
+++ b/lib/TbUiLib/test/src/tst_KeyboardShortcutUtils.cpp
@@ -1,0 +1,248 @@
+/*
+ Copyright (C) 2026 Artsiom Trubchyk
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QCoreApplication>
+#include <QKeyEvent>
+
+#include "ui/ActionExecutionContext.h"
+#include "ui/AppControllerFixture.h"
+#include "ui/CatchConfig.h"
+#include "ui/KeyboardShortcutUtils.h"
+
+#include <cstddef>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb::ui
+{
+namespace
+{
+constexpr auto CyrillicTse = 0x0426;
+
+#if defined(Q_OS_WIN)
+constexpr auto NativeVirtualW = quint32{'W'};
+constexpr auto NativeScanW = quint32{0};
+#elif defined(Q_OS_MACOS)
+constexpr auto NativeVirtualW = quint32{0x0D};
+constexpr auto NativeScanW = quint32{0};
+#elif defined(Q_OS_LINUX)
+constexpr auto NativeVirtualW = quint32{0};
+constexpr auto NativeScanW = quint32{0x19};
+#else
+constexpr auto NativeVirtualW = quint32{0};
+constexpr auto NativeScanW = quint32{0};
+#endif
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+constexpr auto PlatformUsesPhysicalShortcutFallback = true;
+#else
+constexpr auto PlatformUsesPhysicalShortcutFallback = false;
+#endif
+
+QKeyEvent makePhysicalWEvent(
+  const Qt::KeyboardModifiers modifiers = Qt::NoModifier, const int key = CyrillicTse)
+{
+  return QKeyEvent{QEvent::KeyPress, key, modifiers, NativeScanW, NativeVirtualW, 0};
+}
+
+QKeySequence keySequence(const Qt::KeyboardModifiers modifiers, const Qt::Key key)
+{
+  return QKeySequence{static_cast<int>(modifiers.toInt()) | static_cast<int>(key)};
+}
+
+#if defined(Q_OS_MACOS)
+Qt::KeyboardModifier physicalCommandModifier()
+{
+  return QCoreApplication::testAttribute(Qt::AA_MacDontSwapCtrlAndMeta)
+           ? Qt::MetaModifier
+           : Qt::ControlModifier;
+}
+#endif
+
+Action makeAction(
+  const std::filesystem::path& preferencePath,
+  const QKeySequence& shortcut,
+  const bool enabled = true)
+{
+  return Action{
+    preferencePath,
+    "Action",
+    ActionContext::Any,
+    shortcut,
+    [](auto&) {},
+    [enabled](const auto&) { return enabled; }};
+}
+
+} // namespace
+
+TEST_CASE("eventMatchesPhysicalKey")
+{
+  SECTION("matches physical latin letter key on non-latin layout")
+  {
+    const auto event = makePhysicalWEvent();
+    const auto shortcut = QKeySequence{Qt::Key_W};
+
+    CHECK(eventMatchesPhysicalKey(event, shortcut));
+  }
+
+  SECTION("falls back to logical latin letter key when native key data is unavailable")
+  {
+#if !defined(Q_OS_MACOS)
+    // On macOS, kVK_ANSI_A == 0x00, so nativeVirtualKey 0 is a valid key code
+    // and cannot be used to represent an event without native key data.
+    const auto event = QKeyEvent{QEvent::KeyPress, Qt::Key_W, Qt::NoModifier};
+    const auto shortcut = QKeySequence{Qt::Key_W};
+
+    CHECK(eventMatchesPhysicalKey(event, shortcut));
+#endif
+  }
+
+  SECTION("falls back to logical key for non-layout-dependent keys")
+  {
+    const auto event = QKeyEvent{QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier};
+    const auto shortcut = QKeySequence{Qt::Key_Escape};
+
+    CHECK(eventMatchesPhysicalKey(event, shortcut));
+  }
+}
+
+TEST_CASE("shouldUsePhysicalShortcutFallback")
+{
+  SECTION("uses platform-specific fallback policy")
+  {
+    const auto event = makePhysicalWEvent();
+
+    CHECK(
+      shouldUsePhysicalShortcutFallback(event) == PlatformUsesPhysicalShortcutFallback);
+  }
+
+#if defined(Q_OS_MACOS)
+  SECTION("does not use fallback when physical Command is pressed")
+  {
+    const auto event = makePhysicalWEvent(physicalCommandModifier());
+
+    CHECK_FALSE(shouldUsePhysicalShortcutFallback(event));
+  }
+#endif
+}
+
+TEST_CASE("eventMatchesPhysicalShortcutFallback")
+{
+  SECTION("matches physical single-key shortcut only on platforms that need fallback")
+  {
+    const auto event = makePhysicalWEvent();
+    const auto shortcut = QKeySequence{Qt::Key_W};
+
+    CHECK(
+      eventMatchesPhysicalShortcutFallback(event, shortcut)
+      == PlatformUsesPhysicalShortcutFallback);
+  }
+
+  SECTION("matches physical modified shortcut on Linux")
+  {
+    const auto event = makePhysicalWEvent(Qt::ControlModifier);
+    const auto shortcut = keySequence(Qt::ControlModifier, Qt::Key_W);
+
+#if defined(Q_OS_LINUX)
+    CHECK(eventMatchesPhysicalShortcutFallback(event, shortcut));
+#else
+    CHECK_FALSE(eventMatchesPhysicalShortcutFallback(event, shortcut));
+#endif
+  }
+
+#if defined(Q_OS_MACOS)
+  SECTION("does not match physical modified shortcut when physical Command is pressed")
+  {
+    const auto commandModifier = physicalCommandModifier();
+    const auto event = makePhysicalWEvent(commandModifier);
+    const auto shortcut = keySequence(commandModifier, Qt::Key_W);
+
+    CHECK_FALSE(eventMatchesPhysicalShortcutFallback(event, shortcut));
+  }
+#endif
+
+  SECTION("does not report fallback when logical key already matches")
+  {
+    const auto event = makePhysicalWEvent(Qt::NoModifier, Qt::Key_W);
+    const auto shortcut = QKeySequence{Qt::Key_W};
+
+    CHECK_FALSE(eventMatchesPhysicalShortcutFallback(event, shortcut));
+  }
+}
+
+TEST_CASE("findFallbackAction")
+{
+  auto appControllerFixture = AppControllerFixture{};
+  auto& appController = appControllerFixture.appController();
+
+  const auto event = makePhysicalWEvent();
+  const auto context = ActionExecutionContext{appController, nullptr, nullptr};
+
+  auto matchingAction = makeAction("matching", QKeySequence{Qt::Key_W});
+  auto nonMatchingAction = makeAction("nonMatching", QKeySequence{Qt::Key_X});
+  auto disabledMatchingAction =
+    makeAction("disabledMatching", QKeySequence{Qt::Key_W}, false);
+
+  SECTION("returns no match if no action matches")
+  {
+    const auto actions =
+      std::vector<Action*>{&nonMatchingAction, &disabledMatchingAction};
+
+    const auto match = findFallbackAction(event, context, actions);
+
+    CHECK(std::holds_alternative<NoFallbackActionMatch>(match));
+  }
+
+  SECTION("returns the unique matching enabled action only when fallback is enabled")
+  {
+    const auto actions =
+      std::vector<Action*>{&nonMatchingAction, &matchingAction, &disabledMatchingAction};
+
+    const auto match = findFallbackAction(event, context, actions);
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+    REQUIRE(std::holds_alternative<UniqueFallbackActionMatch>(match));
+    CHECK(&std::get<UniqueFallbackActionMatch>(match).action == &matchingAction);
+#else
+    CHECK(std::holds_alternative<NoFallbackActionMatch>(match));
+#endif
+  }
+
+  SECTION(
+    "returns the first matching action if the match is ambiguous and fallback is enabled")
+  {
+    auto otherMatchingAction = makeAction("otherMatching", QKeySequence{Qt::Key_W});
+    const auto actions =
+      std::vector<Action*>{&nonMatchingAction, &matchingAction, &otherMatchingAction};
+
+    const auto match = findFallbackAction(event, context, actions);
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+    REQUIRE(std::holds_alternative<AmbiguousFallbackActionMatch>(match));
+    CHECK(&std::get<AmbiguousFallbackActionMatch>(match).action == &matchingAction);
+#else
+    CHECK(std::holds_alternative<NoFallbackActionMatch>(match));
+#endif
+  }
+}
+
+
+} // namespace tb::ui


### PR DESCRIPTION
Fix shortcuts with non-Latin keyboard layouts by using physical key matching as a fallback when the active layout produces non-Latin logical key codes. On Windows, the fallback is applied only in fly view since QShortcut already handles the transformation natively; on Linux, it applies to both fly view and QShortcut-bound actions; on macOS, it applies to fly view and to QShortcut only when no Command modifier is pressed, preserving Qt's native shortcut behavior.

Fixes #2798.