### PR TITLE
TbFsLib (tests): Fix transitive catch2 include in TestEnvironment.

### DIFF
--- a/lib/TbFsLib/test-utils/src/TestEnvironment.cpp
+++ b/lib/TbFsLib/test-utils/src/TestEnvironment.cpp
@@ -27,7 +27,7 @@
 #include <fstream>
 #include <string>
 
-#include <catch2/catch_test_macros.hpp>
+#include <catch2/interfaces/catch_interfaces_capture.hpp>
 
 
 namespace tb::fs


### PR DESCRIPTION
I couldn't compile trenchbroom with my catch2 version 3.15.1 (on GNU/Linux, release 2026.1) because `Catch::getResultCapture()` is not a resolved symbol in this file. I did some comparison of the header files with catch2-3.8.1 and found that `catch2/interfaces/catch_interfaces_capture.hpp`, which defines `getResultCapture`, was previous being transitively included with `catch2/catch_test_macros.hpp`, but not in 3.15.1.

another candidate to be imported instead is `catch/catch_message.hpp` (like `catch_text_macros.hpp`, it looks like its purpose is to transitively include a grab bag of header files), but it also seems like it's fair game to import the needed header directly. it should work with older catch versions too, but please verify and let me know!
