### PR TITLE
"Flood fill" select for coplanar faces

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -266,7 +266,7 @@ Finally, you can deselect everything by left clicking in the void, or by choosin
 
 ![Selected brush face](images/BrushFaceSelection.png)
 
-To select a brush face, you need to hold #key(Shift) and left click it in the 3D viewport. You can select multiple brush faces by additionally holding #key(Ctrl). To select all faces of a brush, you can left double click that brush while holding #key(Shift). If you additionally hold #key(Ctrl), the faces are added to the current selection. To paint select brush faces, first select one brush face, then left drag while holding #key(Ctrl) and #key(Shift). To deselect all brush faces, simply click in the void or choose #menu(Menu/Edit/Deselect All).
+To select a brush face, you need to hold #key(Shift) and left click it in the 3D viewport. You can select multiple brush faces by additionally holding #key(Ctrl). To select all faces of a brush, you can left double click that brush while holding #key(Shift). If you additionally hold #key(Ctrl), the faces are added to the current selection. To flood fill a whole coplanar surface at once - even where it spans several touching brushes - left double click a face while holding #key(Shift)#key(Alt). Again, hold #key(Ctrl) to add the faces to the current selection. To paint select brush faces, first select one brush face, then left drag while holding #key(Ctrl) and #key(Shift). To deselect all brush faces, simply click in the void or choose #menu(Menu/Edit/Deselect All).
 
 # Editing
 

--- a/lib/TbMdlLib/include/mdl/ModelUtils.h
+++ b/lib/TbMdlLib/include/mdl/ModelUtils.h
@@ -21,6 +21,7 @@
 
 #include "mdl/Hit.h"
 #include "mdl/HitType.h"
+#include "mdl/NodeTree.h"
 
 #include "vm/bbox.h"
 
@@ -37,6 +38,9 @@ class BrushNode;
 class EntityNode;
 class LayerNode;
 class EditorContext;
+
+template <typename T, typename U>
+class octree;
 
 HitType::Type nodeHitType();
 
