### PR TITLE
Add support for a alternative shortcuts

### DIFF
--- a/app/DumpShortcuts/src/Main.cpp
+++ b/app/DumpShortcuts/src/Main.cpp
@@ -72,7 +72,7 @@ QString toString(const QStringList& path, const QString& suffix)
   return result;
 }
 
-QString toString(const QKeySequence& keySequence)
+QString toString(const std::vector<QKeySequence>& keySequences)
 {
   static const std::array<std::tuple<int, QString>, 4> Modifiers = {
     std::make_tuple(static_cast<int>(Qt::CTRL), QString::fromLatin1("Ctrl")),
@@ -82,31 +82,46 @@ QString toString(const QKeySequence& keySequence)
   };
 
   auto result = QString{};
-  result += "{ ";
+  result += "[ ";
 
-  if (keySequence.count() > 0)
+  for (auto i = 0u; i < keySequences.size(); ++i)
   {
-    const auto keyWithModifier = keySequence[0].toCombined();
-    const auto key = keyWithModifier & ~(static_cast<int>(Qt::KeyboardModifierMask));
+    const auto& keySequence = keySequences[i];
 
-    const auto keyPortableText = QKeySequence{key}.toString(QKeySequence::PortableText);
-
-    result += "key: '" + escapeString(keyPortableText) + "', ";
-    result += "modifiers: [";
-    for (const auto& [modifier, portableText] : Modifiers)
+    if (i > 0)
     {
-      if ((keyWithModifier & modifier) != 0)
-      {
-        result += "'" + escapeString(portableText) + "', ";
-      }
+      result += ", ";
     }
-    result += "]";
+
+    result += "{ ";
+
+    if (keySequence.count() > 0)
+    {
+      const auto keyWithModifier = keySequence[0].toCombined();
+      const auto key = keyWithModifier & ~(static_cast<int>(Qt::KeyboardModifierMask));
+
+      const auto keyPortableText = QKeySequence{key}.toString(QKeySequence::PortableText);
+
+      result += "key: '" + escapeString(keyPortableText) + "', ";
+      result += "modifiers: [";
+      for (const auto& [modifier, portableText] : Modifiers)
+      {
+        if ((keyWithModifier & modifier) != 0)
+        {
+          result += "'" + escapeString(portableText) + "', ";
+        }
+      }
+      result += "]";
+    }
+    else
+    {
+      result += "key: '', modifiers: []";
+    }
+
+    result += " }";
   }
-  else
-  {
-    result += "key: '', modifiers: []";
-  }
-  result += " }";
+
+  result += " ]";
   return result;
 }
 

--- a/app/TrenchBroom/resources/documentation/manual/shortcuts_helper.js
+++ b/app/TrenchBroom/resources/documentation/manual/shortcuts_helper.js
@@ -12,21 +12,24 @@ const key_str = (key) => {
 // our menu item lookups.
 const fix_ellipsis = (path) => path.replace("…", "...");
 
-const shortcut_str = (shortcut) => {
+const shortcut_str = (shortcuts) => {
     let result = "";
 
-    if (shortcut) {
-        if (shortcut.key == "") {
-            result = undefined;
-        } else {
-            for (i = 0; i < shortcut.modifiers.length; ++i) {
-                result += key_str(shortcut.modifiers[i]);
-            }
-            result += key_str(shortcut.key);
-        }
-    } else {
-        console.error("unknown shortcut ", shortcut);
-        result += "&laquo;unknown shortcut&raquo;";
+    if (shortcuts.length > 0) {
+      let shortcut = shortcuts[0];
+      if (shortcut) {
+          if (shortcut.key == "") {
+              result = undefined;
+          } else {
+              for (i = 0; i < shortcut.modifiers.length; ++i) {
+                  result += key_str(shortcut.modifiers[i]);
+              }
+              result += key_str(shortcut.key);
+          }
+      } else {
+          console.error("unknown shortcut ", shortcut);
+          result += "&laquo;unknown shortcut&raquo;";
+      }
     }
 
     return result;

--- a/lib/TbBaseLib/include/PreferenceStore.h
+++ b/lib/TbBaseLib/include/PreferenceStore.h
@@ -44,7 +44,6 @@ public:
   virtual bool load(const std::filesystem::path& path, std::string& value) = 0;
   virtual bool load(const std::filesystem::path& path, std::filesystem::path& value) = 0;
   virtual bool load(const std::filesystem::path& path, Color& value) = 0;
-  virtual bool load(const std::filesystem::path& path, QKeySequence& value) = 0;
   virtual bool load(
     const std::filesystem::path& path, std::vector<QKeySequence>& value) = 0;
 
@@ -55,7 +54,6 @@ public:
   virtual void save(
     const std::filesystem::path& path, const std::filesystem::path& value) = 0;
   virtual void save(const std::filesystem::path& path, const Color& value) = 0;
-  virtual void save(const std::filesystem::path& path, const QKeySequence& value) = 0;
   virtual void save(
     const std::filesystem::path& path, const std::vector<QKeySequence>& value) = 0;
 };

--- a/lib/TbBaseLib/include/PreferenceStore.h
+++ b/lib/TbBaseLib/include/PreferenceStore.h
@@ -45,6 +45,8 @@ public:
   virtual bool load(const std::filesystem::path& path, std::filesystem::path& value) = 0;
   virtual bool load(const std::filesystem::path& path, Color& value) = 0;
   virtual bool load(const std::filesystem::path& path, QKeySequence& value) = 0;
+  virtual bool load(
+    const std::filesystem::path& path, std::vector<QKeySequence>& value) = 0;
 
   virtual void save(const std::filesystem::path& path, bool value) = 0;
   virtual void save(const std::filesystem::path& path, int value) = 0;
@@ -54,6 +56,8 @@ public:
     const std::filesystem::path& path, const std::filesystem::path& value) = 0;
   virtual void save(const std::filesystem::path& path, const Color& value) = 0;
   virtual void save(const std::filesystem::path& path, const QKeySequence& value) = 0;
+  virtual void save(
+    const std::filesystem::path& path, const std::vector<QKeySequence>& value) = 0;
 };
 
 } // namespace tb

--- a/lib/TbBaseLib/test-utils/include/TestPreferenceStore.h
+++ b/lib/TbBaseLib/test-utils/include/TestPreferenceStore.h
@@ -33,7 +33,6 @@ public:
   bool load(const std::filesystem::path& path, std::string& value) override;
   bool load(const std::filesystem::path& path, std::filesystem::path& value) override;
   bool load(const std::filesystem::path& path, Color& value) override;
-  bool load(const std::filesystem::path& path, QKeySequence& value) override;
   bool load(const std::filesystem::path& path, std::vector<QKeySequence>& value) override;
 
   void save(const std::filesystem::path& path, bool value) override;
