### PR TITLE
Read and write Quake 3 brush primitives

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -2736,17 +2736,18 @@ classname    Match against a brush entity class name
 
 The file format is specified by an array of maps under the key `fileformats`. The following formats are supported.
 
-Format           Description
-------           -----------
-Standard         Standard Quake map file
-Valve            Valve map file (like Standard, but with more control over UV mapping)
-Quake2           Quake 2 map file with Standard style texture info
-Quake2 (Valve)   Quake 2 map file with Valve style texture info
-Quake3 (legacy)  Quake 3 map file with Standard style texture info
-Quake3 (Valve)   Quake 3 map file with Valve style texture info
-Hexen2           Hexen 2 map file (like Quake, but with an additional, but unused value per face)
+Format                      Description
+------                      -----------
+Standard                    Standard Quake map file
+Valve                       Valve map file (like Standard, but with more control over UV mapping)
+Quake2                      Quake 2 map file with Standard style texture info
+Quake2 (Valve)              Quake 2 map file with Valve style texture info
+Quake3 (legacy)             Quake 3 map file with Standard style texture info
+Quake3 (Valve)              Quake 3 map file with Valve style texture info
+Quake3 (brush primitives)   Quake 3 map file with brush primitives
+Hexen2                      Hexen 2 map file (like Quake, but with an additional, but unused value per face)
 
-Note that the "Quake3" format, which will include Quake 3 brush primitives support, is not yet fully implemented and so is omitted from the list above. The "Quake3 (Valve)" format is as expressive for texture placement as the brush primitives format, but "Quake3 (Valve)" cannot be used to read existing map files that contain brush primitives. Also note that none of the Quake 3 formats yet support patch meshes.
+The "Quake3 (Valve)" format is as expressive for texture placement as the brush primitives format, but "Quake3 (Valve)" cannot be used to read existing map files that contain brush primitives.
 
 Each entry of the array must have the following structure:
 

