### PR TITLE
Add an arch shape to the shape tool

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -456,12 +456,13 @@ Shape                  Description
 -----                  -----------
 Cuboid                 Creates a cuboid shape
 Stairs                 Creates stairs
+Arch                   Creates a semicircular arch
 Cylinder               Creates a cylinder with a variable number of sides; potentially hollow
 Cone                   Creates a cone with a variable number of sides
 Spheroid (UV)          Creates a spheroid shape made up of triangles and quads with two poles
 Spheroid (Icosahedron) Creates a spheroid shape made up of triangles, based on an icosahedron
 
-Note that the cylinder, cone and UV sphere shapes all have similar options, namely the number of sides and a circle mode.
+Note that the cylinder, cone, UV sphere and arch shapes all have similar options, namely the number of sides and a circle mode.
 By using the same values for these options across different shapes, TrenchBroom will create shapes that fit onto each other perfectly.
 
 There are three circle modes that can be selected via the corresponding buttons:
@@ -481,6 +482,8 @@ This hollow cylinder is scalable because its vertices are all aligned on the gri
 ![Asymmetric scalable cylinder](images/ScalableCylinderStretch.gif)
 
 If you create an asymmetric scalable shape, it will not be scaled to fit the bounding box drawn with the mouse like the other shapes. Rather, only the middle portion of it will be elongated so that the vertices remain on the grid. This even applies to cones and UV spheres so that the different shapes still fit together.
+
+The arch is created as the top half of a hollow cylinder. The axis is the direction the arch runs through, like a tunnel. Sides, thickness and circle mode work just like the cylinder, so an arch and a cylinder built with the same values will line up. When using scalable circle mode, drawing the bounds taller than a semicircle will extend the sides straight down, acting as "supports" for the arch. 
 
 ### Creating Complex Shapes
 

--- a/app/TrenchBroom/resources/graphics/images/ShapeTool_Arch.svg
+++ b/app/TrenchBroom/resources/graphics/images/ShapeTool_Arch.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24.000001 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4.3 (fcd0343856, 2026-01-01)"
+   sodipodi:docname="ShapeTool_Arch.svg"
+   inkscape:export-filename="/media/psf/Home/Documents/Code/TrenchBroom_qt/app/resources/graphics/images/DuplicateObjects.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-20.000001 : 28 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="44.000002 : 28 : 1"
+       inkscape:persp3d-origin="12.000001 : 8 : 1"
+       id="perspective4155" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="29.86"
+     inkscape:cx="13.12793"
+     inkscape:cy="10.683188"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     showguides="false"
+     inkscape:snap-grids="true"
+     inkscape:window-width="2048"
+     inkscape:window-height="1013"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:snap-bbox="false"
+     inkscape:bbox-paths="true"
+     objecttolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336"
+       empspacing="4"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid4272"
+       empspacing="4"
+       originx="-0.50000002"
+       originy="-0.5"
+       dotted="true"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1028.3623)">
+    <path
+       style="fill:#ff7f01;fill-opacity:0.247059;stroke:#ff8000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 1.5,1050.8623 1.5,1040.3623 A 10.5,10.5 0 0 1 22.5,1040.3623 V 1050.8623 H 18.5 V 1040.3623 A 6.5,6.5 0 0 0 5.5,1040.3623 V 1050.8623 Z"
+       id="path6"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/lib/KdLib/include/kd/range_fold.h
+++ b/lib/KdLib/include/kd/range_fold.h
@@ -22,11 +22,12 @@
 
 #include <iterator>
 #include <numeric>
+#include <utility>
 
 namespace kdl
 {
 
-auto fold_left = [](auto&& range, auto&& init, auto&& op) {
+inline constexpr auto fold_left = [](auto&& range, auto&& init, auto&& op) {
   return std::accumulate(
     std::begin(range),
     std::end(range),
@@ -34,7 +35,7 @@ auto fold_left = [](auto&& range, auto&& init, auto&& op) {
     std::forward<decltype(op)>(op));
 };
 
-auto fold_right = [](auto&& range, auto&& init, auto&& op) {
+inline constexpr auto fold_right = [](auto&& range, auto&& init, auto&& op) {
   return std::accumulate(
     std::make_reverse_iterator(std::end(range)),
     std::make_reverse_iterator(std::begin(range)),
@@ -42,11 +43,11 @@ auto fold_right = [](auto&& range, auto&& init, auto&& op) {
     std::forward<decltype(op)>(op));
 };
 
-auto fold_left_first = [](auto&& range, auto&& op) {
+inline constexpr auto fold_left_first = [](auto&& range, auto&& op) {
   return fold_left(range, *std::begin(range), std::forward<decltype(op)>(op));
 };
 
-auto fold_right_first = [](auto&& range, auto&& op) {
+inline constexpr auto fold_right_first = [](auto&& range, auto&& op) {
   return fold_right(range, *std::prev(std::end(range)), std::forward<decltype(op)>(op));
 };
 

--- a/lib/KdLib/include/kd/result_fold.h
+++ b/lib/KdLib/include/kd/result_fold.h
@@ -168,6 +168,37 @@ auto collect_results(C&& c)
   return collect_results(std::ranges::begin(c), std::ranges::end(c));
 }
 
+/**
+ * Folds the given range of results into a vector of success values.
+ */
+template <typename I, typename S>
+auto collect_values(I cur, S end)
+{
+  using in_result_type = typename std::iterator_traits<I>::value_type;
+  using in_value_type = typename in_result_type::value_type;
+
+  static_assert(!std::is_same_v<in_value_type, void>);
+
+  using out_value_vector_type = std::vector<in_value_type>;
+
+  auto values = out_value_vector_type{};
+
+  while (cur != end)
+  {
+    std::move(*cur).visit(kdl::overload(
+      [&](in_value_type&& v) { values.push_back(std::move(v)); }, [&](auto&&) {}));
+    ++cur;
+  }
+
+  return values;
+}
+
+template <typename C>
+auto collect_values(C&& c)
+{
+  return collect_values(std::ranges::begin(c), std::ranges::end(c));
+}
+
 template <typename I, typename S, typename F>
 auto select_first(I cur, S end, const F& f)
   -> std::optional<typename decltype(f(*cur))::value_type>
@@ -231,6 +262,21 @@ template <typename C>
 auto operator|(C&& c, const result_collect&)
 {
   return collect_results(std::forward<C>(c));
+}
+
+struct result_values
+{
+};
+
+inline auto values()
+{
+  return result_values{};
+}
+
+template <typename C>
+auto operator|(C&& c, const result_values&)
+{
+  return collect_values(std::forward<C>(c));
 }
 
 } // namespace kdl

--- a/lib/KdLib/test/src/tst_result.cpp
+++ b/lib/KdLib/test/src/tst_result.cpp
@@ -2337,6 +2337,53 @@ TEST_CASE("result")
     }
   }
 
+  SECTION("collect_values")
+  {
+    SECTION("result<int>")
+    {
+      SECTION("empty range")
+      {
+        CHECK(collect_values(std::vector<result<int>>{}) == std::vector<int>{});
+      }
+
+      SECTION("non-empty range")
+      {
+        CHECK(
+          collect_values(std::vector<result<int>>{{1}, {2}, {3}})
+          == std::vector<int>{1, 2, 3});
+      }
+    }
+
+    SECTION("result<int, Error1, Error2>")
+    {
+      using res = result<int, Error1, Error2>;
+
+      SECTION("empty range")
+      {
+        CHECK(collect_values(std::vector<res>{}) == std::vector<int>{});
+      }
+
+      SECTION("only success values")
+      {
+        CHECK(collect_values(std::vector<res>{{1}, {2}, {3}}) == std::vector{1, 2, 3});
+      }
+
+      SECTION("only errors")
+      {
+        CHECK(
+          collect_values(std::vector<res>{Error1{}, Error2{}, Error1{}})
+          == std::vector<int>{});
+      }
+
+      SECTION("mixed results")
+      {
+        CHECK(
+          collect_values(std::vector<res>{{1}, Error2{}, {2}, Error1{}, {3}})
+          == std::vector{1, 2, 3});
+      }
+    }
+  }
+
   SECTION("operator|")
   {
     SECTION("and_then")
@@ -3117,6 +3164,55 @@ TEST_CASE("result")
           const auto collection =
             std::vector<res>{{1}, Error2{}, {2}, Error1{}, {3}} | collect();
           CHECK(collection == out{{1, 2, 3}, {Error2{}, Error1{}}});
+        }
+      }
+    }
+
+    SECTION("values")
+    {
+      SECTION("result<int>")
+      {
+        SECTION("empty range")
+        {
+          const auto collection = std::vector<result<int>>{} | values();
+          CHECK(collection == std::vector<int>{});
+        }
+
+        SECTION("non-empty range")
+        {
+          const auto collection = std::vector<result<int>>{{1}, {2}, {3}} | values();
+          CHECK(collection == std::vector{1, 2, 3});
+        }
+      }
+
+      SECTION("result<int, Error1, Error2>")
+      {
+        using res = result<int, Error1, Error2>;
+
+        SECTION("empty range")
+        {
+          const auto collection = std::vector<res>{} | values();
+          CHECK(collection == std::vector<int>{});
+        }
+
+        SECTION("only success values")
+        {
+          const auto collection = std::vector<res>{{1}, {2}, {3}} | values();
+          CHECK(collection == std::vector{1, 2, 3});
+        }
+
+        SECTION("only errors")
+        {
+          const auto collection =
+            std::vector<res>{Error1{}, Error2{}, Error1{}} | values();
+          CHECK(collection == std::vector<int>{});
+        }
+
+        SECTION("mixed results")
+        {
+          const auto collection =
+            std::vector<res>{{1}, Error2{}, {2}, Error1{}, {3}} | values();
+          CHECK(collection == std::vector{1, 2, 3});
         }
       }
     }

--- a/lib/TbMdlLib/include/mdl/BrushBuilder.h
+++ b/lib/TbMdlLib/include/mdl/BrushBuilder.h
@@ -101,6 +101,21 @@ public:
     vm::axis::type axis,
     const std::string& textureName) const;
 