@@ -43,7 +42,6 @@ public:
   void save(
     const std::filesystem::path& path, const std::filesystem::path& value) override;
   void save(const std::filesystem::path& path, const Color& value) override;
-  void save(const std::filesystem::path& path, const QKeySequence& value) override;
   void save(
     const std::filesystem::path& path, const std::vector<QKeySequence>& value) override;
 };

--- a/lib/TbBaseLib/test-utils/include/TestPreferenceStore.h
+++ b/lib/TbBaseLib/test-utils/include/TestPreferenceStore.h
@@ -34,6 +34,7 @@ public:
   bool load(const std::filesystem::path& path, std::filesystem::path& value) override;
   bool load(const std::filesystem::path& path, Color& value) override;
   bool load(const std::filesystem::path& path, QKeySequence& value) override;
+  bool load(const std::filesystem::path& path, std::vector<QKeySequence>& value) override;
 
   void save(const std::filesystem::path& path, bool value) override;
   void save(const std::filesystem::path& path, int value) override;
@@ -43,6 +44,8 @@ public:
     const std::filesystem::path& path, const std::filesystem::path& value) override;
   void save(const std::filesystem::path& path, const Color& value) override;
   void save(const std::filesystem::path& path, const QKeySequence& value) override;
+  void save(
+    const std::filesystem::path& path, const std::vector<QKeySequence>& value) override;
 };
 
 } // namespace tb

--- a/lib/TbBaseLib/test-utils/src/TestPreferenceStore.cpp
+++ b/lib/TbBaseLib/test-utils/src/TestPreferenceStore.cpp
@@ -57,6 +57,11 @@ bool TestPreferenceStore::load(const std::filesystem::path&, QKeySequence&)
   return false;
 }
 
+bool TestPreferenceStore::load(const std::filesystem::path&, std::vector<QKeySequence>&)
+{
+  return false;
+}
+
 void TestPreferenceStore::save(const std::filesystem::path&, bool) {}
 
 void TestPreferenceStore::save(const std::filesystem::path&, int) {}
@@ -72,6 +77,11 @@ void TestPreferenceStore::save(const std::filesystem::path&, const std::filesyst
 void TestPreferenceStore::save(const std::filesystem::path&, const Color&) {}
 
 void TestPreferenceStore::save(const std::filesystem::path&, const QKeySequence&) {}
+
+void TestPreferenceStore::save(
+  const std::filesystem::path&, const std::vector<QKeySequence>&)
+{
+}
 
 
 } // namespace tb

--- a/lib/TbBaseLib/test-utils/src/TestPreferenceStore.cpp
+++ b/lib/TbBaseLib/test-utils/src/TestPreferenceStore.cpp
@@ -52,11 +52,6 @@ bool TestPreferenceStore::load(const std::filesystem::path&, Color&)
   return false;
 }
 
-bool TestPreferenceStore::load(const std::filesystem::path&, QKeySequence&)
-{
-  return false;
-}
-
 bool TestPreferenceStore::load(const std::filesystem::path&, std::vector<QKeySequence>&)
 {
   return false;
@@ -75,8 +70,6 @@ void TestPreferenceStore::save(const std::filesystem::path&, const std::filesyst
 }
 
 void TestPreferenceStore::save(const std::filesystem::path&, const Color&) {}
-
-void TestPreferenceStore::save(const std::filesystem::path&, const QKeySequence&) {}
 
 void TestPreferenceStore::save(
   const std::filesystem::path&, const std::vector<QKeySequence>&)

--- a/lib/TbBaseLib/test/src/tst_PreferenceManager.cpp
+++ b/lib/TbBaseLib/test/src/tst_PreferenceManager.cpp
@@ -113,12 +113,6 @@ struct MockPreferenceStore : public PreferenceStore
     return false;
   }
 
-  bool load(const std::filesystem::path&, QKeySequence&) override
-  {
-    // cannot test QKeySequence here
-    return false;
-  }
-
   bool load(const std::filesystem::path&, std::vector<QKeySequence>&) override
   {
     // cannot test std::vector<QKeySequence> here
@@ -154,11 +148,6 @@ struct MockPreferenceStore : public PreferenceStore
   void save(const std::filesystem::path& path, const Color& value) override
   {
     values[path] = value;
-  }
-
-  void save(const std::filesystem::path&, const QKeySequence&) override
-  {
-    // can't test QKeySequence here
   }
 
   void save(const std::filesystem::path&, const std::vector<QKeySequence>&) override

--- a/lib/TbBaseLib/test/src/tst_PreferenceManager.cpp
+++ b/lib/TbBaseLib/test/src/tst_PreferenceManager.cpp
@@ -119,6 +119,12 @@ struct MockPreferenceStore : public PreferenceStore
     return false;
   }
 
+  bool load(const std::filesystem::path&, std::vector<QKeySequence>&) override
+  {
+    // cannot test std::vector<QKeySequence> here
+    return false;
+  }
+
   void save(const std::filesystem::path& path, const bool value) override
   {
     values[path] = value;
@@ -153,6 +159,11 @@ struct MockPreferenceStore : public PreferenceStore
   void save(const std::filesystem::path&, const QKeySequence&) override
   {
     // can't test QKeySequence here
+  }
+
+  void save(const std::filesystem::path&, const std::vector<QKeySequence>&) override
+  {
+    // can't test std::vector<QKeySequence> here
   }
 
   std::unordered_map<std::filesystem::path, Value> values;

--- a/lib/TbPreferencesLib/include/Preferences.h
+++ b/lib/TbPreferencesLib/include/Preferences.h
@@ -259,18 +259,18 @@ inline auto CameraFlyMoveSpeed =
 
 inline auto Link2DCameras = Preference<bool>{"Controls/Camera/Link 2D cameras", true};
 
-inline auto CameraFlyForward =
-  Preference<QKeySequence>{"Controls/Camera/Move forward", QKeySequence{'W'}};
-inline auto CameraFlyBackward =
-  Preference<QKeySequence>{"Controls/Camera/Move backward", QKeySequence{'S'}};
-inline auto CameraFlyLeft =
-  Preference<QKeySequence>{"Controls/Camera/Move left", QKeySequence{'A'}};
-inline auto CameraFlyRight =
-  Preference<QKeySequence>{"Controls/Camera/Move right", QKeySequence{'D'}};
-inline auto CameraFlyUp =
-  Preference<QKeySequence>{"Controls/Camera/Move up", QKeySequence{'Q'}};
-inline auto CameraFlyDown =
-  Preference<QKeySequence>{"Controls/Camera/Move down", QKeySequence{'X'}};
+inline auto CameraFlyForward = Preference<std::vector<QKeySequence>>{
+  "Controls/Camera/Move forward", std::vector<QKeySequence>{'W'}};
+inline auto CameraFlyBackward = Preference<std::vector<QKeySequence>>{
+  "Controls/Camera/Move backward", std::vector<QKeySequence>{'S'}};
+inline auto CameraFlyLeft = Preference<std::vector<QKeySequence>>{
+  "Controls/Camera/Move left", std::vector<QKeySequence>{'A'}};
+inline auto CameraFlyRight = Preference<std::vector<QKeySequence>>{
+  "Controls/Camera/Move right", std::vector<QKeySequence>{'D'}};
+inline auto CameraFlyUp = Preference<std::vector<QKeySequence>>{
+  "Controls/Camera/Move up", std::vector<QKeySequence>{'Q'}};
+inline auto CameraFlyDown = Preference<std::vector<QKeySequence>>{
+  "Controls/Camera/Move down", std::vector<QKeySequence>{'X'}};
 
 // Map view config
 inline auto ShowEntityClassnames =
@@ -308,6 +308,6 @@ inline auto EntityLinkMode =
 
 std::vector<Preference<Color>*> colorPreferences();
 
-std::vector<Preference<QKeySequence>*> keyPreferences();
+std::vector<Preference<std::vector<QKeySequence>>*> keyPreferences();
 
 } // namespace tb::Preferences