@@ -93,6 +97,21 @@ std::vector<Node*> collectSelectableNodes(
 std::vector<BrushFaceHandle> collectSelectedBrushFaces(const std::vector<Node*>& nodes);
 std::vector<BrushFaceHandle> collectSelectableBrushFaces(
   const std::vector<Node*>& nodes, const EditorContext& editorContext);
+
+/**
+ * Floods out from the given face and returns every face that forms one connected,
+ * coplanar surface with it, including across touching brushes. Faces only join where they
+ * share an edge, so corners and gaps don't bridge the region.
+ *
+ * Candidate brushes are gathered by querying `nodeTree` with the bounds of each face the
+ * flood reaches, so only brushes near the surface are visited rather than the whole map.
+ * `editorContext` filters out faces that aren't selectable (e.g. on hidden or locked
+ * brushes), which also keeps those brushes from bridging the region.
+ */
+std::vector<BrushFaceHandle> collectConnectedCoplanarFaces(
+  const BrushFaceHandle& startFace,
+  const EditorContext& editorContext,
+  const NodeTree& nodeTree);
 
 vm::bbox3d computeLogicalBounds(
   const std::vector<Node*>& nodes, const vm::bbox3d& defaultBounds = vm::bbox3d());

--- a/lib/TbMdlLib/include/mdl/NodeTree.h
+++ b/lib/TbMdlLib/include/mdl/NodeTree.h
@@ -1,0 +1,32 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "mdl/Octree.h"
+
+#include <cstddef>
+
+namespace tb::mdl
+{
+class Node;
+
+using NodeTree = octree<double, Node*>;
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/WorldNode.h
+++ b/lib/TbMdlLib/include/mdl/WorldNode.h
@@ -25,7 +25,7 @@
 #include "mdl/IdType.h"
 #include "mdl/MapFormat.h"
 #include "mdl/Node.h"
-#include "mdl/Octree.h"
+#include "mdl/NodeTree.h"
 
 #include <memory>
 #include <vector>
@@ -46,7 +46,6 @@ private:
   LayerNode* m_defaultLayer;
   std::unique_ptr<ValidatorRegistry> m_validatorRegistry;
 
-  using NodeTree = octree<double, Node*>;
   std::unique_ptr<NodeTree> m_nodeTree;
   bool m_updateNodeTree;
 

--- a/lib/TbMdlLib/src/ModelUtils.cpp
+++ b/lib/TbMdlLib/src/ModelUtils.cpp
@@ -26,10 +26,19 @@
 #include "mdl/NodeQueries.h"
 
 #include "kd/contracts.h"
+#include "kd/ranges/cartesian_product_view.h"
 #include "kd/ranges/to.h"
 #include "kd/stable_remove_duplicates.h"
 #include "kd/vector_utils.h"
 
+#include "vm/bbox.h"
+#include "vm/intersection.h"
+#include "vm/segment.h"
+
+#include <algorithm>
+#include <ranges>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace tb::mdl
@@ -383,6 +392,104 @@ std::vector<BrushFaceHandle> collectSelectableBrushFaces(
     nodes, [&](const BrushNode& brushNode, const BrushFace& brushFace) {
       return editorContext.selectable(brushNode, brushFace);
     });
+}
+
+std::vector<BrushFaceHandle> collectConnectedCoplanarFaces(
+  const BrushFaceHandle& startFace,
+  const EditorContext& editorContext,
+  const NodeTree& nodeTree)
+{
+  constexpr auto epsilon = vm::constants<double>::almost_zero();
+  const auto& startPlane = startFace.face().boundary();
+
+  struct Candidate
+  {
+    BrushFaceHandle handle;
+    std::vector<vm::segment3d> edges;
+    vm::bbox3d bounds;
+  };
+
+  const auto makeCandidate = [&](const BrushFaceHandle& handle) {
+    const auto vertices = handle.face().vertexPositions();
+    const auto edges =
+      handle.face().edges()
+      | std::views::transform([](const auto* edge) { return edge->segment(); });
+
+    auto builder = vm::bbox3d::builder{};
+    builder.add(std::begin(vertices), std::end(vertices));
+
+    return Candidate{
+      handle,
+      edges | kdl::ranges::to<std::vector>(),
+      builder.bounds().expand(epsilon),
+    };
+  };
+
+  const auto facesShareEdgeSegment = [](const auto& lhs, const auto& rhs) {
+    const auto allEdgePairs = kdl::views::cartesian_product(lhs, rhs);
+    return std::ranges::any_of(allEdgePairs, [](const auto& edgePair) {
+      const auto& [lhsEdge, rhsEdge] = edgePair;
+      return vm::segments_overlap(lhsEdge, rhsEdge, vm::Cd::almost_zero());
+    });
+  };
+
+  // Cache coplanar+selectable faces per brush node so a node hit from multiple flood
+  // directions has its face list computed only once. Querying the node tree keeps the
+  // flood local instead of scanning the whole map, and dropping unselectable faces stops
+  // hidden or locked brushes from bridging the region.
+  auto nodeCache = std::unordered_map<Node*, std::vector<BrushFaceHandle>>{};
+
+  const auto coplanarFacesOf = [&](Node* node) -> const std::vector<BrushFaceHandle>& {
+    auto [it, inserted] = nodeCache.emplace(node, std::vector<BrushFaceHandle>{});
+    if (inserted)
+    {
+      it->second = collectSelectableBrushFaces(std::vector<Node*>{node}, editorContext)
+                   | std::views::filter([&](const auto& handle) {
+                       return handle.face().coplanarWith(startPlane);
+                     })
+                   | kdl::ranges::to<std::vector>();
+    }
+    return it->second;
+  };
+
+  const auto coplanarFacesNear = [&](const vm::bbox3d& bounds) {
+    auto result = std::vector<BrushFaceHandle>{};
+    for (auto* node : nodeTree.find_intersectors(bounds))
+    {
+      kdl::vec_append(result, coplanarFacesOf(node));
+    }
+    return result;
+  };
+
+  // Flood out from the start face, re-querying the tree around each face we reach so a
+  // long row of brushes is followed without ever visiting the rest of the map.
+  auto region = std::vector<BrushFaceHandle>{};
+  auto visited = kdl::vector_set<BrushFaceHandle>{startFace};
+  auto pending = std::vector<Candidate>{};
+  pending.push_back(makeCandidate(startFace));
+
+  while (!pending.empty())
+  {
+    const auto current = kdl::vec_pop_back(pending);
+    region.push_back(current.handle);
+
+    for (const auto& handle : coplanarFacesNear(current.bounds))
+    {
+      if (visited.count(handle) == 0)
+      {
+        auto candidate = makeCandidate(handle);
+        if (
+          current.bounds.intersects(candidate.bounds)
+          && facesShareEdgeSegment(current.edges, candidate.edges))
+        {
+          visited.insert(handle);
+          pending.push_back(std::move(candidate));
+        }
+      }
+    }
+  }
+
+  return region;
 }
 
 vm::bbox3d computeLogicalBounds(

--- a/lib/TbMdlLib/src/WorldNode.cpp
+++ b/lib/TbMdlLib/src/WorldNode.cpp
@@ -79,7 +79,7 @@ MapFormat WorldNode::mapFormat() const
   return m_mapFormat;
 }
 
-const WorldNode::NodeTree& WorldNode::nodeTree() const
+const NodeTree& WorldNode::nodeTree() const
 {
   return *m_nodeTree;
 }

--- a/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
@@ -635,4 +635,150 @@ TEST_CASE("ModelUtils.filterNodes")
   }
 }
 
