### PR TITLE
Don't clear recent documents when loading a map from the commandline

### DIFF
--- a/lib/TbUiLib/src/RecentDocuments.cpp
+++ b/lib/TbUiLib/src/RecentDocuments.cpp
@@ -79,6 +79,7 @@ RecentDocuments::RecentDocuments(
   , m_filterPredicate{std::move(filterPredicate)}
 {
   contract_pre(m_maxSize > 0);
+  reload();
 }
 
 std::vector<std::filesystem::path> RecentDocuments::recentDocuments() const

--- a/lib/TbUiLib/test/src/tst_RecentDocuments.cpp
+++ b/lib/TbUiLib/test/src/tst_RecentDocuments.cpp
@@ -77,23 +77,29 @@ TEST_CASE("RecentDocuments")
     });
 
     auto recentDocuments = RecentDocuments{5, filterPredicate};
-    CHECK(recentDocuments.recentDocuments().empty());
+    CHECK(
+      recentDocuments.recentDocuments()
+      == std::vector<std::filesystem::path>{
+        "1.map",
+        "2.map",
+      });
   }
 
   SECTION("reload")
   {
-    saveRecentDocuments({
-      "1.map",
-      "2.map",
-      "filter.map",
-    });
+    saveRecentDocuments({});
 
     auto recentDocuments = RecentDocuments{5, filterPredicate};
     REQUIRE(recentDocuments.recentDocuments().empty());
 
     auto spy = QSignalSpy{&recentDocuments, SIGNAL(didChange())};
-
     REQUIRE(spy.count() == 0);
+
+    saveRecentDocuments({
+      "1.map",
+      "2.map",
+      "filter.map",
+    });
 
     recentDocuments.reload();
     CHECK(


### PR DESCRIPTION
If a document was loaded on startup, before the load timer loads the recent documents, the recent documents on disk would be overwritten by the single added document. Loading the documents eagerly on construction fixes the issues.

Closes #5288 