--- a/lib/TbPreferencesLib/src/Preferences.cpp
+++ b/lib/TbPreferencesLib/src/Preferences.cpp
@@ -102,7 +102,7 @@ std::vector<Preference<Color>*> colorPreferences()
   };
 }
 
-std::vector<Preference<QKeySequence>*> keyPreferences()
+std::vector<Preference<std::vector<QKeySequence>>*> keyPreferences()
 {
   return {
     &CameraFlyForward,

--- a/lib/TbUiLib/include/ui/Action.h
+++ b/lib/TbUiLib/include/ui/Action.h
@@ -55,7 +55,7 @@ class Action
 private:
   QString m_label;
   ActionContext::Type m_actionContext;
-  Preference<QKeySequence> m_shortcutPreference;
+  Preference<std::vector<QKeySequence>> m_shortcutPreference;
 
   ExecuteFn m_execute;
   EnabledFn m_enabled;
@@ -98,8 +98,8 @@ public:
   const QString& label() const;
   ActionContext::Type actionContext() const;
 
-  const Preference<QKeySequence>& preference() const;
-  Preference<QKeySequence>& preference();
+  const Preference<std::vector<QKeySequence>>& preference() const;
+  Preference<std::vector<QKeySequence>>& preference();
 
   void execute(ActionExecutionContext& context) const;
   bool enabled(const ActionExecutionContext& context) const;

--- a/lib/TbUiLib/include/ui/ActionInfo.h
+++ b/lib/TbUiLib/include/ui/ActionInfo.h
@@ -55,21 +55,21 @@ private:
    */
   std::filesystem::path m_displayPath;
   ActionContext::Type m_actionContext;
-  const Preference<QKeySequence>* m_keyboardShortcutPreference;
+  const Preference<std::vector<QKeySequence>>* m_keyboardShortcutPreference;
 
 public:
   ActionInfo(
     ActionInfoType type,
     std::filesystem::path displayPath,
     ActionContext::Type actionContext,
-    const Preference<QKeySequence>& keyboardShortcutPreference);
+    const Preference<std::vector<QKeySequence>>& keyboardShortcutPreference);
 
   const std::filesystem::path& displayPath() const;
 
   ActionInfoType type() const;
 
   ActionContext::Type actionContext() const;
-  const Preference<QKeySequence>& keyboardShortcutPreference() const;
+  const Preference<std::vector<QKeySequence>>& keyboardShortcutPreference() const;
 
   std::strong_ordering operator<=>(const ActionInfo& other) const;
   bool operator==(const ActionInfo& other) const;

--- a/lib/TbUiLib/include/ui/QPreferenceStore.h
+++ b/lib/TbUiLib/include/ui/QPreferenceStore.h
@@ -61,6 +61,7 @@ public:
   bool load(const std::filesystem::path& path, std::filesystem::path& value) override;
   bool load(const std::filesystem::path& path, Color& value) override;
   bool load(const std::filesystem::path& path, QKeySequence& value) override;
+  bool load(const std::filesystem::path& path, std::vector<QKeySequence>& value) override;
 
   void save(const std::filesystem::path& path, bool value) override;
   void save(const std::filesystem::path& path, float value) override;
@@ -70,6 +71,8 @@ public:
     const std::filesystem::path& path, const std::filesystem::path& value) override;
   void save(const std::filesystem::path& path, const Color& value) override;
   void save(const std::filesystem::path& path, const QKeySequence& value) override;
+  void save(
+    const std::filesystem::path& path, const std::vector<QKeySequence>& value) override;
 };
 
 } // namespace ui

--- a/lib/TbUiLib/include/ui/QPreferenceStore.h
+++ b/lib/TbUiLib/include/ui/QPreferenceStore.h
@@ -60,7 +60,6 @@ public:
   bool load(const std::filesystem::path& path, std::string& value) override;
   bool load(const std::filesystem::path& path, std::filesystem::path& value) override;
   bool load(const std::filesystem::path& path, Color& value) override;
-  bool load(const std::filesystem::path& path, QKeySequence& value) override;
   bool load(const std::filesystem::path& path, std::vector<QKeySequence>& value) override;
 
   void save(const std::filesystem::path& path, bool value) override;
@@ -70,7 +69,6 @@ public:
   void save(
     const std::filesystem::path& path, const std::filesystem::path& value) override;
   void save(const std::filesystem::path& path, const Color& value) override;
-  void save(const std::filesystem::path& path, const QKeySequence& value) override;
   void save(
     const std::filesystem::path& path, const std::vector<QKeySequence>& value) override;
 };

--- a/lib/TbUiLib/include/ui/QPreferenceStoreDelegate.h
+++ b/lib/TbUiLib/include/ui/QPreferenceStoreDelegate.h
@@ -78,7 +78,6 @@ public:
   bool load(const std::filesystem::path& path, std::string& value);
   bool load(const std::filesystem::path& path, std::filesystem::path& value);
   bool load(const std::filesystem::path& path, Color& value);
-  bool load(const std::filesystem::path& path, QKeySequence& value);
   bool load(const std::filesystem::path& path, std::vector<QKeySequence>& value);
 
   void save(const std::filesystem::path& path, bool value);
@@ -87,7 +86,6 @@ public:
   void save(const std::filesystem::path& path, const std::string& value);
   void save(const std::filesystem::path& path, const std::filesystem::path& value);
   void save(const std::filesystem::path& path, const Color& value);
-  void save(const std::filesystem::path& path, const QKeySequence& value);
   void save(const std::filesystem::path& path, const std::vector<QKeySequence>& value);
 
 private:

--- a/lib/TbUiLib/include/ui/QPreferenceStoreDelegate.h
+++ b/lib/TbUiLib/include/ui/QPreferenceStoreDelegate.h
@@ -79,6 +79,7 @@ public:
   bool load(const std::filesystem::path& path, std::filesystem::path& value);
   bool load(const std::filesystem::path& path, Color& value);
   bool load(const std::filesystem::path& path, QKeySequence& value);
+  bool load(const std::filesystem::path& path, std::vector<QKeySequence>& value);
 
   void save(const std::filesystem::path& path, bool value);
   void save(const std::filesystem::path& path, float value);
@@ -87,6 +88,7 @@ public:
   void save(const std::filesystem::path& path, const std::filesystem::path& value);
   void save(const std::filesystem::path& path, const Color& value);
   void save(const std::filesystem::path& path, const QKeySequence& value);
+  void save(const std::filesystem::path& path, const std::vector<QKeySequence>& value);
 
 private:
   void loadCache();

--- a/lib/TbUiLib/src/Action.cpp
+++ b/lib/TbUiLib/src/Action.cpp
@@ -38,7 +38,7 @@ Action::Action(
   std::optional<QString> statusTip)
   : m_label{std::move(label)}
   , m_actionContext{actionContext}
-  , m_shortcutPreference{std::move(preferencePath), defaultShortcut}
+  , m_shortcutPreference{std::move(preferencePath), {defaultShortcut}}
   , m_execute{std::move(execute)}
   , m_enabled{std::move(enabled)}
   , m_checked{std::move(checked)}
@@ -98,12 +98,12 @@ ActionContext::Type Action::actionContext() const
   return m_actionContext;
 }
 
-const Preference<QKeySequence>& Action::preference() const
+const Preference<std::vector<QKeySequence>>& Action::preference() const
 {
   return m_shortcutPreference;
 }
 
-Preference<QKeySequence>& Action::preference()
+Preference<std::vector<QKeySequence>>& Action::preference()
 {
   return KDL_CONST_OVERLOAD(preference());
 }

--- a/lib/TbUiLib/src/ActionBuilder.cpp
+++ b/lib/TbUiLib/src/ActionBuilder.cpp
@@ -29,26 +29,27 @@
 #include "ui/ImageUtils.h"
 
 #include "kd/contracts.h"
+#include "kd/ranges/to.h"
 
 namespace tb::ui
 {
 
 void updateActionKeySequence(QAction& qAction, const Action& tAction)
 {
-  const auto& shortcutPreference = pref(tAction.preference());
-  if (!shortcutPreference.isEmpty())
+  const auto& keySequences = pref(tAction.preference());
+
+  auto tooltip = tAction.label();
+  for (const auto& keySequence : keySequences)
   {
-    const auto tooltip = QObject::tr("%1 (%2)")
-                           .arg(tAction.label())
-                           .arg(shortcutPreference.toString(QKeySequence::NativeText));
-    qAction.setToolTip(tooltip);
-  }
-  else
-  {
-    qAction.setToolTip(tAction.label());
+    if (!keySequence.isEmpty())
+    {
+      tooltip.append(
+        QObject::tr(" (%1)").arg(keySequence.toString(QKeySequence::NativeText)));
+    }
   }
 
-  qAction.setShortcut(shortcutPreference);
+  qAction.setToolTip(tooltip);
+  qAction.setShortcuts(keySequences | kdl::ranges::to<QList>());
 }
 
 namespace

--- a/lib/TbUiLib/src/ActionInfo.cpp
+++ b/lib/TbUiLib/src/ActionInfo.cpp
@@ -35,22 +35,24 @@ namespace tb::ui
 namespace
 {
 
-struct ActionConflictCmp
+struct ActionConflictKey
 {
-  bool operator()(const ActionInfo& lhs, const ActionInfo& rhs) const
+  ActionContext::Type actionContext;
+  QKeySequence keySequence;
+
+  bool operator<(const ActionConflictKey& other) const
   {
-    if (actionContextMatches(lhs.actionContext(), rhs.actionContext()))
+    if (actionContextMatches(actionContext, other.actionContext))
     {
       // if the two have the same sequence, they would be in conflict, so we compare the
       // sequences
-      const auto& lhsKeySequence = pref(lhs.keyboardShortcutPreference());
-      const auto& rhsKeySequence = pref(rhs.keyboardShortcutPreference());
-      return lhsKeySequence < rhsKeySequence;
+      return keySequence < other.keySequence;
     }
     // otherwise, we just compare by the action context
-    return lhs.actionContext() < rhs.actionContext();
+    return actionContext < other.actionContext;
   }
 };
+
 
 } // namespace
 
@@ -58,7 +60,7 @@ ActionInfo::ActionInfo(
   const ActionInfoType type,
   std::filesystem::path displayPath,
   const ActionContext::Type actionContext,
-  const Preference<QKeySequence>& keyboardShortcutPreference)
+  const Preference<std::vector<QKeySequence>>& keyboardShortcutPreference)
   : m_type{type}
   , m_displayPath{std::move(displayPath)}
   , m_actionContext{actionContext}
@@ -81,7 +83,8 @@ ActionContext::Type ActionInfo::actionContext() const
   return m_actionContext;
 }
 
-const Preference<QKeySequence>& ActionInfo::keyboardShortcutPreference() const
+const Preference<std::vector<QKeySequence>>& ActionInfo::keyboardShortcutPreference()
+  const
 {
   return *m_keyboardShortcutPreference;
 }
@@ -104,21 +107,25 @@ bool ActionInfo::operator==(const ActionInfo& other) const
 
 std::vector<size_t> findConflicts(const std::vector<ActionInfo>& actionInfos)
 {
-  auto entries = std::map<ActionInfo, size_t, ActionConflictCmp>{};
+  auto entries = std::map<ActionConflictKey, size_t>{};
   auto conflicts = std::vector<size_t>{};
 
   for (const auto& [index, actionInfo] : actionInfos | kdl::views::enumerate)
   {
-    const auto& keySequence = pref(actionInfo.keyboardShortcutPreference());
-    if (keySequence.count() > 0)
+    const auto actionIndex = static_cast<size_t>(index);
+    for (const auto& keySequence : pref(actionInfo.keyboardShortcutPreference()))
     {
-      const auto [it, noConflict] = entries.emplace(actionInfo, index);
-      if (!noConflict)
+      if (keySequence.count() > 0)
       {
-        // found a duplicate, so there are conflicts
-        const auto otherIndex = it->second;
-        conflicts.emplace_back(otherIndex);
-        conflicts.emplace_back(index);
+        const auto [it, noConflict] = entries.emplace(
+          ActionConflictKey{actionInfo.actionContext(), keySequence}, actionIndex);
+        if (!noConflict && it->second != actionIndex)
+        {
+          // found a duplicate, so there are conflicts
+          const auto otherIndex = it->second;
+          conflicts.emplace_back(otherIndex);
+          conflicts.emplace_back(actionIndex);
+        }
       }
     }
   }

--- a/lib/TbUiLib/src/FlyModeHelper.cpp
+++ b/lib/TbUiLib/src/FlyModeHelper.cpp
@@ -40,19 +40,22 @@ qint64 msecsSinceReference()
   return timer.msecsSinceReference();
 }
 