+TEST_CASE("ModelUtils.collectConnectedCoplanarFaces")
+{
+  constexpr auto worldBounds = vm::bbox3d{8192.0};
+  constexpr auto mapFormat = MapFormat::Standard;
+  const auto builder = BrushBuilder{mapFormat, worldBounds};
+
+  auto worldNode = WorldNode{{}, {}, mapFormat};
+  auto editorContext = EditorContext{};
+
+  // The flood finds adjacent brushes by querying the world's node tree by bounds rather
+  // than scanning the whole map.
+  const auto& nodeTree = worldNode.nodeTree();
+
+  // Boxes are 64 tall sitting on z=0, so every top face lands on the same plane (z=64).
+  // Laying them out in xy makes the coplanar regions easy to reason about.
+  const auto boxBounds = [&](const vm::bbox3d& bounds) {
+    auto* node = new BrushNode{builder.createCuboid(bounds, "material") | kdl::value()};
+    worldNode.defaultLayer()->addChild(node);
+    return node;
+  };
+
+  const auto box = [&](
+                     const double x0, const double y0, const double x1, const double y1) {
+    return boxBounds(vm::bbox3d{{x0, y0, 0}, {x1, y1, 64}});
+  };
+
+  const auto topFace = [](auto* node) {
+    return BrushFaceHandle{node, *node->brush().findFace(vm::vec3d{0, 0, 1})};
+  };
+
+  SECTION("Single cube selects only the clicked face")
+  {
+    auto* a = box(0, 0, 64, 64);
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a)}));
+  }
+
+  SECTION("Two boxes sharing a wall select both coplanar top faces")
+  {
+    auto* a = box(0, 0, 64, 64);
+    auto* b = box(64, 0, 128, 64);
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(
+      region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a), topFace(b)}));
+  }
+
+  SECTION("Three boxes in a row select all three top faces")
+  {
+    auto* a = box(0, 0, 64, 64);
+    auto* b = box(64, 0, 128, 64);
+    auto* c = box(128, 0, 192, 64);
+
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(
+      region,
+      UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a), topFace(b), topFace(c)}));
+  }
+
+  SECTION("Traversal stops at a perpendicular face")
+  {
+    auto* a = box(0, 0, 64, 64);
+    // A wall standing on a's +Y edge: it shares that edge but its faces are perpendicular
+    // to a's top face, so none of them are coplanar.
+    boxBounds(vm::bbox3d{{0, 64, 64}, {64, 128, 128}});
+
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+
+    CHECK_THAT(region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a)}));
+  }
+
+  SECTION("T-junction with partial edge overlap is connected")
+  {
+    auto* a = box(0, 0, 64, 64);
+    // b touches only part of a's +X edge (y in [16, 48]).
+    auto* b = box(64, 16, 128, 48);
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(
+      region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a), topFace(b)}));
+  }
+
+  SECTION("Vertex-only contact is not connected")
+  {
+    auto* a = box(0, 0, 64, 64);
+    // b touches a only at the single corner (64, 64).
+    box(64, 64, 128, 128);
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a)}));
+  }
+
+  SECTION("A gap between coplanar faces is not connected")
+  {
+    auto* a = box(0, 0, 64, 64);
+    // b is coplanar but separated from a by a 16 unit gap.
+    box(80, 0, 144, 64);
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a)}));
+  }
+
+  SECTION("A hidden or locked brush does not bridge the region")
+  {
+    auto* a = box(0, 0, 64, 64);
+    auto* b = box(64, 0, 128, 64);
+    auto* c = box(128, 0, 192, 64);
+
+    // With b selectable the whole row is connected.
+    CHECK_THAT(
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree),
+      UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a), topFace(b), topFace(c)}));
+
+    // Locking b makes it unselectable, so it neither gets selected nor bridges a to c.
+    b->setLockState(LockState::Locked);
+    const auto region =
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree);
+    CHECK_THAT(region, UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a)}));
+  }
+
+  SECTION("A far-away coplanar cluster is not selected")
+  {
+    auto* a = box(0, 0, 64, 64);
+    auto* b = box(64, 0, 128, 64);
+
+    // c and far form their own connected, coplanar cluster far across the map; the chain
+    // back to the a-b row is broken by a wide gap.
+    auto* c = box(4096, 0, 4160, 64);
+    auto* far = box(4160, 0, 4224, 64);
+
+    // Flooding from that cluster selects far, so it is a face that would be selected if
+    // the flood ever reached it.
+    CHECK_THAT(
+      collectConnectedCoplanarFaces(topFace(c), editorContext, nodeTree),
+      UnorderedEquals(std::vector<BrushFaceHandle>{topFace(c), topFace(far)}));
+
+    // Flooding from the a-b row never crosses the gap, so far stays out of the region.
+    CHECK_THAT(
+      collectConnectedCoplanarFaces(topFace(a), editorContext, nodeTree),
+      UnorderedEquals(std::vector<BrushFaceHandle>{topFace(a), topFace(b)}));
+  }
+}
+
 } // namespace tb::mdl