+  /**
+   * Creates a semicircular arch as a band of voussoir (wedge) brushes. The arch is the
+   * upper half of a hollow cylinder: its flat springing line sits on the bottom of the
+   * bounds and it rises to fill them. `axis` is the tunnel (extrusion) direction; the
+   * arch rises along the more vertical of the two remaining axes. `thickness` is the wall
+   * thickness of the band. The circle shape selects the same modes as the cylinder
+   * shapes.
+   */
+  Result<std::vector<Brush>> createArch(
+    const vm::bbox3d& bounds,
+    double thickness,
+    const CircleShape& circleShape,
+    vm::axis::type axis,
+    const std::string& textureName) const;
+
   Result<Brush> createCone(
     const vm::bbox3d& bounds,
     const CircleShape& circleShape,

--- a/lib/TbMdlLib/src/BrushBuilder.cpp
+++ b/lib/TbMdlLib/src/BrushBuilder.cpp
@@ -24,6 +24,7 @@
 #include "mdl/BrushFace.h"
 
 #include "kd/contracts.h"
+#include "kd/range_utils.h"
 #include "kd/ranges/concat_view.h"
 #include "kd/ranges/to.h"
 #include "kd/result.h"
@@ -35,6 +36,7 @@
 #include "vm/mat.h"
 #include "vm/mat_ext.h"
 
+#include <algorithm>
 #include <cmath>
 #include <ranges>
 #include <string>
@@ -493,14 +495,158 @@ Result<std::vector<Brush>> BrushBuilder::createHollowCylinder(
 namespace
 {
 
+// Maps the tunnel (extrusion) axis to the span and vertical axes of the arch's
+// cross-section. Arches rise along world Z where possible so they stand upright.
+struct ArchAxes
+{
+  size_t tunnel;
+  size_t span;
+  size_t vertical;
+};
+
+ArchAxes archAxes(const vm::axis::type axis)
+{
+  switch (axis)
+  {
+  case vm::axis::x:
+    return {vm::axis::x, vm::axis::y, vm::axis::z};
+  case vm::axis::y:
+    return {vm::axis::y, vm::axis::x, vm::axis::z};
+  default: // vm::axis::z
+    return {vm::axis::z, vm::axis::x, vm::axis::y};
+  }
+}
+
+// Interpolates the point on segment a->b at vertical coordinate v.
+vm::vec2d crossingAtV(const vm::vec2d& a, const vm::vec2d& b, const double v)
+{
+  const auto t = (v - a.y()) / (b.y() - a.y());
+  return vm::vec2d{a.x() + (b.x() - a.x()) * t, v};
+}
+
+} // namespace
+
+Result<std::vector<Brush>> BrushBuilder::createArch(
+  const vm::bbox3d& bounds,
+  const double thickness,
+  const CircleShape& circleShape,
+  const vm::axis::type axis,
+  const std::string& textureName) const
+{
+  const auto axes = archAxes(axis);
+
+  const auto sMin = bounds.min[axes.span];
+  const auto sMax = bounds.max[axes.span];
+  const auto vMin = bounds.min[axes.vertical];
+  const auto vMax = bounds.max[axes.vertical];
+  const auto wMin = bounds.min[axes.tunnel];
+  const auto wMax = bounds.max[axes.tunnel];
+  const auto height = vMax - vMin;
+  const auto span = sMax - sMin;
+
+  // The bounds are often degenerate mid-drag; emit no brushes rather than erroring.
+  if (height <= 0.0 || span <= 0.0)
+  {
+    return Result<std::vector<Brush>>{std::vector<Brush>{}};
+  }
+
+  // Upper half of an ellipse whose diameter lies on the springing line (v == vMin). Build
+  // the full ellipse in a bounds doubled downwards, then keep only the upper half,
+  // reusing the cylinder circle-mode machinery.
+  const auto circleBounds = vm::bbox2d{{sMin, vMin - height}, {sMax, vMax}};
+
+  const auto outer = makeCircle(circleShape, circleBounds);
+
+  return makeHollowCylinderInnerCircle(outer, thickness, circleShape, circleBounds)
+         | kdl::transform([&](const auto& inner) {
+             contract_assert(inner.size() == outer.size());
+             const auto n = outer.size();
+
+             const auto isUpper = [&](const size_t i) { return outer[i].y() >= vMin; };
+
+             // Start of the contiguous upper run: an upper vertex whose predecessor is
+             // below.
+             const auto firstUpper = kdl::index_of(
+               std::views::iota(0u, n),
+               [&](const auto i) { return isUpper(i) && !isUpper((i + n - 1) % n); });
+
+             if (!firstUpper)
+             {
+               return std::vector<Brush>{};
+             }
+
+             const auto upper =
+               std::views::iota(0u, n) | std::views::transform([&](const auto i) {
+                 return (*firstUpper + i) % n;
+               })
+               | std::views::take_while(isUpper) | kdl::ranges::to<std::vector>();
+
+             // Cap both ends with a foot on the springing line so the arch sits flat.
+             const auto first = upper.front();
+             const auto last = upper.back();
+             const auto beforeFirst = (first + n - 1) % n;
+             const auto afterLast = (last + 1) % n;
+
+             const auto clampToSpring = [&](const auto p) {
+               return vm::vec2d{p.x(), std::max(p.y(), vMin)};
+             };
+
+             auto outerBoundary = std::vector<vm::vec2d>{};
+             auto innerBoundary = std::vector<vm::vec2d>{};
+             outerBoundary.push_back(crossingAtV(outer[beforeFirst], outer[first], vMin));
+             innerBoundary.push_back(crossingAtV(inner[beforeFirst], inner[first], vMin));
+             for (const auto i : upper)
+             {
+               outerBoundary.push_back(outer[i]);
+               innerBoundary.push_back(clampToSpring(inner[i]));
+             }
+             outerBoundary.push_back(crossingAtV(outer[last], outer[afterLast], vMin));
+             innerBoundary.push_back(crossingAtV(inner[last], inner[afterLast], vMin));
+
+             const auto toPoint = [&](const vm::vec2d& p, const double w) {
+               auto result = vm::vec3d{};
+               result[axes.span] = p.x();
+               result[axes.vertical] = p.y();
+               result[axes.tunnel] = w;
+               return result;
+             };
+
+             // Build each voussoir independently, skipping any that are degenerate
+             // mid-drag.
+             return std::views::iota(0u, outerBoundary.size() - 1)
+                    | std::views::transform([&](const auto j) {
+                        const auto& o0 = outerBoundary[j];
+                        const auto& o1 = outerBoundary[j + 1];
+                        const auto& i0 = innerBoundary[j];
+                        const auto& i1 = innerBoundary[j + 1];
+
+                        const auto vertices = std::vector{
+                          toPoint(o0, wMin),
+                          toPoint(o0, wMax),
+                          toPoint(o1, wMin),
+                          toPoint(o1, wMax),
+                          toPoint(i0, wMin),
+                          toPoint(i0, wMax),
+                          toPoint(i1, wMin),
+                          toPoint(i1, wMax),
+                        };
+
+                        return createBrush(vertices, textureName);
+                      })
+                    | kdl::values();
+           });
+}
+
+namespace
+{
 auto setZ(const std::vector<vm::vec2d>& vertices, const double z)
 {
   return vertices | std::views::transform([&](const auto& v) { return vm::vec3d{v, z}; })
          | kdl::ranges::to<std::vector>();
 }
 
-/** If a scalable cone is stretched, it doesn't have one vertex as the tip. Instead, the
- * tip is an edge.
+/** If a scalable cone is stretched, it doesn't have one vertex as the tip. Instead,
+ * the tip is an edge.
  */
 auto makeScalableConeTip(const vm::bbox3d& boundsXY)
 {
@@ -550,7 +696,6 @@ Result<Brush> BrushBuilder::createCone(
 
 namespace
 {
-
 auto subDivideRatios(const std::vector<double>& ratios)
 {
   auto newRatios = std::vector<double>{};

--- a/lib/TbMdlLib/test-utils/include/mdl/Matchers.h
+++ b/lib/TbMdlLib/test-utils/include/mdl/Matchers.h
@@ -32,7 +32,23 @@
 
 namespace tb::mdl
 {
+class Brush;
 class Node;
+
+class BrushVertexMatcher : public Catch::Matchers::MatcherBase<Brush>
+{
+  const Brush& m_expected;
+  double m_epsilon;
+
+public:
+  BrushVertexMatcher(const Brush& expected, double epsilon);
+
+  bool match(const Brush& in) const override;
+
+  std::string describe() const override;
+};
+
+BrushVertexMatcher MatchesBrushVertices(const Brush& expected, double epsilon);
 
 class NodeMatcher : public Catch::Matchers::MatcherBase<Node>
 {

--- a/lib/TbMdlLib/test-utils/src/Matchers.cpp
+++ b/lib/TbMdlLib/test-utils/src/Matchers.cpp
@@ -34,6 +34,7 @@
 #include "mdl/WorldNode.h"
 
 #include "vm/approx.h"
+#include "vm/vec.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -125,6 +126,46 @@ bool valueOpsMatch(const std::optional<ValueOp>& lhs, const std::optional<ValueO
 }
 
 } // namespace
+
+BrushVertexMatcher::BrushVertexMatcher(const Brush& expected, const double epsilon)
+  : m_expected{expected}
+  , m_epsilon{epsilon}
+{
+}
+
+bool BrushVertexMatcher::match(const Brush& in) const
+{
+  if (in.vertexCount() != m_expected.vertexCount())
+  {
+    return false;
+  }
+
+  auto unmatchedPositions = in.vertexPositions();
+  for (const auto& expectedPosition : m_expected.vertexPositions())
+  {
+    const auto it = std::ranges::find_if(unmatchedPositions, [&](const auto& position) {
+      return vm::is_equal(position, expectedPosition, m_epsilon);
+    });
+    if (it == unmatchedPositions.end())
+    {
+      return false;
+    }
+    unmatchedPositions.erase(it);
+  }
+
+  return true;
+}
+
+std::string BrushVertexMatcher::describe() const
+{
+  return fmt::format(
+    "has the same vertex positions as the expected brush with epsilon {}", m_epsilon);
+}
+
+BrushVertexMatcher MatchesBrushVertices(const Brush& expected, const double epsilon)
+{
+  return BrushVertexMatcher{expected, epsilon};
+}
 
 NodeMatcher::NodeMatcher(const Node& expected)
   : m_expected{expected}

--- a/lib/TbMdlLib/test-utils/test/CMakeLists.txt
+++ b/lib/TbMdlLib/test-utils/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(TbMdlTestUtilsLibTest)
 
 target_sources(TbMdlTestUtilsLibTest PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Matchers.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_StringMakers.cpp
 )
 
@@ -17,4 +18,3 @@ target_link_libraries(TbMdlTestUtilsLibTest
 
 include(Catch)
 catch_discover_tests(TbMdlTestUtilsLibTest)
-

--- a/lib/TbMdlLib/test-utils/test/src/tst_Matchers.cpp
+++ b/lib/TbMdlLib/test-utils/test/src/tst_Matchers.cpp
@@ -1,0 +1,51 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mdl/BrushBuilder.h"
+#include "mdl/MapFormat.h"
+#include "mdl/Matchers.h"
+
+#include "kd/result.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb::mdl
+{
+
+TEST_CASE("MatchesBrushVertices")
+{
+  const auto builder = BrushBuilder{MapFormat::Standard, vm::bbox3d{8192.0}};
+
+  const auto expected =
+    builder.createCuboid(vm::bbox3d{{0, 0, 0}, {1, 1, 1}}, "material") | kdl::value();
+  const auto actual =
+    builder.createCuboid(vm::bbox3d{{0.01, 0.01, 0.01}, {1.01, 1.01, 1.01}}, "material")
+    | kdl::value();
+
+  const auto differentVertexCount =
+    builder.createBrush(
+      std::vector<vm::vec3d>{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}}, "material")
+    | kdl::value();
+
+  CHECK_THAT(actual, MatchesBrushVertices(expected, 0.02));
+  CHECK_THAT(actual, !MatchesBrushVertices(expected, 0.005));
+  CHECK_THAT(differentVertexCount, !MatchesBrushVertices(expected, 0.02));
+}
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_BrushBuilder.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushBuilder.cpp
@@ -282,6 +282,208 @@ TEST_CASE("BrushBuilder")
         })
       | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
+
+  SECTION("createArch")
+  {
+    auto builder = BrushBuilder{MapFormat::Standard, worldBounds};
+
+    SECTION("Arch with different circle modes")
+    {
+      const auto bounds = vm::bbox3d{{-128, -64, 0}, {128, 64, 64}};
+
+      SECTION("Edge aligned")
+      {
+        builder.createArch(bounds, 16.0, EdgeAlignedCircle{16}, vm::axis::y, "someName")
+          | kdl::transform([&](const auto& brushes) {
+              REQUIRE(brushes.size() == 9u);
+              CHECK(getMergedBounds(brushes) == bounds);
+
+              // Check only one brush to avoid clutter.
+              const auto expectedBrush = makeBrush({
+                {{112, -64, 6.9638421181958083},
+                 {112, 64, 0},
+                 {112, 64, 6.9638421181958083}},
+                {{128, 64, 12.730391512298111},
+                 {112, -64, 6.9638421181958083},
+                 {112, 64, 6.9638421181958083}},
+                {{128, -64, 12.730391512298111},
+                 {112, -64, 0},
+                 {112, -64, 6.9638421181958083}},
+                {{128, 64, 0}, {112, -64, 0}, {128, -64, 0}},
+                {{128, 64, 12.730391512298111}, {112, 64, 0}, {128, 64, 0}},
+                {{128, 64, 12.730391512298111},
+                 {128, -64, 0},
+                 {128, -64, 12.730391512298111}},
+              });
+
+              CHECK_THAT(
+                brushes, Contains(MatchesBrushVertices(expectedBrush, vertexEpsilon)));
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
+      }
+
+      SECTION("Vertex aligned")
+      {
+        builder.createArch(bounds, 16.0, VertexAlignedCircle{16}, vm::axis::y, "someName")
+          | kdl::transform([&](const auto& brushes) {
+              REQUIRE(brushes.size() == 8u);
+              CHECK(getMergedBounds(brushes) == bounds);
+
+              // Check only one brush to avoid clutter.
+              const auto expectedBrush = makeBrush({
+                {{105.05776674599576, 64, 14.384730312563047},
+                 {110.78036826717545, -64, 0},
+                 {110.78036826717545, 64, 0}},
+                {{118.2565801614447, 64, 24.491739671365746},
+                 {105.05776674599576, -64, 14.384730312563047},
+                 {105.05776674599576, 64, 14.384730312563047}},
+                {{128, -64, 0},
+                 {105.05776674599576, -64, 14.384730312563047},
+                 {118.2565801614447, -64, 24.491739671365746}},
+                {{128, 64, 0}, {110.78036826717545, -64, 0}, {128, -64, 0}},
+                {{128, 64, 0},
+                 {105.05776674599576, 64, 14.384730312563047},
+                 {110.78036826717545, 64, 0}},
+                {{128, 64, 0},
+                 {118.2565801614447, -64, 24.491739671365746},
+                 {118.2565801614447, 64, 24.491739671365746}},
+              });
+
+              CHECK_THAT(
+                brushes, Contains(MatchesBrushVertices(expectedBrush, vertexEpsilon)));
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
+      }
+
+      SECTION("Scalable")
+      {
+        builder.createArch(bounds, 16.0, ScalableCircle{0}, vm::axis::y, "someName")
+          | kdl::transform([&](const auto& brushes) {
+              REQUIRE(brushes.size() == 7u);
+              CHECK(getMergedBounds(brushes) == bounds);
+
+              // Check only one brush to avoid clutter.
+              const auto expectedBrush = makeBrush({
+                {{112, -64, 12}, {112, 64, 0}, {112, 64, 12}},
+                {{128, 64, 16}, {112, -64, 12}, {112, 64, 12}},
+                {{128, -64, 16}, {112, -64, 0}, {112, -64, 12}},
+                {{128, 64, 0}, {112, -64, 0}, {128, -64, 0}},
+                {{128, 64, 16}, {112, 64, 0}, {128, 64, 0}},
+                {{128, 64, 16}, {128, -64, 0}, {128, -64, 16}},
+              });
+
+              CHECK(std::ranges::find(brushes, expectedBrush) != brushes.end());
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
+      }
+    }
+
+    SECTION("Arch with different tunnel axes")
+    {
+      SECTION("X axis")
+      {
+        const auto bounds = vm::bbox3d{{-64, -128, 0}, {64, 128, 64}};
+        builder.createArch(bounds, 16.0, EdgeAlignedCircle{8}, vm::axis::x, "someName")
+          | kdl::transform([&](const auto& brushes) {
+              REQUIRE(brushes.size() == 5u);
+              CHECK(getMergedBounds(brushes) == bounds);
+
+              // Check only one brush to avoid clutter.
+              const auto expectedBrush = makeBrush({
+                {{-64, 112, 16.621124171879767},
+                 {-64, 128, 0},
+                 {-64, 128, 26.509667991878086}},
+                {{64, 112, 16.621124171879767},
+                 {-64, 112, 0},
+                 {-64, 112, 16.621124171879767}},
+                {{64, 128, 26.509667991878086},
+                 {-64, 112, 16.621124171879767},
+                 {-64, 128, 26.509667991878086}},
+                {{64, 128, 0}, {-64, 112, 0}, {64, 112, 0}},
+                {{64, 128, 26.509667991878086}, {-64, 128, 0}, {64, 128, 0}},
+                {{64, 128, 26.509667991878086},
+                 {64, 112, 0},
+                 {64, 112, 16.621124171879767}},
+              });
+
+              CHECK_THAT(
+                brushes, Contains(MatchesBrushVertices(expectedBrush, vertexEpsilon)));
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
+      }
+
+      SECTION("Y axis")
+      {
+        const auto bounds = vm::bbox3d{{-128, -64, 0}, {128, 64, 64}};
+        builder.createArch(bounds, 16.0, EdgeAlignedCircle{8}, vm::axis::y, "someName")
+          | kdl::transform([&](const auto& brushes) {
+              REQUIRE(brushes.size() == 5u);
+              CHECK(getMergedBounds(brushes) == bounds);
+
+              // Check only one brush to avoid clutter.
+              const auto expectedBrush = makeBrush({
+                {{112, -64, 16.621124171879767},
+                 {112, 64, 0},
+                 {112, 64, 16.621124171879767}},
+                {{128, 64, 26.509667991878086},
+                 {112, -64, 16.621124171879767},
+                 {112, 64, 16.621124171879767}},
+                {{128, -64, 26.509667991878086},
+                 {112, -64, 0},
+                 {112, -64, 16.621124171879767}},
+                {{128, 64, 0}, {112, -64, 0}, {128, -64, 0}},
+                {{128, 64, 26.509667991878086}, {112, 64, 0}, {128, 64, 0}},
+                {{128, 64, 26.509667991878086},
+                 {128, -64, 0},
+                 {128, -64, 26.509667991878086}},
+              });
+
+              CHECK_THAT(
+                brushes, Contains(MatchesBrushVertices(expectedBrush, vertexEpsilon)));
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
+      }
+    }
+
+    SECTION("Degenerate bounds do not error")
+    {
+      SECTION("Zero height")
+      {
+        CHECK(
+          builder.createArch(
+            vm::bbox3d{{-128, -64, 0}, {128, 64, 0}},
+            16.0,
+            EdgeAlignedCircle{12},
+            vm::axis::x,
+            "someName")
+          == Result<std::vector<Brush>>{std::vector<Brush>{}});
+      }
+
+      SECTION("Zero span")
+      {
+        CHECK(
+          builder.createArch(
+            vm::bbox3d{{-128, 0, 0}, {128, 0, 64}},
+            16.0,
+            EdgeAlignedCircle{12},
+            vm::axis::x,
+            "someName")
+          == Result<std::vector<Brush>>{std::vector<Brush>{}});
+      }
+
+      SECTION("Zero extrusion depth")
+      {
+        CHECK(
+          builder.createArch(
+            vm::bbox3d{{0, -64, 0}, {0, 64, 64}},
+            16.0,
+            EdgeAlignedCircle{12},
+            vm::axis::x,
+            "someName")
+          == Result<std::vector<Brush>>{std::vector<Brush>{}});
+      }
+    }
+  }
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_BrushBuilder.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushBuilder.cpp
@@ -22,14 +22,21 @@
 #include "mdl/BrushFace.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/MapFormat.h"
+#include "mdl/Matchers.h"
 #include "mdl/Polyhedron3.h"
 
+#include "kd/range_fold.h"
 #include "kd/ranges/to.h"
 #include "kd/result.h"
 
+#include "vm/constants.h"
+
+#include <algorithm>
 #include <string>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_contains.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 namespace tb::mdl
 {
@@ -55,27 +62,37 @@ auto makeBrush(const std::vector<std::tuple<vm::vec3d, vm::vec3d, vm::vec3d>>& f
          | kdl::value();
 };
 
+auto getMergedBounds(const std::vector<Brush>& brushes)
+{
+  return kdl::fold_left_first(
+    brushes | std::views::transform([](const auto& brush) { return brush.bounds(); }),
+    [](const auto& lhs, const auto& rhs) { return vm::merge(lhs, rhs); });
+}
+
 } // namespace
 
 TEST_CASE("BrushBuilder")
 {
+  using Catch::Matchers::Contains;
+  using Catch::Matchers::RangeEquals;
+
   const auto worldBounds = vm::bbox3d{8192.0};
+  const auto vertexEpsilon = vm::Cd::almost_zero();
 
   SECTION("createCube")
   {
     auto builder = BrushBuilder{MapFormat::Standard, worldBounds};
 
-    const auto cube = builder.createCube(128.0, "someName") | kdl::value();
-    CHECK(cube.fullySpecified());
-    CHECK(cube.bounds() == vm::bbox3d{-64.0, +64.0});
+    builder.createCube(128.0, "someName") | kdl::transform([](const auto& cube) {
+      CHECK(cube.fullySpecified());
+      CHECK(cube.bounds() == vm::bbox3d{-64.0, +64.0});
 
-    const auto faces = cube.faces();
-    CHECK(faces.size() == 6u);
-
-    for (size_t i = 0; i < faces.size(); ++i)
-    {
-      CHECK(faces[i].attributes().materialName() == "someName");
-    }
+      CHECK_THAT(
+        cube.faces() | std::views::transform([](const auto& face) {
+          return face.attributes().materialName();
+        }),
+        RangeEquals(std::vector<std::string>{6u, "someName"}));
+    }) | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
 
   SECTION("createCubeDefaults")
@@ -91,24 +108,15 @@ TEST_CASE("BrushBuilder")
 
     auto builder = BrushBuilder{MapFormat::Standard, worldBounds, defaultAttribs};
 
-    const auto cube = builder.createCube(128.0, "someName") | kdl::value();
-    CHECK(cube.fullySpecified());
-    CHECK(cube.bounds() == vm::bbox3d{-64.0, +64.0});
+    builder.createCube(128.0, "someName") | kdl::transform([&](const auto& cube) {
+      CHECK(cube.fullySpecified());
+      CHECK(cube.bounds() == vm::bbox3d{-64.0, +64.0});
 
-    const auto faces = cube.faces();
-    CHECK(faces.size() == 6u);
-
-    for (size_t i = 0; i < faces.size(); ++i)
-    {
-      CHECK(faces[i].attributes().materialName() == "someName");
-      CHECK(faces[i].attributes().offset() == vm::vec2f{0.5f, 0.5f});
-      CHECK(faces[i].attributes().scale() == vm::vec2f{0.5f, 0.5f});
-      CHECK(faces[i].attributes().rotation() == 45.0f);
-      CHECK(faces[i].attributes().surfaceContents() == 1);
-      CHECK(faces[i].attributes().surfaceFlags() == 2);
-      CHECK(faces[i].attributes().surfaceValue() == 0.1f);
-      CHECK(faces[i].attributes().color() == Color{RgbB{255, 255, 255}});
-    }
+      CHECK_THAT(
+        cube.faces()
+          | std::views::transform([](const auto& face) { return face.attributes(); }),
+        RangeEquals(std::vector{6u, BrushFaceAttributes{"someName", defaultAttribs}}));
+    }) | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
 
   SECTION("createBrushDefaults")
@@ -124,36 +132,29 @@ TEST_CASE("BrushBuilder")
 
     auto builder = BrushBuilder{MapFormat::Standard, worldBounds, defaultAttribs};
 
-    const auto brush = builder.createBrush(
-                         Polyhedron3{
-                           vm::vec3d{-64, -64, -64},
-                           vm::vec3d{-64, -64, +64},
-                           vm::vec3d{-64, +64, -64},
-                           vm::vec3d{-64, +64, +64},
-                           vm::vec3d{+64, -64, -64},
-                           vm::vec3d{+64, -64, +64},
-                           vm::vec3d{+64, +64, -64},
-                           vm::vec3d{+64, +64, +64},
-                         },
-                         "someName")
-                       | kdl::value();
-    CHECK(brush.fullySpecified());
-    CHECK(brush.bounds() == vm::bbox3d{-64.0, +64.0});
+    builder.createBrush(
+      Polyhedron3{
+        vm::vec3d{-64, -64, -64},
+        vm::vec3d{-64, -64, +64},
+        vm::vec3d{-64, +64, -64},
+        vm::vec3d{-64, +64, +64},
+        vm::vec3d{+64, -64, -64},
+        vm::vec3d{+64, -64, +64},
+        vm::vec3d{+64, +64, -64},
+        vm::vec3d{+64, +64, +64},
+      },
+      "someName")
+      | kdl::transform([&](const auto& brush) {
+          CHECK(brush.fullySpecified());
+          CHECK(brush.bounds() == vm::bbox3d{-64.0, +64.0});
 
-    const auto faces = brush.faces();
-    CHECK(faces.size() == 6u);
-
-    for (size_t i = 0; i < faces.size(); ++i)
-    {
-      CHECK(faces[i].attributes().materialName() == "someName");
-      CHECK(faces[i].attributes().offset() == vm::vec2f{0.5f, 0.5f});
-      CHECK(faces[i].attributes().scale() == vm::vec2f{0.5f, 0.5f});
-      CHECK(faces[i].attributes().rotation() == 45.0f);
-      CHECK(faces[i].attributes().surfaceContents() == 1);
-      CHECK(faces[i].attributes().surfaceFlags() == 2);
-      CHECK(faces[i].attributes().surfaceValue() == 0.1f);
-      CHECK(faces[i].attributes().color() == Color{RgbB{255, 255, 255}});
-    }
+          CHECK_THAT(
+            brush.faces()
+              | std::views::transform([](const auto& face) { return face.attributes(); }),
+            RangeEquals(
+              std::vector{6u, BrushFaceAttributes{"someName", defaultAttribs}}));
+        })
+      | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
 
   SECTION("createCylinder")
@@ -162,97 +163,124 @@ TEST_CASE("BrushBuilder")
 
     SECTION("Edge aligned cylinder")
     {
-      const auto cylinder = builder.createCylinder(
+      builder.createCylinder(
         vm::bbox3d{{-32, -32, -32}, {32, 32, 32}},
         EdgeAlignedCircle{4},
         vm::axis::z,
-        "someName");
+        "someName")
+        | kdl::transform([](const auto& cylinder) {
+            CHECK(cylinder.bounds() == vm::bbox3d{{-32, -32, -32}, {32, 32, 32}});
 
-      CHECK(
-        cylinder
-        == Result<Brush>{makeBrush({
-          {{-32, -32, 32}, {-32, 32, -32}, {-32, 32, 32}},
-          {{32, -32, 32}, {-32, -32, -32}, {-32, -32, 32}},
-          {{32, 32, -32}, {-32, -32, -32}, {32, -32, -32}},
-          {{32, 32, 32}, {-32, -32, 32}, {-32, 32, 32}},
-          {{32, 32, 32}, {-32, 32, -32}, {32, 32, -32}},
-          {{32, 32, 32}, {32, -32, -32}, {32, -32, 32}},
-        })});
+            CHECK(
+              cylinder
+              == makeBrush({
+                {{-32, -32, 32}, {-32, 32, -32}, {-32, 32, 32}},
+                {{32, -32, 32}, {-32, -32, -32}, {-32, -32, 32}},
+                {{32, 32, -32}, {-32, -32, -32}, {32, -32, -32}},
+                {{32, 32, 32}, {-32, -32, 32}, {-32, 32, 32}},
+                {{32, 32, 32}, {-32, 32, -32}, {32, 32, -32}},
+                {{32, 32, 32}, {32, -32, -32}, {32, -32, 32}},
+              }));
+          })
+        | kdl::transform_error([](const auto& e) { FAIL(e); });
     }
 
     SECTION("Scalable Cylinder")
     {
       SECTION("In square bounds")
       {
-        const auto cylinder = builder.createCylinder(
+        builder.createCylinder(
           vm::bbox3d{{-32, -32, -32}, {32, 32, 32}},
           ScalableCircle{0},
           vm::axis::z,
-          "someName");
+          "someName")
+          | kdl::transform([](const auto& cylinder) {
+              CHECK(cylinder.bounds() == vm::bbox3d{{-32, -32, -32}, {32, 32, 32}});
 
-        CHECK(
-          cylinder
-          == Result<Brush>{makeBrush({
-            {{-32, -8, 32}, {-32, 8, -32}, {-32, 8, 32}},
-            {{-24, -24, 32}, {-32, -8, -32}, {-32, -8, 32}},
-            {{-24, 24, 32}, {-32, 8, -32}, {-24, 24, -32}},
-            {{-8, -32, 32}, {-24, -24, -32}, {-24, -24, 32}},
-            {{-8, 32, 32}, {-24, 24, -32}, {-8, 32, -32}},
-            {{8, -32, 32}, {-8, -32, -32}, {-8, -32, 32}},
-            {{32, 8, -32}, {24, -24, -32}, {32, -8, -32}},
-            {{32, 8, 32}, {8, 32, 32}, {24, 24, 32}},
-            {{8, 32, 32}, {-8, 32, -32}, {8, 32, -32}},
-            {{24, -24, 32}, {8, -32, -32}, {8, -32, 32}},
-            {{24, 24, 32}, {8, 32, -32}, {24, 24, -32}},
-            {{32, -8, 32}, {24, -24, -32}, {24, -24, 32}},
-            {{32, 8, 32}, {24, 24, -32}, {32, 8, -32}},
-            {{32, 8, 32}, {32, -8, -32}, {32, -8, 32}},
-          })});
+              CHECK(
+                cylinder
+                == makeBrush({
+                  {{-32, -8, 32}, {-32, 8, -32}, {-32, 8, 32}},
+                  {{-24, -24, 32}, {-32, -8, -32}, {-32, -8, 32}},
+                  {{-24, 24, 32}, {-32, 8, -32}, {-24, 24, -32}},
+                  {{-8, -32, 32}, {-24, -24, -32}, {-24, -24, 32}},
+                  {{-8, 32, 32}, {-24, 24, -32}, {-8, 32, -32}},
+                  {{8, -32, 32}, {-8, -32, -32}, {-8, -32, 32}},
+                  {{32, 8, -32}, {24, -24, -32}, {32, -8, -32}},
+                  {{32, 8, 32}, {8, 32, 32}, {24, 24, 32}},
+                  {{8, 32, 32}, {-8, 32, -32}, {8, 32, -32}},
+                  {{24, -24, 32}, {8, -32, -32}, {8, -32, 32}},
+                  {{24, 24, 32}, {8, 32, -32}, {24, 24, -32}},
+                  {{32, -8, 32}, {24, -24, -32}, {24, -24, 32}},
+                  {{32, 8, 32}, {24, 24, -32}, {32, 8, -32}},
+                  {{32, 8, 32}, {32, -8, -32}, {32, -8, 32}},
+                }));
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
       }
 
       SECTION("In rectangular bounds")
       {
-        const auto cylinder = builder.createCylinder(
+        builder.createCylinder(
           vm::bbox3d{{-64, -32, -32}, {64, 32, 32}},
           ScalableCircle{0},
           vm::axis::z,
-          "someName");
+          "someName")
+          | kdl::transform([](const auto& cylinder) {
+              CHECK(cylinder.bounds() == vm::bbox3d{{-64, -32, -32}, {64, 32, 32}});
 
-        CHECK(
-          cylinder
-          == Result<Brush>{makeBrush({
-            {{-64, -8, 32}, {-64, 8, -32}, {-64, 8, 32}},
-            {{-56, -24, 32}, {-64, -8, -32}, {-64, -8, 32}},
-            {{-56, 24, 32}, {-64, 8, -32}, {-56, 24, -32}},
-            {{-40, -32, 32}, {-56, -24, -32}, {-56, -24, 32}},
-            {{-40, 32, 32}, {-56, 24, -32}, {-40, 32, -32}},
-            {{40, -32, 32}, {-40, -32, -32}, {-40, -32, 32}},
-            {{64, 8, -32}, {56, -24, -32}, {64, -8, -32}},
-            {{64, 8, 32}, {40, 32, 32}, {56, 24, 32}},
-            {{40, 32, 32}, {-40, 32, -32}, {40, 32, -32}},
-            {{56, -24, 32}, {40, -32, -32}, {40, -32, 32}},
-            {{56, 24, 32}, {40, 32, -32}, {56, 24, -32}},
-            {{64, -8, 32}, {56, -24, -32}, {56, -24, 32}},
-            {{64, 8, 32}, {56, 24, -32}, {64, 8, -32}},
-            {{64, 8, 32}, {64, -8, -32}, {64, -8, 32}},
-          })});
+              CHECK(
+                cylinder
+                == makeBrush({
+                  {{-64, -8, 32}, {-64, 8, -32}, {-64, 8, 32}},
+                  {{-56, -24, 32}, {-64, -8, -32}, {-64, -8, 32}},
+                  {{-56, 24, 32}, {-64, 8, -32}, {-56, 24, -32}},
+                  {{-40, -32, 32}, {-56, -24, -32}, {-56, -24, 32}},
+                  {{-40, 32, 32}, {-56, 24, -32}, {-40, 32, -32}},
+                  {{40, -32, 32}, {-40, -32, -32}, {-40, -32, 32}},
+                  {{64, 8, -32}, {56, -24, -32}, {64, -8, -32}},
+                  {{64, 8, 32}, {40, 32, 32}, {56, 24, 32}},
+                  {{40, 32, 32}, {-40, 32, -32}, {40, 32, -32}},
+                  {{56, -24, 32}, {40, -32, -32}, {40, -32, 32}},
+                  {{56, 24, 32}, {40, 32, -32}, {56, 24, -32}},
+                  {{64, -8, 32}, {56, -24, -32}, {56, -24, 32}},
+                  {{64, 8, 32}, {56, 24, -32}, {64, 8, -32}},
+                  {{64, 8, 32}, {64, -8, -32}, {64, -8, 32}},
+                }));
+            })
+          | kdl::transform_error([](const auto& e) { FAIL(e); });
       }
     }
   }
 
-
   SECTION("createHollowCylinder")
   {
     auto builder = BrushBuilder{MapFormat::Standard, worldBounds};
-    const auto cylinder = builder.createHollowCylinder(
-      vm::bbox3d{{-32, -32, -32}, {32, 32, 32}},
-      8.0,
-      EdgeAlignedCircle{8},
-      vm::axis::z,
-      "someName");
 
-    REQUIRE(cylinder);
-    CHECK(cylinder.value().size() == 8);
+    const auto bounds = vm::bbox3d{{-32, -32, -32}, {32, 32, 32}};
+    builder.createHollowCylinder(
+      bounds, 8.0, EdgeAlignedCircle{8}, vm::axis::z, "someName")
+      | kdl::transform([&](const auto& brushes) {
+          REQUIRE(brushes.size() == 8u);
+          CHECK(getMergedBounds(brushes) == bounds);
+
+          // Check only one brush to avoid clutter.
+          const auto outerOffset = 13.254833995939043;
+          const auto innerMin = -9.9411254969542853;
+          const auto innerMax = 9.9411254969542835;
+          const auto expectedBrush = makeBrush({
+            {{24, innerMin, 32}, {24, innerMax, -32}, {24, innerMax, 32}},
+            {{24, innerMax, -32}, {32, outerOffset, 32}, {24, innerMax, 32}},
+            {{32, -outerOffset, 32}, {24, innerMin, -32}, {24, innerMin, 32}},
+            {{32, outerOffset, -32}, {24, innerMin, -32}, {32, -outerOffset, -32}},
+            {{32, outerOffset, 32}, {24, innerMin, 32}, {24, innerMax, 32}},
+            {{32, outerOffset, 32}, {32, -outerOffset, -32}, {32, -outerOffset, 32}},
+          });
+
+          CHECK_THAT(
+            brushes, Contains(MatchesBrushVertices(expectedBrush, vertexEpsilon)));
+        })
+      | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
 }
 

--- a/lib/TbUiLib/include/ui/DrawShapeToolExtensions.h
+++ b/lib/TbUiLib/include/ui/DrawShapeToolExtensions.h
@@ -193,6 +193,31 @@ public:
     const vm::bbox3d& bounds, const ShapeParameters& parameters) const override;
 };
 
+class DrawShapeToolArchShapeExtensionPage : public DrawShapeToolCircularShapeExtensionPage
+{
+public:
+  explicit DrawShapeToolArchShapeExtensionPage(
+    MapDocument& document, ShapeParameters& parameters, QWidget* parent = nullptr);
+
+private:
+  ShapeParameters& m_parameters;
+
+  Q_OBJECT
+};
+
+class DrawShapeToolArchExtension : public DrawShapeToolExtension
+{
+public:
+  explicit DrawShapeToolArchExtension(MapDocument& document);
+
+  const std::string& name() const override;
+  const std::filesystem::path& iconPath() const override;
+  DrawShapeToolExtensionPage* createToolPage(
+    ShapeParameters& parameters, QWidget* parent) override;
+  Result<std::vector<mdl::Brush>> createBrushes(
+    const vm::bbox3d& bounds, const ShapeParameters& parameters) const override;
+};
+
 std::vector<std::unique_ptr<DrawShapeToolExtension>> createDrawShapeToolExtensions(
   MapDocument& document);
 

--- a/lib/TbUiLib/src/DrawShapeToolExtensions.cpp
+++ b/lib/TbUiLib/src/DrawShapeToolExtensions.cpp
@@ -634,12 +634,77 @@ Result<std::vector<mdl::Brush>> DrawShapeToolStairsExtension::createBrushes(
          | kdl::fold;
 }
 
+DrawShapeToolArchShapeExtensionPage::DrawShapeToolArchShapeExtensionPage(
+  MapDocument& document, ShapeParameters& parameters, QWidget* parent)
+  : DrawShapeToolCircularShapeExtensionPage{parameters, parent}
+  , m_parameters{parameters}
+{
+  auto* thicknessLabel = new QLabel{tr("Thickness: ")};
+  auto* thicknessBox = new QDoubleSpinBox{};
+  thicknessBox->setRange(1, 1024);
+
+  connect(
+    thicknessBox,
+    QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+    this,
+    [&](const auto thickness) { m_parameters.setThickness(thickness); });
+
+  addWidget(thicknessLabel);
+  addWidget(thicknessBox);
+  addApplyButton(document);
+
+  m_notifierConnection += m_parameters.parametersDidChangeNotifier.connect(
+    [=, this]() { thicknessBox->setValue(m_parameters.thickness()); });
+}
+
+DrawShapeToolArchExtension::DrawShapeToolArchExtension(MapDocument& document)
+  : DrawShapeToolExtension{document}
+{
+}
+
+const std::string& DrawShapeToolArchExtension::name() const
+{
+  static const auto name = std::string{"Arch"};
+  return name;
+}
+
+const std::filesystem::path& DrawShapeToolArchExtension::iconPath() const
+{
+  static const auto path = std::filesystem::path{"ShapeTool_Arch.svg"};
+  return path;
+}
+
+DrawShapeToolExtensionPage* DrawShapeToolArchExtension::createToolPage(
+  ShapeParameters& parameters, QWidget* parent)
+{
+  return new DrawShapeToolArchShapeExtensionPage{m_document, parameters, parent};
+}
+
+Result<std::vector<mdl::Brush>> DrawShapeToolArchExtension::createBrushes(
+  const vm::bbox3d& bounds, const ShapeParameters& parameters) const
+{
+  auto& map = m_document.map();
+
+  const auto builder = mdl::BrushBuilder{
+    map.worldNode().mapFormat(),
+    map.worldBounds(),
+    map.gameInfo().gameConfig.faceAttribsConfig.defaults};
+
+  return builder.createArch(
+    bounds,
+    parameters.thickness(),
+    parameters.circleShape(),
+    parameters.axis(),
+    map.currentMaterialName());
+}
+
 std::vector<std::unique_ptr<DrawShapeToolExtension>> createDrawShapeToolExtensions(
   MapDocument& document)
 {
   auto result = std::vector<std::unique_ptr<DrawShapeToolExtension>>{};
   result.push_back(std::make_unique<DrawShapeToolCuboidExtension>(document));
   result.push_back(std::make_unique<DrawShapeToolStairsExtension>(document));
+  result.push_back(std::make_unique<DrawShapeToolArchExtension>(document));
   result.push_back(std::make_unique<DrawShapeToolCylinderExtension>(document));
   result.push_back(std::make_unique<DrawShapeToolConeExtension>(document));
   result.push_back(std::make_unique<DrawShapeToolUVSphereExtension>(document));

--- a/lib/TbUiLib/test/src/tst_DrawShapeToolExtensions.cpp
+++ b/lib/TbUiLib/test/src/tst_DrawShapeToolExtensions.cpp
@@ -24,6 +24,8 @@
 #include "ui/DrawShapeToolExtensions.h"
 #include "ui/MapDocumentFixture.h"
 
+#include "kd/range_fold.h"
+
 #include <catch2/catch_test_macros.hpp>
 
 namespace tb::ui
@@ -441,6 +443,35 @@ TEST_CASE("DrawShapeToolStairsExtension")
       const auto result = extension.createBrushes(bounds, parameters);
       REQUIRE(result.is_success());
     }
+  }
+}
+
+TEST_CASE("DrawShapeToolArchExtension")
+{
+  auto fixture = MapDocumentFixture{};
+  auto& document = fixture.create();
+  auto extension = DrawShapeToolArchExtension{document};
+  auto parameters = ShapeParameters{};
+
+  SECTION("createBrushes wires parameters to the brush builder")
+  {
+    const auto bounds = vm::bbox3d{{-128, -64, 0}, {128, 64, 64}};
+    parameters.setAxis(vm::axis::y);
+    parameters.setCircleShape(mdl::EdgeAlignedCircle{8});
+    parameters.setThickness(16.0);
+
+    extension.createBrushes(bounds, parameters)
+      | kdl::transform([&](const auto& brushes) {
+          CHECK(brushes.size() == 5u);
+
+          CHECK(
+            kdl::fold_left_first(
+              brushes
+                | std::views::transform([](const auto& brush) { return brush.bounds(); }),
+              [](const auto& lhs, const auto& rhs) { return vm::merge(lhs, rhs); })
+            == bounds);
+        })
+      | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
 }
 


### PR DESCRIPTION
Hi there, this PR adds an Arch shape to the shape tool. It's built as the top half of a hollow cylinder, reusing the existing circular-shape controls. So it inherits the same edge/vertex-aligned and scalable CZG modes, and thickness. Screenshot of an example Arch below. I shared this with folks on Discord and they seemed interested in the feature as they'd find it helpful. 

<img width="999" height="478" alt="image" src="https://github.com/user-attachments/assets/4e72b672-3cf4-494f-a503-fbeb660b7813" />