-bool eventMatchesShortcut(const QKeySequence& shortcut, const QKeyEvent& event)
+bool eventMatchesShortcut(
+  const std::vector<QKeySequence>& shortcuts, const QKeyEvent& event)
 {
-  if (shortcut.isEmpty())
-  {
-    return false;
-  }
+  return std::ranges::any_of(shortcuts, [&](const auto& shortcut) {
+    if (shortcut.isEmpty())
+    {
+      return false;
+    }
 
-  // NOTE: For triggering fly mode we only support single keys.
-  // e.g. you can't bind Shift+W to fly forward, only Shift or W.
-  const auto modifiers = Qt::KeyboardModifiers{};
-  const auto key = event.keyCombination().key();
-  const auto eventSequence = QKeySequence{QKeyCombination{modifiers, key}};
-  return eventSequence.matches(shortcut) == QKeySequence::ExactMatch;
+    // NOTE: For triggering fly mode we only support single keys.
+    // e.g. you can't bind Shift+W to fly forward, only Shift or W.
+    const auto modifiers = Qt::KeyboardModifiers{};
+    const auto key = event.keyCombination().key();
+    const auto eventSequence = QKeySequence{QKeyCombination{modifiers, key}};
+    return eventSequence.matches(shortcut) == QKeySequence::ExactMatch;
+  });
 }
 
 } // namespace