--- a/lib/TbUiLib/src/SelectionTool.cpp
+++ b/lib/TbUiLib/src/SelectionTool.cpp
@@ -44,6 +44,8 @@
 #include "kd/contracts.h"
 
 #include <algorithm>
+#include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -91,21 +93,39 @@ std::vector<mdl::Node*> collectSelectableChildren(
   return mdl::collectSelectableNodes(node->children(), editorContext);
 }
 
+bool canHandleLeftClick(
+  const InputState& inputState, const mdl::EditorContext& editorContext)
+{
+  return inputState.mouseButtonsPressed(MouseButtons::Left)
+         && editorContext.canChangeSelection();
+}
+
 bool handleClick(const InputState& inputState, const mdl::EditorContext& editorContext)
 {
-  if (!inputState.mouseButtonsPressed(MouseButtons::Left))
-  {
-    return false;
-  }
-  if (!inputState.checkModifierKeys(
-        ModifierKeyPressed::DontCare,
-        ModifierKeyPressed::No,
-        ModifierKeyPressed::DontCare))
-  {
-    return false;
-  }
+  return canHandleLeftClick(inputState, editorContext)
+         && inputState.checkModifierKeys(
+           ModifierKeyPressed::DontCare,
+           ModifierKeyPressed::No,
+           ModifierKeyPressed::DontCare);
+}
 
-  return editorContext.canChangeSelection();
+void replaceOrExtendFaceSelection(
+  mdl::Map& map,
+  const InputState& inputState,
+  const std::vector<mdl::BrushFaceHandle>& faces,
+  std::string_view transactionName)
+{
+  auto transaction = mdl::Transaction{map, std::string{transactionName}};
+  if (!isMultiClick(inputState))
+  {
+    deselectAll(map);
+  }
+  else if (map.selection().hasNodes())
+  {
+    convertToFaceSelection(map);
+  }
+  selectBrushFaces(map, faces);
+  transaction.commit();
 }
 
 void adjustGrid(const InputState& inputState, mdl::Grid& grid)