--- a/app/TrenchBroom/resources/games/Neverball/GameConfig.cfg
+++ b/app/TrenchBroom/resources/games/Neverball/GameConfig.cfg
@@ -4,7 +4,7 @@
     "icon": "Icon.png",
     "experimental": true,
     "fileformats": [
-        { "format": "Quake3", "initialmap": "initial_neverball_map.map" }
+        { "format": "Quake3 (legacy)", "initialmap": "initial_neverball_map.map" }
     ],
     "filesystem": {
         "searchpath": ".",

--- a/app/TrenchBroom/resources/games/Quake3/GameConfig.cfg
+++ b/app/TrenchBroom/resources/games/Quake3/GameConfig.cfg
@@ -4,10 +4,9 @@
     "icon": "Icon.png",
     "experimental": true,
     "fileformats": [
-// brush primitives not yet implemented
-//        { "format": "Quake3" },
         { "format": "Quake3 (Valve)" },
-        { "format": "Quake3 (legacy)" }
+        { "format": "Quake3 (legacy)" },
+        { "format": "Quake3 (brush primitives)" }
     ],
     "filesystem": {
         "searchpath": "baseq3",

--- a/app/TrenchBroom/resources/games/Quetoo/GameConfig.cfg
+++ b/app/TrenchBroom/resources/games/Quetoo/GameConfig.cfg
@@ -4,7 +4,7 @@
     "icon": "Icon.png",
     "fileformats": [
         { "format": "Quake3 (Valve)" },
-        { "format": "Quake3" }
+        { "format": "Quake3 (legacy)" }
     ],
     "filesystem": {
         "searchpath": "default",

--- a/app/TrenchBroom/resources/games/Wrath/GameConfig.cfg
+++ b/app/TrenchBroom/resources/games/Wrath/GameConfig.cfg
@@ -4,9 +4,8 @@
     "icon": "Icon.png",
     "experimental": true,
     "fileformats": [
-// brush primitives not yet implemented
-//      { "format": "Quake3" },
         { "format": "Quake3 (Valve)" },
+        { "format": "Quake3 (brush primitives" },
         { "format": "Quake3 (legacy)" }
     ],
     "filesystem": {

--- a/lib/TbMdlLib/CMakeLists.txt
+++ b/lib/TbMdlLib/CMakeLists.txt
@@ -164,6 +164,7 @@ target_sources(TbMdlLib
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PropertyKeyWithDoubleQuotationMarksValidator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PropertyValueWithDoubleQuotationMarksValidator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PushSelection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Quake3BrushPrimitive.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Quake3Shader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Quake3ShaderParser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ReparentNodesCommand.cpp

--- a/lib/TbMdlLib/include/mdl/BrushFace.h
+++ b/lib/TbMdlLib/include/mdl/BrushFace.h
@@ -51,6 +51,7 @@ namespace mdl
 {
 class UVCoordSystem;
 class UVCoordSystemSnapshot;
+struct Quake3BrushPrimitiveMatrix;
 enum class WrapStyle;
 enum class MapFormat;
 
@@ -94,6 +95,13 @@ private:
 
   AssetReference<gl::Material> m_materialReference;
   std::unique_ptr<UVCoordSystem> m_uvCoordSystem;
+
+  // For faces loaded from a Quake 3 brush primitive: the raw texture matrix, kept until
+  // the material (and hence the real texture size) is available so the projection can
+  // be converted exactly. Null once the conversion has been finalized (or for any other
+  // face).
+  std::unique_ptr<Quake3BrushPrimitiveMatrix> m_brushPrimitiveMatrix;
+
   BrushFaceGeometry* m_geometry = nullptr;
 
   mutable size_t m_lineNumber = 0;
@@ -164,6 +172,25 @@ public:
     const vm::vec3d& vAxis,
     MapFormat mapFormat);
 
+  /**
+   * Creates a face from a Quake 3 brush primitive texture matrix.
+   *
+   * Used when loading a Quake 3 (brush primitives) format map. The matrix yields
+   * normalized texture coordinates, so a faithful conversion needs the texture size,
+   * which is not yet known while loading. The face is therefore given a provisional
+   * projection (assuming a 64x64 texture) and keeps the raw matrix so that
+   * finalizeBrushPrimitiveProjection() can recompute it once the material is assigned.
+   *
+   * The returned face has a UVCoordSystem matching the given format.
+   */
+  static Result<BrushFace> createFromBrushPrimitive(
+    const vm::vec3d& point1,
+    const vm::vec3d& point2,
+    const vm::vec3d& point3,
+    const BrushFaceAttributes& attributes,
+    const Quake3BrushPrimitiveMatrix& matrix,
+    MapFormat mapFormat);
+
   static Result<BrushFace> create(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
@@ -213,6 +240,17 @@ public:
   vm::vec2f modOffset(const vm::vec2f& offset) const;
 
   bool setMaterial(gl::Material* material);
+
+  /**
+   * Finalizes a face loaded from a Quake 3 brush primitive: if a raw texture matrix is
+   * still pending and the assigned material's texture has been loaded, the projection is
+   * recomputed using the real texture size and decomposed into offset/scale/rotation, and
+   * the pending matrix is cleared. Returns true if the projection changed.
+   *
+   * Does nothing (returns false) for faces without a pending matrix or whose texture is
+   * not yet available, in which case the provisional 64x64 projection is kept.
+   */
+  bool finalizeBrushPrimitiveProjection();
 
   vm::vec3d uAxis() const;
   vm::vec3d vAxis() const;

--- a/lib/TbMdlLib/include/mdl/BrushNode.h
+++ b/lib/TbMdlLib/include/mdl/BrushNode.h
@@ -82,6 +82,12 @@ public:
 
   void setFaceMaterial(size_t faceIndex, gl::Material* material);
 
+  /**
+   * Finalizes a face loaded from a Quake 3 brush primitive now that its texture is
+   * available. See BrushFace::finalizeBrushPrimitiveProjection().
+   */
+  void finalizeBrushPrimitiveFace(size_t faceIndex);
+
   bool contains(const Node& node) const;
   bool intersects(const Node& node) const;
 

--- a/lib/TbMdlLib/include/mdl/Map.h
+++ b/lib/TbMdlLib/include/mdl/Map.h
@@ -336,7 +336,10 @@ private:
   void updateFaceTags(const std::vector<BrushFaceHandle>& faces);
   void updateAllFaceTags();
 
-  void updateFaceTagsAfterResourcesWhereProcessed(
+  void updateFaceTagsAfterResourcesWereProcessed(
+    const std::vector<gl::ResourceId>& resourceIds);
+
+  void finalizeBrushPrimitiveFacesAfterResourcesWereProcessed(
     const std::vector<gl::ResourceId>& resourceIds);
 
 private: // validation

--- a/lib/TbMdlLib/include/mdl/MapFileSerializer.h
+++ b/lib/TbMdlLib/include/mdl/MapFileSerializer.h
@@ -79,7 +79,7 @@ private:
   size_t startLine();
 
 private: // threadsafe
-  PrecomputedString writeBrushFaces(const Brush& brush) const;
+  PrecomputedString writeBrush(const Brush& brush) const;
   virtual void writeBrushFace(std::ostream& stream, const BrushFace& face) const = 0;
 
   PrecomputedString writePatch(const BezierPatch& patch) const;

--- a/lib/TbMdlLib/include/mdl/MapFileSerializer.h
+++ b/lib/TbMdlLib/include/mdl/MapFileSerializer.h
@@ -79,8 +79,9 @@ private:
   size_t startLine();
 
 private: // threadsafe
-  virtual void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const = 0;
   PrecomputedString writeBrushFaces(const Brush& brush) const;
+  virtual void writeBrushFace(std::ostream& stream, const BrushFace& face) const = 0;
+
   PrecomputedString writePatch(const BezierPatch& patch) const;
 };
 

--- a/lib/TbMdlLib/include/mdl/MapFileSerializer.h
+++ b/lib/TbMdlLib/include/mdl/MapFileSerializer.h
@@ -42,17 +42,19 @@ class PatchNode;
 
 class MapFileSerializer : public NodeSerializer
 {
+protected:
+  struct PrecomputedString
+  {
+    std::string string;
+    size_t lineCount;
+  };
+
 private:
   using LineStack = std::vector<size_t>;
   LineStack m_startLineStack;
   size_t m_line;
   std::ostream& m_stream;
 
-  struct PrecomputedString
-  {
-    std::string string;
-    size_t lineCount;
-  };
   std::unordered_map<const Node*, PrecomputedString> m_nodeToPrecomputedString;
 
 public:
@@ -79,7 +81,7 @@ private:
   size_t startLine();
 
 private: // threadsafe
-  PrecomputedString writeBrush(const Brush& brush) const;
+  virtual PrecomputedString writeBrush(const Brush& brush) const;
   virtual void writeBrushFace(std::ostream& stream, const BrushFace& face) const = 0;
 
   PrecomputedString writePatch(const BezierPatch& patch) const;

--- a/lib/TbMdlLib/include/mdl/MapFormat.h
+++ b/lib/TbMdlLib/include/mdl/MapFormat.h
@@ -67,10 +67,6 @@ enum class MapFormat
    */
   Quake3_Valve,
   /**
-   * Quake 3 with brush primitives, also allows Quake 2 brushes
-   */
-  Quake3,
-  /**
    * Quake 3 with brush primitives (brushDef). Uses a parallel, face-aligned UV coordinate
    * system.
    */

--- a/lib/TbMdlLib/include/mdl/MapFormat.h
+++ b/lib/TbMdlLib/include/mdl/MapFormat.h
@@ -70,6 +70,11 @@ enum class MapFormat
    * Quake 3 with brush primitives, also allows Quake 2 brushes
    */
   Quake3,
+  /**
+   * Quake 3 with brush primitives (brushDef). Uses a parallel, face-aligned UV coordinate
+   * system.
+   */
+  Quake3_BrushPrimitives,
 };
 
 std::ostream& operator<<(std::ostream& lhs, MapFormat rhs);

--- a/lib/TbMdlLib/include/mdl/MapParser.h
+++ b/lib/TbMdlLib/include/mdl/MapParser.h
@@ -37,6 +37,7 @@ namespace mdl
 {
 class EntityProperty;
 class BrushFaceAttributes;
+struct Quake3BrushPrimitiveMatrix;
 
 class MapParser
 {
@@ -68,6 +69,15 @@ protected: // subclassing interface for users of the parser
     const BrushFaceAttributes& attribs,
     const vm::vec3d& uAxis,
     const vm::vec3d& vAxis,
+    ParserStatus& status) = 0;
+  virtual void onBrushPrimitiveFace(
+    const FileLocation& location,
+    MapFormat targetMapFormat,
+    const vm::vec3d& point1,
+    const vm::vec3d& point2,
+    const vm::vec3d& point3,
+    const BrushFaceAttributes& attribs,
+    const Quake3BrushPrimitiveMatrix& matrix,
     ParserStatus& status) = 0;
   virtual void onPatch(
     const FileLocation& startLocation,

--- a/lib/TbMdlLib/include/mdl/MapReader.h
+++ b/lib/TbMdlLib/include/mdl/MapReader.h
@@ -169,6 +169,15 @@ protected: // implement MapParser interface
     const vm::vec3d& uAxis,
     const vm::vec3d& vAxis,
     ParserStatus& status) override;
+  void onBrushPrimitiveFace(
+    const FileLocation& location,
+    MapFormat targetMapFormat,
+    const vm::vec3d& point1,
+    const vm::vec3d& point2,
+    const vm::vec3d& point3,
+    const BrushFaceAttributes& attribs,
+    const Quake3BrushPrimitiveMatrix& matrix,
+    ParserStatus& status) override;
   void onPatch(
     const FileLocation& startLocation,
     const FileLocation& endLocation,

--- a/lib/TbMdlLib/include/mdl/ParallelUVCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParallelUVCoordSystem.h
@@ -31,6 +31,13 @@
 namespace tb::mdl
 {
 
+/**
+ * Generates two vectors which are perpendicular to `normal` and perpendicular to each
+ * other. These are the axes of a parallel UV coordinate system with rotation 0, so they
+ * define the reference frame that a rotation angle is measured against.
+ */
+std::tuple<vm::vec3d, vm::vec3d> computeInitialAxes(const vm::vec3d& normal);
+
 class ParallelUVCoordSystemSnapshot : public UVCoordSystemSnapshot
 {
 private:

--- a/lib/TbMdlLib/include/mdl/Quake3BrushPrimitive.h
+++ b/lib/TbMdlLib/include/mdl/Quake3BrushPrimitive.h
@@ -89,4 +89,34 @@ Quake3BrushPrimitiveMatrix uvAxesToBrushPrimitiveMatrix(
   const vm::vec2f& offset,
   const vm::vec2f& textureSize);
 
+/**
+ * A brush primitive texture matrix decomposed into TrenchBroom's parallel UV coordinate
+ * system. Unlike Quake3BrushPrimitiveUVAxes, the projection scale and rotation are kept
+ * as separate, human-readable attributes (the axes are unit length and merely encode the
+ * rotation) instead of being folded into the axes. This lets a loaded brush primitive
+ * face report the same offset/scale/rotation the user would see in NetRadiant and round
+ * trip through a save/load cycle.
+ */
+struct Quake3BrushPrimitiveParallelUV
+{
+  vm::vec3d uAxis;
+  vm::vec3d vAxis;
+  vm::vec2f offset;
+  vm::vec2f scale;
+  float rotation;
+};
+
+/**
+ * Decomposes a brush primitive texture matrix into a parallel UV coordinate system, given
+ * the face normal and the texture's dimensions. The result reproduces the matrix exactly
+ * (it is the inverse of the serialization performed by uvAxesToBrushPrimitiveMatrix)
+ * while keeping the scale and rotation as separate attributes. The rotation is measured
+ * against TrenchBroom's parallel base axes (see computeInitialAxes()), so it matches a
+ * natively created face.
+ */
+Quake3BrushPrimitiveParallelUV brushPrimitiveMatrixToParallelUV(
+  const vm::vec3d& normal,
+  const Quake3BrushPrimitiveMatrix& matrix,
+  const vm::vec2f& textureSize);
+
 } // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/Quake3BrushPrimitive.h
+++ b/lib/TbMdlLib/include/mdl/Quake3BrushPrimitive.h
@@ -1,0 +1,92 @@
+/*
+ Copyright (C) 2026 Thomas Jones
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "vm/vec.h"
+
+#include <tuple>
+
+namespace tb::mdl
+{
+
+/**
+ * Quake 3 brush primitive ("brushDef") texture matrix as it appears in a .map file:
+ *
+ *     ( ( row0.x row0.y row0.z ) ( row1.x row1.y row1.z ) )
+ *
+ * The matrix maps a point on the face plane (expressed in the face's axis base, see
+ * computeAxisBase()) to texture coordinates that are normalized so that 1.0 corresponds
+ * to one full texture repeat:
+ *
+ *     s = row0.x * (texX . p) + row0.y * (texY . p) + row0.z
+ *     t = row1.x * (texX . p) + row1.y * (texY . p) + row1.z
+ */
+struct Quake3BrushPrimitiveMatrix
+{
+  vm::vec3d row0;
+  vm::vec3d row1;
+
+  friend bool operator==(
+    const Quake3BrushPrimitiveMatrix& lhs,
+    const Quake3BrushPrimitiveMatrix& rhs) = default;
+};
+
+/**
+ * World space U/V axes plus a texture offset (in texels) that reproduce a brush primitive
+ * texture matrix in TrenchBroom's parallel UV coordinate system (xScale = yScale = 1,
+ * rotation = 0).
+ */
+struct Quake3BrushPrimitiveUVAxes
+{
+  vm::vec3d uAxis;
+  vm::vec3d vAxis;
+  vm::vec2f offset;
+};
+
+/**
+ * Computes the Quake 3 brush primitive "axis base" for a face with the given normal: two
+ * orthonormal vectors `{ texX, texY }` spanning the face plane. This matches GtkRadiant's
+ * ComputeAxisBase() so that brush primitive texture matrices are interpreted identically.
+ */
+std::tuple<vm::vec3d, vm::vec3d> computeAxisBase(const vm::vec3d& normal);
+
+/**
+ * Converts a brush primitive texture matrix into world space U/V axes and a texel offset,
+ * given the face normal and the texture's dimensions. The result can be passed to
+ * BrushFace::createFromValve() to build a parallel UV coordinate system.
+ */
+Quake3BrushPrimitiveUVAxes brushPrimitiveMatrixToUVAxes(
+  const vm::vec3d& normal,
+  const Quake3BrushPrimitiveMatrix& matrix,
+  const vm::vec2f& textureSize);
+
+/**
+ * Inverse of brushPrimitiveMatrixToUVAxes(): converts the effective world space U/V axes
+ * (i.e. the stored axes already divided by their scale) and texel offset of a parallel UV
+ * coordinate system back into a brush primitive texture matrix.
+ */
+Quake3BrushPrimitiveMatrix uvAxesToBrushPrimitiveMatrix(
+  const vm::vec3d& normal,
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const vm::vec2f& offset,
+  const vm::vec2f& textureSize);
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/StandardMapParser.h
+++ b/lib/TbMdlLib/include/mdl/StandardMapParser.h
@@ -124,11 +124,10 @@ private:
 
   void parseObjects(ParserStatus& status);
   void parseObject(ParserStatus& status);
-  void parseBrush(
-    ParserStatus& status, const FileLocation& startLocation, bool primitive);
+  void parseBrush(ParserStatus& status, const FileLocation& startLocation);
   void parseBrushPrimitive(ParserStatus& status, const FileLocation& startLocation);
 
-  void parseFace(ParserStatus& status, bool primitive);
+  void parseFace(ParserStatus& status);
   void parseQuakeFace(ParserStatus& status);
   void parseQuake2Face(ParserStatus& status);
   void parseQuake2ValveFace(ParserStatus& status);

--- a/lib/TbMdlLib/include/mdl/StandardMapParser.h
+++ b/lib/TbMdlLib/include/mdl/StandardMapParser.h
@@ -124,9 +124,9 @@ private:
 
   void parseObjects(ParserStatus& status);
   void parseObject(ParserStatus& status);
-  void parseBrushPrimitive(ParserStatus& status, const FileLocation& startLocation);
   void parseBrush(
     ParserStatus& status, const FileLocation& startLocation, bool primitive);
+  void parseBrushPrimitive(ParserStatus& status, const FileLocation& startLocation);
 
   void parseFace(ParserStatus& status, bool primitive);
   void parseQuakeFace(ParserStatus& status);

--- a/lib/TbMdlLib/include/mdl/StandardMapParser.h
+++ b/lib/TbMdlLib/include/mdl/StandardMapParser.h
@@ -135,7 +135,7 @@ private:
   void parseHexen2Face(ParserStatus& status);
   void parseDaikatanaFace(ParserStatus& status);
   void parseValveFace(ParserStatus& status);
-  void parsePrimitiveFace(ParserStatus& status);
+  void parseBrushPrimitiveFace(ParserStatus& status);
 
   void parsePatch(ParserStatus& status, const FileLocation& startLocation);
 

--- a/lib/TbMdlLib/src/BrushFace.cpp
+++ b/lib/TbMdlLib/src/BrushFace.cpp
@@ -25,6 +25,7 @@
 #include "mdl/ParallelUVCoordSystem.h"
 #include "mdl/ParaxialUVCoordSystem.h"
 #include "mdl/Polyhedron.h"
+#include "mdl/Quake3BrushPrimitive.h"
 #include "mdl/TagMatcher.h"
 #include "mdl/TagVisitor.h"
 #include "mdl/UVCoordSystem.h"
@@ -66,6 +67,10 @@ BrushFace::BrushFace(const BrushFace& other)
   , m_attributes{other.m_attributes}
   , m_materialReference{other.m_materialReference}
   , m_uvCoordSystem{other.m_uvCoordSystem ? other.m_uvCoordSystem->clone() : nullptr}
+  , m_brushPrimitiveMatrix{
+      other.m_brushPrimitiveMatrix
+        ? std::make_unique<Quake3BrushPrimitiveMatrix>(*other.m_brushPrimitiveMatrix)
+        : nullptr}
   , m_lineNumber{other.m_lineNumber}
   , m_lineCount{other.m_lineCount}
   , m_selected{other.m_selected}
@@ -81,6 +86,7 @@ BrushFace::BrushFace(BrushFace&& other) noexcept
   , m_attributes{std::move(other.m_attributes)}
   , m_materialReference{std::move(other.m_materialReference)}
   , m_uvCoordSystem{std::move(other.m_uvCoordSystem)}
+  , m_brushPrimitiveMatrix{std::move(other.m_brushPrimitiveMatrix)}
   , m_geometry{other.m_geometry}
   , m_lineNumber{other.m_lineNumber}
   , m_lineCount{other.m_lineCount}
@@ -105,6 +111,7 @@ void swap(BrushFace& lhs, BrushFace& rhs) noexcept
   swap(lhs.m_attributes, rhs.m_attributes);
   swap(lhs.m_materialReference, rhs.m_materialReference);
   swap(lhs.m_uvCoordSystem, rhs.m_uvCoordSystem);
+  swap(lhs.m_brushPrimitiveMatrix, rhs.m_brushPrimitiveMatrix);
   swap(lhs.m_geometry, rhs.m_geometry);
   swap(lhs.m_lineNumber, rhs.m_lineNumber);
   swap(lhs.m_lineCount, rhs.m_lineCount);
@@ -196,6 +203,46 @@ Result<BrushFace> BrushFace::createFromValve(
   }
 
   return BrushFace::create(point1, point2, point3, attribs, std::move(uvCoordSystem));
+}
+
+Result<BrushFace> BrushFace::createFromBrushPrimitive(
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const vm::vec3d& point3,
+  const BrushFaceAttributes& inputAttribs,
+  const Quake3BrushPrimitiveMatrix& matrix,
+  const MapFormat mapFormat)
+{
+  contract_pre(mapFormat != MapFormat::Unknown);
+
+  // The real texture size is not known yet, so build a provisional projection assuming
+  // the Quake 3 default of 64x64. This is exact for 64x64 textures; for other sizes
+  // finalizeBrushPrimitiveProjection() recomputes it once the material has been assigned.
+  auto normal = vm::vec3d{0, 0, 1};
+  if (const auto plane = vm::from_points(point1, point2, point3))
+  {
+    normal = plane->normal;
+  }
+
+  const auto uv = brushPrimitiveMatrixToParallelUV(normal, matrix, vm::vec2f{64, 64});
+
+  auto attribs = inputAttribs;
+  attribs.setOffset(uv.offset);
+  attribs.setScale(uv.scale);
+  attribs.setRotation(uv.rotation);
+
+  return createFromValve(point1, point2, point3, attribs, uv.uAxis, uv.vAxis, mapFormat)
+         | kdl::transform([&](BrushFace&& face) {
+             // Only parallel formats can reproduce the projection exactly, so only they
+             // need the deferred, texture-size aware conversion. A paraxial target (e.g.
+             // Quake 3 legacy) keeps the provisional projection.
+             if (isParallelUVCoordSystem(mapFormat))
+             {
+               face.m_brushPrimitiveMatrix =
+                 std::make_unique<Quake3BrushPrimitiveMatrix>(matrix);
+             }
+             return std::move(face);
+           });
 }
 
 Result<BrushFace> BrushFace::create(
@@ -513,6 +560,33 @@ bool BrushFace::setMaterial(gl::Material* material)
   }
 
   m_materialReference = AssetReference(material);
+  return true;
+}
+
+bool BrushFace::finalizeBrushPrimitiveProjection()
+{
+  if (!m_brushPrimitiveMatrix)
+  {
+    return false;
+  }
+
+  // Resources are processed asynchronously, so wait until the material's texture has been
+  // loaded and textureSize() reports the real dimensions. Until then keep the provisional
+  // 64x64 projection; this is retried whenever the texture resource has been processed.
+  if (!gl::getTexture(material()))
+  {
+    return false;
+  }
+
+  const auto uv = brushPrimitiveMatrixToParallelUV(
+    m_boundary.normal, *m_brushPrimitiveMatrix, textureSize());
+
+  m_uvCoordSystem = std::make_unique<ParallelUVCoordSystem>(uv.uAxis, uv.vAxis);
+  m_attributes.setOffset(uv.offset);
+  m_attributes.setScale(uv.scale);
+  m_attributes.setRotation(uv.rotation);
+
+  m_brushPrimitiveMatrix.reset();
   return true;
 }
 

--- a/lib/TbMdlLib/src/BrushNode.cpp
+++ b/lib/TbMdlLib/src/BrushNode.cpp
@@ -139,6 +139,15 @@ void BrushNode::setFaceMaterial(const size_t faceIndex, gl::Material* material)
   invalidateVertexCache();
 }
 
+void BrushNode::finalizeBrushPrimitiveFace(const size_t faceIndex)
+{
+  if (m_brush.face(faceIndex).finalizeBrushPrimitiveProjection())
+  {
+    invalidateIssues();
+    invalidateVertexCache();
+  }
+}
+
 static bool containsPatch(const Brush& brush, const PatchGrid& grid)
 {
   if (!brush.bounds().contains(grid.bounds))

--- a/lib/TbMdlLib/src/Map.cpp
+++ b/lib/TbMdlLib/src/Map.cpp
@@ -1072,7 +1072,7 @@ void Map::updateAllFaceTags()
     [](PatchNode&) {}));
 }
 
-void Map::updateFaceTagsAfterResourcesWhereProcessed(
+void Map::updateFaceTagsAfterResourcesWereProcessed(
   const std::vector<gl::ResourceId>& resourceIds)
 {
   // Some textures contain embedded default values for surface flags and such, so we
@@ -1099,6 +1099,37 @@ void Map::updateFaceTagsAfterResourcesWhereProcessed(
           {
             brushNode.updateFaceTags(i, *m_tagManager);
           }
+        }
+      }
+    },
+    [](PatchNode&) {}));
+}
+
+void Map::finalizeBrushPrimitiveFacesAfterResourcesWereProcessed(
+  const std::vector<gl::ResourceId>& resourceIds)
+{
+  // Faces loaded from Quake 3 brush primitives keep their raw texture matrix until the
+  // texture size is known. Textures are processed asynchronously, so we convert the
+  // projection here, once the relevant texture resources have been processed.
+
+  const auto materials = m_materialManager->findMaterialsByTextureResourceId(resourceIds);
+  const auto materialSet =
+    std::unordered_set<const gl::Material*>{materials.begin(), materials.end()};
+
+  worldNode().accept(kdl::overload(
+    [](auto&& thisLambda, WorldNode& worldNode) { worldNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, LayerNode& layerNode) { layerNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, GroupNode& groupNode) { groupNode.visitChildren(thisLambda); },
+    [](auto&& thisLambda, EntityNode& entityNode) {
+      entityNode.visitChildren(thisLambda);
+    },
+    [&](BrushNode& brushNode) {
+      const auto& faces = brushNode.brush().faces();
+      for (size_t i = 0; i < faces.size(); ++i)
+      {
+        if (materialSet.contains(faces[i].material()))
+        {
+          brushNode.finalizeBrushPrimitiveFace(i);
         }
       }
     },
@@ -1709,7 +1740,8 @@ void Map::brushFacesDidChange(const std::vector<BrushFaceHandle>& brushFaces)
 
 void Map::resourcesWereProcessed(const std::vector<gl::ResourceId>& resourceIds)
 {
-  updateFaceTagsAfterResourcesWhereProcessed(resourceIds);
+  finalizeBrushPrimitiveFacesAfterResourcesWereProcessed(resourceIds);
+  updateFaceTagsAfterResourcesWereProcessed(resourceIds);
 }
 
 void Map::selectionWillChange()

--- a/lib/TbMdlLib/src/MapFileSerializer.cpp
+++ b/lib/TbMdlLib/src/MapFileSerializer.cpp
@@ -56,7 +56,7 @@ public:
   }
 
 private:
-  void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const override
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
   {
     writeFacePoints(stream, face);
     writeMaterialInfo(stream, face);
@@ -150,7 +150,7 @@ public:
   }
 
 private:
-  void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const override
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
   {
     writeFacePoints(stream, face);
     writeMaterialInfo(stream, face);
@@ -184,7 +184,7 @@ public:
   }
 
 private:
-  void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const override
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
   {
     writeFacePoints(stream, face);
     writeValveMaterialInfo(stream, face);
@@ -211,7 +211,7 @@ public:
   }
 
 private:
-  void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const override
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
   {
     writeFacePoints(stream, face);
     writeMaterialInfo(stream, face);
@@ -247,7 +247,7 @@ public:
   }
 
 private:
-  void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const override
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
   {
     writeFacePoints(stream, face);
     writeMaterialInfo(stream, face);
@@ -265,7 +265,7 @@ public:
   }
 
 private:
-  void doWriteBrushFace(std::ostream& stream, const BrushFace& face) const override
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
   {
     writeFacePoints(stream, face);
     writeValveMaterialInfo(stream, face);
@@ -408,7 +408,7 @@ void MapFileSerializer::doBrush(const BrushNode& brushNode)
 void MapFileSerializer::doBrushFace(const BrushFace& face)
 {
   const size_t lines = 1u;
-  doWriteBrushFace(m_stream, face);
+  writeBrushFace(m_stream, face);
   face.setFilePosition(m_line, lines);
   m_line += lines;
 }
@@ -454,7 +454,7 @@ MapFileSerializer::PrecomputedString MapFileSerializer::writeBrushFaces(
   auto stream = std::stringstream{};
   for (const auto& face : brush.faces())
   {
-    doWriteBrushFace(stream, face);
+    writeBrushFace(stream, face);
   }
   return {stream.str(), brush.faces().size()};
 }

--- a/lib/TbMdlLib/src/MapFileSerializer.cpp
+++ b/lib/TbMdlLib/src/MapFileSerializer.cpp
@@ -340,7 +340,7 @@ void MapFileSerializer::doBeginFile(
                    return std::visit(
                      kdl::overload(
                        [&](const BrushNode* brushNode) {
-                         return Entry{brushNode, writeBrushFaces(brushNode->brush())};
+                         return Entry{brushNode, writeBrush(brushNode->brush())};
                        },
                        [&](const PatchNode* patchNode) {
                          return Entry{patchNode, writePatch(patchNode->patch())};
@@ -448,7 +448,7 @@ size_t MapFileSerializer::startLine()
 /**
  * Threadsafe
  */
-MapFileSerializer::PrecomputedString MapFileSerializer::writeBrushFaces(
+MapFileSerializer::PrecomputedString MapFileSerializer::writeBrush(
   const Brush& brush) const
 {
   auto stream = std::stringstream{};

--- a/lib/TbMdlLib/src/MapFileSerializer.cpp
+++ b/lib/TbMdlLib/src/MapFileSerializer.cpp
@@ -28,12 +28,15 @@
 #include "mdl/GroupNode.h"
 #include "mdl/LayerNode.h"
 #include "mdl/PatchNode.h"
+#include "mdl/Quake3BrushPrimitive.h"
 #include "mdl/WorldNode.h"
 
 #include "kd/contracts.h"
 #include "kd/overload.h"
 #include "kd/string_format.h"
 #include "kd/task_manager.h"
+
+#include "vm/plane.h"
 
 #include <fmt/format.h>
 
@@ -198,6 +201,75 @@ private:
   }
 };
 
+class Quake3FileSerializer : public Quake2FileSerializer
+{
+public:
+  explicit Quake3FileSerializer(std::ostream& stream)
+    : Quake2FileSerializer{stream}
+  {
+  }
+
+private:
+  // Quake 3 brushes are written as brush primitives: the faces are wrapped in a
+  // `brushDef { ... }` block and each face stores a texture projection matrix instead of
+  // the legacy offset/rotation/scale values.
+  PrecomputedString writeBrush(const Brush& brush) const override
+  {
+    auto stream = std::stringstream{};
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "brushDef\n{{\n");
+    for (const auto& face : brush.faces())
+    {
+      writeBrushFace(stream, face);
+    }
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "}}\n");
+    // brushDef + opening brace + faces + closing brace
+    return {stream.str(), brush.faces().size() + 3};
+  }
+
+  void writeBrushFace(std::ostream& stream, const BrushFace& face) const override
+  {
+    writeFacePoints(stream, face);
+    writePrimitiveMaterialInfo(stream, face);
+    writeSurfaceAttributes(stream, face);
+
+    fmt::format_to(std::ostreambuf_iterator<char>{stream}, "\n");
+  }
+
+  void writePrimitiveMaterialInfo(std::ostream& stream, const BrushFace& face) const
+  {
+    const auto& materialName = face.attributes().materialName().empty()
+                                 ? BrushFaceAttributes::NoMaterialName
+                                 : face.attributes().materialName();
+
+    // Reconstruct the brush primitive texture matrix from the face's parallel UV axes.
+    // The stored axes are divided by their scale to obtain the effective projection, and
+    // the texture size that the reader folds into the axes is removed again.
+    const auto xScale = face.attributes().xScale();
+    const auto yScale = face.attributes().yScale();
+    const auto uAxis = xScale != 0.0f ? face.uAxis() / double(xScale) : face.uAxis();
+    const auto vAxis = yScale != 0.0f ? face.vAxis() / double(yScale) : face.vAxis();
+
+    const auto matrix = uvAxesToBrushPrimitiveMatrix(
+      face.boundary().normal,
+      uAxis,
+      vAxis,
+      face.attributes().offset(),
+      face.textureSize());
+
+    fmt::format_to(
+      std::ostreambuf_iterator<char>{stream},
+      " ( ( {} {} {} ) ( {} {} {} ) ) {}",
+      matrix.row0.x(),
+      matrix.row0.y(),
+      matrix.row0.z(),
+      matrix.row1.x(),
+      matrix.row1.y(),
+      matrix.row1.z(),
+      shouldQuoteMaterialName(materialName) ? quoteMaterialName(materialName)
+                                            : materialName);
+  }
+};
+
 class DaikatanaFileSerializer : public Quake2FileSerializer
 {
 private:
@@ -281,10 +353,11 @@ std::unique_ptr<NodeSerializer> MapFileSerializer::create(
   case MapFormat::Standard:
     return std::make_unique<QuakeFileSerializer>(stream);
   case MapFormat::Quake2:
-    // TODO 2427: Implement Quake3 serializers and use them
-  case MapFormat::Quake3:
   case MapFormat::Quake3_Legacy:
+  case MapFormat::Quake3:
     return std::make_unique<Quake2FileSerializer>(stream);
+  case MapFormat::Quake3_BrushPrimitives:
+    return std::make_unique<Quake3FileSerializer>(stream);
   case MapFormat::Quake2_Valve:
   case MapFormat::Quake3_Valve:
     return std::make_unique<Quake2ValveFileSerializer>(stream);

--- a/lib/TbMdlLib/src/MapFileSerializer.cpp
+++ b/lib/TbMdlLib/src/MapFileSerializer.cpp
@@ -354,7 +354,6 @@ std::unique_ptr<NodeSerializer> MapFileSerializer::create(
     return std::make_unique<QuakeFileSerializer>(stream);
   case MapFormat::Quake2:
   case MapFormat::Quake3_Legacy:
-  case MapFormat::Quake3:
     return std::make_unique<Quake2FileSerializer>(stream);
   case MapFormat::Quake3_BrushPrimitives:
     return std::make_unique<Quake3FileSerializer>(stream);

--- a/lib/TbMdlLib/src/MapFormat.cpp
+++ b/lib/TbMdlLib/src/MapFormat.cpp
@@ -53,17 +53,13 @@ MapFormat formatFromName(const std::string& formatName)
   {
     return MapFormat::Daikatana;
   }
-  if (formatName == "Quake3 (legacy)")
+  if (formatName == "Quake3" || formatName == "Quake3 (legacy)")
   {
     return MapFormat::Quake3_Legacy;
   }
   if (formatName == "Quake3 (Valve)")
   {
     return MapFormat::Quake3_Valve;
-  }
-  if (formatName == "Quake3")
-  {
-    return MapFormat::Quake3;
   }
   if (formatName == "Quake3 (brush primitives)")
   {
@@ -103,9 +99,6 @@ std::ostream& operator<<(std::ostream& lhs, const MapFormat rhs)
   case MapFormat::Quake3_Valve:
     lhs << "Quake3_Valve";
     break;
-  case MapFormat::Quake3:
-    lhs << "Quake3";
-    break;
   case MapFormat::Quake3_BrushPrimitives:
     lhs << "Quake3_BrushPrimitives";
     break;
@@ -133,8 +126,6 @@ std::string formatName(const MapFormat format)
     return "Quake3 (legacy)";
   case MapFormat::Quake3_Valve:
     return "Quake3 (Valve)";
-  case MapFormat::Quake3:
-    return "Quake3";
   case MapFormat::Quake3_BrushPrimitives:
     return "Quake3 (brush primitives)";
   case MapFormat::Unknown:
@@ -163,17 +154,9 @@ std::vector<MapFormat> compatibleFormats(const MapFormat format)
     return {
       MapFormat::Quake3_Legacy,
       MapFormat::Quake3_Valve,
-      MapFormat::Quake3,
       MapFormat::Quake3_BrushPrimitives};
   case MapFormat::Quake3_Valve:
     return {
-      MapFormat::Quake3_Valve,
-      MapFormat::Quake3,
-      MapFormat::Quake3_Legacy,
-      MapFormat::Quake3_BrushPrimitives};
-  case MapFormat::Quake3:
-    return {
-      MapFormat::Quake3,
       MapFormat::Quake3_Valve,
       MapFormat::Quake3_Legacy,
       MapFormat::Quake3_BrushPrimitives};
@@ -181,7 +164,6 @@ std::vector<MapFormat> compatibleFormats(const MapFormat format)
     return {
       MapFormat::Quake3_BrushPrimitives,
       MapFormat::Quake3_Valve,
-      MapFormat::Quake3,
       MapFormat::Quake3_Legacy};
   case MapFormat::Unknown:
     return {MapFormat::Unknown};
@@ -205,7 +187,6 @@ bool isParallelUVCoordSystem(const MapFormat format)
   case MapFormat::Hexen2:
   case MapFormat::Daikatana:
   case MapFormat::Quake3_Legacy:
-  case MapFormat::Quake3:
   case MapFormat::Unknown:
     return false;
     switchDefault();
@@ -218,7 +199,7 @@ bool hasPatchSupport(const MapFormat format)
   {
   case MapFormat::Quake3_Valve:
   case MapFormat::Quake3_Legacy:
-  case MapFormat::Quake3:
+  case MapFormat::Quake3_BrushPrimitives:
     return true;
   case MapFormat::Valve:
   case MapFormat::Quake2_Valve:

--- a/lib/TbMdlLib/src/MapFormat.cpp
+++ b/lib/TbMdlLib/src/MapFormat.cpp
@@ -65,6 +65,10 @@ MapFormat formatFromName(const std::string& formatName)
   {
     return MapFormat::Quake3;
   }
+  if (formatName == "Quake3 (brush primitives)")
+  {
+    return MapFormat::Quake3_BrushPrimitives;
+  }
   return MapFormat::Unknown;
 }
 
@@ -102,6 +106,9 @@ std::ostream& operator<<(std::ostream& lhs, const MapFormat rhs)
   case MapFormat::Quake3:
     lhs << "Quake3";
     break;
+  case MapFormat::Quake3_BrushPrimitives:
+    lhs << "Quake3_BrushPrimitives";
+    break;
   }
   return lhs;
 }
@@ -128,6 +135,8 @@ std::string formatName(const MapFormat format)
     return "Quake3 (Valve)";
   case MapFormat::Quake3:
     return "Quake3";
+  case MapFormat::Quake3_BrushPrimitives:
+    return "Quake3 (brush primitives)";
   case MapFormat::Unknown:
     return "Unknown";
     switchDefault();
@@ -151,11 +160,29 @@ std::vector<MapFormat> compatibleFormats(const MapFormat format)
   case MapFormat::Daikatana:
     return {MapFormat::Daikatana};
   case MapFormat::Quake3_Legacy:
-    return {MapFormat::Quake3_Legacy, MapFormat::Quake3_Valve, MapFormat::Quake3};
+    return {
+      MapFormat::Quake3_Legacy,
+      MapFormat::Quake3_Valve,
+      MapFormat::Quake3,
+      MapFormat::Quake3_BrushPrimitives};
   case MapFormat::Quake3_Valve:
-    return {MapFormat::Quake3_Valve, MapFormat::Quake3, MapFormat::Quake3_Legacy};
+    return {
+      MapFormat::Quake3_Valve,
+      MapFormat::Quake3,
+      MapFormat::Quake3_Legacy,
+      MapFormat::Quake3_BrushPrimitives};
   case MapFormat::Quake3:
-    return {MapFormat::Quake3, MapFormat::Quake3_Valve, MapFormat::Quake3_Legacy};
+    return {
+      MapFormat::Quake3,
+      MapFormat::Quake3_Valve,
+      MapFormat::Quake3_Legacy,
+      MapFormat::Quake3_BrushPrimitives};
+  case MapFormat::Quake3_BrushPrimitives:
+    return {
+      MapFormat::Quake3_BrushPrimitives,
+      MapFormat::Quake3_Valve,
+      MapFormat::Quake3,
+      MapFormat::Quake3_Legacy};
   case MapFormat::Unknown:
     return {MapFormat::Unknown};
     switchDefault();
@@ -169,6 +196,9 @@ bool isParallelUVCoordSystem(const MapFormat format)
   case MapFormat::Valve:
   case MapFormat::Quake2_Valve:
   case MapFormat::Quake3_Valve:
+  // Quake 3 brush primitives (brushDef) use parallel (face-aligned) texture projection,
+  // so the brush primitives format stores a parallel UV coordinate system.
+  case MapFormat::Quake3_BrushPrimitives:
     return true;
   case MapFormat::Standard:
   case MapFormat::Quake2:

--- a/lib/TbMdlLib/src/MapReader.cpp
+++ b/lib/TbMdlLib/src/MapReader.cpp
@@ -33,6 +33,7 @@
 #include "mdl/LockState.h"
 #include "mdl/MapFormat.h"
 #include "mdl/PatchNode.h"
+#include "mdl/Quake3BrushPrimitive.h"
 #include "mdl/VisibilityState.h"
 #include "mdl/WorldNode.h"
 
@@ -169,6 +170,26 @@ void MapReader::onValveBrushFace(
 {
   BrushFace::createFromValve(
     point1, point2, point3, attribs, uAxis, vAxis, targetMapFormat)
+    | kdl::transform([&](BrushFace&& face) {
+        face.setFilePosition(location.line, location.column.value_or(1));
+        onBrushFace(std::move(face), status);
+      })
+    | kdl::transform_error(
+      [&](auto e) { status.error(location, fmt::format("Skipping face: {}", e.msg)); });
+}
+
+void MapReader::onBrushPrimitiveFace(
+  const FileLocation& location,
+  const MapFormat targetMapFormat,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const vm::vec3d& point3,
+  const BrushFaceAttributes& attribs,
+  const Quake3BrushPrimitiveMatrix& matrix,
+  ParserStatus& status)
+{
+  BrushFace::createFromBrushPrimitive(
+    point1, point2, point3, attribs, matrix, targetMapFormat)
     | kdl::transform([&](BrushFace&& face) {
         face.setFilePosition(location.line, location.column.value_or(1));
         onBrushFace(std::move(face), status);

--- a/lib/TbMdlLib/src/ParallelUVCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParallelUVCoordSystem.cpp
@@ -38,19 +38,6 @@ namespace
 {
 
 /**
- * Generates two vectors which are perpendicular to `normal` and perpendicular to each
- * other.
- */
-std::tuple<vm::vec3d, vm::vec3d> computeInitialAxes(const vm::vec3d& normal)
-{
-  const auto uAxis = vm::find_abs_max_component(normal) == vm::axis::z
-                       ? vm::normalize(vm::cross(vm::vec3d{0, 1, 0}, normal))
-                       : vm::normalize(vm::cross(vm::vec3d{0, 0, 1}, normal));
-
-  return {uAxis, vm::normalize(vm::cross(uAxis, normal))};
-}
-
-/**
  * Rotate CCW by `angle` radians about `normal`.
  */
 std::tuple<vm::vec3d, vm::vec3d> applyRotation(
@@ -64,6 +51,15 @@ std::tuple<vm::vec3d, vm::vec3d> applyRotation(
 }
 
 } // namespace
+
+std::tuple<vm::vec3d, vm::vec3d> computeInitialAxes(const vm::vec3d& normal)
+{
+  const auto uAxis = vm::find_abs_max_component(normal) == vm::axis::z
+                       ? vm::normalize(vm::cross(vm::vec3d{0, 1, 0}, normal))
+                       : vm::normalize(vm::cross(vm::vec3d{0, 0, 1}, normal));
+
+  return {uAxis, vm::normalize(vm::cross(uAxis, normal))};
+}
 
 ParallelUVCoordSystemSnapshot::ParallelUVCoordSystemSnapshot(
   const vm::vec3d& uAxis, const vm::vec3d& vAxis)
@@ -113,8 +109,8 @@ ParallelUVCoordSystem::ParallelUVCoordSystem(
 {
   const auto normal = vm::normalize(vm::cross(point2 - point0, point1 - point0));
   std::tie(m_uAxis, m_vAxis) = computeInitialAxes(normal);
-  std::tie(m_uAxis, m_vAxis) =
-    applyRotation(uAxis(), vAxis(), normal, double(attribs.rotation()));
+  std::tie(m_uAxis, m_vAxis) = applyRotation(
+    uAxis(), vAxis(), normal, vm::to_radians(double(attribs.rotation())));
 }
 
 ParallelUVCoordSystem::ParallelUVCoordSystem(

--- a/lib/TbMdlLib/src/Quake3BrushPrimitive.cpp
+++ b/lib/TbMdlLib/src/Quake3BrushPrimitive.cpp
@@ -1,0 +1,108 @@
+/*
+ Copyright (C) 2026 Thomas Jones
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mdl/Quake3BrushPrimitive.h"
+
+#include "vm/vec.h"
+
+#include <cmath>
+
+namespace tb::mdl
+{
+
+std::tuple<vm::vec3d, vm::vec3d> computeAxisBase(const vm::vec3d& normal)
+{
+  // This is a direct port of GtkRadiant's ComputeAxisBase() so that brush primitive
+  // texture matrices are interpreted exactly as the original editor authored them.
+  // https://github.com/TTimo/GtkRadiant/blob/270af88f3c2471f6773bded0b5760a3115b52965/radiant/brush_primit.cpp#L70
+  auto n = normal;
+
+  // do some cleaning to avoid degenerate cases
+  if (std::abs(n.x()) < 1e-6)
+  {
+    n[0] = 0.0;
+  }
+  if (std::abs(n.y()) < 1e-6)
+  {
+    n[1] = 0.0;
+  }
+  if (std::abs(n.z()) < 1e-6)
+  {
+    n[2] = 0.0;
+  }
+
+  const auto rotY = -std::atan2(n.z(), std::sqrt(n.y() * n.y() + n.x() * n.x()));
+  const auto rotZ = std::atan2(n.y(), n.x());
+
+  const auto texX = vm::vec3d{-std::sin(rotZ), std::cos(rotZ), 0.0};
+  const auto texY = vm::vec3d{
+    -std::sin(rotY) * std::cos(rotZ), -std::sin(rotY) * std::sin(rotZ), -std::cos(rotY)};
+
+  return {texX, texY};
+}
+
+Quake3BrushPrimitiveUVAxes brushPrimitiveMatrixToUVAxes(
+  const vm::vec3d& normal,
+  const Quake3BrushPrimitiveMatrix& matrix,
+  const vm::vec2f& textureSize)
+{
+  const auto [texX, texY] = computeAxisBase(normal);
+
+  const auto texW = double(textureSize.x());
+  const auto texH = double(textureSize.y());
+
+  // The brush primitive matrix yields texture coordinates normalized to texture repeats,
+  // whereas TrenchBroom expresses U/V axes in texels (it divides by the texture size when
+  // computing UV coordinates). Folding the texture size into the axes and offset lets us
+  // store the projection as a parallel UV coordinate system with unit scale.
+  return {
+    texW * (matrix.row0.x() * texX + matrix.row0.y() * texY),
+    texH * (matrix.row1.x() * texX + matrix.row1.y() * texY),
+    vm::vec2f{
+      float(matrix.row0.z()) * textureSize.x(), float(matrix.row1.z()) * textureSize.y()},
+  };
+}
+
+Quake3BrushPrimitiveMatrix uvAxesToBrushPrimitiveMatrix(
+  const vm::vec3d& normal,
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const vm::vec2f& offset,
+  const vm::vec2f& textureSize)
+{
+  const auto [texX, texY] = computeAxisBase(normal);
+
+  const auto texW = double(textureSize.x());
+  const auto texH = double(textureSize.y());
+
+  // Project the world space axes back onto the (orthonormal) axis base and remove the
+  // texture size that brushPrimitiveMatrixToUVAxes() folded in.
+  return {
+    vm::vec3d{
+      vm::dot(uAxis, texX) / texW,
+      vm::dot(uAxis, texY) / texW,
+      double(offset.x()) / texW},
+    vm::vec3d{
+      vm::dot(vAxis, texX) / texH,
+      vm::dot(vAxis, texY) / texH,
+      double(offset.y()) / texH},
+  };
+}
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/src/Quake3BrushPrimitive.cpp
+++ b/lib/TbMdlLib/src/Quake3BrushPrimitive.cpp
@@ -19,9 +19,13 @@
 
 #include "mdl/Quake3BrushPrimitive.h"
 
+#include "mdl/ParallelUVCoordSystem.h"
+
+#include "vm/scalar.h"
 #include "vm/vec.h"
 
 #include <cmath>
+#include <tuple>
 
 namespace tb::mdl
 {
@@ -103,6 +107,52 @@ Quake3BrushPrimitiveMatrix uvAxesToBrushPrimitiveMatrix(
       vm::dot(vAxis, texY) / texH,
       double(offset.y()) / texH},
   };
+}
+
+Quake3BrushPrimitiveParallelUV brushPrimitiveMatrixToParallelUV(
+  const vm::vec3d& normal,
+  const Quake3BrushPrimitiveMatrix& matrix,
+  const vm::vec2f& textureSize)
+{
+  const auto uvAxes = brushPrimitiveMatrixToUVAxes(normal, matrix, textureSize);
+
+  const auto lenU = vm::length(uvAxes.uAxis);
+  const auto lenV = vm::length(uvAxes.vAxis);
+
+  // Store unit axes and keep the projection scale as a separate attribute, so that
+  // TrenchBroom reports the same scale factor NetRadiant would (e.g. 0.5) instead of
+  // baking it into the axes as a length of 2.
+  auto uAxis = lenU > 0.0 ? uvAxes.uAxis / lenU : uvAxes.uAxis;
+  auto vAxis = lenV > 0.0 ? uvAxes.vAxis / lenV : uvAxes.vAxis;
+  auto scale = vm::vec2f{
+    lenU > 0.0 ? float(1.0 / lenU) : 1.0f, lenV > 0.0 ? float(1.0 / lenV) : 1.0f};
+
+  // A negative determinant of the matrix' linear part means the projection is mirrored.
+  // TrenchBroom represents this with a negative scale factor rather than a flipped axis,
+  // so fold the mirroring into the V axis (matching NetRadiant's TexMatToFakeTexCoords,
+  // which resolves the "which axis was flipped" ambiguity in favour of V).
+  const auto determinant =
+    matrix.row0.x() * matrix.row1.y() - matrix.row0.y() * matrix.row1.x();
+  if (determinant < 0.0)
+  {
+    vAxis = -vAxis;
+    scale = vm::vec2f{scale.x(), -scale.y()};
+  }
+
+  // Measure the rotation about the texture normal (the cross of the parallel base axes),
+  // the same axis ParallelUVCoordSystem::setRotation rotates about, so a face rotated in
+  // the editor round trips through a save and load unchanged. atan2 yields a small signed
+  // angle at 0 (rather than the acos based measure_angle, which can flip to ~360 for an
+  // unrotated face); vm::correct then snaps that residual noise to 0 before it is folded
+  // into the [0, 360) range.
+  const auto [baseUAxis, baseVAxis] = computeInitialAxes(normal);
+  const auto textureNormal = vm::cross(baseUAxis, baseVAxis);
+  const auto cosRotation = vm::dot(uAxis, baseUAxis);
+  const auto sinRotation = vm::dot(vm::cross(baseUAxis, uAxis), textureNormal);
+  const auto rotation = vm::normalize_degrees(
+    float(vm::correct(vm::to_degrees(std::atan2(sinRotation, cosRotation)), 4)));
+
+  return {uAxis, vAxis, uvAxes.offset, scale, rotation};
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/src/StandardMapParser.cpp
+++ b/lib/TbMdlLib/src/StandardMapParser.cpp
@@ -28,7 +28,6 @@
 
 #include "kd/contracts.h"
 
-#include "vm/plane.h"
 #include "vm/vec.h"
 
 #include <string>
@@ -645,29 +644,14 @@ void StandardMapParser::parseBrushPrimitiveFace(ParserStatus& status)
     attribs.setSurfaceValue(parseFloat());
   }
 
-  // The brush primitive texture matrix is expressed relative to the face plane's axis
-  // base and yields normalized texture coordinates, so converting it into TrenchBroom's
-  // (texel based) parallel UV coordinate system requires the face normal and the texture
-  // size. The texture size is not yet known while parsing (materials are assigned to
-  // faces afterwards), so we assume the Quake 3 default of 64x64. This is exact for 64x64
-  // textures and for any face that is subsequently saved (the real texture size is used
-  // when serializing). See TODO 2427.
-  const auto textureSize = vm::vec2f{64, 64};
-
-  auto normal = vm::vec3d{0, 0, 1};
-  if (const auto plane = vm::from_points(p1, p2, p3))
-  {
-    normal = plane->normal;
-  }
-
-  const auto uvAxes = brushPrimitiveMatrixToUVAxes(normal, {row0, row1}, textureSize);
-
-  attribs.setOffset(uvAxes.offset);
-  attribs.setScale(vm::vec2f{1, 1});
-  attribs.setRotation(0.0f);
-
-  onValveBrushFace(
-    location, m_targetMapFormat, p1, p2, p3, attribs, uvAxes.uAxis, uvAxes.vAxis, status);
+  // The brush primitive texture matrix yields normalized texture coordinates, so
+  // converting it into TrenchBroom's (texel based) parallel UV coordinate system requires
+  // the texture size, which is not yet known while parsing (materials are assigned
+  // afterwards). We therefore pass the raw matrix on and defer the conversion until the
+  // material (and hence the real texture size) is available (see
+  // BrushFace::finalizeBrushPrimitiveProjection).
+  onBrushPrimitiveFace(
+    location, m_targetMapFormat, p1, p2, p3, attribs, {row0, row1}, status);
 }
 
 void StandardMapParser::parsePatch(

--- a/lib/TbMdlLib/src/StandardMapParser.cpp
+++ b/lib/TbMdlLib/src/StandardMapParser.cpp
@@ -360,7 +360,7 @@ void StandardMapParser::parseObject(ParserStatus& status)
     }
   }
   else if (
-    m_sourceMapFormat == MapFormat::Quake3 || m_sourceMapFormat == MapFormat::Quake3_Valve
+    m_sourceMapFormat == MapFormat::Quake3_Valve
     || m_sourceMapFormat == MapFormat::Quake3_Legacy)
   {
     // We expect either a patch or a regular brush.
@@ -439,7 +439,6 @@ void StandardMapParser::parseFace(ParserStatus& status)
     break;
   case MapFormat::Quake2:
   case MapFormat::Quake3_Legacy:
-  case MapFormat::Quake3:
     parseQuake2Face(status);
     break;
   case MapFormat::Quake2_Valve:

--- a/lib/TbMdlLib/src/StandardMapParser.cpp
+++ b/lib/TbMdlLib/src/StandardMapParser.cpp
@@ -375,16 +375,6 @@ void StandardMapParser::parseObject(ParserStatus& status)
   m_tokenizer.nextToken(QuakeMapToken::CBrace);
 }
 
-void StandardMapParser::parseBrushPrimitive(
-  ParserStatus& status, const FileLocation& startLocation)
-{
-  auto token = m_tokenizer.nextToken(QuakeMapToken::String);
-  expect(BrushPrimitiveId, token);
-  m_tokenizer.nextToken(QuakeMapToken::OBrace);
-  parseBrush(status, startLocation, true);
-  m_tokenizer.nextToken(QuakeMapToken::CBrace);
-}
-
 void StandardMapParser::parseBrush(
   ParserStatus& status, const FileLocation& startLocation, const bool primitive)
 {
@@ -428,6 +418,16 @@ void StandardMapParser::parseBrush(
       QuakeMapToken::Comment,
       QuakeMapToken::OParenthesis | QuakeMapToken::CBrace | QuakeMapToken::Eof);
   }
+}
+
+void StandardMapParser::parseBrushPrimitive(
+  ParserStatus& status, const FileLocation& startLocation)
+{
+  auto token = m_tokenizer.nextToken(QuakeMapToken::String);
+  expect(BrushPrimitiveId, token);
+  m_tokenizer.nextToken(QuakeMapToken::OBrace);
+  parseBrush(status, startLocation, true);
+  m_tokenizer.nextToken(QuakeMapToken::CBrace);
 }
 
 void StandardMapParser::parseFace(ParserStatus& status, const bool primitive)

--- a/lib/TbMdlLib/src/StandardMapParser.cpp
+++ b/lib/TbMdlLib/src/StandardMapParser.cpp
@@ -457,7 +457,7 @@ void StandardMapParser::parseFace(ParserStatus& status, const bool primitive)
   case MapFormat::Quake3:
     if (primitive)
     {
-      parsePrimitiveFace(status);
+      parseBrushPrimitiveFace(status);
     }
     else
     {
@@ -629,7 +629,7 @@ void StandardMapParser::parseValveFace(ParserStatus& status)
     location, m_targetMapFormat, p1, p2, p3, attribs, uAxis, vAxis, status);
 }
 
-void StandardMapParser::parsePrimitiveFace(ParserStatus& status)
+void StandardMapParser::parseBrushPrimitiveFace(ParserStatus& status)
 {
   /* const auto line = */ m_tokenizer.line();
 

--- a/lib/TbMdlLib/src/StandardMapParser.cpp
+++ b/lib/TbMdlLib/src/StandardMapParser.cpp
@@ -24,9 +24,11 @@
 #include "ParserStatus.h"
 #include "mdl/BrushFace.h"
 #include "mdl/EntityProperties.h"
+#include "mdl/Quake3BrushPrimitive.h"
 
 #include "kd/contracts.h"
 
+#include "vm/plane.h"
 #include "vm/vec.h"
 
 #include <string>
@@ -228,11 +230,26 @@ Result<void> StandardMapParser::parseBrushFaces(ParserStatus& status)
 {
   try
   {
-    while (m_tokenizer.peekToken(QuakeMapToken::OParenthesis | QuakeMapToken::Eof)
-             .hasType(QuakeMapToken::OParenthesis))
+    static constexpr auto ExpectedToken =
+      QuakeMapToken::OParenthesis | QuakeMapToken::Eof;
+
+    if (m_sourceMapFormat == MapFormat::Quake3_BrushPrimitives)
     {
-      // TODO 2427: detect the face type when parsing Quake3 map faces!
-      parseFace(status, false);
+      // Quake 3 brush faces are serialized as brush primitive faces (with a texture
+      // matrix), so when reading individual faces (e.g. when pasting UV alignment) we
+      // parse them as primitives.
+
+      while (m_tokenizer.peekToken(ExpectedToken).hasType(QuakeMapToken::OParenthesis))
+      {
+        parseBrushPrimitiveFace(status);
+      }
+    }
+    else
+    {
+      while (m_tokenizer.peekToken(ExpectedToken).hasType(QuakeMapToken::OParenthesis))
+      {
+        parseFace(status);
+      }
     }
 
     return kdl::void_success;
@@ -328,29 +345,22 @@ void StandardMapParser::parseObject(ParserStatus& status)
 
   const auto startLocation = token.location();
 
-  if (m_sourceMapFormat == MapFormat::Quake3)
+  if (m_sourceMapFormat == MapFormat::Quake3_BrushPrimitives)
   {
-    // We expect either a brush primitive, a patch or a regular brush.
-    token = m_tokenizer.peekToken(QuakeMapToken::String | QuakeMapToken::OParenthesis);
-    if (token.hasType(QuakeMapToken::String))
+    // We expect either a patch or a brush primitive.
+    token = m_tokenizer.peekToken(QuakeMapToken::String);
+    expect({BrushPrimitiveId, PatchId}, token);
+    if (token.data() == BrushPrimitiveId)
     {
-      expect({BrushPrimitiveId, PatchId}, token);
-      if (token.data() == BrushPrimitiveId)
-      {
-        parseBrushPrimitive(status, startLocation);
-      }
-      else
-      {
-        parsePatch(status, startLocation);
-      }
+      parseBrushPrimitive(status, startLocation);
     }
     else
     {
-      parseBrush(status, startLocation, false);
+      parsePatch(status, startLocation);
     }
   }
   else if (
-    m_sourceMapFormat == MapFormat::Quake3_Valve
+    m_sourceMapFormat == MapFormat::Quake3 || m_sourceMapFormat == MapFormat::Quake3_Valve
     || m_sourceMapFormat == MapFormat::Quake3_Legacy)
   {
     // We expect either a patch or a regular brush.
@@ -362,13 +372,13 @@ void StandardMapParser::parseObject(ParserStatus& status)
     }
     else
     {
-      parseBrush(status, startLocation, false);
+      parseBrush(status, startLocation);
     }
   }
   else
   {
     token = m_tokenizer.peekToken(QuakeMapToken::OParenthesis);
-    parseBrush(status, startLocation, false);
+    parseBrush(status, startLocation);
   }
 
   // consume final closing brace
@@ -376,7 +386,7 @@ void StandardMapParser::parseObject(ParserStatus& status)
 }
 
 void StandardMapParser::parseBrush(
-  ParserStatus& status, const FileLocation& startLocation, const bool primitive)
+  ParserStatus& status, const FileLocation& startLocation)
 {
   auto beginBrushCalled = false;
 
@@ -388,28 +398,19 @@ void StandardMapParser::parseBrush(
     switch (token.type())
     {
     case QuakeMapToken::OParenthesis:
-      // TODO 2427: handle brush primitives
-      if (!beginBrushCalled && !primitive)
+      if (!beginBrushCalled)
       {
         onBeginBrush(startLocation, status);
         beginBrushCalled = true;
       }
-      parseFace(status, primitive);
+      parseFace(status);
       break;
     case QuakeMapToken::CBrace:
-      // TODO 2427: handle brush primitives
-      if (!primitive)
+      if (!beginBrushCalled)
       {
-        if (!beginBrushCalled)
-        {
-          onBeginBrush(startLocation, status);
-        }
-        onEndBrush(token.location(), status);
+        onBeginBrush(startLocation, status);
       }
-      else
-      {
-        status.warn(startLocation, "Skipping brush primitive: currently not supported");
-      }
+      onEndBrush(token.location(), status);
       return;
       switchDefault();
     }
@@ -423,14 +424,13 @@ void StandardMapParser::parseBrush(
 void StandardMapParser::parseBrushPrimitive(
   ParserStatus& status, const FileLocation& startLocation)
 {
-  auto token = m_tokenizer.nextToken(QuakeMapToken::String);
-  expect(BrushPrimitiveId, token);
+  expect({BrushPrimitiveId}, m_tokenizer.nextToken(QuakeMapToken::String));
   m_tokenizer.nextToken(QuakeMapToken::OBrace);
-  parseBrush(status, startLocation, true);
+  parseBrush(status, startLocation);
   m_tokenizer.nextToken(QuakeMapToken::CBrace);
 }
 
-void StandardMapParser::parseFace(ParserStatus& status, const bool primitive)
+void StandardMapParser::parseFace(ParserStatus& status)
 {
   switch (m_sourceMapFormat)
   {
@@ -439,6 +439,7 @@ void StandardMapParser::parseFace(ParserStatus& status, const bool primitive)
     break;
   case MapFormat::Quake2:
   case MapFormat::Quake3_Legacy:
+  case MapFormat::Quake3:
     parseQuake2Face(status);
     break;
   case MapFormat::Quake2_Valve:
@@ -454,15 +455,8 @@ void StandardMapParser::parseFace(ParserStatus& status, const bool primitive)
   case MapFormat::Valve:
     parseValveFace(status);
     break;
-  case MapFormat::Quake3:
-    if (primitive)
-    {
-      parseBrushPrimitiveFace(status);
-    }
-    else
-    {
-      parseQuake2Face(status);
-    }
+  case MapFormat::Quake3_BrushPrimitives:
+    parseBrushPrimitiveFace(status);
     break;
   case MapFormat::Unknown:
     // cannot happen
@@ -631,18 +625,16 @@ void StandardMapParser::parseValveFace(ParserStatus& status)
 
 void StandardMapParser::parseBrushPrimitiveFace(ParserStatus& status)
 {
-  /* const auto line = */ m_tokenizer.line();
+  const auto location = m_tokenizer.location();
 
-  /* const auto [p1, p2, p3] = */ parseFacePoints(status);
+  const auto [p1, p2, p3] = parseFacePoints(status);
 
   m_tokenizer.nextToken(QuakeMapToken::OParenthesis);
-
-  /* const auto [uAxis, vAxis] = */ parsePrimitiveUVAxes(status);
+  const auto [row0, row1] = parsePrimitiveUVAxes(status);
   m_tokenizer.nextToken(QuakeMapToken::CParenthesis);
 
   const auto materialName = parseMaterialName(status);
 
-  // TODO 2427: what to set for offset, rotation, scale?!
   auto attribs = BrushFaceAttributes{materialName};
 
   // Quake 2 extra info is optional
@@ -654,8 +646,29 @@ void StandardMapParser::parseBrushPrimitiveFace(ParserStatus& status)
     attribs.setSurfaceValue(parseFloat());
   }
 
-  // TODO 2427: create a brush face
-  // brushFace(line, p1, p2, p3, attribs, uAxis, vAxis, status);
+  // The brush primitive texture matrix is expressed relative to the face plane's axis
+  // base and yields normalized texture coordinates, so converting it into TrenchBroom's
+  // (texel based) parallel UV coordinate system requires the face normal and the texture
+  // size. The texture size is not yet known while parsing (materials are assigned to
+  // faces afterwards), so we assume the Quake 3 default of 64x64. This is exact for 64x64
+  // textures and for any face that is subsequently saved (the real texture size is used
+  // when serializing). See TODO 2427.
+  const auto textureSize = vm::vec2f{64, 64};
+
+  auto normal = vm::vec3d{0, 0, 1};
+  if (const auto plane = vm::from_points(p1, p2, p3))
+  {
+    normal = plane->normal;
+  }
+
+  const auto uvAxes = brushPrimitiveMatrixToUVAxes(normal, {row0, row1}, textureSize);
+
+  attribs.setOffset(uvAxes.offset);
+  attribs.setScale(vm::vec2f{1, 1});
+  attribs.setRotation(0.0f);
+
+  onValveBrushFace(
+    location, m_targetMapFormat, p1, p2, p3, attribs, uvAxes.uAxis, uvAxes.vAxis, status);
 }
 
 void StandardMapParser::parsePatch(

--- a/lib/TbMdlLib/test-utils/test/src/tst_StringMakers.cpp
+++ b/lib/TbMdlLib/test-utils/test/src/tst_StringMakers.cpp
@@ -39,14 +39,14 @@ namespace tb::mdl
 
 TEST_CASE("convertToString")
 {
-  auto worldNode = WorldNode({}, Entity{}, MapFormat::Quake3);
+  auto worldNode = WorldNode({}, Entity{}, MapFormat::Quake3_Legacy);
 
   // explicitly set link IDs
   setLinkId(worldNode, "world_link_id");
 
   CHECK(convertToString(worldNode) == R"(WorldNode{
   m_entityPropertyConfig: EntityPropertyConfig{defaultModelScaleExpression: nullopt, setDefaultProperties: 0, updateAnglePropertyAfterTransform: 1},
-  m_mapFormat: Quake3,
+  m_mapFormat: Quake3_Legacy,
   m_entity: Entity{m_properties: [EntityProperty{m_key: classname, m_value: worldspawn}], m_protectedProperties: []},
   m_children: [
     LayerNode{
@@ -81,7 +81,7 @@ TEST_CASE("convertToString")
 
   CHECK(convertToString(worldNode) == R"(WorldNode{
   m_entityPropertyConfig: EntityPropertyConfig{defaultModelScaleExpression: nullopt, setDefaultProperties: 0, updateAnglePropertyAfterTransform: 1},
-  m_mapFormat: Quake3,
+  m_mapFormat: Quake3_Legacy,
   m_entity: Entity{m_properties: [EntityProperty{m_key: classname, m_value: worldspawn}], m_protectedProperties: []},
   m_children: [
     LayerNode{

--- a/lib/TbMdlLib/test/CMakeLists.txt
+++ b/lib/TbMdlLib/test/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(TbMdlLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_PointTrace.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Polyhedron.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_PortalFile.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Quake3BrushPrimitive.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Quake3ShaderParser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Selection.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Tagging.cpp

--- a/lib/TbMdlLib/test/src/tst_BrushFace.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushFace.cpp
@@ -31,6 +31,7 @@
 #include "mdl/ParallelUVCoordSystem.h"
 #include "mdl/ParaxialUVCoordSystem.h"
 #include "mdl/Polyhedron.h"
+#include "mdl/Quake3BrushPrimitive.h"
 #include "mdl/TestUtils.h"
 
 #include "kd/collection_utils.h"
@@ -41,6 +42,9 @@
 #include "vm/approx.h"
 #include "vm/mat.h"
 #include "vm/mat_ext.h"
+#include "vm/plane.h"
+#include "vm/quat.h"
+#include "vm/scalar.h"
 #include "vm/vec.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
@@ -933,6 +937,123 @@ TEST_CASE("BrushFace")
         CHECK(face.attributes().scale() == vm::vec2f{-1, 1});
       }
     }
+  }
+}
+
+TEST_CASE("BrushFace.brushPrimitiveProjection")
+{
+  // Points on a plane whose normal is computed the same way BrushFace does.
+  const auto p1 = vm::vec3d{0, 0, 0};
+  const auto p2 = vm::vec3d{0, 64, 0};
+  const auto p3 = vm::vec3d{64, 0, 0};
+  const auto normal = vm::from_points(p1, p2, p3)->normal;
+
+  // Build the texture matrix a 128x128 texture would produce for a face with scale 0.5,
+  // rotation 30 and offset (16, -8).
+  const auto textureSize = vm::vec2f{128, 128};
+  const auto scale = vm::vec2f{0.5f, 0.5f};
+  const auto rotation = 30.0f;
+  const auto offset = vm::vec2f{16, -8};
+
+  const auto [baseUAxis, baseVAxis] = computeInitialAxes(normal);
+  const auto textureNormal = vm::cross(baseUAxis, baseVAxis);
+  const auto rot = vm::quatd{textureNormal, vm::to_radians(double(rotation))};
+  const auto matrix = uvAxesToBrushPrimitiveMatrix(
+    normal,
+    (rot * baseUAxis) / double(scale.x()),
+    (rot * baseVAxis) / double(scale.y()),
+    offset,
+    textureSize);
+
+  auto face =
+    BrushFace::createFromBrushPrimitive(
+      p1, p2, p3, BrushFaceAttributes{"m"}, matrix, MapFormat::Quake3_BrushPrimitives)
+    | kdl::value();
+
+  SECTION("provisional projection assumes a 64x64 texture until finalized")
+  {
+    // Scale and offset are half of the real values because they were derived assuming a
+    // 64x64 rather than a 128x128 texture; rotation is texture-size independent.
+    CHECK(face.attributes().scale() == vm::approx{vm::vec2f{1, 1}, 0.0001f});
+    CHECK(face.attributes().offset() == vm::approx{vm::vec2f{8, -4}, 0.0001f});
+    CHECK(face.attributes().rotation() == vm::approx{rotation, 0.01f});
+  }
+
+  SECTION("finalizing with the real texture size restores the attributes")
+  {
+    auto material = gl::Material{"m", gl::createTextureResource(gl::Texture{128, 128})};
+    face.setMaterial(&material);
+
+    CHECK(face.finalizeBrushPrimitiveProjection());
+
+    CHECK(face.attributes().scale() == vm::approx{scale, 0.0001f});
+    CHECK(face.attributes().offset() == vm::approx{offset, 0.0001f});
+    CHECK(face.attributes().rotation() == vm::approx{rotation, 0.01f});
+
+    // Finalizing is a one-shot operation: there is nothing left to do afterwards.
+    CHECK_FALSE(face.finalizeBrushPrimitiveProjection());
+  }
+
+  SECTION("finalizing does nothing while the texture is unavailable")
+  {
+    CHECK_FALSE(face.finalizeBrushPrimitiveProjection());
+    CHECK(face.attributes().scale() == vm::approx{vm::vec2f{1, 1}, 0.0001f});
+  }
+}
+
+TEST_CASE("BrushFace.brushPrimitiveProjectionRoundTrip")
+{
+  // A face built from a brush primitive matrix and finalized with the real texture size
+  // reports the offset, scale and rotation it was built from, for any combination of
+  // modified attributes. A mirror is folded onto the V axis (negative Y scale).
+  const auto p1 = vm::vec3d{0, 0, 0};
+  const auto p2 = vm::vec3d{0, 64, 0};
+  const auto p3 = vm::vec3d{64, 0, 0};
+  const auto normal = vm::from_points(p1, p2, p3)->normal;
+  const auto [baseUAxis, baseVAxis] = computeInitialAxes(normal);
+  const auto textureNormal = vm::cross(baseUAxis, baseVAxis);
+
+  struct TestCase
+  {
+    vm::vec2f textureSize;
+    vm::vec2f offset;
+    vm::vec2f scale;
+    float rotation;
+  };
+
+  // clang-format off
+  const auto testCases = std::vector<TestCase>{
+    {{128, 256}, {16, -8},   {0.5f, 0.5f},  30.0f},
+    {{128, 128}, {-10, -20}, {0.5f, -0.5f}, 45.0f},
+    {{64, 128},  {12, 7},    {0.75f, 1.5f}, 180.0f},
+    {{256, 256}, {5, 5},     {2.0f, 0.5f},  270.0f},
+  };
+  // clang-format on
+
+  for (const auto& testCase : testCases)
+  {
+    const auto rot = vm::quatd{textureNormal, vm::to_radians(double(testCase.rotation))};
+    const auto matrix = uvAxesToBrushPrimitiveMatrix(
+      normal,
+      (rot * baseUAxis) / double(testCase.scale.x()),
+      (rot * baseVAxis) / double(testCase.scale.y()),
+      testCase.offset,
+      testCase.textureSize);
+
+    auto face =
+      BrushFace::createFromBrushPrimitive(
+        p1, p2, p3, BrushFaceAttributes{"m"}, matrix, MapFormat::Quake3_BrushPrimitives)
+      | kdl::value();
+
+    const auto w = size_t(testCase.textureSize.x());
+    const auto h = size_t(testCase.textureSize.y());
+    auto material = gl::Material{"m", gl::createTextureResource(gl::Texture{w, h})};
+    face.setMaterial(&material);
+
+    CHECK(face.finalizeBrushPrimitiveProjection());
+    CHECK(face.attributes().offset() == vm::approx{testCase.offset, 0.0001f});
+    CHECK(face.attributes().scale() == vm::approx{testCase.scale, 0.0001f});
+    CHECK(face.attributes().rotation() == vm::approx{testCase.rotation, 0.01f});
   }
 }
 

--- a/lib/TbMdlLib/test/src/tst_BrushNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushNode.cpp
@@ -55,7 +55,7 @@ TEST_CASE("BrushNode")
     const auto worldBounds = vm::bbox3d{4096.0};
 
     auto* brushNode = new BrushNode{
-      BrushBuilder{MapFormat::Quake3, worldBounds}.createCube(64.0, "testure")
+      BrushBuilder{MapFormat::Quake3_Legacy, worldBounds}.createCube(64.0, "testure")
       | kdl::value()};
     auto entityNode = EntityNode{Entity{}};
 
@@ -161,7 +161,7 @@ TEST_CASE("BrushNode")
     {
       const auto worldBounds = vm::bbox3d{8192.0};
 
-      auto builder = BrushBuilder{MapFormat::Quake3, worldBounds};
+      auto builder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
       auto brushNode =
         BrushNode{builder.createCube(64.0, "some_material") | kdl::value()};
       transformNode(
@@ -192,7 +192,7 @@ TEST_CASE("BrushNode")
     {
       const auto worldBounds = vm::bbox3d{8192.0};
 
-      auto builder = BrushBuilder{MapFormat::Quake3, worldBounds};
+      auto builder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
 
       auto brushNode =
         BrushNode{builder.createCube(64.0, "some_material") | kdl::value()};

--- a/lib/TbMdlLib/test/src/tst_EditorContext.cpp
+++ b/lib/TbMdlLib/test/src/tst_EditorContext.cpp
@@ -52,7 +52,7 @@ protected:
 
   EditorContextTest()
     : worldBounds{8192.0}
-    , worldNode{{}, {}, MapFormat::Quake3}
+    , worldNode{{}, {}, MapFormat::Quake3_Legacy}
   {
   }
 

--- a/lib/TbMdlLib/test/src/tst_EntityNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_EntityNode.cpp
@@ -51,7 +51,7 @@ namespace tb::mdl
 TEST_CASE("EntityNodeTest.canAddChild")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto layerNode = LayerNode{Layer{"layer"}};
@@ -78,7 +78,7 @@ TEST_CASE("EntityNodeTest.canAddChild")
 TEST_CASE("EntityNodeTest.canRemoveChild")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   const auto worldNode = WorldNode{{}, {}, mapFormat};
   auto layerNode = LayerNode{Layer{"layer"}};
@@ -105,7 +105,7 @@ TEST_CASE("EntityNodeTest.canRemoveChild")
 TEST_CASE("EntityNodeTest.setPointEntity")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto entityNode = EntityNode{Entity{}};
   auto brushNode1 = BrushNode{

--- a/lib/TbMdlLib/test/src/tst_GroupNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_GroupNode.cpp
@@ -101,7 +101,7 @@ TEST_CASE("GroupNode.openAndClose")
 TEST_CASE("GroupNode.canAddChild")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto layerNode = LayerNode{Layer{"layer"}};
@@ -140,7 +140,7 @@ TEST_CASE("GroupNode.canAddChild")
 TEST_CASE("GroupNode.canRemoveChild")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   const auto worldNode = WorldNode{{}, {}, mapFormat};
   auto layerNode = LayerNode{Layer{"layer"}};

--- a/lib/TbMdlLib/test/src/tst_Issue.cpp
+++ b/lib/TbMdlLib/test/src/tst_Issue.cpp
@@ -64,12 +64,12 @@ TEST_CASE("Issue.addSelectableNodes")
   auto* innerGroupNode = new GroupNode{Group{"inner"}};
   auto* pointEntityNode = new EntityNode{Entity{}};
   auto* brushNode = new BrushNode{
-    BrushBuilder{MapFormat::Quake3, worldBounds}.createCube(64.0, "material")
+    BrushBuilder{MapFormat::Quake3_Legacy, worldBounds}.createCube(64.0, "material")
     | kdl::value()};
 
   auto* brushEntityNode = new EntityNode{Entity{}};
   auto* entityBrushNode = new BrushNode{
-    BrushBuilder{MapFormat::Quake3, worldBounds}.createCube(64.0, "material")
+    BrushBuilder{MapFormat::Quake3_Legacy, worldBounds}.createCube(64.0, "material")
     | kdl::value()};
   brushEntityNode->addChild(entityBrushNode);
 

--- a/lib/TbMdlLib/test/src/tst_LayerNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_LayerNode.cpp
@@ -44,7 +44,7 @@ TEST_CASE("LayerNode")
   SECTION("canAddChild")
   {
     constexpr auto worldBounds = vm::bbox3d{8192.0};
-    constexpr auto mapFormat = MapFormat::Quake3;
+    constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
     auto worldNode = WorldNode{{}, {}, mapFormat};
     auto layerNode = LayerNode{Layer{"layer"}};
@@ -71,7 +71,7 @@ TEST_CASE("LayerNode")
   SECTION("canRemoveChild")
   {
     constexpr auto worldBounds = vm::bbox3d{8192.0};
-    constexpr auto mapFormat = MapFormat::Quake3;
+    constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
     auto worldNode = WorldNode{{}, {}, mapFormat};
     auto layerNode = LayerNode{Layer{"layer"}};

--- a/lib/TbMdlLib/test/src/tst_LinkedGroupUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_LinkedGroupUtils.cpp
@@ -166,7 +166,7 @@ auto MatchesLinkIds(std::vector<std::vector<const Node*>> expected)
 TEST_CASE("collectLinkedGroups")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -662,7 +662,7 @@ TEST_CASE("updateLinkedGroups")
     // see https://github.com/TrenchBroom/TrenchBroom/issues/4257
 
     const auto worldBounds = vm::bbox3d{8192.0};
-    const auto brushBuilder = BrushBuilder{MapFormat::Quake3, worldBounds};
+    const auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
 
     auto sourceGroupNode = GroupNode{Group{"name"}};
     auto* sourceBrushNode =
@@ -720,7 +720,7 @@ TEST_CASE("updateLinkedGroups")
 
 TEST_CASE("initializeLinkIds")
 {
-  auto brushBuilder = BrushBuilder{MapFormat::Quake3, vm::bbox3d{8192.0}};
+  auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, vm::bbox3d{8192.0}};
 
   auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
   auto& layerNode = *worldNode.defaultLayer();
@@ -1046,7 +1046,7 @@ TEST_CASE("initializeLinkIds")
 TEST_CASE("resetLinkIds")
 {
   const auto worldBounds = vm::bbox3d{8192.0};
-  auto brushBuilder = BrushBuilder{MapFormat::Quake3, worldBounds};
+  auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
 
   auto* outerGroupNode = new GroupNode{Group{"outer"}};
   auto* outerEntityNode = new EntityNode{Entity{}};

--- a/lib/TbMdlLib/test/src/tst_Map_CopyPaste.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_CopyPaste.cpp
@@ -333,7 +333,7 @@ common/caulk
 }
 })";
 
-      auto& map = fixture.create({.mapFormat = MapFormat::Quake3});
+      auto& map = fixture.create({.mapFormat = MapFormat::Quake3_Legacy});
       const auto& worldNode = map.worldNode();
 
       const auto& defaultLayerNode = *worldNode.defaultLayer();

--- a/lib/TbMdlLib/test/src/tst_Map_Initialization.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Initialization.cpp
@@ -320,7 +320,7 @@ TEST_CASE("Map_Initialization")
       gameInfo.gameConfig.fileFormats = std::vector<MapFormatConfig>{
         {"Valve", {}},
         {"Standard", {}},
-        {"Quake3", {}},
+        {"Quake3 (Valve)", {}},
       };
 
       SECTION("Detect Valve Format Map")

--- a/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
@@ -53,7 +53,7 @@ using namespace Catch::Matchers;
 TEST_CASE("ModelUtils.findContainingLayer")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -85,7 +85,7 @@ TEST_CASE("ModelUtils.findContainingLayer")
 TEST_CASE("ModelUtils.findContainingGroup")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -119,7 +119,7 @@ TEST_CASE("ModelUtils.findContainingGroup")
 TEST_CASE("ModelUtils.findOutermostClosedGroup")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -183,7 +183,7 @@ TEST_CASE("ModelUtils.findOutermostClosedGroup")
 TEST_CASE("ModelUtils.collectTouchingNodes")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -258,7 +258,7 @@ TEST_CASE("ModelUtils.collectTouchingNodes")
 TEST_CASE("ModelUtils.collectContainedNodes")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -333,7 +333,7 @@ TEST_CASE("ModelUtils.collectContainedNodes")
 TEST_CASE("ModelUtils.collectSelectedNodes")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -400,7 +400,7 @@ TEST_CASE("ModelUtils.collectSelectedNodes")
 TEST_CASE("ModelUtils.collectSelectableNodes")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -449,7 +449,7 @@ TEST_CASE("ModelUtils.collectSelectableNodes")
 TEST_CASE("ModelUtils.collectSelectedBrushFaces")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -485,7 +485,7 @@ TEST_CASE("ModelUtils.collectSelectedBrushFaces")
 TEST_CASE("ModelUtils.collectSelectableBrushFaces")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto* selectableBrushNode = new BrushNode{
@@ -507,7 +507,7 @@ TEST_CASE("ModelUtils.collectSelectableBrushFaces")
 TEST_CASE("ModelUtils.computeLogicalBounds")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -551,7 +551,7 @@ TEST_CASE("ModelUtils.computeLogicalBounds")
 TEST_CASE("ModelUtils.computePhysicalBounds")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -595,7 +595,7 @@ TEST_CASE("ModelUtils.computePhysicalBounds")
 TEST_CASE("ModelUtils.filterNodes")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 

--- a/lib/TbMdlLib/test/src/tst_NodeHandleManager.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeHandleManager.cpp
@@ -169,7 +169,7 @@ TEST_CASE("NodeHandleManager")
   manager.registerHandleType<TestEdgeHandle>();
 
   const auto worldBounds = vm::bbox3d{8192.0};
-  auto brushBuilder = BrushBuilder{MapFormat::Quake3, worldBounds};
+  auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
   auto brushNode = BrushNode{brushBuilder.createCube(32.0, "material").value()};
 
   auto sharedBrushNode = BrushNode{translateBrush(

--- a/lib/TbMdlLib/test/src/tst_NodeHandles.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeHandles.cpp
@@ -66,7 +66,7 @@ auto testCamera(const vm::vec3f& position)
 TEST_CASE("VertexHandle")
 {
   const auto worldBounds = vm::bbox3d{8192.0};
-  auto brushBuilder = BrushBuilder{MapFormat::Quake3, worldBounds};
+  auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
   auto brushNode = BrushNode{brushBuilder.createCube(32.0, "material").value()};
 
   SECTION("getHandles")
@@ -108,7 +108,7 @@ TEST_CASE("VertexHandle")
 TEST_CASE("EdgeHandle")
 {
   const auto worldBounds = vm::bbox3d{8192.0};
-  auto brushBuilder = BrushBuilder{MapFormat::Quake3, worldBounds};
+  auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
   auto brushNode = BrushNode{brushBuilder.createCube(32.0, "material").value()};
 
   SECTION("getHandles")
@@ -169,7 +169,7 @@ TEST_CASE("EdgeHandle")
 TEST_CASE("FaceHandle")
 {
   const auto worldBounds = vm::bbox3d{8192.0};
-  auto brushBuilder = BrushBuilder{MapFormat::Quake3, worldBounds};
+  auto brushBuilder = BrushBuilder{MapFormat::Quake3_Legacy, worldBounds};
   auto brushNode = BrushNode{brushBuilder.createCube(32.0, "material").value()};
 
   SECTION("getHandles")

--- a/lib/TbMdlLib/test/src/tst_NodeIndex.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeIndex.cpp
@@ -81,7 +81,7 @@ TEST_CASE("NodeIndex")
         {
           {"some_key", "a_value"},
         },
-        MapFormat::Quake3};
+        MapFormat::Quake3_Legacy};
 
       i.addNode(worldNode);
 

--- a/lib/TbMdlLib/test/src/tst_NodeQueries.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeQueries.cpp
@@ -44,7 +44,7 @@ using namespace Catch::Matchers;
 TEST_CASE("NodeQueries")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
 
@@ -226,7 +226,7 @@ TEST_CASE("NodeQueries")
 TEST_CASE("collectBrushFaces")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto* brushNode = new BrushNode{

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "Matchers.h"
+#include "TestParserStatus.h"
+#include "gl/Material.h"
+#include "gl/Texture.h"
 #include "mdl/BrushBuilder.h"
 #include "mdl/BrushFace.h"
 #include "mdl/BrushFaceAttributes.h"
@@ -33,9 +36,14 @@
 #include "mdl/TestUtils.h"
 #include "mdl/VisibilityState.h"
 #include "mdl/WorldNode.h"
+#include "mdl/WorldReader.h"
 
 #include "kd/result.h"
 #include "kd/task_manager.h"
+
+#include "vm/approx.h"
+#include "vm/vec.h"
+#include "vm/vec_io.h" // IWYU pragma: keep
 
 #include <fmt/format.h>
 
@@ -310,8 +318,10 @@ TEST_CASE("NodeWriter")
 
     const auto actual = str.str();
 
-    // Brush primitives are serialised as brushes wrapped in a brushDef block, and each
-    // face stores a 2x3 texture projection matrix.
+    // Brush primitives are serialized as brushes wrapped in a brushDef block, and each
+    // face stores a 2x3 texture projection matrix. The surface contents/flags/value are
+    // always written because NetRadiant fails to load a brush primitive face without
+    // them.
     CHECK(actual == R"(// entity 0
 {
 "classname" "worldspawn"
@@ -319,16 +329,94 @@ TEST_CASE("NodeWriter")
 {
 brushDef
 {
-( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
-( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
-( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) ( ( 0 1 0 ) ( -1 0 0 ) ) e1u1/test
-( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) ( ( 0 1 0 ) ( -1 0 0 ) ) e1u1/test
-( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
-( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
+( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test 0 0 0
+( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test 0 0 0
+( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) ( ( 0 1 0 ) ( -1 0 0 ) ) e1u1/test 0 0 0
+( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) ( ( 0 1 0 ) ( -1 0 0 ) ) e1u1/test 0 0 0
+( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test 0 0 0
+( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test 0 0 0
 }
 }
 }
 )");
+  }
+
+  SECTION("quake3BrushPrimitivesRoundTrip")
+  {
+    // A brush primitive face whose offset, scale and rotation are all modified must
+    // survive a write and read back through the real serializer and parser. A mirror is
+    // folded onto the V axis, so mirrored faces use a negative Y scale.
+    const auto worldBounds = vm::bbox3d{8192.0};
+    auto status = TestParserStatus{};
+
+    struct TestCase
+    {
+      vm::vec2f textureSize;
+      vm::vec2f offset;
+      vm::vec2f scale;
+      float rotation;
+    };
+
+    // clang-format off
+    const auto testCases = std::vector<TestCase>{
+      {{128, 256}, {16, -8},   {0.5f, 0.5f},  30.0f},
+      {{128, 128}, {-10, -20}, {0.5f, -0.5f}, 45.0f},
+      {{64, 128},  {12, 7},    {0.75f, 1.5f}, 180.0f},
+      {{256, 256}, {5, 5},     {2.0f, 0.5f},  270.0f},
+    };
+    // clang-format on
+
+    for (const auto& testCase : testCases)
+    {
+      const auto w = size_t(testCase.textureSize.x());
+      const auto h = size_t(testCase.textureSize.y());
+      auto material = gl::Material{"test", gl::createTextureResource(gl::Texture{w, h})};
+
+      // Build a cube whose every face carries the modified projection, so all six normals
+      // are exercised. The material is assigned so the writer uses the real texture size.
+      auto map = WorldNode{{}, {}, MapFormat::Quake3_BrushPrimitives};
+      auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+      auto brush = builder.createCube(64.0, "test") | kdl::value();
+      for (size_t i = 0; i < brush.faces().size(); ++i)
+      {
+        auto& face = brush.face(i);
+        face.setMaterial(&material);
+        auto attribs = face.attributes();
+        attribs.setOffset(testCase.offset);
+        attribs.setScale(testCase.scale);
+        attribs.setRotation(testCase.rotation);
+        face.setAttributes(attribs);
+      }
+      map.defaultLayer()->addChild(new BrushNode{std::move(brush)});
+
+      auto str = std::stringstream{};
+      auto writer = NodeWriter{map, str};
+      writer.writeMap(taskManager);
+
+      const auto serialized = str.str();
+      auto reader = WorldReader{serialized, MapFormat::Quake3_BrushPrimitives, {}};
+      auto worldResult = reader.read(worldBounds, status, taskManager);
+      REQUIRE(worldResult);
+
+      const auto& world = worldResult.value();
+      auto* readBrushNode =
+        static_cast<BrushNode*>(world->defaultLayer()->children().front());
+
+      // The parser leaves a provisional 64x64 projection; finalize each face with its
+      // real texture the way the resource pipeline does, then check the attributes.
+      for (size_t i = 0; i < readBrushNode->brush().faces().size(); ++i)
+      {
+        readBrushNode->setFaceMaterial(i, &material);
+        readBrushNode->finalizeBrushPrimitiveFace(i);
+      }
+
+      for (const auto& face : readBrushNode->brush().faces())
+      {
+        CHECK(face.attributes().offset() == vm::approx{testCase.offset, 0.0001f});
+        CHECK(face.attributes().scale() == vm::approx{testCase.scale, 0.0001f});
+        CHECK(face.attributes().rotation() == vm::approx{testCase.rotation, 0.01f});
+      }
+    }
   }
 
   SECTION("writeQuake3Map keeps legacy faces, not brush primitives")

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -52,7 +52,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeEmptyMap")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -70,7 +70,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeWorldspawn")
   {
-    auto map = mdl::WorldNode{{}, {{"message", "holy damn"}}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {{"message", "holy damn"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -89,9 +89,9 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeDefaultLayerProperties")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    map.defaultLayer()->setVisibilityState(mdl::VisibilityState::Hidden);
-    map.defaultLayer()->setLockState(mdl::LockState::Locked);
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    map.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
+    map.defaultLayer()->setLockState(LockState::Locked);
 
     auto layer = map.defaultLayer()->layer();
     layer.setColor(RgbF{0.25f, 0.75f, 1.0f});
@@ -118,9 +118,9 @@ TEST_CASE("NodeWriter")
 
   SECTION("stripTbProperties")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    map.defaultLayer()->setVisibilityState(mdl::VisibilityState::Hidden);
-    map.defaultLayer()->setLockState(mdl::LockState::Locked);
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    map.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
+    map.defaultLayer()->setLockState(LockState::Locked);
 
     auto layer = map.defaultLayer()->layer();
     layer.setColor(RgbF{0.25f, 0.75f, 1.0f});
@@ -146,9 +146,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Daikatana};
+    auto map = WorldNode{{}, {}, MapFormat::Daikatana};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
     auto brush1 = builder.createCube(64.0, "none") | kdl::value();
     for (auto& face : brush1.faces())
     {
@@ -156,11 +156,10 @@ TEST_CASE("NodeWriter")
       attributes.setColor(RgbF{1.0f, 0.5f, 0.25f});
       face.setAttributes(attributes);
     }
-    auto* brushNode1 = new mdl::BrushNode{std::move(brush1)};
+    auto* brushNode1 = new BrushNode{std::move(brush1)};
     map.defaultLayer()->addChild(brushNode1);
 
-    auto* brushNode2 =
-      new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto* brushNode2 = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     map.defaultLayer()->addChild(brushNode2);
 
     auto str = std::stringstream{};
@@ -199,9 +198,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake2_Valve};
+    auto map = WorldNode{{}, {}, MapFormat::Quake2_Valve};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
     auto brush1 = builder.createCube(64.0, "e1u1/alarm0") | kdl::value();
 
     // set +Z face to e1u1/brwater with contents 0, flags 0, value 0
@@ -232,7 +231,7 @@ TEST_CASE("NodeWriter")
     }
     // other faces are e1u1/alarm0 with unset contents/flags/value
 
-    auto* brushNode1 = new mdl::BrushNode{std::move(brush1)};
+    auto* brushNode1 = new BrushNode{std::move(brush1)};
     map.defaultLayer()->addChild(brushNode1);
 
     auto str = std::stringstream{};
@@ -263,11 +262,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake3_Valve};
+    auto map = WorldNode{{}, {}, MapFormat::Quake3_Valve};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode1 =
-      new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode1 = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     map.defaultLayer()->addChild(brushNode1);
 
     auto str = std::stringstream{};
@@ -298,10 +296,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     map.defaultLayer()->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -331,17 +329,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto layer = mdl::Layer{"Custom Layer"};
-    REQUIRE(layer.sortIndex() == mdl::Layer::invalidSortIndex());
+    auto layer = Layer{"Custom Layer"};
+    REQUIRE(layer.sortIndex() == Layer::invalidSortIndex());
     layer.setSortIndex(0);
 
-    auto* layerNode = new mdl::LayerNode{std::move(layer)};
+    auto* layerNode = new LayerNode{std::move(layer)};
     map.addChild(layerNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     layerNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -378,15 +376,15 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeWorldspawnWithCustomLayerWithSortIndex")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto layer = mdl::Layer{"Custom Layer"};
+    auto layer = Layer{"Custom Layer"};
     layer.setSortIndex(1);
     layer.setOmitFromExport(true);
 
-    auto* layerNode = new mdl::LayerNode{std::move(layer)};
-    layerNode->setLockState(mdl::LockState::Locked);
-    layerNode->setVisibilityState(mdl::VisibilityState::Hidden);
+    auto* layerNode = new LayerNode{std::move(layer)};
+    layerNode->setLockState(LockState::Locked);
+    layerNode->setVisibilityState(VisibilityState::Hidden);
 
     map.addChild(layerNode);
 
@@ -420,14 +418,14 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "group_link_id");
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "group_link_id");
     map.defaultLayer()->addChild(groupNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     groupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -466,17 +464,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode = new mdl::LayerNode{mdl::Layer{"Custom Layer"}};
+    auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
     map.addChild(layerNode);
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "group_link_id");
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "group_link_id");
     layerNode->addChild(groupNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     groupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -524,21 +522,21 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode = new mdl::LayerNode{mdl::Layer{"Custom Layer"}};
+    auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
     map.addChild(layerNode);
 
-    auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"Outer Group"}};
-    mdl::setLinkId(*outerGroupNode, "outer_group_link_id");
+    auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
+    setLinkId(*outerGroupNode, "outer_group_link_id");
     layerNode->addChild(outerGroupNode);
 
-    auto* innerGroupNode = new mdl::GroupNode{mdl::Group{"Inner Group"}};
-    mdl::setLinkId(*innerGroupNode, "inner_group_link_id");
+    auto* innerGroupNode = new GroupNode{Group{"Inner Group"}};
+    setLinkId(*innerGroupNode, "inner_group_link_id");
     outerGroupNode->addChild(innerGroupNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     innerGroupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -596,28 +594,28 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode1 = new mdl::LayerNode{mdl::Layer{"Custom Layer 1"}};
+    auto* layerNode1 = new LayerNode{Layer{"Custom Layer 1"}};
     layerNode1->setPersistentId(1u);
     map.addChild(layerNode1);
 
-    auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"Outer Group"}};
+    auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
     outerGroupNode->setPersistentId(21u);
-    mdl::setLinkId(*outerGroupNode, "outer_group_link_id");
+    setLinkId(*outerGroupNode, "outer_group_link_id");
     layerNode1->addChild(outerGroupNode);
 
-    auto* innerGroupNode = new mdl::GroupNode{mdl::Group{"Inner Group"}};
+    auto* innerGroupNode = new GroupNode{Group{"Inner Group"}};
     innerGroupNode->setPersistentId(7u);
-    mdl::setLinkId(*innerGroupNode, "inner_group_link_id");
+    setLinkId(*innerGroupNode, "inner_group_link_id");
     outerGroupNode->addChild(innerGroupNode);
 
-    auto* layerNode2 = new mdl::LayerNode{mdl::Layer{"Custom Layer 2"}};
+    auto* layerNode2 = new LayerNode{Layer{"Custom Layer 2"}};
     layerNode2->setPersistentId(12u);
     map.addChild(layerNode2);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     innerGroupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -679,8 +677,8 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
 
     // default layer (omit from export)
     auto defaultLayer = map.defaultLayer()->layer();
@@ -688,38 +686,38 @@ TEST_CASE("NodeWriter")
     map.defaultLayer()->setLayer(std::move(defaultLayer));
 
     auto* defaultLayerPointEntityNode =
-      new mdl::EntityNode{mdl::Entity{{{"classname", "defaultLayerPointEntity"}}}};
+      new EntityNode{Entity{{{"classname", "defaultLayerPointEntity"}}}};
 
     auto* defaultLayerBrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "defaultMaterial") | kdl::value()};
+      new BrushNode{builder.createCube(64.0, "defaultMaterial") | kdl::value()};
     map.defaultLayer()->addChild(defaultLayerPointEntityNode);
     map.defaultLayer()->addChild(defaultLayerBrushNode);
 
     // layer1 (omit from export)
-    auto layer1 = mdl::Layer{"Custom Layer 1"};
+    auto layer1 = Layer{"Custom Layer 1"};
     layer1.setOmitFromExport(true);
 
-    auto* layerNode1 = new mdl::LayerNode{std::move(layer1)};
+    auto* layerNode1 = new LayerNode{std::move(layer1)};
     map.addChild(layerNode1);
 
     auto* layer1PointEntityNode =
-      new mdl::EntityNode{mdl::Entity{{{"classname", "layer1PointEntity"}}}};
+      new EntityNode{Entity{{{"classname", "layer1PointEntity"}}}};
     layerNode1->addChild(layer1PointEntityNode);
 
     auto* layer1BrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "layer1Material") | kdl::value()};
+      new BrushNode{builder.createCube(64.0, "layer1Material") | kdl::value()};
     layerNode1->addChild(layer1BrushNode);
 
     // layer2
-    auto* layerNode2 = new mdl::LayerNode{mdl::Layer{"Custom Layer 2"}};
+    auto* layerNode2 = new LayerNode{Layer{"Custom Layer 2"}};
     map.addChild(layerNode2);
 
     auto* layer2PointEntityNode =
-      new mdl::EntityNode{mdl::Entity{{{"classname", "layer2PointEntity"}}}};
+      new EntityNode{Entity{{{"classname", "layer2PointEntity"}}}};
     layerNode2->addChild(layer2PointEntityNode);
 
     auto* layer2BrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "layer2Material") | kdl::value()};
+      new BrushNode{builder.createCube(64.0, "layer2Material") | kdl::value()};
     layerNode2->addChild(layer2BrushNode);
 
     auto str = std::stringstream{};
@@ -761,9 +759,9 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeMapWithInheritedLock")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode = new mdl::LayerNode{mdl::Layer{"Custom Layer"}};
+    auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
     map.addChild(layerNode);
 
     // WorldNode's lock state is not persisted.
@@ -771,9 +769,9 @@ TEST_CASE("NodeWriter")
     // So this should result in both the default layer and custom layer being written
     // unlocked.
 
-    map.setLockState(mdl::LockState::Locked);
-    map.defaultLayer()->setLockState(mdl::LockState::Inherited);
-    layerNode->setLockState(mdl::LockState::Inherited);
+    map.setLockState(LockState::Locked);
+    map.defaultLayer()->setLockState(LockState::Inherited);
+    layerNode->setLockState(LockState::Inherited);
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -800,19 +798,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
 
-    auto* worldBrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "some") | kdl::value()};
-    auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"Outer Group"}};
-    auto* innerGroupNode = new mdl::GroupNode{mdl::Group{"Inner Group"}};
-    auto* innerBrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto* worldBrushNode = new BrushNode{builder.createCube(64.0, "some") | kdl::value()};
+    auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
+    auto* innerGroupNode = new GroupNode{Group{"Inner Group"}};
+    auto* innerBrushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
 
-    mdl::setLinkId(*outerGroupNode, "outer_group_link_id");
-    mdl::setLinkId(*innerGroupNode, "inner_group_link_id");
+    setLinkId(*outerGroupNode, "outer_group_link_id");
+    setLinkId(*innerGroupNode, "inner_group_link_id");
 
     innerGroupNode->addChild(innerBrushNode);
     outerGroupNode->addChild(innerGroupNode);
@@ -864,10 +860,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto worldNode = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "group_link_id");
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "group_link_id");
     worldNode.defaultLayer()->addChild(groupNode);
 
     SECTION("Group node with identity transformation does not write transformation")
@@ -897,8 +893,7 @@ TEST_CASE("NodeWriter")
 
     SECTION("Group node with changed transformation writes transformation")
     {
-      mdl::transformNode(
-        *groupNode, vm::translation_matrix(vm::vec3d{32, 0, 0}), worldBounds);
+      transformNode(*groupNode, vm::translation_matrix(vm::vec3d{32, 0, 0}), worldBounds);
 
       auto str = std::stringstream{};
       auto writer = NodeWriter{worldNode, str};
@@ -929,17 +924,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto worldNode = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "asdf");
-    mdl::transformNode(
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "asdf");
+    transformNode(
       *groupNode, vm::translation_matrix(vm::vec3d(32.0, 0.0, 0.0)), worldBounds);
     worldNode.defaultLayer()->addChild(groupNode);
 
     auto* groupNodeClone =
-      static_cast<mdl::GroupNode*>(groupNode->cloneRecursively(worldBounds));
-    mdl::transformNode(
+      static_cast<GroupNode*>(groupNode->cloneRecursively(worldBounds));
+    transformNode(
       *groupNodeClone, vm::translation_matrix(vm::vec3d(0.0, 16.0, 0.0)), worldBounds);
 
     worldNode.defaultLayer()->addChild(groupNodeClone);
@@ -967,13 +962,13 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeProtectedEntityProperties")
   {
-    auto worldNode = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     SECTION("No protected properties")
     {
-      auto entity = mdl::Entity{};
+      auto entity = Entity{};
       entity.setProtectedProperties({});
-      auto* entityNode = new mdl::EntityNode{std::move(entity)};
+      auto* entityNode = new EntityNode{std::move(entity)};
       worldNode.defaultLayer()->addChild(entityNode);
 
       auto str = std::stringstream{};
@@ -991,9 +986,9 @@ TEST_CASE("NodeWriter")
 
     SECTION("Some protected properties")
     {
-      auto entity = mdl::Entity{};
+      auto entity = Entity{};
       entity.setProtectedProperties({"asdf", "some", "with;semicolon"});
-      auto* entityNode = new mdl::EntityNode{std::move(entity)};
+      auto* entityNode = new EntityNode{std::move(entity)};
       worldNode.defaultLayer()->addChild(entityNode);
 
       auto str = std::stringstream{};
@@ -1015,9 +1010,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1040,8 +1035,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writePropertiesWithQuotationMarks")
   {
-    mdl::WorldNode map(
-      {}, {{"message", "\"holy damn\", he said"}}, mdl::MapFormat::Standard);
+    WorldNode map({}, {{"message", "\"holy damn\", he said"}}, MapFormat::Standard);
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1061,8 +1055,8 @@ TEST_CASE("NodeWriter")
 
   SECTION("writePropertiesWithEscapedQuotationMarks")
   {
-    auto map = mdl::WorldNode{
-      {}, {{"message", R"(\"holy damn\", he said)"}}, mdl::MapFormat::Standard};
+    auto map =
+      WorldNode{{}, {{"message", R"(\"holy damn\", he said)"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1083,8 +1077,7 @@ TEST_CASE("NodeWriter")
   // https://github.com/TrenchBroom/TrenchBroom/issues/1739
   SECTION("writePropertiesWithNewlineEscapeSequence")
   {
-    auto map =
-      mdl::WorldNode{{}, {{"message", "holy damn\\nhe said"}}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {{"message", "holy damn\\nhe said"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1105,14 +1098,14 @@ TEST_CASE("NodeWriter")
   // https://github.com/TrenchBroom/TrenchBroom/issues/2556
   SECTION("writePropertiesWithTrailingBackslash")
   {
-    auto map = mdl::WorldNode{
+    auto map = WorldNode{
       {},
       {
         {R"(message\)", R"(holy damn\)"},
         {R"(message2)", R"(holy damn\\)"},
         {R"(message3)", R"(holy damn\\\)"},
       },
-      mdl::MapFormat::Standard};
+      MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -336,7 +336,7 @@ brushDef
     const auto worldBounds = vm::bbox3d{8192.0};
 
     // NOLINTNEXTLINE(misc-const-correctness)
-    auto map = WorldNode{{}, {}, MapFormat::Quake3};
+    auto map = WorldNode{{}, {}, MapFormat::Quake3_Legacy};
 
     auto builder = BrushBuilder{map.mapFormat(), worldBounds};
     auto* brushNode1 =

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -292,6 +292,69 @@ TEST_CASE("NodeWriter")
     CHECK(actual == expected);
   }
 
+  SECTION("writeQuake3BrushPrimitivesMap")
+  {
+    const auto worldBounds = vm::bbox3d{8192.0};
+
+    // NOLINTNEXTLINE(misc-const-correctness)
+    auto map = WorldNode{{}, {}, MapFormat::Quake3_BrushPrimitives};
+
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode1 =
+      new BrushNode{builder.createCube(64.0, "e1u1/test") | kdl::value()};
+    map.defaultLayer()->addChild(brushNode1);
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{map, str};
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+
+    // Brush primitives are serialised as brushes wrapped in a brushDef block, and each
+    // face stores a 2x3 texture projection matrix.
+    CHECK(actual == R"(// entity 0
+{
+"classname" "worldspawn"
+// brush 0
+{
+brushDef
+{
+( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
+( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
+( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) ( ( 0 1 0 ) ( -1 0 0 ) ) e1u1/test
+( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) ( ( 0 1 0 ) ( -1 0 0 ) ) e1u1/test
+( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
+( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) ( ( 1 0 0 ) ( 0 1 0 ) ) e1u1/test
+}
+}
+}
+)");
+  }
+
+  SECTION("writeQuake3Map keeps legacy faces, not brush primitives")
+  {
+    const auto worldBounds = vm::bbox3d{8192.0};
+
+    // NOLINTNEXTLINE(misc-const-correctness)
+    auto map = WorldNode{{}, {}, MapFormat::Quake3};
+
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode1 =
+      new BrushNode{builder.createCube(64.0, "e1u1/test") | kdl::value()};
+    map.defaultLayer()->addChild(brushNode1);
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{map, str};
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+
+    // The plain Quake 3 format must keep legacy face output so existing maps and other
+    // games (Neverball, Quetoo) are unaffected.
+    CHECK(actual.find("brushDef") == std::string::npos);
+    CHECK(actual.find("e1u1/test") != std::string::npos);
+  }
+
   SECTION("writeWorldspawnWithBrushInDefaultLayer")
   {
     const auto worldBounds = vm::bbox3d{8192.0};

--- a/lib/TbMdlLib/test/src/tst_ObjSerializer.cpp
+++ b/lib/TbMdlLib/test/src/tst_ObjSerializer.cpp
@@ -52,11 +52,11 @@ TEST_CASE("ObjSerializer.writeBrush")
 
   auto taskManager = kdl::task_manager{};
 
-  auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake3};
+  auto map = WorldNode{{}, {}, MapFormat::Quake3};
 
-  auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+  auto builder = BrushBuilder{map.mapFormat(), worldBounds};
   auto* brushNode =
-    new mdl::BrushNode{builder.createCube(64.0, "some_material") | kdl::value()};
+    new BrushNode{builder.createCube(64.0, "some_material") | kdl::value()};
   map.defaultLayer()->addChild(brushNode);
 
   auto objStream = std::ostringstream{};
@@ -121,10 +121,10 @@ TEST_CASE("ObjSerializer.writePatch")
 
   auto taskManager = kdl::task_manager{};
 
-  auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake3};
+  auto map = WorldNode{{}, {}, MapFormat::Quake3};
 
-  auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-  auto* patchNode = new mdl::PatchNode{mdl::BezierPatch{
+  auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+  auto* patchNode = new PatchNode{BezierPatch{
     3,
     3,
     {{0, 0, 0},
@@ -404,11 +404,11 @@ TEST_CASE("ObjSerializer.writeRelativeMaterialPath")
   auto material = gl::Material{"some_material", std::move(textureResource)};
   material.setRelativePath("textures/some_material.png");
 
-  auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake3};
+  auto map = WorldNode{{}, {}, MapFormat::Quake3};
 
-  auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+  auto builder = BrushBuilder{map.mapFormat(), worldBounds};
   auto* brushNode =
-    new mdl::BrushNode{builder.createCube(64.0, "some_material") | kdl::value()};
+    new BrushNode{builder.createCube(64.0, "some_material") | kdl::value()};
   map.defaultLayer()->addChild(brushNode);
 
   for (size_t i = 0; i < brushNode->brush().faceCount(); ++i)

--- a/lib/TbMdlLib/test/src/tst_ObjSerializer.cpp
+++ b/lib/TbMdlLib/test/src/tst_ObjSerializer.cpp
@@ -52,7 +52,7 @@ TEST_CASE("ObjSerializer.writeBrush")
 
   auto taskManager = kdl::task_manager{};
 
-  auto map = WorldNode{{}, {}, MapFormat::Quake3};
+  auto map = WorldNode{{}, {}, MapFormat::Quake3_Legacy};
 
   auto builder = BrushBuilder{map.mapFormat(), worldBounds};
   auto* brushNode =
@@ -121,7 +121,7 @@ TEST_CASE("ObjSerializer.writePatch")
 
   auto taskManager = kdl::task_manager{};
 
-  auto map = WorldNode{{}, {}, MapFormat::Quake3};
+  auto map = WorldNode{{}, {}, MapFormat::Quake3_Legacy};
 
   auto builder = BrushBuilder{map.mapFormat(), worldBounds};
   auto* patchNode = new PatchNode{BezierPatch{
@@ -404,7 +404,7 @@ TEST_CASE("ObjSerializer.writeRelativeMaterialPath")
   auto material = gl::Material{"some_material", std::move(textureResource)};
   material.setRelativePath("textures/some_material.png");
 
-  auto map = WorldNode{{}, {}, MapFormat::Quake3};
+  auto map = WorldNode{{}, {}, MapFormat::Quake3_Legacy};
 
   auto builder = BrushBuilder{map.mapFormat(), worldBounds};
   auto* brushNode =

--- a/lib/TbMdlLib/test/src/tst_ParseGameConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseGameConfig.cpp
@@ -501,7 +501,7 @@ TEST_CASE("GameConfigParser")
 {
     "version": 9,
     "name": "Extras",
-    "fileformats": [ { "format": "Quake3" } ],
+    "fileformats": [ { "format": "Quake3 (legacy)" } ],
     "filesystem": {
         "searchpath": "baseq3",
         "packageformat": { "extension": "pk3", "format": "zip" }
@@ -730,7 +730,7 @@ TEST_CASE("GameConfigParser")
         {},
         {},
         false,
-        {mdl::MapFormatConfig{"Quake3", {}}},
+        {mdl::MapFormatConfig{"Quake3 (legacy)", {}}},
         mdl::FileSystemConfig{{"baseq3"}, mdl::PackageFormatConfig{{".pk3"}, "zip"}},
         mdl::MaterialConfig{
           {"textures"},

--- a/lib/TbMdlLib/test/src/tst_Quake3BrushPrimitive.cpp
+++ b/lib/TbMdlLib/test/src/tst_Quake3BrushPrimitive.cpp
@@ -18,12 +18,16 @@
  */
 
 #include "mdl/CatchConfig.h"
+#include "mdl/ParallelUVCoordSystem.h"
 #include "mdl/Quake3BrushPrimitive.h"
 
 #include "vm/approx.h"
+#include "vm/quat.h"
+#include "vm/scalar.h"
 #include "vm/vec.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
+#include <tuple>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
@@ -105,6 +109,73 @@ TEST_CASE("Quake3BrushPrimitive")
     CHECK(uvAxes.uAxis == vm::approx{texX, 0.0001});
     CHECK(uvAxes.vAxis == vm::approx{texY, 0.0001});
     CHECK(uvAxes.offset == vm::vec2f{0, 0});
+  }
+
+  SECTION("parallel UV decomposition round trips modified attributes")
+  {
+    // Build the projection that a face with the given offset/scale/rotation would have,
+    // serialize it to a brush primitive matrix (the way the map writer does), then
+    // decompose it back and check the attributes survive. This mirrors a save/load round
+    // trip and covers non-64 texture sizes, so it fails for the old code that always
+    // assumed 64x64 and discarded scale/rotation.
+    struct TestCase
+    {
+      vm::vec3d normal;
+      vm::vec2f textureSize;
+      vm::vec2f offset;
+      vm::vec2f scale;
+      float rotation;
+    };
+
+    // clang-format off
+    const auto testCases = std::vector<TestCase>{
+      {{0, 0, 1},  {64, 64},   {0, 0},   {0.5f, 0.5f},   0.0f},
+      {{0, 0, 1},  {128, 128}, {16, -8}, {0.5f, 0.5f},   0.0f},
+      {{0, 0, 1},  {128, 256}, {10, 20}, {0.25f, 2.0f},  30.0f},
+      {{0, 1, 0},  {64, 128},  {-12, 7}, {1.0f, 0.5f},   210.0f},
+      {{1, 0, 0},  {256, 256}, {5, 5},   {0.75f, 0.75f}, 90.0f},
+      {vm::normalize(vm::vec3d{1, 2, 3}),
+                   {64, 64},   {3, -4},  {0.5f, 1.5f},   45.0f},
+      // a mirror is folded onto the V axis, so a mirrored face has a negative Y scale
+      {{0, 0, 1},  {128, 128}, {-10, -20}, {0.5f, -0.5f}, 45.0f},
+      // rotations at the 180 and 270 degree boundaries with all attributes modified
+      {{0, 1, 0},  {64, 128},  {12, 7},    {0.75f, 1.5f}, 180.0f},
+      {{1, 0, 0},  {256, 256}, {5, 5},     {2.0f, 0.5f},  270.0f},
+      // a second oblique normal
+      {vm::normalize(vm::vec3d{-3, 1, -2}),
+                   {128, 256}, {6, -9},    {0.5f, 1.5f},  90.0f},
+    };
+    // clang-format on
+
+    for (const auto& testCase : testCases)
+    {
+      const auto [baseUAxis, baseVAxis] = computeInitialAxes(testCase.normal);
+      const auto textureNormal = vm::cross(baseUAxis, baseVAxis);
+      const auto rotation =
+        vm::quatd{textureNormal, vm::to_radians(double(testCase.rotation))};
+      const auto uAxis = rotation * baseUAxis;
+      const auto vAxis = rotation * baseVAxis;
+
+      // the effective axes as stored by the serializer (axes divided by their scale)
+      const auto effectiveUAxis = uAxis / double(testCase.scale.x());
+      const auto effectiveVAxis = vAxis / double(testCase.scale.y());
+
+      const auto matrix = uvAxesToBrushPrimitiveMatrix(
+        testCase.normal,
+        effectiveUAxis,
+        effectiveVAxis,
+        testCase.offset,
+        testCase.textureSize);
+
+      const auto uv =
+        brushPrimitiveMatrixToParallelUV(testCase.normal, matrix, testCase.textureSize);
+
+      CHECK(uv.offset == vm::approx{testCase.offset, 0.0001f});
+      CHECK(uv.scale == vm::approx{testCase.scale, 0.0001f});
+      CHECK(uv.rotation == vm::approx{testCase.rotation, 0.01f});
+      CHECK(uv.uAxis == vm::approx{uAxis, 0.0001});
+      CHECK(uv.vAxis == vm::approx{vAxis, 0.0001});
+    }
   }
 }
 

--- a/lib/TbMdlLib/test/src/tst_Quake3BrushPrimitive.cpp
+++ b/lib/TbMdlLib/test/src/tst_Quake3BrushPrimitive.cpp
@@ -1,0 +1,111 @@
+/*
+ Copyright (C) 2010 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mdl/CatchConfig.h"
+#include "mdl/Quake3BrushPrimitive.h"
+
+#include "vm/approx.h"
+#include "vm/vec.h"
+#include "vm/vec_io.h" // IWYU pragma: keep
+
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb::mdl
+{
+
+TEST_CASE("Quake3BrushPrimitive")
+{
+  SECTION("computeAxisBase produces an orthonormal in-plane basis")
+  {
+    const auto normals = std::vector<vm::vec3d>{
+      {0, 0, 1},
+      {0, 0, -1},
+      {1, 0, 0},
+      {-1, 0, 0},
+      {0, 1, 0},
+      {0, -1, 0},
+      vm::normalize(vm::vec3d{1, 2, 3}),
+      vm::normalize(vm::vec3d{-3, 1, -2}),
+    };
+
+    for (const auto& normal : normals)
+    {
+      const auto [texX, texY] = computeAxisBase(normal);
+
+      CHECK(vm::length(texX) == vm::approx{1.0, 0.0001});
+      CHECK(vm::length(texY) == vm::approx{1.0, 0.0001});
+      CHECK(vm::dot(texX, texY) == vm::approx{0.0, 0.0001});
+      CHECK(vm::dot(texX, normal) == vm::approx{0.0, 0.0001});
+      CHECK(vm::dot(texY, normal) == vm::approx{0.0, 0.0001});
+    }
+  }
+
+  SECTION("brush primitive matrix round trips through UV axes")
+  {
+    struct TestCase
+    {
+      vm::vec3d normal;
+      Quake3BrushPrimitiveMatrix matrix;
+      vm::vec2f textureSize;
+    };
+
+    // clang-format off
+    const auto testCases = std::vector<TestCase>{
+      {{0, 0, 1},  {{0.03125, 0.0, 14.0}, {0.0, 0.03125, 4.5}},     {64, 64}},
+      {{0, 1, 0},  {{0.01, -0.02, 3.0},   {0.005, 0.015, -7.0}},    {128, 256}},
+      {{1, 0, 0},  {{0.0, 0.015625, 0.0}, {0.015625, 0.0, 0.0}},    {64, 64}},
+      {vm::normalize(vm::vec3d{1, 2, 3}),
+                   {{0.02, 0.01, 1.25},   {-0.01, 0.03, -2.5}},     {64, 128}},
+    };
+    // clang-format on
+
+    for (const auto& testCase : testCases)
+    {
+      const auto uvAxes = brushPrimitiveMatrixToUVAxes(
+        testCase.normal, testCase.matrix, testCase.textureSize);
+
+      const auto roundTripped = uvAxesToBrushPrimitiveMatrix(
+        testCase.normal, uvAxes.uAxis, uvAxes.vAxis, uvAxes.offset, testCase.textureSize);
+
+      CHECK(roundTripped.row0 == vm::approx{testCase.matrix.row0, 0.0001});
+      CHECK(roundTripped.row1 == vm::approx{testCase.matrix.row1, 0.0001});
+    }
+  }
+
+  SECTION("brush primitive matrix maps to the expected UV axes")
+  {
+    // A floor facing up, textured at one repeat per 64 units with no offset. With a 64x64
+    // texture this collapses to the bare axis base, which is the simplest case to verify.
+    const auto normal = vm::vec3d{0, 0, 1};
+    const auto matrix =
+      Quake3BrushPrimitiveMatrix{{1.0 / 64.0, 0.0, 0.0}, {0.0, 1.0 / 64.0, 0.0}};
+    const auto textureSize = vm::vec2f{64, 64};
+
+    const auto uvAxes = brushPrimitiveMatrixToUVAxes(normal, matrix, textureSize);
+    const auto [texX, texY] = computeAxisBase(normal);
+
+    CHECK(uvAxes.uAxis == vm::approx{texX, 0.0001});
+    CHECK(uvAxes.vAxis == vm::approx{texY, 0.0001});
+    CHECK(uvAxes.offset == vm::vec2f{0, 0});
+  }
+}
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_WorldNode.cpp
+++ b/lib/TbMdlLib/test/src/tst_WorldNode.cpp
@@ -46,7 +46,7 @@ using namespace Catch::Matchers;
 TEST_CASE("WorldNodeTest.canAddChild")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   const auto worldNode = WorldNode{{}, {}, mapFormat};
   auto layerNode = LayerNode{Layer{"layer"}};
@@ -73,7 +73,7 @@ TEST_CASE("WorldNodeTest.canAddChild")
 TEST_CASE("WorldNodeTest.canRemoveChild")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   const auto worldNode = WorldNode{{}, {}, mapFormat};
   auto layerNode = LayerNode{Layer{"layer"}};
@@ -101,7 +101,7 @@ TEST_CASE("WorldNodeTest.canRemoveChild")
 TEST_CASE("WorldNodeTest.nodeTreeUpdates")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto* layerNode = new LayerNode{Layer{"layer"}};
@@ -250,7 +250,7 @@ TEST_CASE("WorldNodeTest.nodeTreeUpdates")
 TEST_CASE("WorldNodeTest.rebuildNodeTree")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto* layerNode = new LayerNode{Layer{"layer"}};
@@ -291,7 +291,7 @@ TEST_CASE("WorldNodeTest.rebuildNodeTree")
 TEST_CASE("WorldNodeTest.disableNodeTreeUpdates")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};
-  constexpr auto mapFormat = MapFormat::Quake3;
+  constexpr auto mapFormat = MapFormat::Quake3_Legacy;
 
   auto worldNode = WorldNode{{}, {}, mapFormat};
   auto* layerNode = new LayerNode{Layer{"layer"}};

--- a/lib/TbMdlLib/test/src/tst_WorldReader.cpp
+++ b/lib/TbMdlLib/test/src/tst_WorldReader.cpp
@@ -64,7 +64,7 @@ TEST_CASE("WorldReader")
   SECTION("Empty map")
   {
     const auto data = "";
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -79,7 +79,7 @@ TEST_CASE("WorldReader")
   {
     const auto data = "{}";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -100,7 +100,7 @@ TEST_CASE("WorldReader")
 )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -108,11 +108,11 @@ TEST_CASE("WorldReader")
     const auto& worldNode = worldResult.value();
     CHECK(worldNode != nullptr);
     CHECK(worldNode->childCount() == 1u);
-    auto* defaultLayer = dynamic_cast<mdl::LayerNode*>(worldNode->children().at(0));
+    auto* defaultLayer = dynamic_cast<LayerNode*>(worldNode->children().at(0));
     REQUIRE(defaultLayer != nullptr);
     REQUIRE(!defaultLayer->hasChildren());
 
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("message"));
     CHECK(*worldNode->entity().property("message") == "yay");
 
@@ -132,7 +132,7 @@ TEST_CASE("WorldReader")
 }
 )";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -155,7 +155,7 @@ TEST_CASE("WorldReader")
 )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -163,7 +163,7 @@ TEST_CASE("WorldReader")
     const auto& world = worldResult.value();
     REQUIRE(world != nullptr);
     REQUIRE(world->childCount() == 1u);
-    auto* defaultLayer = dynamic_cast<mdl::LayerNode*>(world->children().at(0));
+    auto* defaultLayer = dynamic_cast<LayerNode*>(world->children().at(0));
     REQUIRE(defaultLayer != nullptr);
 
     CHECK(defaultLayer->layer().color() == Color{RgbF{0.0f, 1.0f, 0.0f}});
@@ -187,25 +187,24 @@ TEST_CASE("WorldReader")
 )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
 
     const auto& worldNode = worldResult.value();
     CHECK(worldNode != nullptr);
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("message"));
     CHECK(*worldNode->entity().property("message") == "yay");
 
     CHECK(worldNode->childCount() == 1u);
-    auto* defaultLayerNode = dynamic_cast<mdl::LayerNode*>(worldNode->children().front());
+    auto* defaultLayerNode = dynamic_cast<LayerNode*>(worldNode->children().front());
     CHECK(defaultLayerNode != nullptr);
     CHECK(defaultLayerNode->childCount() == 1u);
-    CHECK(defaultLayerNode->layer().sortIndex() == mdl::Layer::defaultLayerSortIndex());
+    CHECK(defaultLayerNode->layer().sortIndex() == Layer::defaultLayerSortIndex());
 
-    auto* entityNode =
-      static_cast<mdl::EntityNode*>(defaultLayerNode->children().front());
+    auto* entityNode = static_cast<EntityNode*>(defaultLayerNode->children().front());
     CHECK(entityNode->entity().hasProperty("classname"));
     CHECK(*entityNode->entity().property("classname") == "info_player_deathmatch");
     CHECK(entityNode->entity().hasProperty("origin"));
@@ -229,7 +228,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -239,7 +238,7 @@ TEST_CASE("WorldReader")
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
 
-    auto* brushNode = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brushNode = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brushNode, false);
     const auto& faces = brushNode->brush().faces();
     CHECK(faces.size() == 6u);
@@ -309,7 +308,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -319,7 +318,7 @@ TEST_CASE("WorldReader")
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
 
-    auto* brushNode = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brushNode = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brushNode, false);
     const auto& faces = brushNode->brush().faces();
     CHECK(faces.size() == 6u);
@@ -352,7 +351,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -362,7 +361,7 @@ TEST_CASE("WorldReader")
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
 
-    auto* brushNode = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brushNode = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brushNode, false);
     const auto& faces = brushNode->brush().faces();
     CHECK(faces.size() == 6u);
@@ -426,7 +425,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Valve, {}};
+    auto reader = WorldReader{data, MapFormat::Valve, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -435,7 +434,7 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, true);
   }
 
@@ -454,7 +453,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -464,7 +463,7 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, false);
 
     SECTION("surface attributes for face attribsExplicit")
@@ -524,7 +523,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2_Valve, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2_Valve, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -533,7 +532,7 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, true);
   }
 
@@ -554,7 +553,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake3_Valve, {}};
+    auto reader = WorldReader{data, MapFormat::Quake3_Valve, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -563,7 +562,7 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, true);
   }
 
@@ -582,7 +581,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Daikatana, {}};
+    auto reader = WorldReader{data, MapFormat::Daikatana, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -592,8 +591,7 @@ TEST_CASE("WorldReader")
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
 
-    const auto* brushNode =
-      static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    const auto* brushNode = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brushNode, false);
     const auto& brush = brushNode->brush();
 
@@ -627,7 +625,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Daikatana, {}};
+    auto reader = WorldReader{data, MapFormat::Daikatana, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -637,8 +635,7 @@ TEST_CASE("WorldReader")
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
 
-    const auto* brushNode =
-      static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    const auto* brushNode = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brushNode, false);
     const auto& brush = brushNode->brush();
 
@@ -679,7 +676,7 @@ TEST_CASE("WorldReader")
 )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Daikatana, {}};
+    auto reader = WorldReader{data, MapFormat::Daikatana, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -688,7 +685,7 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, false);
   }
 
@@ -707,7 +704,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -716,7 +713,7 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, false);
   }
 
@@ -757,7 +754,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -765,12 +762,12 @@ TEST_CASE("WorldReader")
     const auto& world = worldResult.value();
     CHECK(world->childCount() == 2u);
 
-    auto* defaultLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(0));
-    auto* myLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(1));
+    auto* defaultLayerNode = dynamic_cast<LayerNode*>(world->children().at(0));
+    auto* myLayerNode = dynamic_cast<LayerNode*>(world->children().at(1));
     CHECK(defaultLayerNode != nullptr);
     CHECK(myLayerNode != nullptr);
 
-    CHECK(defaultLayerNode->layer().sortIndex() == mdl::Layer::defaultLayerSortIndex());
+    CHECK(defaultLayerNode->layer().sortIndex() == Layer::defaultLayerSortIndex());
     // The layer didn't have a sort index (saved in an older version of TB), so it's
     // assigned 0
     CHECK(myLayerNode->layer().sortIndex() == 0);
@@ -805,7 +802,7 @@ TEST_CASE("WorldReader")
 "_tb_layer_omit_from_export" "1"
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -814,9 +811,9 @@ TEST_CASE("WorldReader")
     REQUIRE(world->childCount() == 3u);
 
     // NOTE: They are listed in world->children() in file order, not sort index order
-    auto* defaultLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(0));
-    auto* sortNode1 = dynamic_cast<mdl::LayerNode*>(world->children().at(1));
-    auto* sortNode0 = dynamic_cast<mdl::LayerNode*>(world->children().at(2));
+    auto* defaultLayerNode = dynamic_cast<LayerNode*>(world->children().at(0));
+    auto* sortNode1 = dynamic_cast<LayerNode*>(world->children().at(1));
+    auto* sortNode0 = dynamic_cast<LayerNode*>(world->children().at(2));
 
     REQUIRE(defaultLayerNode != nullptr);
     REQUIRE(sortNode0 != nullptr);
@@ -825,7 +822,7 @@ TEST_CASE("WorldReader")
     CHECK(sortNode0->name() == "Sort Index 0");
     CHECK(sortNode1->name() == "Sort Index 1");
 
-    CHECK(defaultLayerNode->layer().sortIndex() == mdl::Layer::defaultLayerSortIndex());
+    CHECK(defaultLayerNode->layer().sortIndex() == Layer::defaultLayerSortIndex());
     CHECK(sortNode0->layer().sortIndex() == 0);
     CHECK(sortNode1->layer().sortIndex() == 1);
 
@@ -867,7 +864,7 @@ TEST_CASE("WorldReader")
 "_tb_layer_sort_index" "1"
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -876,10 +873,10 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 4u);
 
     // NOTE: They are listed in world->children() in file order, not sort index order
-    auto* defaultLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(0));
-    auto* sortNode5 = dynamic_cast<mdl::LayerNode*>(world->children().at(1));
-    auto* sortNode3 = dynamic_cast<mdl::LayerNode*>(world->children().at(2));
-    auto* sortNode1 = dynamic_cast<mdl::LayerNode*>(world->children().at(3));
+    auto* defaultLayerNode = dynamic_cast<LayerNode*>(world->children().at(0));
+    auto* sortNode5 = dynamic_cast<LayerNode*>(world->children().at(1));
+    auto* sortNode3 = dynamic_cast<LayerNode*>(world->children().at(2));
+    auto* sortNode1 = dynamic_cast<LayerNode*>(world->children().at(3));
 
     REQUIRE(nullptr != defaultLayerNode);
     REQUIRE(nullptr != sortNode1);
@@ -890,7 +887,7 @@ TEST_CASE("WorldReader")
     CHECK(sortNode3->name() == "Sort Index 3");
     CHECK(sortNode5->name() == "Sort Index 5");
 
-    CHECK(defaultLayerNode->layer().sortIndex() == mdl::Layer::defaultLayerSortIndex());
+    CHECK(defaultLayerNode->layer().sortIndex() == Layer::defaultLayerSortIndex());
     // We allow gaps in sort indices so they remain 1, 3, 5
     CHECK(sortNode1->layer().sortIndex() == 1);
     CHECK(sortNode3->layer().sortIndex() == 3);
@@ -946,7 +943,7 @@ TEST_CASE("WorldReader")
 "_tb_layer_sort_index" "12"
 })end";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -955,13 +952,13 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 7u);
 
     // NOTE: They are listed in world->children() in file order, not sort index order
-    auto* defaultLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(0));
-    auto* sortMinusOneNode = dynamic_cast<mdl::LayerNode*>(world->children().at(1));
-    auto* sortNode8 = dynamic_cast<mdl::LayerNode*>(world->children().at(2));
-    auto* sortNode8second = dynamic_cast<mdl::LayerNode*>(world->children().at(3));
-    auto* sortNode10 = dynamic_cast<mdl::LayerNode*>(world->children().at(4));
-    auto* sortNode10second = dynamic_cast<mdl::LayerNode*>(world->children().at(5));
-    auto* sortNode12 = dynamic_cast<mdl::LayerNode*>(world->children().at(6));
+    auto* defaultLayerNode = dynamic_cast<LayerNode*>(world->children().at(0));
+    auto* sortMinusOneNode = dynamic_cast<LayerNode*>(world->children().at(1));
+    auto* sortNode8 = dynamic_cast<LayerNode*>(world->children().at(2));
+    auto* sortNode8second = dynamic_cast<LayerNode*>(world->children().at(3));
+    auto* sortNode10 = dynamic_cast<LayerNode*>(world->children().at(4));
+    auto* sortNode10second = dynamic_cast<LayerNode*>(world->children().at(5));
+    auto* sortNode12 = dynamic_cast<LayerNode*>(world->children().at(6));
 
     REQUIRE(nullptr != defaultLayerNode);
     REQUIRE(nullptr != sortMinusOneNode);
@@ -978,7 +975,7 @@ TEST_CASE("WorldReader")
     CHECK(sortNode10second->name() == "Sort Index 10 (second)");
     CHECK(sortNode12->name() == "Sort Index 12");
 
-    CHECK(defaultLayerNode->layer().sortIndex() == mdl::Layer::defaultLayerSortIndex());
+    CHECK(defaultLayerNode->layer().sortIndex() == Layer::defaultLayerSortIndex());
 
     // This one was invalid so it got moved to the end
     CHECK(sortMinusOneNode->layer().sortIndex() == 13);
@@ -1042,7 +1039,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1118,7 +1115,7 @@ TEST_CASE("WorldReader")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1163,7 +1160,7 @@ TEST_CASE("WorldReader")
 }
 )";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1172,15 +1169,14 @@ TEST_CASE("WorldReader")
     CHECK(world->childCount() == 2u);
 
     // NOTE: They are listed in world->children() in file order, not sort index order
-    auto* defaultLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(0));
-    auto* customLayerNode = dynamic_cast<mdl::LayerNode*>(world->children().at(1));
+    auto* defaultLayerNode = dynamic_cast<LayerNode*>(world->children().at(0));
+    auto* customLayerNode = dynamic_cast<LayerNode*>(world->children().at(1));
 
     REQUIRE(defaultLayerNode != nullptr);
     REQUIRE(customLayerNode != nullptr);
 
-    auto* groupNode1 = dynamic_cast<mdl::GroupNode*>(customLayerNode->children().front());
-    auto* groupNode2 =
-      dynamic_cast<mdl::GroupNode*>(defaultLayerNode->children().front());
+    auto* groupNode1 = dynamic_cast<GroupNode*>(customLayerNode->children().front());
+    auto* groupNode2 = dynamic_cast<GroupNode*>(defaultLayerNode->children().front());
 
     REQUIRE(groupNode1 != nullptr);
     REQUIRE(groupNode2 != nullptr);
@@ -1210,7 +1206,7 @@ TEST_CASE("WorldReader")
             })";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake3, {}};
+    auto reader = WorldReader{data, MapFormat::Quake3, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1247,7 +1243,7 @@ brushDef
 })";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake3, {}};
+    auto reader = WorldReader{data, MapFormat::Quake3, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1278,7 +1274,7 @@ common/caulk
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake3, {}};
+    auto reader = WorldReader{data, MapFormat::Quake3, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1287,7 +1283,7 @@ common/caulk
     CHECK(world->defaultLayer()->childCount() == 1u);
 
     const auto* patchNode =
-      dynamic_cast<mdl::PatchNode*>(world->defaultLayer()->children().front());
+      dynamic_cast<PatchNode*>(world->defaultLayer()->children().front());
     CHECK(patchNode != nullptr);
 
     const auto& patch = patchNode->patch();
@@ -1297,7 +1293,7 @@ common/caulk
 
     CHECK_THAT(
       patch.controlPoints(),
-      Equals(std::vector<mdl::BezierPatch::Point>{
+      Equals(std::vector<BezierPatch::Point>{
         {-64, -64, 4, 0, 0},
         {-64, 0, 4, 0, -0.25},
         {-64, 64, 4, 0, -0.5},
@@ -1327,7 +1323,7 @@ common/caulk
 })";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Quake2, {}};
+    auto reader = WorldReader{data, MapFormat::Quake2, {}};
 
     CHECK_NOTHROW(reader.read(worldBounds, status, taskManager));
   }
@@ -1340,7 +1336,7 @@ common/caulk
 "message" "yay \"Mr. Robot!\""
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1350,7 +1346,7 @@ common/caulk
     CHECK(worldNode->childCount() == 1u);
     CHECK_FALSE(worldNode->children().front()->hasChildren());
 
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("message"));
     CHECK(*worldNode->entity().property("message") == "yay \\\"Mr. Robot!\\\"");
   }
@@ -1363,7 +1359,7 @@ common/caulk
 "path" "c:\a\b\c\"
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1373,7 +1369,7 @@ common/caulk
     CHECK(worldNode->childCount() == 1u);
     CHECK_FALSE(worldNode->children().front()->hasChildren());
 
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("path"));
     CHECK(*worldNode->entity().property("path") == "c:\\a\\b\\c\\");
   }
@@ -1386,7 +1382,7 @@ common/caulk
 "path" "c:\\a\\b\\c\\"
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1396,7 +1392,7 @@ common/caulk
     CHECK(worldNode->childCount() == 1u);
     CHECK_FALSE(worldNode->children().front()->hasChildren());
 
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("path"));
     CHECK(*worldNode->entity().property("path") == "c:\\\\a\\\\b\\\\c\\\\");
   }
@@ -1409,7 +1405,7 @@ common/caulk
 "message" "test\\"
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1419,7 +1415,7 @@ common/caulk
     CHECK(worldNode->childCount() == 1u);
     CHECK_FALSE(worldNode->children().front()->hasChildren());
 
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("message"));
     CHECK(*worldNode->entity().property("message") == "test\\\\");
   }
@@ -1433,7 +1429,7 @@ common/caulk
 "message" "vm::line1\nvm::line2d"
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1443,7 +1439,7 @@ common/caulk
     CHECK(worldNode->childCount() == 1u);
     CHECK_FALSE(worldNode->children().front()->hasChildren());
 
-    CHECK(worldNode->entity().hasProperty(mdl::EntityPropertyKeys::Classname));
+    CHECK(worldNode->entity().hasProperty(EntityPropertyKeys::Classname));
     CHECK(worldNode->entity().hasProperty("message"));
     CHECK(*worldNode->entity().property("message") == "vm::line1\\nvm::line2d");
   }
@@ -1454,7 +1450,7 @@ common/caulk
     const auto file = fs::Disk::openFile(mapPath) | kdl::value();
     auto fileReader = file->reader().buffer();
 
-    auto worldReader = WorldReader{fileReader.stringView(), mdl::MapFormat::Quake2, {}};
+    auto worldReader = WorldReader{fileReader.stringView(), MapFormat::Quake2, {}};
     auto worldResult = worldReader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
 
@@ -1462,11 +1458,11 @@ common/caulk
     REQUIRE(worldNode != nullptr);
     REQUIRE(1u == worldNode->childCount());
 
-    auto* layerNode = dynamic_cast<mdl::LayerNode*>(worldNode->children().at(0));
+    auto* layerNode = dynamic_cast<LayerNode*>(worldNode->children().at(0));
     REQUIRE(layerNode != nullptr);
     REQUIRE(1u == layerNode->childCount());
 
-    auto* brushNode = dynamic_cast<mdl::BrushNode*>(layerNode->children().at(0));
+    auto* brushNode = dynamic_cast<BrushNode*>(layerNode->children().at(0));
     REQUIRE(brushNode != nullptr);
 
     CHECK(brushNode->logicalBounds() == vm::bbox3d{{-512, -512, -64}, {512, 512, 0}});
@@ -1494,7 +1490,7 @@ common/caulk
 })";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1503,17 +1499,17 @@ common/caulk
     REQUIRE(world != nullptr);
     REQUIRE(world->childCount() == 1u);
 
-    auto* defaultLayer = dynamic_cast<mdl::LayerNode*>(world->children().front());
+    auto* defaultLayer = dynamic_cast<LayerNode*>(world->children().front());
     REQUIRE(defaultLayer != nullptr);
     REQUIRE(defaultLayer->childCount() == 1u);
 
-    auto* brush = dynamic_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = dynamic_cast<BrushNode*>(defaultLayer->children().front());
     REQUIRE(brush != nullptr);
 
     for (const auto& face : brush->brush().faces())
     {
       CHECK(!face.attributes().materialName().empty());
-      CHECK(face.attributes().materialName() == mdl::BrushFaceAttributes::NoMaterialName);
+      CHECK(face.attributes().materialName() == BrushFaceAttributes::NoMaterialName);
     }
   }
 
@@ -1552,7 +1548,7 @@ common/caulk
       materialName);
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1562,12 +1558,12 @@ common/caulk
     REQUIRE(worldNode->childCount() == 1u);
 
     const auto* defaultLayerNode =
-      dynamic_cast<mdl::LayerNode*>(worldNode->children().front());
+      dynamic_cast<LayerNode*>(worldNode->children().front());
     REQUIRE(defaultLayerNode != nullptr);
     REQUIRE(defaultLayerNode->childCount() == 1u);
 
     const auto* brushNode =
-      dynamic_cast<mdl::BrushNode*>(defaultLayerNode->children().front());
+      dynamic_cast<BrushNode*>(defaultLayerNode->children().front());
     REQUIRE(brushNode != nullptr);
 
     CHECK(brushNode->brush().face(0).attributes().materialName() == expectedName);
@@ -1598,7 +1594,7 @@ common/caulk
             )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1608,9 +1604,8 @@ common/caulk
     CHECK(world->defaultLayer()->childCount() == 2u);
 
     auto* groupNode1 =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children().front());
-    auto* groupNode2 =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children().back());
+      dynamic_cast<GroupNode*>(world->defaultLayer()->children().front());
+    auto* groupNode2 = dynamic_cast<GroupNode*>(world->defaultLayer()->children().back());
 
     REQUIRE(groupNode1 != nullptr);
     REQUIRE(groupNode2 != nullptr);
@@ -1643,7 +1638,7 @@ common/caulk
             )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1652,8 +1647,7 @@ common/caulk
     REQUIRE(world != nullptr);
     CHECK(world->defaultLayer()->childCount() == 1);
 
-    auto* groupNode =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children().front());
+    auto* groupNode = dynamic_cast<GroupNode*>(world->defaultLayer()->children().front());
 
     CHECK(groupNode != nullptr);
     CHECK(groupNode->linkId() == "abcd");
@@ -1693,7 +1687,7 @@ common/caulk
             )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1702,12 +1696,9 @@ common/caulk
     REQUIRE(world != nullptr);
     CHECK(world->defaultLayer()->childCount() == 3u);
 
-    auto* groupNode1 =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[0]);
-    auto* groupNode2 =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[1]);
-    auto* groupNode3 =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[2]);
+    auto* groupNode1 = dynamic_cast<GroupNode*>(world->defaultLayer()->children()[0]);
+    auto* groupNode2 = dynamic_cast<GroupNode*>(world->defaultLayer()->children()[1]);
+    auto* groupNode3 = dynamic_cast<GroupNode*>(world->defaultLayer()->children()[2]);
 
     REQUIRE(groupNode1 != nullptr);
     REQUIRE(groupNode2 != nullptr);
@@ -1742,7 +1733,7 @@ common/caulk
             )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1751,8 +1742,7 @@ common/caulk
     REQUIRE(world != nullptr);
     CHECK(world->defaultLayer()->childCount() == 1u);
 
-    auto* groupNode =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children().front());
+    auto* groupNode = dynamic_cast<GroupNode*>(world->defaultLayer()->children().front());
     CHECK(groupNode != nullptr);
 
     CHECK(groupNode->group().transformation() == vm::mat4x4d{});
@@ -1841,7 +1831,7 @@ common/caulk
             )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1851,32 +1841,32 @@ common/caulk
     REQUIRE(world->defaultLayer()->childCount() == 4u);
 
     const auto* groupNode_1_abcd =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[0]);
+      dynamic_cast<GroupNode*>(world->defaultLayer()->children()[0]);
 
     REQUIRE(groupNode_1_abcd->childCount() == 1u);
     const auto* groupNode_1_2_abcd =
-      dynamic_cast<mdl::GroupNode*>(groupNode_1_abcd->children().front());
+      dynamic_cast<GroupNode*>(groupNode_1_abcd->children().front());
 
     const auto* groupNode_2_xyz =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[1]);
+      dynamic_cast<GroupNode*>(world->defaultLayer()->children()[1]);
 
     REQUIRE(groupNode_2_xyz->childCount() == 1u);
     const auto* groupNode_2_1_xyz =
-      dynamic_cast<mdl::GroupNode*>(groupNode_2_xyz->children().front());
+      dynamic_cast<GroupNode*>(groupNode_2_xyz->children().front());
 
     const auto* groupNode_3_xyz =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[2]);
+      dynamic_cast<GroupNode*>(world->defaultLayer()->children()[2]);
 
     const auto* groupNode_4_fgh =
-      dynamic_cast<mdl::GroupNode*>(world->defaultLayer()->children()[3]);
+      dynamic_cast<GroupNode*>(world->defaultLayer()->children()[3]);
 
     REQUIRE(groupNode_4_fgh->childCount() == 1u);
     const auto* groupNode_4_1 =
-      dynamic_cast<mdl::GroupNode*>(groupNode_4_fgh->children().front());
+      dynamic_cast<GroupNode*>(groupNode_4_fgh->children().front());
 
     REQUIRE(groupNode_4_1->childCount() == 1u);
     const auto* groupNode_4_1_1_fgh =
-      dynamic_cast<mdl::GroupNode*>(groupNode_4_1->children().front());
+      dynamic_cast<GroupNode*>(groupNode_4_1->children().front());
 
     CHECK(groupNode_1_abcd->linkId() == "abcd");
     CHECK(
@@ -1926,7 +1916,7 @@ common/caulk
             )";
 
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
@@ -1937,8 +1927,7 @@ common/caulk
 
     SECTION("Empty list")
     {
-      auto* entityNode =
-        dynamic_cast<mdl::EntityNode*>(world->defaultLayer()->children()[0]);
+      auto* entityNode = dynamic_cast<EntityNode*>(world->defaultLayer()->children()[0]);
       REQUIRE(entityNode != nullptr);
 
       CHECK_THAT(
@@ -1948,8 +1937,7 @@ common/caulk
 
     SECTION("Two protected properties")
     {
-      auto* entityNode =
-        dynamic_cast<mdl::EntityNode*>(world->defaultLayer()->children()[1]);
+      auto* entityNode = dynamic_cast<EntityNode*>(world->defaultLayer()->children()[1]);
       REQUIRE(entityNode != nullptr);
 
       CHECK_THAT(
@@ -1959,8 +1947,7 @@ common/caulk
 
     SECTION("Escaped semicolon")
     {
-      auto* entityNode =
-        dynamic_cast<mdl::EntityNode*>(world->defaultLayer()->children()[2]);
+      auto* entityNode = dynamic_cast<EntityNode*>(world->defaultLayer()->children()[2]);
       REQUIRE(entityNode != nullptr);
 
       CHECK_THAT(
@@ -1980,7 +1967,7 @@ common/caulk
 
     auto worldResult = WorldReader::tryRead(
       data,
-      {mdl::MapFormat::Standard, mdl::MapFormat::Valve},
+      {MapFormat::Standard, MapFormat::Valve},
       worldBounds,
       {},
       status,
@@ -1989,7 +1976,7 @@ common/caulk
 
     const auto& world = worldResult.value();
     REQUIRE(world != nullptr);
-    CHECK(world->mapFormat() == mdl::MapFormat::Standard);
+    CHECK(world->mapFormat() == MapFormat::Standard);
   }
 }
 
@@ -2015,7 +2002,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
     auto world = reader.read(worldBounds, status, taskManager);
     CHECK(world != nullptr);
   }
@@ -2035,7 +2022,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
 }
 })";
 
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
 
@@ -2046,7 +2033,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
 
-    auto* brushNode = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brushNode = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brushNode, false);
     const auto& faces = brushNode->brush().faces();
     CHECK(faces.size() == 6u);
@@ -2072,7 +2059,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
 ( -559 1090 96 ) ( -598 1090 96 ) ( -598 1055 96 ) mt_sr_v13 -16 0 0 1 1
 }
 })";
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
 
@@ -2082,7 +2069,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, false);
   }
 
@@ -2100,7 +2087,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
 ( -32 1136 32 ) ( -32 1152 -96 ) ( -32 1120 -96 ) b_rc_v4 0 32 90 1 1
 }
 })";
-    auto reader = WorldReader{data, mdl::MapFormat::Standard, {}};
+    auto reader = WorldReader{data, MapFormat::Standard, {}};
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
 
@@ -2110,7 +2097,7 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
     CHECK(world->childCount() == 1u);
     auto* defaultLayer = world->children().front();
     CHECK(defaultLayer->childCount() == 1u);
-    auto* brush = static_cast<mdl::BrushNode*>(defaultLayer->children().front());
+    auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, false);
   }
 }

--- a/lib/TbMdlLib/test/src/tst_WorldReader.cpp
+++ b/lib/TbMdlLib/test/src/tst_WorldReader.cpp
@@ -1248,7 +1248,7 @@ common/caulk
 }
 })";
 
-    auto reader = WorldReader{data, MapFormat::Quake3, {}};
+    auto reader = WorldReader{data, MapFormat::Quake3_Legacy, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);

--- a/lib/TbMdlLib/test/src/tst_WorldReader.cpp
+++ b/lib/TbMdlLib/test/src/tst_WorldReader.cpp
@@ -1206,51 +1206,25 @@ TEST_CASE("WorldReader")
             })";
 
 
-    auto reader = WorldReader{data, MapFormat::Quake3, {}};
+    auto reader = WorldReader{data, MapFormat::Quake3_BrushPrimitives, {}};
 
     auto worldResult = reader.read(worldBounds, status, taskManager);
     REQUIRE(worldResult);
 
     const auto& world = worldResult.value();
-    // TODO 2427: Assert one brush!
-    CHECK(world->defaultLayer()->childCount() == 0u);
-  }
-
-  SECTION("Brush primitive and legacy brush")
-  {
-    const auto data = R"(
-{
-"classname" "worldspawn"
-{
-brushDef
-{
-( -64 64 64 ) ( 64 -64 64 ) ( -64 -64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
-( -64 64 64 ) ( 64 64 -64 ) ( 64 64 64 ) ( ( 0.015625 0 0 ) ( 0 0.015625 0 ) ) common/caulk 0 0 0
-( 64 64 64 ) ( 64 -64 -64 ) ( 64 -64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
-( 64 64 -64 ) ( -64 -64 -64 ) ( 64 -64 -64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
-( 64 -64 -64 ) ( -64 -64 64 ) ( 64 -64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
-( -64 -64 64 ) ( -64 64 -64 ) ( -64 64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
-}
-}
-{
-( 64 64 64 ) ( 64 -64 64 ) ( -64 64 64 ) common/caulk 0 0 0 1 1 134217728 0 0
-( 64 64 64 ) ( -64 64 64 ) ( 64 64 -64 ) common/caulk 0 0 0 1 1 134217728 0 0
-( 64 64 64 ) ( 64 64 -64 ) ( 64 -64 64 ) common/caulk 0 0 0 1 1 134217728 0 0
-( -64 -64 -64 ) ( 64 -64 -64 ) ( -64 64 -64 ) common/caulk 0 0 0 1 1 134217728 0 0
-( -64 -64 -64 ) ( -64 -64 64 ) ( 64 -64 -64 ) common/caulk 0 0 0 1 1 134217728 0 0
-( -64 -64 -64 ) ( -64 64 -64 ) ( -64 -64 64 ) common/caulk 0 0 0 1 1 134217728 0 0
-}
-})";
-
-
-    auto reader = WorldReader{data, MapFormat::Quake3, {}};
-
-    auto worldResult = reader.read(worldBounds, status, taskManager);
-    REQUIRE(worldResult);
-
-    const auto& world = worldResult.value();
-    // TODO 2427: Assert two brushes!
     CHECK(world->defaultLayer()->childCount() == 1u);
+
+    auto* brushNode = static_cast<BrushNode*>(world->defaultLayer()->children().front());
+
+    // brush primitives are stored in a parallel UV coordinate system (issue 2427)
+    checkBrushUVCoordSystem(brushNode, true);
+
+    const auto& faces = brushNode->brush().faces();
+    CHECK(faces.size() == 6u);
+    for (const auto& face : faces)
+    {
+      CHECK(face.attributes().materialName() == "common/caulk");
+    }
   }
 
   SECTION("Quake 3 patch")
@@ -2099,6 +2073,68 @@ TEST_CASE("WorldReader (Regression)", "[regression]")
     CHECK(defaultLayer->childCount() == 1u);
     auto* brush = static_cast<BrushNode*>(defaultLayer->children().front());
     checkBrushUVCoordSystem(brush, false);
+  }
+}
+
+TEST_CASE("WorldReader format autodetection")
+{
+  // The brush primitives (brushDef) parser also accepts bare legacy brushes, so for
+  // auto-detection to be correct the candidate list must try the legacy format before the
+  // brush primitives format. This guards against the regression that caused legacy maps
+  // to be saved as brushDef.
+  auto taskManager = kdl::task_manager{};
+  const auto worldBounds = vm::bbox3d{8192.0};
+  auto status = TestParserStatus{};
+
+  const auto candidates = std::vector{
+    MapFormat::Quake3_Legacy,
+    MapFormat::Quake3_Valve,
+    MapFormat::Quake3_BrushPrimitives,
+  };
+
+  SECTION("a legacy map is detected as Quake3 (legacy), not brushDef")
+  {
+    const auto data = R"(
+{
+"classname" "worldspawn"
+{
+( -0 -0 -16 ) ( -0 -0  -0 ) ( 64 -0 -16 ) common/caulk 0 0 0 1 1
+( -0 -0 -16 ) ( -0 64 -16 ) ( -0 -0  -0 ) common/caulk 0 0 0 1 1
+( -0 -0 -16 ) ( 64 -0 -16 ) ( -0 64 -16 ) common/caulk 0 0 0 1 1
+( 64 64  -0 ) ( -0 64  -0 ) ( 64 64 -16 ) common/caulk 0 0 0 1 1
+( 64 64  -0 ) ( 64 64 -16 ) ( 64 -0  -0 ) common/caulk 0 0 0 1 1
+( 64 64  -0 ) ( 64 -0  -0 ) ( -0 64  -0 ) common/caulk 0 0 0 1 1
+}
+})";
+
+    auto world =
+      WorldReader::tryRead(data, candidates, worldBounds, {}, status, taskManager);
+    REQUIRE(world);
+    CHECK(world.value()->mapFormat() == MapFormat::Quake3_Legacy);
+  }
+
+  SECTION("a brush primitive map is detected as Quake3 (brush primitives)")
+  {
+    const auto data = R"(
+{
+"classname" "worldspawn"
+{
+brushDef
+{
+( -64 64 64 ) ( 64 -64 64 ) ( -64 -64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
+( -64 64 64 ) ( 64 64 -64 ) ( 64 64 64 ) ( ( 0.015625 0 0 ) ( 0 0.015625 0 ) ) common/caulk 0 0 0
+( 64 64 64 ) ( 64 -64 -64 ) ( 64 -64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
+( 64 64 -64 ) ( -64 -64 -64 ) ( 64 -64 -64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
+( 64 -64 -64 ) ( -64 -64 64 ) ( 64 -64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
+( -64 -64 64 ) ( -64 64 -64 ) ( -64 64 64 ) ( ( 0.015625 0 -0 ) ( -0 0.015625 0 ) ) common/caulk 0 0 0
+}
+}
+})";
+
+    auto world =
+      WorldReader::tryRead(data, candidates, worldBounds, {}, status, taskManager);
+    REQUIRE(world);
+    CHECK(world.value()->mapFormat() == MapFormat::Quake3_BrushPrimitives);
   }
 }
 


### PR DESCRIPTION
Parse and serialise `brushDef` faces through their texture matrix, porting GtkRadiant's `ComputeAxisBase` so the projection is interpreted identically.

The Quake3 map format is now treated as a parallel UV coordinate system.

This implements brush primitive support and resolves the #2427 TODOs.