--- a/lib/TbUiLib/src/KeyboardPreferencePane.cpp
+++ b/lib/TbUiLib/src/KeyboardPreferencePane.cpp
@@ -52,16 +52,18 @@ KeyboardPreferencePane::KeyboardPreferencePane(
 {
   m_proxy->setSourceModel(m_model);
   m_proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
-  m_proxy->setFilterKeyColumn(2); // Filter based on the text in the Description column
+  m_proxy->setFilterKeyColumn(3); // Filter based on the text in the Description column
 
   m_table->setModel(m_proxy);
 
   m_table->setHorizontalHeader(new QHeaderView(Qt::Horizontal));
   m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::Fixed);
-  m_table->horizontalHeader()->resizeSection(0, 150);
+  m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Fixed);
+  m_table->horizontalHeader()->resizeSection(0, 100);
+  m_table->horizontalHeader()->resizeSection(1, 100);
   m_table->horizontalHeader()->setSectionResizeMode(
-    1, QHeaderView::ResizeMode::ResizeToContents);
-  m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeMode::Stretch);
+    2, QHeaderView::ResizeMode::ResizeToContents);
+  m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeMode::Stretch);
 
   // Tighter than default vertical row height, without the overhead of autoresizing
   m_table->verticalHeader()->setDefaultSectionSize(

--- a/lib/TbUiLib/src/KeyboardShortcutModel.cpp
+++ b/lib/TbUiLib/src/KeyboardShortcutModel.cpp
@@ -100,13 +100,17 @@ QVariant KeyboardShortcutModel::data(const QModelIndex& index, const int role) c
   if (role == Qt::DisplayRole || role == Qt::EditRole)
   {
     const auto& actionInfo = this->actionInfo(index.row());
+
     auto& prefs = PreferenceManager::instance();
+    const auto& keyboardShortcuts =
+      prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
+
     switch (index.column())
     {
     case 0:
-      return prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
+      return !keyboardShortcuts.empty() ? keyboardShortcuts[0] : QKeySequence{};
     case 1:
-      return prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
+      return keyboardShortcuts.size() > 1 ? keyboardShortcuts[1] : QKeySequence{};
     case 2:
       return QString::fromStdString(actionContextName(actionInfo.actionContext()));
     case 3:
@@ -134,7 +138,33 @@ bool KeyboardShortcutModel::setData(
 
   // We take a copy here on purpose in order to set the key further below.
   auto& actionInfo = this->actionInfo(index.row());
-  prefs.set(actionInfo.keyboardShortcutPreference(), value.value<QKeySequence>());
+  auto keyboardShortcuts = prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
+
+  switch (index.column())
+  {
+  case 0:
+    if (keyboardShortcuts.empty())
+    {
+      keyboardShortcuts.emplace_back();
+    }
+    keyboardShortcuts[0] = value.value<QKeySequence>();
+    break;
+  case 1:
+    if (keyboardShortcuts.empty())
+    {
+      keyboardShortcuts.emplace_back();
+    }
+    if (keyboardShortcuts.size() == 1)
+    {
+      keyboardShortcuts.emplace_back();
+    }
+    keyboardShortcuts[1] = value.value<QKeySequence>();
+    break;
+  default:
+    break;
+  }
+
+  prefs.set(actionInfo.keyboardShortcutPreference(), std::move(keyboardShortcuts));
 
   updateConflicts();
 

--- a/lib/TbUiLib/src/KeyboardShortcutModel.cpp
+++ b/lib/TbUiLib/src/KeyboardShortcutModel.cpp
@@ -55,7 +55,7 @@ void KeyboardShortcutModel::reset()
   updateConflicts();
   if (totalActionCount() > 0)
   {
-    emit dataChanged(createIndex(0, 0), createIndex(totalActionCount() - 1, 2));
+    emit dataChanged(createIndex(0, 0), createIndex(totalActionCount() - 1, 3));
   }
 }
 
@@ -66,8 +66,8 @@ int KeyboardShortcutModel::rowCount(const QModelIndex& /* parent */) const
 
 int KeyboardShortcutModel::columnCount(const QModelIndex& /* parent */) const
 {
-  // Shortcut, Context, Description
-  return 3;
+  // Shortcut, Alternative, Context, Description
+  return 4;
 }
 
 QVariant KeyboardShortcutModel::headerData(
@@ -75,9 +75,17 @@ QVariant KeyboardShortcutModel::headerData(
 {
   if (orientation == Qt::Horizontal && role == Qt::DisplayRole)
   {
-    return section == 0   ? QString{"Shortcut"}
-           : section == 1 ? QString{"Context"}
-                          : QString{"Description"};
+    switch (section)
+    {
+    case 0:
+      return QString{"Shortcut"};
+    case 1:
+      return QString{"Alternative"};
+    case 2:
+      return QString{"Context"};
+    case 3:
+      return QString{"Description"};
+    }
   }
   return QVariant{};
 }
@@ -88,24 +96,29 @@ QVariant KeyboardShortcutModel::data(const QModelIndex& index, const int role) c
   {
     return QVariant{};
   }
+
   if (role == Qt::DisplayRole || role == Qt::EditRole)
   {
     const auto& actionInfo = this->actionInfo(index.row());
-    if (index.column() == 0)
+    auto& prefs = PreferenceManager::instance();
+    switch (index.column())
     {
-      auto& prefs = PreferenceManager::instance();
+    case 0:
       return prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
-    }
-    if (index.column() == 1)
-    {
+    case 1:
+      return prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
+    case 2:
       return QString::fromStdString(actionContextName(actionInfo.actionContext()));
+    case 3:
+      return QString::fromStdString(actionInfo.displayPath().generic_string());
     }
-    return QString::fromStdString(actionInfo.displayPath().generic_string());
   }
+
   if (role == Qt::ForegroundRole && hasConflicts(index))
   {
     return QBrush{Qt::red};
   }
+
   return QVariant{};
 }
 
@@ -136,9 +149,14 @@ Qt::ItemFlags KeyboardShortcutModel::flags(const QModelIndex& index) const
     return Qt::ItemIsEnabled;
   }
 
-  return index.column() == 0
-           ? Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable
-           : Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+  switch (index.column())
+  {
+  case 0:
+  case 1:
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
+  default:
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+  }
 }
 
 size_t KeyboardShortcutModel::maxKeySequenceCount(const QModelIndex& index) const
@@ -304,7 +322,7 @@ int KeyboardShortcutModel::totalActionCount() const
 
 bool KeyboardShortcutModel::checkIndex(const QModelIndex& index) const
 {
-  return index.isValid() && index.column() < 3 && index.row() < totalActionCount();
+  return index.isValid() && index.column() < 4 && index.row() < totalActionCount();
 }
 
 } // namespace tb::ui

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -298,11 +298,11 @@ void MapViewBase::createActions()
   m_shortcuts.clear();
 
   auto visitor = [this](const Action& action) {
-    const auto& keySequence = pref(action.preference());
+    const auto& keySequences = pref(action.preference());
 
     auto* shortcut = new QShortcut{this};
     shortcut->setContext(Qt::WidgetWithChildrenShortcut);
-    shortcut->setKey(keySequence);
+    shortcut->setKeys(keySequences | kdl::ranges::to<QList>());
     connect(
       shortcut, &QShortcut::activated, this, [this, &action] { triggerAction(action); });
     connect(shortcut, &QShortcut::activatedAmbiguously, this, [this, &action] {
@@ -324,7 +324,7 @@ void MapViewBase::updateActionBindings()
 {
   for (auto& [shortcut, action] : m_shortcuts)
   {
-    shortcut->setKey(pref(action->preference()));
+    shortcut->setKeys(pref(action->preference()) | kdl::ranges::to<QList>());
   }
 }
 

--- a/lib/TbUiLib/src/QPreferenceStore.cpp
+++ b/lib/TbUiLib/src/QPreferenceStore.cpp
@@ -68,11 +68,6 @@ bool QPreferenceStore::load(const std::filesystem::path& path, Color& value)
   return m_delegate->load(path, value);
 }
 
-bool QPreferenceStore::load(const std::filesystem::path& path, QKeySequence& value)
-{
-  return m_delegate->load(path, value);
-}
-
 bool QPreferenceStore::load(
   const std::filesystem::path& path, std::vector<QKeySequence>& value)
 {
@@ -105,11 +100,6 @@ void QPreferenceStore::save(
 }
 
 void QPreferenceStore::save(const std::filesystem::path& path, const Color& value)
-{
-  m_delegate->save(path, value);
-}
-
-void QPreferenceStore::save(const std::filesystem::path& path, const QKeySequence& value)
 {
   m_delegate->save(path, value);
 }

--- a/lib/TbUiLib/src/QPreferenceStore.cpp
+++ b/lib/TbUiLib/src/QPreferenceStore.cpp
@@ -72,6 +72,12 @@ bool QPreferenceStore::load(const std::filesystem::path& path, QKeySequence& val
 {
   return m_delegate->load(path, value);
 }
+
+bool QPreferenceStore::load(
+  const std::filesystem::path& path, std::vector<QKeySequence>& value)
+{
+  return m_delegate->load(path, value);
+}
 void QPreferenceStore::save(const std::filesystem::path& path, const bool value)
 {
   m_delegate->save(path, value);
@@ -104,6 +110,12 @@ void QPreferenceStore::save(const std::filesystem::path& path, const Color& valu
 }
 
 void QPreferenceStore::save(const std::filesystem::path& path, const QKeySequence& value)
+{
+  m_delegate->save(path, value);
+}
+
+void QPreferenceStore::save(
+  const std::filesystem::path& path, const std::vector<QKeySequence>& value)
 {
   m_delegate->save(path, value);
 }

--- a/lib/TbUiLib/src/QPreferenceStoreDelegate.cpp
+++ b/lib/TbUiLib/src/QPreferenceStoreDelegate.cpp
@@ -216,22 +216,6 @@ bool QPreferenceStoreDelegate::load(const std::filesystem::path& path, Color& va
 }
 
 bool QPreferenceStoreDelegate::load(
-  const std::filesystem::path& path, QKeySequence& value)
-{
-  if (const auto iValue = m_cache.find(path); iValue != m_cache.end())
-  {
-    const auto& jsonValue = iValue->second;
-    if (jsonValue.isString())
-    {
-      value = QKeySequence::fromString(jsonValue.toString(), QKeySequence::PortableText);
-      return true;
-    }
-  }
-
-  return false;
-}
-
-bool QPreferenceStoreDelegate::load(
   const std::filesystem::path& path, std::vector<QKeySequence>& value)
 {
   if (const auto iValue = m_cache.find(path); iValue != m_cache.end())
@@ -297,13 +281,6 @@ void QPreferenceStoreDelegate::save(
 void QPreferenceStoreDelegate::save(const std::filesystem::path& path, const Color& value)
 {
   save(path, value.toString());
-}
-
-void QPreferenceStoreDelegate::save(
-  const std::filesystem::path& path, const QKeySequence& value)
-{
-  m_cache[path] = QJsonValue{value.toString(QKeySequence::PortableText)};
-  triggerSaveChanges();
 }
 
 void QPreferenceStoreDelegate::save(

--- a/lib/TbUiLib/src/QPreferenceStoreDelegate.cpp
+++ b/lib/TbUiLib/src/QPreferenceStoreDelegate.cpp
@@ -23,6 +23,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QFileSystemWatcher>
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QKeySequence>
@@ -34,6 +35,9 @@
 #include "Macros.h"
 #include "ui/QPathUtils.h"
 
+#include "kd/ranges/to.h"
+
+#include <ranges>
 #include <unordered_map>
 
 namespace tb::ui
@@ -227,6 +231,37 @@ bool QPreferenceStoreDelegate::load(
   return false;
 }
 
+bool QPreferenceStoreDelegate::load(
+  const std::filesystem::path& path, std::vector<QKeySequence>& value)
+{
+  if (const auto iValue = m_cache.find(path); iValue != m_cache.end())
+  {
+    const auto& jsonValue = iValue->second;
+    if (jsonValue.isArray())
+    {
+      const auto jsonArray = jsonValue.toArray();
+      if (std::ranges::all_of(jsonArray, [](const auto& x) { return x.isString(); }))
+      {
+        value =
+          jsonArray | std::views::transform([](const auto& x) {
+            return QKeySequence::fromString(x.toString(), QKeySequence::PortableText);
+          })
+          | kdl::ranges::to<std::vector>();
+        return true;
+      }
+    }
+    else if (jsonValue.isString())
+    {
+      // fallback for legacy preference files
+      value.push_back(
+        QKeySequence::fromString(jsonValue.toString(), QKeySequence::PortableText));
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void QPreferenceStoreDelegate::save(const std::filesystem::path& path, const bool value)
 {
   m_cache[path] = QJsonValue{value};
@@ -268,6 +303,19 @@ void QPreferenceStoreDelegate::save(
   const std::filesystem::path& path, const QKeySequence& value)
 {
   m_cache[path] = QJsonValue{value.toString(QKeySequence::PortableText)};
+  triggerSaveChanges();
+}
+
+void QPreferenceStoreDelegate::save(
+  const std::filesystem::path& path, const std::vector<QKeySequence>& value)
+{
+  auto jsonArray = QJsonArray{};
+  for (const auto& keySequence : value)
+  {
+    jsonArray.push_back(QJsonValue{keySequence.toString(QKeySequence::PortableText)});
+  }
+
+  m_cache[path] = std::move(jsonArray);
   triggerSaveChanges();
 }
 

--- a/lib/TbUiLib/test-utils/include/ui/StringMakers.h
+++ b/lib/TbUiLib/test-utils/include/ui/StringMakers.h
@@ -22,7 +22,9 @@
 #pragma once
 
 class QJsonValue;
+class QKeySequence;
 class QString;
 
 std::ostream& operator<<(std::ostream& lhs, const QJsonValue& rhs);
+std::ostream& operator<<(std::ostream& lhs, const QKeySequence& rhs);
 std::ostream& operator<<(std::ostream& lhs, const QString& rhs);

--- a/lib/TbUiLib/test-utils/src/StringMakers.cpp
+++ b/lib/TbUiLib/test-utils/src/StringMakers.cpp
@@ -20,6 +20,7 @@
 #include "ui/StringMakers.h"
 
 #include <QJsonValue>
+#include <QKeySequence>
 #include <QString>
 #include <QVariant>
 
@@ -34,6 +35,11 @@ std::ostream& operator<<(std::ostream& lhs, const QJsonValue& rhs)
            "QJsonValue<{}>({})",
            asVariant.typeName(),
            qUtf8Printable(asVariant.toString()));
+}
+
+std::ostream& operator<<(std::ostream& lhs, const QKeySequence& rhs)
+{
+  return lhs << qUtf8Printable(rhs.toString(QKeySequence::NativeText));
 }
 
 std::ostream& operator<<(std::ostream& lhs, const QString& rhs)

--- a/lib/TbUiLib/test/CMakeLists.txt
+++ b/lib/TbUiLib/test/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(TbUiLibTest
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RunAllTests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ActionContext.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ActionInfo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Actions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CameraTool3D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ClipTool.cpp

--- a/lib/TbUiLib/test/src/tst_ActionInfo.cpp
+++ b/lib/TbUiLib/test/src/tst_ActionInfo.cpp
@@ -20,10 +20,12 @@
 #include <QKeySequence>
 
 #include "ui/ActionInfo.h"
+#include "ui/StringMakers.h"
 
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 
 namespace tb::ui
@@ -34,7 +36,7 @@ namespace
 {
 
 auto makeActionInfo(
-  const Preference<QKeySequence>& preference,
+  const Preference<std::vector<QKeySequence>>& preference,
   const ActionContext::Type actionContext = ActionContext::Any)
 {
   return ActionInfo{
@@ -53,8 +55,10 @@ TEST_CASE("ActionInfo")
   {
     SECTION("Ignores empty shortcuts")
     {
-      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{}};
-      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{}};
+      const auto preference1 =
+        Preference<std::vector<QKeySequence>>{"Action 1", {QKeySequence{}}};
+      const auto preference2 =
+        Preference<std::vector<QKeySequence>>{"Action 2", {QKeySequence{}}};
 
       CHECK_THAT(
         findConflicts({makeActionInfo(preference1), makeActionInfo(preference2)}),
@@ -63,8 +67,10 @@ TEST_CASE("ActionInfo")
 
     SECTION("Ignores distinct shortcuts")
     {
-      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
-      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'B'}};
+      const auto preference1 =
+        Preference<std::vector<QKeySequence>>{"Action 1", {QKeySequence{'A'}}};
+      const auto preference2 =
+        Preference<std::vector<QKeySequence>>{"Action 2", {QKeySequence{'B'}}};
 
       CHECK_THAT(
         findConflicts({makeActionInfo(preference1), makeActionInfo(preference2)}),
@@ -73,8 +79,10 @@ TEST_CASE("ActionInfo")
 
     SECTION("Ignores matching shortcuts in disjoint action contexts")
     {
-      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
-      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'A'}};
+      const auto preference1 =
+        Preference<std::vector<QKeySequence>>{"Action 1", {QKeySequence{'A'}}};
+      const auto preference2 =
+        Preference<std::vector<QKeySequence>>{"Action 2", {QKeySequence{'A'}}};
 
       CHECK_THAT(
         findConflicts({
@@ -90,8 +98,10 @@ TEST_CASE("ActionInfo")
 
     SECTION("Reports matching shortcuts in overlapping action contexts")
     {
-      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
-      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'A'}};
+      const auto preference1 =
+        Preference<std::vector<QKeySequence>>{"Action 1", {QKeySequence{'A'}}};
+      const auto preference2 =
+        Preference<std::vector<QKeySequence>>{"Action 2", {QKeySequence{'A'}}};
 
       CHECK_THAT(
         findConflicts({
@@ -107,9 +117,12 @@ TEST_CASE("ActionInfo")
 
     SECTION("Reports later duplicates against the first matching shortcut")
     {
-      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
-      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'A'}};
-      const auto preference3 = Preference<QKeySequence>{"Action 3", QKeySequence{'A'}};
+      const auto preference1 =
+        Preference<std::vector<QKeySequence>>{"Action 1", {QKeySequence{'A'}}};
+      const auto preference2 =
+        Preference<std::vector<QKeySequence>>{"Action 2", {QKeySequence{'A'}}};
+      const auto preference3 =
+        Preference<std::vector<QKeySequence>>{"Action 3", {QKeySequence{'A'}}};
 
       CHECK_THAT(
         findConflicts({
@@ -118,6 +131,55 @@ TEST_CASE("ActionInfo")
           makeActionInfo(preference3),
         }),
         UnorderedEquals(std::vector<size_t>{0, 1, 0, 2}));
+    }
+
+    SECTION("Reports matching shortcuts in multi-shortcut preferences")
+    {
+      const auto preference1 = Preference<std::vector<QKeySequence>>{
+        "Action 1", {QKeySequence{'A'}, QKeySequence{'B'}}};
+
+      const auto preference2 = GENERATE(
+        Preference<std::vector<QKeySequence>>{
+          "Action 2", {QKeySequence{'C'}, QKeySequence{'B'}}},
+        Preference<std::vector<QKeySequence>>{
+          "Action 2", {QKeySequence{'B'}, QKeySequence{'C'}}});
+
+      CAPTURE(preference2);
+
+      CHECK_THAT(
+        findConflicts({
+          makeActionInfo(preference1),
+          makeActionInfo(preference2),
+        }),
+        UnorderedEquals(std::vector<size_t>{0, 1}));
+    }
+
+    SECTION("Ignores duplicate shortcuts in the same multi-shortcut preference")
+    {
+      const auto preference = Preference<std::vector<QKeySequence>>{
+        "Action", {QKeySequence{'A'}, QKeySequence{'A'}}};
+
+      CHECK_THAT(
+        findConflicts({
+          makeActionInfo(preference),
+        }),
+        UnorderedEquals(std::vector<size_t>{}));
+    }
+
+    SECTION(
+      "Reports duplicate shortcuts in the same preference only against other actions")
+    {
+      const auto preference1 = Preference<std::vector<QKeySequence>>{
+        "Action 1", {QKeySequence{'A'}, QKeySequence{'A'}}};
+      const auto preference2 =
+        Preference<std::vector<QKeySequence>>{"Action 2", {QKeySequence{'A'}}};
+
+      CHECK_THAT(
+        findConflicts({
+          makeActionInfo(preference1),
+          makeActionInfo(preference2),
+        }),
+        UnorderedEquals(std::vector<size_t>{0, 1}));
     }
   }
 }

--- a/lib/TbUiLib/test/src/tst_ActionInfo.cpp
+++ b/lib/TbUiLib/test/src/tst_ActionInfo.cpp
@@ -1,0 +1,125 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QKeySequence>
+
+#include "ui/ActionInfo.h"
+
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+
+namespace tb::ui
+{
+using Catch::Matchers::UnorderedEquals;
+
+namespace
+{
+
+auto makeActionInfo(
+  const Preference<QKeySequence>& preference,
+  const ActionContext::Type actionContext = ActionContext::Any)
+{
+  return ActionInfo{
+    ActionInfoType::Menu,
+    preference.path,
+    actionContext,
+    preference,
+  };
+}
+
+} // namespace
+
+TEST_CASE("ActionInfo")
+{
+  SECTION("findConflicts")
+  {
+    SECTION("Ignores empty shortcuts")
+    {
+      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{}};
+      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{}};
+
+      CHECK_THAT(
+        findConflicts({makeActionInfo(preference1), makeActionInfo(preference2)}),
+        UnorderedEquals(std::vector<size_t>{}));
+    }
+
+    SECTION("Ignores distinct shortcuts")
+    {
+      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
+      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'B'}};
+
+      CHECK_THAT(
+        findConflicts({makeActionInfo(preference1), makeActionInfo(preference2)}),
+        UnorderedEquals(std::vector<size_t>{}));
+    }
+
+    SECTION("Ignores matching shortcuts in disjoint action contexts")
+    {
+      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
+      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'A'}};
+
+      CHECK_THAT(
+        findConflicts({
+          makeActionInfo(
+            preference1,
+            ActionContext::View2D | ActionContext::NoSelection | ActionContext::NoTool),
+          makeActionInfo(
+            preference2,
+            ActionContext::View3D | ActionContext::NoSelection | ActionContext::NoTool),
+        }),
+        UnorderedEquals(std::vector<size_t>{}));
+    }
+
+    SECTION("Reports matching shortcuts in overlapping action contexts")
+    {
+      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
+      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'A'}};
+
+      CHECK_THAT(
+        findConflicts({
+          makeActionInfo(
+            preference1,
+            ActionContext::View2D | ActionContext::NoSelection | ActionContext::NoTool),
+          makeActionInfo(
+            preference2,
+            ActionContext::AnyView | ActionContext::NoSelection | ActionContext::NoTool),
+        }),
+        UnorderedEquals(std::vector<size_t>{0, 1}));
+    }
+
+    SECTION("Reports later duplicates against the first matching shortcut")
+    {
+      const auto preference1 = Preference<QKeySequence>{"Action 1", QKeySequence{'A'}};
+      const auto preference2 = Preference<QKeySequence>{"Action 2", QKeySequence{'A'}};
+      const auto preference3 = Preference<QKeySequence>{"Action 3", QKeySequence{'A'}};
+
+      CHECK_THAT(
+        findConflicts({
+          makeActionInfo(preference1),
+          makeActionInfo(preference2),
+          makeActionInfo(preference3),
+        }),
+        UnorderedEquals(std::vector<size_t>{0, 1, 0, 2}));
+    }
+  }
+}
+
+} // namespace tb::ui

--- a/lib/TbUiLib/test/src/tst_QPreferenceStore.cpp
+++ b/lib/TbUiLib/test/src/tst_QPreferenceStore.cpp
@@ -19,6 +19,7 @@
 
 #include <QCoreApplication>
 #include <QJsonObject>
+#include <QKeySequence>
 #include <QLockFile>
 
 #include "Observer.h"
@@ -33,6 +34,7 @@
 #include <filesystem>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
@@ -130,6 +132,23 @@ TEST_CASE("QPreferenceStore")
     auto value = std::string{};
     CHECK(preferenceStore.load("some/path", value));
     CHECK(value == "asdf");
+  }
+
+  SECTION("loads legacy shortcut string as key sequence vector")
+  {
+    env.createFile(preferenceFilename, R"({
+  "some/path": "Ctrl+Alt+W"
+}
+)");
+
+    auto preferenceStore = QPreferenceStore{pathAsQString(preferenceFilePath), 50ms};
+
+    auto value = std::vector<QKeySequence>{};
+    CHECK(preferenceStore.load("some/path", value));
+    CHECK(
+      value
+      == std::vector<QKeySequence>{
+        QKeySequence::fromString("Ctrl+Alt+W", QKeySequence::PortableText)});
   }
 
   SECTION("preferences aren't saved immediately")


### PR DESCRIPTION
To improve support for people using multiple keyboard layouts (e.g. for non-latin languages), we add one column to the keyboard shortcut editor. For each entry, a user can set an alternative shortcut. This way, a user switching between latin and non-latin layouts can set up up their shortcuts so that they work in both.

In a followup, we will add the ability to export / import the shortcut preferences, and support for builtin presets for some languages.