@@ -380,21 +400,8 @@ bool SelectionTool::mouseDoubleClick(const InputState& inputState)
       const auto& face = faceHandle->face();
       if (editorContext.selectable(*brushNode, face))
       {
-        if (isMultiClick(inputState))
-        {
-          if (map.selection().hasNodes())
-          {
-            convertToFaceSelection(map);
-          }
-          selectBrushFaces(map, mdl::toHandles(brushNode));
-        }
-        else
-        {
-          auto transaction = mdl::Transaction{map, "Select Brush Faces"};
-          deselectAll(map);
-          selectBrushFaces(map, mdl::toHandles(brushNode));
-          transaction.commit();
-        }
+        replaceOrExtendFaceSelection(
+          map, inputState, mdl::toHandles(brushNode), "Select Brush Faces");
       }
     }
   }

--- a/lib/TbUiLib/src/SelectionTool.cpp
+++ b/lib/TbUiLib/src/SelectionTool.cpp
@@ -36,6 +36,7 @@
 #include "mdl/Node.h"
 #include "mdl/Transaction.h"
 #include "mdl/TransactionScope.h"
+#include "mdl/WorldNode.h"
 #include "render/RenderContext.h"
 #include "ui/GestureTracker.h"
 #include "ui/InputState.h"
@@ -80,6 +81,12 @@ bool isFaceClick(const InputState& inputState)
 bool isMultiClick(const InputState& inputState)
 {
   return inputState.modifierKeysDown(ModifierKeys::CtrlCmd);
+}
+
+bool isCoplanarFaceClick(const InputState& inputState)
+{
+  return inputState.checkModifierKeys(
+    ModifierKeyPressed::DontCare, ModifierKeyPressed::Yes, ModifierKeyPressed::Yes);
 }
 
 const mdl::Hit& firstHit(const InputState& inputState, const mdl::HitFilter& hitFilter)
@@ -385,6 +392,29 @@ bool SelectionTool::mouseDoubleClick(const InputState& inputState)
 
   auto& map = m_document.map();
   const auto& editorContext = map.editorContext();
+
+  // Shift+Alt double click flood fills the clicked face's coplanar surface. Alt is
+  // held here, which handleClick() rejects, so we have to catch it before that.
+  if (isCoplanarFaceClick(inputState))
+  {
+    if (!canHandleLeftClick(inputState, editorContext))
+    {
+      return false;
+    }
+
+    const auto hit = firstHit(inputState, type(mdl::BrushNode::BrushHitType));
+    if (const auto faceHandle = mdl::hitToFaceHandle(hit))
+    {
+      if (editorContext.selectable(*faceHandle->node(), faceHandle->face()))
+      {
+        const auto region = mdl::collectConnectedCoplanarFaces(
+          *faceHandle, editorContext, map.worldNode().nodeTree());
+        replaceOrExtendFaceSelection(
+          map, inputState, region, "Select Connected Coplanar Faces");
+      }
+    }
+    return true;
+  }
 
   if (!handleClick(inputState, editorContext))
   {

--- a/lib/TbUiLib/test/src/tst_SelectionTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SelectionTool.cpp
@@ -314,6 +314,72 @@ TEST_CASE("SelectionTool")
             }
           }
 
+          WHEN("A brush node with a coplanar face exists and its front face is selected")
+          {
+            auto coplanarBrush =
+              builder.createCube(
+                32.0,
+                "left_face",
+                "right_face",
+                "front_face",
+                "back_face",
+                "top_face",
+                "bottom_face")
+              | kdl::and_then([&](auto b) {
+                  return b.transform(
+                           map.worldBounds(),
+                           vm::translation_matrix(vm::vec3d{32, 0, 0}),
+                           false)
+                         | kdl::transform([&]() { return std::move(b); });
+                })
+              | kdl::value();
+
+            auto* coplanarBrushNode = new mdl::BrushNode{std::move(coplanarBrush)};
+            addNodes(map, {{parentForNodes(map), {coplanarBrushNode}}});
+
+            const auto coplanarTopFaceIndex =
+              *coplanarBrushNode->brush().findFace("top_face");
+            mdl::selectBrushFaces(map, {{brushNode, frontFaceIndex}});
+
+            AND_WHEN("I select all adjacent coplanar faces")
+            {
+              inputState.setModifierKeys(ModifierKeys::Shift | ModifierKeys::Alt);
+              inputState.mouseDown(MouseButtons::Left);
+              tool.mouseDoubleClick(inputState);
+              inputState.mouseUp(MouseButtons::Left);
+
+              THEN("The clicked face's coplanar region is selected")
+              {
+                CHECK_THAT(
+                  map.selection().brushFaces,
+                  UnorderedEquals(std::vector<mdl::BrushFaceHandle>{
+                    {brushNode, topFaceIndex},
+                    {coplanarBrushNode, coplanarTopFaceIndex}}));
+                CHECK_FALSE(map.selection().hasNodes());
+              }
+            }
+
+            AND_WHEN("I add all adjacent coplanar faces")
+            {
+              inputState.setModifierKeys(
+                ModifierKeys::CtrlCmd | ModifierKeys::Shift | ModifierKeys::Alt);
+              inputState.mouseDown(MouseButtons::Left);
+              tool.mouseDoubleClick(inputState);
+              inputState.mouseUp(MouseButtons::Left);
+
+              THEN("The clicked face's coplanar region is added to the selection")
+              {
+                CHECK_THAT(
+                  map.selection().brushFaces,
+                  UnorderedEquals(std::vector<mdl::BrushFaceHandle>{
+                    {brushNode, frontFaceIndex},
+                    {brushNode, topFaceIndex},
+                    {coplanarBrushNode, coplanarTopFaceIndex}}));
+                CHECK_FALSE(map.selection().hasNodes());
+              }
+            }
+          }
+
           WHEN("I click once")
           {
             inputState.mouseDown(MouseButtons::Left);

--- a/lib/VmLib/include/vm/intersection.h
+++ b/lib/VmLib/include/vm/intersection.h
@@ -27,6 +27,7 @@
 #include "vm/plane.h"
 #include "vm/ray.h"
 #include "vm/scalar.h"
+#include "vm/segment.h"
 #include "vm/util.h"
 #include "vm/vec.h"
 
@@ -592,6 +593,48 @@ constexpr std::optional<T> intersect_line_line(const line<T, 2>& l1, const line<
   }
 
   return std::nullopt;
+}
+
+/**
+ * Checks whether the given segments are collinear and overlap in more than a single
+ * point, i.e. they share a stretch of their common line rather than just touching at an
+ * end.
+ *
+ * @tparam T the component type
+ * @tparam S the number of components
+ * @param lhs the first segment
+ * @param rhs the second segment
+ * @param epsilon an epsilon value
+ * @return true if the segments are collinear and overlap by more than the given epsilon,
+ * and false otherwise
+ */
+template <typename T, size_t S>
+bool segments_overlap(const segment<T, S>& lhs, const segment<T, S>& rhs, const T epsilon)
+{
+  const auto axis = lhs.end() - lhs.start();
+  const auto length = vm::length(axis);
+  if (length < epsilon)
+  {
+    return false;
+  }
+
+  const auto direction = axis / length;
+  const auto project = [&](const vec<T, S>& p) {
+    return dot(p - lhs.start(), direction);
+  };
+  const auto on_line = [&](const vec<T, S>& p, const T t) {
+    return is_equal(p, lhs.start() + direction * t, epsilon);
+  };
+
+  const auto t0 = project(rhs.start());
+  const auto t1 = project(rhs.end());
+  if (!on_line(rhs.start(), t0) || !on_line(rhs.end(), t1))
+  {
+    return false;
+  }
+
+  const auto overlap = min(length, max(t0, t1)) - max(T(0), min(t0, t1));
+  return overlap > epsilon;
 }
 
 /**

--- a/lib/VmLib/test/src/tst_intersection.cpp
+++ b/lib/VmLib/test/src/tst_intersection.cpp
@@ -24,6 +24,8 @@
 #include "vm/approx.h"
 #include "vm/intersection.h"
 #include "vm/quat.h"
+#include "vm/segment.h"
+#include "vm/segment_io.h" // IWYU pragma: keep
 #include "vm/vec.h"
 #include "vm/vec_ext.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
@@ -31,6 +33,7 @@
 #include <array>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 namespace vm
 {
@@ -509,5 +512,49 @@ TEST_CASE("intersection.intersect_bbox_polygon")
     // polygon edge intersects bbox
     CHECK(intersect_bbox_polygon(bbox4, std::begin(poly), std::end(poly)));
   }
+}
+
+TEST_CASE("intersection.segments_overlap")
+{
+  static constexpr auto epsilon = constants<double>::almost_zero();
+
+  const auto [s1, s2, expectedOverlap] = GENERATE(table<segment3d, segment3d, bool>({
+    // [==] [==] // disjoint
+    {{{0, 0, 0}, {3, 0, 0}}, {{4, 0, 0}, {7, 0, 0}}, false},
+    // [==][==] // abutting
+    {{{0, 0, 0}, {3, 0, 0}}, {{3, 0, 0}, {6, 0, 0}}, false},
+    // [==][==] // abutting, swapped
+    {{{0, 0, 0}, {3, 0, 0}}, {{-2, 0, 0}, {0, 0, 0}}, false},
+    // [==[]==] // overlap
+    {{{0, 0, 0}, {3, 0, 0}}, {{2, 0, 0}, {5, 0, 0}}, true},
+    // [==[]==] // overlap, swapped
+    {{{0, 0, 0}, {3, 0, 0}}, {{-1, 0, 0}, {2, 0, 0}}, true},
+    // [=[==]=] // s1 contains s2, no coincident ends
+    {{{0, 0, 0}, {3, 0, 0}}, {{1, 0, 0}, {2, 0, 0}}, true},
+    // [=[==]=] // s2 contains s1, no coincident ends
+    {{{0, 0, 0}, {3, 0, 0}}, {{-1, 0, 0}, {4, 0, 0}}, true},
+    // [=[===] // s1 contains s2, right ends coincide
+    {{{0, 0, 0}, {3, 0, 0}}, {{1, 0, 0}, {3, 0, 0}}, true},
+    // [===]=] // s1 contains s2, left ends coincide
+    {{{0, 0, 0}, {3, 0, 0}}, {{0, 0, 0}, {2, 0, 0}}, true},
+    // [===] // s1 and s2 coincide
+    {{{0, 0, 0}, {3, 0, 0}}, {{0, 0, 0}, {3, 0, 0}}, true},
+
+    // [==[]==] // overlap, but offset
+    {{{0, 0, 0}, {3, 0, 0}}, {{2, 0, 1}, {5, 0, 1}}, false},
+    // [===] // overlap, but crossing
+    {{{0, 0, 0}, {3, 0, 0}}, {{0, 0, 1}, {3, 0, -1}}, false},
+
+    // [==[]==] // overlap by 2* epsilon, just above threshold
+    {{{0, 0, 0}, {3, 0, 0}}, {{3 - 2 * epsilon, 0, 0}, {6 - 2 * epsilon, 0, 0}}, true},
+    // [==[]==] // overlap by epsilon, exactly at threshold
+    {{{0, 0, 0}, {3, 0, 0}}, {{3 - epsilon, 0, 0}, {6 - epsilon, 0, 0}}, false},
+    // [==[]==] // overlap by epsilon/2, just below threshold
+    {{{0, 0, 0}, {3, 0, 0}}, {{3 - epsilon / 2, 0, 0}, {6 - epsilon / 2, 0, 0}}, false},
+  }));
+
+  CAPTURE(s1, s2);
+
+  CHECK(segments_overlap(s1, s2, epsilon) == expectedOverlap);
 }
 } // namespace vm


### PR DESCRIPTION
This PR adds a way to select all coplanar faces across a connected surface at once. I've found it useful while building out the  upcoming "sweep tool" for extruding a set of faces (PR for that incoming soon). 

Hold Ctrl+Shift+Alt and double click a face and it flood fills out to every connected coplanar face, including across touching brushes. It reuses the existing brush-face double click conventions, Shift meaning face select and Ctrl making it additive. The flood itself is a small helper with unit tests. Also added a line in the manual for the feature. 

Feel free to adjust as you see fit. It was the best key combo I could come up with given existing shortcuts.