### PR TITLE
Add `Launch Engine` task to compile profiles

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -1693,6 +1693,20 @@ Parameters
 Stop on nonzero error code
 :    Stop the compilation process if this tool returns an error.
 
+### Launch Engine
+
+Starts one of the current game's configured Launch Engine profiles.
+
+This is useful as the final task in a compile profile, after exporting the map, running compile tools, and copying the output files into the game directory.
+
+#### Parameters
+
+Engine Profile
+:    The Launch Engine profile to start.
+
+Stop on launch failure
+:    Stop the compilation process if the engine cannot be launched. If this is unchecked, the failure is reported and the remaining tasks continue.
+
 ### Copy Files
 
 Copies one or more files. Relative paths are implicitly relative to the working directory.
@@ -1751,10 +1765,11 @@ It is recommended to use the following general process for compiling maps and to
 2. Add an *Export Map* task and set its target to `${MAP_BASE_NAME}-compile.map`.
 3. Add *Run Tool* tasks for the compilation tools that you wish to run. Use the expressions `${MAP_BASE_NAME}-compile.map` and `${MAP_BASE_NAME}.bsp` to specify the input and output files for the tools. Since you have set a working directory, you don't need to specify absolute paths here.
 4. Finally, add a *Copy Files* task and set its source to `${MAP_BASE_NAME}.bsp` and its target to `${GAME_DIR_PATH}/${MODS[-1]}/maps`. This copies the file to the maps directory within the last enabled mod.
+5. Optionally add a *Launch Engine* task at the end to start the game with the latest compiled files.
 
-The last step will copy the bsp file to the appropriate directory within the game path. You can add more *Copy Files* tasks if the compilation produces more than just a bsp file (e.g. lightmap files). Alternatively, you can use a wildcard expression such as `${MAP_BASE_NAME}.*` to copy related files.
+The last step will copy the bsp file to the appropriate directory within the game path. You can add more *Copy Files* tasks if the compilation produces more than just a bsp file (e.g. lightmap files). Alternatively, you can use a wildcard expression such as `${MAP_BASE_NAME}.*` to copy related files. If you add a *Launch Engine* task, place it after any file copying tasks so the game starts with the latest compiled output.
 
-To run a compilation profile, click the 'Run' button in the compilation dialog. Note that the 'Run' button changes into a 'Stop' button once the compilation profile is running. If you click on this button again, TrenchBroom will terminate the currently running tool. A running compilation will also be terminated if you close the compilation dialog or if you close the main window, but TrenchBroom will ask you before this happens. Note that the compilation tools are run in the background. You can keep working on your map if you wish.
+To run a compilation profile, click the 'Compile' button in the compilation dialog. Once the compilation profile is running, you can click the 'Stop' button to terminate the currently running tool. A running compilation will also be terminated if you close the compilation dialog or if you close the main window, but TrenchBroom will ask you before this happens. Note that the compilation tools are run in the background. You can keep working on your map if you wish.
 
 If you want to test your compilation profile without actually running it, click the 'Test' button. A test run will only print what each task will do without actually executing it.
 
@@ -1764,7 +1779,7 @@ Once the compilation is done, you can launch a game engine and check out your ma
 
 Before you can launch a game engine in TrenchBroom, you have to make your engine(s) known to TrenchBroom. You can do this by bringing up the game engine profile dialog either from the launch dialog (see below) or from the [game configuration](#game_configuration).
 
-There are two ways to launch a game engine from within TrenchBroom. Either click the 'Launch' button in the compilation dialog or choose #menu(Menu/Run/Launch...). This brings up the launch dialog shown in the following screenshot.
+You can launch a game engine manually by clicking the 'Launch' button in the compilation dialog or choosing #menu(Menu/Run/Launch...). This brings up the launch dialog shown in the following screenshot.
 
 ![Launch Dialog (Mac OS X)](images/LaunchGameEngineDialog.png)
 

--- a/lib/TbMdlLib/include/mdl/CompilationTask.h
+++ b/lib/TbMdlLib/include/mdl/CompilationTask.h
@@ -73,12 +73,23 @@ struct CompilationRunTool
     CompilationRunTool, enabled, toolSpec, parameterSpec, treatNonZeroResultCodeAsError);
 };
 
+struct CompilationLaunchEngine
+{
+  bool enabled;
+  std::string engineProfileId;
+  bool treatLaunchFailureAsError;
+
+  kdl_reflect_decl(
+    CompilationLaunchEngine, enabled, engineProfileId, treatLaunchFailureAsError);
+};
+
 using CompilationTask = std::variant<
   CompilationExportMap,
   CompilationCopyFiles,
   CompilationRenameFile,
   CompilationDeleteFiles,
-  CompilationRunTool>;
+  CompilationRunTool,
+  CompilationLaunchEngine>;
 
 std::ostream& operator<<(std::ostream& lhs, const CompilationTask& rhs);
 

--- a/lib/TbMdlLib/include/mdl/GameEngineProfile.h
+++ b/lib/TbMdlLib/include/mdl/GameEngineProfile.h
@@ -29,6 +29,7 @@ namespace tb::mdl
 
 struct GameEngineProfile
 {
+  std::string id;
   std::string name;
   std::filesystem::path path;
   std::string parameterSpec;

--- a/lib/TbMdlLib/include/mdl/GameManager.h
+++ b/lib/TbMdlLib/include/mdl/GameManager.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "Notifier.h"
 #include "mdl/CompilationConfig.h"
 #include "mdl/GameInfo.h"
 
@@ -45,6 +46,9 @@ private:
   std::vector<GameInfo> m_gameInfos;
 
 public:
+  Notifier<const GameInfo&> compilationConfigDidChangeNotifier;
+  Notifier<const GameInfo&> gameEngineConfigDidChangeNotifier;
+
   GameManager(
     std::unique_ptr<fs::WritableFileSystem> configFs, std::vector<GameInfo> gameInfos);
 

--- a/lib/TbMdlLib/src/CompilationConfig.cpp
+++ b/lib/TbMdlLib/src/CompilationConfig.cpp
@@ -72,6 +72,15 @@ el::Value toValue(const CompilationTask& task)
         map["tool"] = el::Value{runTool.toolSpec};
         map["parameters"] = el::Value{runTool.parameterSpec};
         return map;
+      },
+      [](const CompilationLaunchEngine& launchEngine) {
+        auto map = el::MapType{};
+        map["type"] = el::Value{"launchEngine"};
+        map["enabled"] = el::Value{launchEngine.enabled};
+        map["engineProfileId"] = el::Value{launchEngine.engineProfileId};
+        map["treatLaunchFailureAsError"] =
+          el::Value{launchEngine.treatLaunchFailureAsError};
+        return map;
       }),
     task)};
 }

--- a/lib/TbMdlLib/src/CompilationTask.cpp
+++ b/lib/TbMdlLib/src/CompilationTask.cpp
@@ -36,6 +36,8 @@ kdl_reflect_impl(CompilationDeleteFiles);
 
 kdl_reflect_impl(CompilationRunTool);
 
+kdl_reflect_impl(CompilationLaunchEngine);
+
 std::ostream& operator<<(std::ostream& lhs, const CompilationTask& rhs)
 {
   std::visit([&](const auto& x) { lhs << x; }, rhs);

--- a/lib/TbMdlLib/src/GameEngineConfig.cpp
+++ b/lib/TbMdlLib/src/GameEngineConfig.cpp
@@ -30,6 +30,7 @@ namespace
 el::Value toValue(const GameEngineProfile& profile)
 {
   return el::Value{el::MapType{
+    {"id", el::Value{profile.id}},
     {"name", el::Value{profile.name}},
     {"path", el::Value{profile.path.string()}},
     {"parameters", el::Value{profile.parameterSpec}},

--- a/lib/TbMdlLib/src/GameManager.cpp
+++ b/lib/TbMdlLib/src/GameManager.cpp
@@ -205,38 +205,60 @@ void backupFile(
   }
 }
 
+template <typename Config>
+Result<void> writeConfig(
+  fs::WritableFileSystem& fs,
+  GameInfo& gameInfo,
+  Config GameInfo::* configField,
+  bool GameInfo::* parseFailedField,
+  Config newConfig,
+  const std::filesystem::path& filename,
+  const std::string_view configLabel,
+  Logger& logger)
+{
+  auto& currentConfig = gameInfo.*configField;
+  auto& parseFailed = gameInfo.*parseFailedField;
+
+  if (!parseFailed && currentConfig == newConfig)
+  {
+    // NOTE: this is not just an optimization, but important for ensuring that
+    // we don't clobber data saved by a newer version of TB, unless we actually
+    // make changes to the config in this version of TB (see:
+    // https://github.com/TrenchBroom/TrenchBroom/issues/3424)
+    logger.debug() << "Skipping writing unchanged " << configLabel << " for "
+                   << gameInfo.gameConfig.name;
+    return Result<void>{};
+  }
+
+  const auto profilesPath = gameInfo.gameConfig.configFileFolder() / filename;
+  backupFile(fs, profilesPath, parseFailed, logger);
+
+  return fs.createDirectory(profilesPath.parent_path()) | kdl::and_then([&](auto) {
+           auto stream = std::stringstream{};
+           stream << toValue(newConfig) << "\n";
+           return fs.createFileAtomic(profilesPath, stream.str());
+         })
+         | kdl::transform([&]() {
+             currentConfig = std::move(newConfig);
+             logger.debug() << "Wrote " << configLabel << " to " << profilesPath;
+           });
+}
+
 Result<void> writeCompilationConfig(
   fs::WritableFileSystem& fs,
   GameInfo& gameInfo,
   CompilationConfig compilationConfig,
   Logger& logger)
 {
-  if (
-    !gameInfo.compilationConfigParseFailed
-    && gameInfo.compilationConfig == compilationConfig)
-  {
-    // NOTE: this is not just an optimization, but important for ensuring that
-    // we don't clobber data saved by a newer version of TB, unless we actually
-    // make changes to the config in this version of TB (see:
-    // https://github.com/TrenchBroom/TrenchBroom/issues/3424)
-    logger.debug() << "Skipping writing unchanged compilation config for "
-                   << gameInfo.gameConfig.name;
-    return Result<void>{};
-  }
-
-  const auto profilesPath =
-    gameInfo.gameConfig.configFileFolder() / compilationConfigFilename;
-  backupFile(fs, profilesPath, gameInfo.compilationConfigParseFailed, logger);
-
-  return fs.createDirectory(profilesPath.parent_path()) | kdl::and_then([&](auto) {
-           auto stream = std::stringstream{};
-           stream << toValue(compilationConfig) << "\n";
-           return fs.createFileAtomic(profilesPath, stream.str());
-         })
-         | kdl::transform([&]() {
-             gameInfo.compilationConfig = std::move(compilationConfig);
-             logger.debug() << "Wrote compilation config to " << profilesPath;
-           });
+  return writeConfig(
+    fs,
+    gameInfo,
+    &GameInfo::compilationConfig,
+    &GameInfo::compilationConfigParseFailed,
+    std::move(compilationConfig),
+    compilationConfigFilename,
+    "compilation config",
+    logger);
 }
 
 Result<void> writeGameEngineConfig(
@@ -245,32 +267,15 @@ Result<void> writeGameEngineConfig(
   GameEngineConfig gameEngineConfig,
   Logger& logger)
 {
-  if (
-    !gameInfo.gameEngineConfigParseFailed
-    && gameInfo.gameEngineConfig == gameEngineConfig)
-  {
-    // NOTE: this is not just an optimization, but important for ensuring that
-    // we don't clobber data saved by a newer version of TB, unless we actually
-    // make changes to the config in this version of TB (see:
-    // https://github.com/TrenchBroom/TrenchBroom/issues/3424)
-    logger.debug() << "Skipping writing unchanged game engine config for "
-                   << gameInfo.gameConfig.name;
-    return Result<void>{};
-  }
-
-  const auto profilesPath =
-    gameInfo.gameConfig.configFileFolder() / gameEngineConfigFilename;
-  backupFile(fs, profilesPath, gameInfo.gameEngineConfigParseFailed, logger);
-
-  return fs.createDirectory(profilesPath.parent_path()) | kdl::and_then([&](auto) {
-           auto stream = std::stringstream{};
-           stream << toValue(gameEngineConfig) << "\n";
-           return fs.createFileAtomic(profilesPath, stream.str());
-         })
-         | kdl::transform([&]() {
-             gameInfo.gameEngineConfig = std::move(gameEngineConfig);
-             logger.debug() << "Wrote game engine config to " << profilesPath;
-           });
+  return writeConfig(
+    fs,
+    gameInfo,
+    &GameInfo::gameEngineConfig,
+    &GameInfo::gameEngineConfigParseFailed,
+    std::move(gameEngineConfig),
+    gameEngineConfigFilename,
+    "game engine config",
+    logger);
 }
 
 } // namespace

--- a/lib/TbMdlLib/src/GameManager.cpp
+++ b/lib/TbMdlLib/src/GameManager.cpp
@@ -206,11 +206,11 @@ void backupFile(
 }
 
 template <typename Config>
-Result<void> writeConfig(
+Result<bool> writeConfig(
   fs::WritableFileSystem& fs,
   GameInfo& gameInfo,
-  Config GameInfo::* configField,
-  bool GameInfo::* parseFailedField,
+  Config GameInfo::*configField,
+  bool GameInfo::*parseFailedField,
   Config newConfig,
   const std::filesystem::path& filename,
   const std::string_view configLabel,
@@ -227,7 +227,7 @@ Result<void> writeConfig(
     // https://github.com/TrenchBroom/TrenchBroom/issues/3424)
     logger.debug() << "Skipping writing unchanged " << configLabel << " for "
                    << gameInfo.gameConfig.name;
-    return Result<void>{};
+    return false;
   }
 
   const auto profilesPath = gameInfo.gameConfig.configFileFolder() / filename;
@@ -241,10 +241,11 @@ Result<void> writeConfig(
          | kdl::transform([&]() {
              currentConfig = std::move(newConfig);
              logger.debug() << "Wrote " << configLabel << " to " << profilesPath;
+             return true;
            });
 }
 
-Result<void> writeCompilationConfig(
+Result<bool> writeCompilationConfig(
   fs::WritableFileSystem& fs,
   GameInfo& gameInfo,
   CompilationConfig compilationConfig,
@@ -261,7 +262,9 @@ Result<void> writeCompilationConfig(
     logger);
 }
 
-Result<void> writeGameEngineConfig(
+// Returns whether gameInfo.gameEngineConfig was actually updated (false if the write
+// was skipped because the config was unchanged), so callers can gate a notifier on it.
+Result<bool> writeGameEngineConfig(
   fs::WritableFileSystem& fs,
   GameInfo& gameInfo,
   GameEngineConfig gameEngineConfig,
@@ -322,7 +325,13 @@ Result<void> GameManager::updateCompilationConfig(
   if (auto* info = gameInfo(gameName))
   {
     return writeCompilationConfig(
-      *m_configFs, *info, std::move(compilationConfig), logger);
+             *m_configFs, *info, std::move(compilationConfig), logger)
+           | kdl::transform([&](const auto changed) {
+               if (changed)
+               {
+                 compilationConfigDidChangeNotifier(*info);
+               }
+             });
   }
   return Error{fmt::format("Unknown game: {}", gameName)};
 }
@@ -332,7 +341,13 @@ Result<void> GameManager::updateGameEngineConfig(
 {
   if (auto* info = gameInfo(gameName))
   {
-    return writeGameEngineConfig(*m_configFs, *info, std::move(gameEngineConfig), logger);
+    return writeGameEngineConfig(*m_configFs, *info, std::move(gameEngineConfig), logger)
+           | kdl::transform([&](const auto changed) {
+               if (changed)
+               {
+                 gameEngineConfigDidChangeNotifier(*info);
+               }
+             });
   }
   return Error{fmt::format("Unknown game: {}", gameName)};
 }

--- a/lib/TbMdlLib/src/ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/src/ParseCompilationConfig.cpp
@@ -113,6 +113,24 @@ CompilationRunTool toToolTask(
   };
 }
 
+CompilationLaunchEngine toLaunchEngineTask(
+  const el::EvaluationContext& context, const el::Value& value)
+{
+  const auto enabled = value.contains(context, "enabled")
+                         ? value.at(context, "enabled").booleanValue(context)
+                         : true;
+  const auto treatLaunchFailureAsError =
+    value.contains(context, "treatLaunchFailureAsError")
+      ? value.at(context, "treatLaunchFailureAsError").booleanValue(context)
+      : false;
+
+  return {
+    enabled,
+    value.at(context, "engineProfileId").stringValue(context),
+    treatLaunchFailureAsError,
+  };
+}
+
 CompilationTask toTask(const el::EvaluationContext& context, const el::Value& value)
 {
   const auto typeName = value.at(context, "type").stringValue(context);
@@ -136,6 +154,10 @@ CompilationTask toTask(const el::EvaluationContext& context, const el::Value& va
   if (typeName == "tool")
   {
     return toToolTask(context, value);
+  }
+  if (typeName == "launchEngine")
+  {
+    return toLaunchEngineTask(context, value);
   }
 
   throw ParserException{fmt::format("Unknown compilation task type '{}'", typeName)};

--- a/lib/TbMdlLib/src/ParseGameEngineConfig.cpp
+++ b/lib/TbMdlLib/src/ParseGameEngineConfig.cpp
@@ -41,9 +41,9 @@ namespace
 GameEngineProfile toProfile(const el::EvaluationContext& context, const el::Value& value)
 {
   return {
-    value.at(context, "name").stringValue(context),
-    std::filesystem::path{value.at(context, "path").stringValue(context)},
-    value.at(context, "parameters").stringValue(context),
+    .name = value.at(context, "name").stringValue(context),
+    .path = std::filesystem::path{value.at(context, "path").stringValue(context)},
+    .parameterSpec = value.at(context, "parameters").stringValue(context),
   };
 }
 

--- a/lib/TbMdlLib/src/ParseGameEngineConfig.cpp
+++ b/lib/TbMdlLib/src/ParseGameEngineConfig.cpp
@@ -19,6 +19,7 @@
 
 #include "mdl/ParseGameEngineConfig.h"
 
+#include "Uuid.h"
 #include "el/EvaluationContext.h"
 #include "el/ParseExpression.h"
 #include "el/Value.h"
@@ -41,6 +42,8 @@ namespace
 GameEngineProfile toProfile(const el::EvaluationContext& context, const el::Value& value)
 {
   return {
+    .id = value.contains(context, "id") ? value.at(context, "id").stringValue(context)
+                                        : generateUuid(),
     .name = value.at(context, "name").stringValue(context),
     .path = std::filesystem::path{value.at(context, "path").stringValue(context)},
     .parameterSpec = value.at(context, "parameters").stringValue(context),

--- a/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
@@ -258,6 +258,45 @@ TEST_CASE("toValue")
         enabled,
         treatNonZeroResultCodeAsError)));
   }
+
+  SECTION("launch engine task")
+  {
+    const auto enabled = GENERATE(true, false);
+    const auto treatLaunchFailureAsError = GENERATE(true, false);
+
+    CHECK(
+      toValue(CompilationConfig{{
+        {"name",
+         "workDirSpec",
+         {
+           CompilationLaunchEngine{
+             enabled,
+             "engineProfileId",
+             treatLaunchFailureAsError,
+           },
+         }},
+      }})
+      == parse(fmt::format(
+        R"({{
+        "version": 1.0,
+        "profiles": [
+          {{
+            "name": "name",
+            "workdir": "workDirSpec",
+            "tasks": [
+              {{
+                "type": "launchEngine",
+                "enabled": {},
+                "engineProfileId": "engineProfileId",
+                "treatLaunchFailureAsError": {}
+              }}
+            ]
+          }}
+        ]
+      }})",
+        enabled,
+        treatLaunchFailureAsError)));
+  }
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_GameManager.cpp
+++ b/lib/TbMdlLib/test/src/tst_GameManager.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Logger.h"
+#include "Uuid.h"
 #include "fs/TestEnvironment.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/GameManager.h"
@@ -337,6 +338,7 @@ TEST_CASE("GameManager")
           const auto gameEngineConfig = GameEngineConfig{
             .profiles = {
               {
+                .id = generateUuid(),
                 .name = "name",
                 .path = "workDir",
                 .parameterSpec = "parameters",

--- a/lib/TbMdlLib/test/src/tst_GameManager.cpp
+++ b/lib/TbMdlLib/test/src/tst_GameManager.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Logger.h"
+#include "Observer.h"
 #include "Uuid.h"
 #include "fs/TestEnvironment.h"
 #include "mdl/CatchConfig.h"
@@ -308,6 +309,9 @@ TEST_CASE("GameManager")
               },
             }};
 
+          auto compilationConfigDidChange =
+            Observer<GameInfo>{gameManager.compilationConfigDidChangeNotifier};
+
           REQUIRE(gameManager.updateCompilationConfig("Quake", compilationConfig, logger)
                     .is_success());
 
@@ -315,6 +319,13 @@ TEST_CASE("GameManager")
           REQUIRE(gameInfo != nullptr);
           CHECK(gameInfo->compilationConfig == compilationConfig);
           CHECK(env.fileExists(userPath / "Quake/CompilationProfiles.cfg"));
+          CHECK(compilationConfigDidChange.notifications == std::vector{*gameInfo});
+
+          // updating with the same config again should not notify
+          compilationConfigDidChange.reset();
+          REQUIRE(gameManager.updateCompilationConfig("Quake", compilationConfig, logger)
+                    .is_success());
+          CHECK(compilationConfigDidChange.notifications == std::vector<GameInfo>{});
         })
       | kdl::transform_error([](const auto& e) { FAIL(e); });
   }
@@ -345,6 +356,9 @@ TEST_CASE("GameManager")
               },
             }};
 
+          auto gameEngineConfigDidChange =
+            Observer<GameInfo>{gameManager.gameEngineConfigDidChangeNotifier};
+
           REQUIRE(gameManager.updateGameEngineConfig("Quake", gameEngineConfig, logger)
                     .is_success());
 
@@ -352,6 +366,13 @@ TEST_CASE("GameManager")
           REQUIRE(gameInfo != nullptr);
           CHECK(gameInfo->gameEngineConfig == gameEngineConfig);
           CHECK(env.fileExists(userPath / "Quake/GameEngineProfiles.cfg"));
+          CHECK(gameEngineConfigDidChange.notifications == std::vector{*gameInfo});
+
+          // updating with the same config again should not notify
+          gameEngineConfigDidChange.reset();
+          REQUIRE(gameManager.updateGameEngineConfig("Quake", gameEngineConfig, logger)
+                    .is_success());
+          CHECK(gameEngineConfigDidChange.notifications == std::vector<GameInfo>{});
         })
       | kdl::transform_error([](const auto& e) { FAIL(e); });
   }

--- a/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
@@ -413,7 +413,82 @@ TEST_CASE("CompilationConfigParser")
       }});
   }
 
-  SECTION("parseOneProfileWithNameAndFourTasks")
+  SECTION("parseOneProfileWithNameAndOneLaunchEngineTaskWithMissingEngineProfileId")
+  {
+    const auto config = R"(
+{
+  'version': 1,
+  'profiles': [
+    {
+      'name' : 'A profile',
+      'workdir' : '',
+      'tasks': [ {  'type' : 'launchEngine' } ]
+    }
+  ]
+})";
+
+    CHECK(parseCompilationConfig(config).is_error());
+  }
+
+  SECTION("parseOneProfileWithNameAndOneLaunchEngineTask")
+  {
+    const auto config = R"(
+{
+  'version': 1,
+  'unexpectedKey': '',
+  'profiles': [{
+      'name' : 'A profile',
+      'unexpectedKey' : '',
+      'workdir' : '',
+      'tasks' : [{
+        'type' : 'launchEngine',
+        'unexpectedKey' : '',
+        'engineProfileId' : 'Quakespasm'
+      }]
+    }]
+})";
+
+    CHECK(
+      parseCompilationConfig(config)
+      == mdl::CompilationConfig{{
+        {"A profile",
+         "",
+         {
+           mdl::CompilationLaunchEngine{
+             K(enabled), "Quakespasm", !K(treatLaunchFailureAsError)},
+         }},
+      }});
+  }
+
+  SECTION("parseOneProfileWithNameAndOneLaunchEngineTaskWithLaunchFailureAsError")
+  {
+    const auto config = R"(
+{
+  'version': 1,
+  'profiles': [{
+      'name' : 'A profile',
+      'workdir' : '',
+      'tasks' : [{
+        'type' : 'launchEngine',
+        'engineProfileId' : 'Quakespasm',
+        'treatLaunchFailureAsError': true
+      }]
+    }]
+})";
+
+    CHECK(
+      parseCompilationConfig(config)
+      == mdl::CompilationConfig{{
+        {"A profile",
+         "",
+         {
+           mdl::CompilationLaunchEngine{
+             K(enabled), "Quakespasm", K(treatLaunchFailureAsError)},
+         }},
+      }});
+  }
+
+  SECTION("parseOneProfileWithNameAndFiveTasks")
   {
     const auto config = R"(
 {
@@ -443,6 +518,12 @@ TEST_CASE("CompilationConfigParser")
       'type':'delete',
       'target': 'some other target',
       'enabled': false
+    },
+    {
+      'type':'launchEngine',
+      'engineProfileId': 'Quakespasm',
+      'treatLaunchFailureAsError': true,
+      'enabled': true
     }]
   }]
 })";
@@ -458,6 +539,8 @@ TEST_CASE("CompilationConfigParser")
            mdl::CompilationCopyFiles{!K(enabled), "the source", "the target"},
            mdl::CompilationRenameFile{K(enabled), "the source", "the target"},
            mdl::CompilationDeleteFiles{!K(enabled), "some other target"},
+           mdl::CompilationLaunchEngine{
+             K(enabled), "Quakespasm", K(treatLaunchFailureAsError)},
          }},
       }});
   }

--- a/lib/TbMdlLib/test/src/tst_ParseGameEngineConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseGameEngineConfig.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Uuid.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/GameEngineConfig.h"
 #include "mdl/ParseGameEngineConfig.h"
@@ -102,15 +103,60 @@ TEST_CASE("GameEngineConfigParserTest.parseTwoProfiles")
     parseGameEngineConfig(config)
     == mdl::GameEngineConfig{
       {{
+         .id = generateUuid(),
          .name = "winquake",
          .path = R"(C:\Quake\winquake.exe)",
          .parameterSpec = "-flag1 -flag2",
        },
        {
+         .id = generateUuid(),
          .name = "glquake",
          .path = R"(C:\Quake\glquake.exe)",
          .parameterSpec = "-flag3 -flag4",
        }}});
+}
+
+TEST_CASE("GameEngineConfigParserTest.parseProfileWithExplicitId")
+{
+  const auto config = R"(
+{
+	"profiles": [
+		{
+			"name": "winquake",
+			"parameters": "-flag1 -flag2",
+			"path": "C:\\Quake\\winquake.exe",
+			"id": "11111111-2222-3333-4444-555555555555"
+		}
+	],
+	"version": 1
+}
+)";
+
+  const auto result = parseGameEngineConfig(config);
+  REQUIRE(result);
+  REQUIRE(result.value().profiles.size() == 1u);
+  CHECK(result.value().profiles[0].id == "11111111-2222-3333-4444-555555555555");
+}
+
+TEST_CASE("GameEngineConfigParserTest.parseProfileWithoutIdGeneratesId")
+{
+  const auto config = R"(
+{
+	"profiles": [
+		{
+			"name": "winquake",
+			"parameters": "-flag1 -flag2",
+			"path": "C:\\Quake\\winquake.exe"
+		}
+	],
+	"version": 1
+}
+)";
+
+  const auto result = parseGameEngineConfig(config);
+  REQUIRE(result);
+  REQUIRE(result.value().profiles.size() == 1u);
+  CHECK(result.value().profiles[0].id != "");
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_ParseGameEngineConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseGameEngineConfig.cpp
@@ -101,8 +101,16 @@ TEST_CASE("GameEngineConfigParserTest.parseTwoProfiles")
   CHECK(
     parseGameEngineConfig(config)
     == mdl::GameEngineConfig{
-      {{"winquake", R"(C:\Quake\winquake.exe)", "-flag1 -flag2"},
-       {"glquake", R"(C:\Quake\glquake.exe)", "-flag3 -flag4"}}});
+      {{
+         .name = "winquake",
+         .path = R"(C:\Quake\winquake.exe)",
+         .parameterSpec = "-flag1 -flag2",
+       },
+       {
+         .name = "glquake",
+         .path = R"(C:\Quake\glquake.exe)",
+         .parameterSpec = "-flag3 -flag4",
+       }}});
 }
 
 } // namespace tb::mdl

--- a/lib/TbUiLib/include/ui/CompilationDialog.h
+++ b/lib/TbUiLib/include/ui/CompilationDialog.h
@@ -21,6 +21,7 @@
 
 #include <QDialog>
 
+#include "NotifierConnection.h"
 #include "ui/CompilationRun.h"
 
 class QLabel;
@@ -56,6 +57,8 @@ private:
   QLabel* m_currentRunLabel = nullptr;
   QTextEdit* m_output = nullptr;
   CompilationRun m_run;
+
+  NotifierConnection m_notifierConnection;
 
 public:
   explicit CompilationDialog(

--- a/lib/TbUiLib/include/ui/CompilationDialog.h
+++ b/lib/TbUiLib/include/ui/CompilationDialog.h
@@ -21,7 +21,6 @@
 
 #include <QDialog>
 
-#include "NotifierConnection.h"
 #include "ui/CompilationRun.h"
 
 class QLabel;
@@ -57,8 +56,6 @@ private:
   QLabel* m_currentRunLabel = nullptr;
   QTextEdit* m_output = nullptr;
   CompilationRun m_run;
-
-  NotifierConnection m_notifierConnection;
 
 public:
   explicit CompilationDialog(

--- a/lib/TbUiLib/include/ui/CompilationProfileEditor.h
+++ b/lib/TbUiLib/include/ui/CompilationProfileEditor.h
@@ -79,6 +79,7 @@ private slots:
 
 public:
   void setProfile(mdl::CompilationProfile* profile);
+  void refreshTaskEditors();
 
 private:
   void refresh();

--- a/lib/TbUiLib/include/ui/CompilationProfileManager.h
+++ b/lib/TbUiLib/include/ui/CompilationProfileManager.h
@@ -21,6 +21,7 @@
 
 #include <QWidget>
 
+#include "NotifierConnection.h"
 #include "mdl/CompilationConfig.h"
 
 #include <string>
@@ -37,6 +38,7 @@ struct CompilationProfile;
 
 namespace ui
 {
+class AppController;
 class CompilationProfileListBox;
 class CompilationProfileEditor;
 class MapDocument;
@@ -51,20 +53,25 @@ class CompilationProfileManager : public QWidget
 {
   Q_OBJECT
 private:
+  MapDocument& m_document;
   mdl::CompilationConfig m_config;
   CompilationProfileListBox* m_profileList = nullptr;
   CompilationProfileEditor* m_profileEditor = nullptr;
   QAbstractButton* m_removeProfileButton = nullptr;
 
+  NotifierConnection m_notifierConnection;
+
 public:
   CompilationProfileManager(
-    MapDocument& document, mdl::CompilationConfig config, QWidget* parent = nullptr);
+    AppController& appController,
+    MapDocument& document,
+    mdl::CompilationConfig config,
+    QWidget* parent = nullptr);
 
   const mdl::CompilationProfile* selectedProfile() const;
   bool selectProfile(const mdl::CompilationProfile& profile);
   void selectFirstProfile();
   const mdl::CompilationConfig& config() const;
-  void refreshTaskEditors();
 
 private:
   void updateGui();

--- a/lib/TbUiLib/include/ui/CompilationProfileManager.h
+++ b/lib/TbUiLib/include/ui/CompilationProfileManager.h
@@ -64,6 +64,7 @@ public:
   bool selectProfile(const mdl::CompilationProfile& profile);
   void selectFirstProfile();
   const mdl::CompilationConfig& config() const;
+  void refreshTaskEditors();
 
 private:
   void updateGui();

--- a/lib/TbUiLib/include/ui/CompilationRunner.h
+++ b/lib/TbUiLib/include/ui/CompilationRunner.h
@@ -172,6 +172,24 @@ private slots:
   deleteCopyAndMove(CompilationRunToolTaskRunner);
 };
 
+class CompilationLaunchEngineTaskRunner : public CompilationTaskRunner
+{
+  Q_OBJECT
+private:
+  mdl::CompilationLaunchEngine m_task;
+
+public:
+  CompilationLaunchEngineTaskRunner(
+    CompilationContext& context, mdl::CompilationLaunchEngine task);
+  ~CompilationLaunchEngineTaskRunner() override;
+
+private:
+  void doExecute() override;
+  void doTerminate() override;
+
+  deleteCopyAndMove(CompilationLaunchEngineTaskRunner);
+};
+
 class CompilationRunner : public QObject
 {
   Q_OBJECT

--- a/lib/TbUiLib/include/ui/CompilationTaskListBox.h
+++ b/lib/TbUiLib/include/ui/CompilationTaskListBox.h
@@ -201,6 +201,7 @@ public:
 
 public:
   void reloadTasks();
+  void updateTasks();
 
 private:
   size_t itemCount() const override;

--- a/lib/TbUiLib/include/ui/CompilationTaskListBox.h
+++ b/lib/TbUiLib/include/ui/CompilationTaskListBox.h
@@ -26,6 +26,7 @@
 
 class QCheckBox;
 class QCompleter;
+class QComboBox;
 class QHBoxLayout;
 class QLayout;
 class QLineEdit;
@@ -185,6 +186,28 @@ private slots:
   void toolSpecChanged(const QString& text);
   void parameterSpecChanged(const QString& text);
   void treatNonZeroResultCodeAsErrorChanged(int state);
+};
+
+class CompilationLaunchEngineTaskEditor : public CompilationTaskEditorBase
+{
+  Q_OBJECT
+private:
+  QComboBox* m_engineProfileEditor = nullptr;
+  QCheckBox* m_treatLaunchFailureAsError = nullptr;
+
+public:
+  CompilationLaunchEngineTaskEditor(
+    MapDocument& document,
+    mdl::CompilationProfile& profile,
+    mdl::CompilationTask& task,
+    QWidget* parent = nullptr);
+
+private:
+  void updateItem() override;
+  mdl::CompilationLaunchEngine& task();
+private slots:
+  void engineProfileChanged(int index);
+  void treatLaunchFailureAsErrorChanged(int state);
 };
 
 class CompilationTaskListBox : public ControlListBox

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -62,6 +62,15 @@ CompilationDialog::CompilationDialog(
   setMinimumSize(600, 300);
   resize(800, 600);
   updateCompileButtons();
+
+  m_notifierConnection +=
+    m_appController.gameManager().gameEngineConfigDidChangeNotifier.connect(
+      [this](const auto& gameInfo) {
+        if (&gameInfo == &m_document.map().gameInfo())
+        {
+          m_profileManager->refreshTaskEditors();
+        }
+      });
 }
 
 bool CompilationDialog::selectProfile(const mdl::CompilationProfile& profile)

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -62,15 +62,6 @@ CompilationDialog::CompilationDialog(
   setMinimumSize(600, 300);
   resize(800, 600);
   updateCompileButtons();
-
-  m_notifierConnection +=
-    m_appController.gameManager().gameEngineConfigDidChangeNotifier.connect(
-      [this](const auto& gameInfo) {
-        if (&gameInfo == &m_document.map().gameInfo())
-        {
-          m_profileManager->refreshTaskEditors();
-        }
-      });
 }
 
 bool CompilationDialog::selectProfile(const mdl::CompilationProfile& profile)
@@ -98,7 +89,8 @@ void CompilationDialog::createGui()
 
   const auto& compilationConfig = m_document.map().gameInfo().compilationConfig;
 
-  m_profileManager = new CompilationProfileManager{m_document, compilationConfig};
+  m_profileManager =
+    new CompilationProfileManager{m_appController, m_document, compilationConfig};
 
   auto* outputPanel = new TitledPanel{tr("Output")};
   m_output = new QTextEdit{};

--- a/lib/TbUiLib/src/CompilationProfileEditor.cpp
+++ b/lib/TbUiLib/src/CompilationProfileEditor.cpp
@@ -28,6 +28,8 @@
 
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
+#include "mdl/GameInfo.h"
+#include "mdl/Map.h"
 #include "ui/BitmapButton.h"
 #include "ui/BorderLine.h"
 #include "ui/CompilationTaskListBox.h"
@@ -207,6 +209,7 @@ void CompilationProfileEditor::addTask()
   auto* renameFileAction = menu.addAction("Rename File");
   auto* deleteFilesAction = menu.addAction("Delete Files");
   auto* runToolAction = menu.addAction("Run Tool");
+  auto* launchEngineAction = menu.addAction("Launch Engine");
 
   auto task = [&](const auto* chosenAction) -> std::optional<mdl::CompilationTask> {
     if (chosenAction == exportMapAction)
@@ -232,6 +235,14 @@ void CompilationProfileEditor::addTask()
     {
       return mdl::CompilationRunTool{
         K(enabled), "", "", !K(treatNonZeroResultCodeAsError)};
+    }
+    if (chosenAction == launchEngineAction)
+    {
+      const auto& engineProfiles = m_document.map().gameInfo().gameEngineConfig.profiles;
+      return mdl::CompilationLaunchEngine{
+        K(enabled),
+        engineProfiles.empty() ? "" : engineProfiles.front().id,
+        !K(treatLaunchFailureAsError)};
     }
     {
       return std::nullopt;

--- a/lib/TbUiLib/src/CompilationProfileEditor.cpp
+++ b/lib/TbUiLib/src/CompilationProfileEditor.cpp
@@ -332,6 +332,12 @@ void CompilationProfileEditor::setProfile(mdl::CompilationProfile* profile)
   refresh();
 }
 
+void CompilationProfileEditor::refreshTaskEditors()
+{
+  m_taskList->updateTasks();
+  refresh();
+}
+
 void CompilationProfileEditor::refresh()
 {
   if (m_profile)

--- a/lib/TbUiLib/src/CompilationProfileManager.cpp
+++ b/lib/TbUiLib/src/CompilationProfileManager.cpp
@@ -143,6 +143,11 @@ const mdl::CompilationConfig& CompilationProfileManager::config() const
   return m_config;
 }
 
+void CompilationProfileManager::refreshTaskEditors()
+{
+  m_profileEditor->refreshTaskEditors();
+}
+
 void CompilationProfileManager::addProfile()
 {
   m_config.profiles.push_back(mdl::CompilationProfile{"unnamed", "${MAP_DIR_PATH}", {}});

--- a/lib/TbUiLib/src/CompilationProfileManager.cpp
+++ b/lib/TbUiLib/src/CompilationProfileManager.cpp
@@ -24,10 +24,14 @@
 
 #include "mdl/CompilationConfig.h"
 #include "mdl/CompilationProfile.h"
+#include "mdl/GameManager.h"
+#include "mdl/Map.h"
+#include "ui/AppController.h"
 #include "ui/BitmapButton.h"
 #include "ui/BorderLine.h"
 #include "ui/CompilationProfileEditor.h"
 #include "ui/CompilationProfileListBox.h"
+#include "ui/MapDocument.h"
 #include "ui/MiniToolBarLayout.h"
 #include "ui/QStyleUtils.h"
 #include "ui/TitledPanel.h"
@@ -39,8 +43,12 @@ namespace tb::ui
 {
 
 CompilationProfileManager::CompilationProfileManager(
-  MapDocument& document, mdl::CompilationConfig config, QWidget* parent)
+  AppController& appController,
+  MapDocument& document,
+  mdl::CompilationConfig config,
+  QWidget* parent)
   : QWidget{parent}
+  , m_document{document}
   , m_config{std::move(config)}
 {
   setBaseWindowColor(this);
@@ -111,6 +119,15 @@ CompilationProfileManager::CompilationProfileManager(
   {
     m_profileList->setCurrentRow(0);
   }
+
+  m_notifierConnection +=
+    appController.gameManager().gameEngineConfigDidChangeNotifier.connect(
+      [this](const auto& gameInfo) {
+        if (&gameInfo == &m_document.map().gameInfo())
+        {
+          m_profileEditor->refreshTaskEditors();
+        }
+      });
 }
 
 const mdl::CompilationProfile* CompilationProfileManager::selectedProfile() const
@@ -141,11 +158,6 @@ void CompilationProfileManager::selectFirstProfile()
 const mdl::CompilationConfig& CompilationProfileManager::config() const
 {
   return m_config;
-}
-
-void CompilationProfileManager::refreshTaskEditors()
-{
-  m_profileEditor->refreshTaskEditors();
 }
 
 void CompilationProfileManager::addProfile()

--- a/lib/TbUiLib/src/CompilationRunner.cpp
+++ b/lib/TbUiLib/src/CompilationRunner.cpp
@@ -32,9 +32,12 @@
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
 #include "mdl/ExportOptions.h"
+#include "mdl/GameEngineProfile.h"
+#include "mdl/GameInfo.h"
 #include "mdl/Map.h"
 #include "ui/CompilationContext.h"
 #include "ui/CompilationVariables.h"
+#include "ui/LaunchGameEngine.h"
 #include "ui/QPathUtils.h"
 
 #include "kd/cmd_utils.h"
@@ -49,6 +52,7 @@
 #include <fmt/format.h>
 #include <fmt/std.h>
 
+#include <algorithm>
 #include <ranges>
 #include <string>
 
@@ -473,6 +477,71 @@ void CompilationRunToolTaskRunner::processReadyReadStandardOutput()
   }
 }
 
+CompilationLaunchEngineTaskRunner::CompilationLaunchEngineTaskRunner(
+  CompilationContext& context, mdl::CompilationLaunchEngine task)
+  : CompilationTaskRunner{context}
+  , m_task{std::move(task)}
+{
+}
+
+CompilationLaunchEngineTaskRunner::~CompilationLaunchEngineTaskRunner() = default;
+
+void CompilationLaunchEngineTaskRunner::doExecute()
+{
+  emit start();
+
+  const auto fail = [&](const QString& message) {
+    m_context << "#### Launch failed: " << message << "\n";
+    if (m_task.treatLaunchFailureAsError)
+    {
+      emit error();
+    }
+    else
+    {
+      m_context << "#### Continuing despite launch failure\n";
+      emit end();
+    }
+  };
+
+  if (m_task.engineProfileId.empty())
+  {
+    fail("Engine profile is not set");
+    return;
+  }
+
+  const auto& engineProfiles = m_context.map().gameInfo().gameEngineConfig.profiles;
+  const auto profileIt = std::ranges::find_if(engineProfiles, [&](const auto& profile) {
+    return profile.id == m_task.engineProfileId;
+  });
+
+  if (profileIt == std::end(engineProfiles))
+  {
+    fail(
+      QString{"Engine profile '"} + QString::fromStdString(m_task.engineProfileId)
+      + "' was not found");
+    return;
+  }
+
+  const auto& profile = *profileIt;
+  m_context << "#### Launching engine profile '" << QString::fromStdString(profile.name)
+            << "' at '" << pathAsQString(profile.path) << "'\n";
+
+  if (m_context.test())
+  {
+    emit end();
+    return;
+  }
+
+  launchGameEngineProfile(profile, LaunchGameEngineVariables{m_context.map()})
+    | kdl::transform([&]() {
+        m_context << "#### Launched\n";
+        emit end();
+      })
+    | kdl::transform_error([&](auto e) { fail(QString::fromStdString(e.msg)); });
+}
+
+void CompilationLaunchEngineTaskRunner::doTerminate() {}
+
 CompilationRunner::CompilationRunner(
   CompilationContext context, const mdl::CompilationProfile& profile, QObject* parent)
   : QObject{parent}
@@ -525,6 +594,13 @@ CompilationRunner::TaskRunnerList CompilationRunner::createTaskRunners(
           {
             result.push_back(
               std::make_unique<CompilationRunToolTaskRunner>(context, runTool));
+          }
+        },
+        [&](const mdl::CompilationLaunchEngine& launchEngine) {
+          if (launchEngine.enabled)
+          {
+            result.push_back(
+              std::make_unique<CompilationLaunchEngineTaskRunner>(context, launchEngine));
           }
         }),
       task);

--- a/lib/TbUiLib/src/CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/src/CompilationTaskListBox.cpp
@@ -586,6 +586,13 @@ void CompilationTaskListBox::reloadTasks()
   reload();
 }
 
+void CompilationTaskListBox::updateTasks()
+{
+  // Refresh existing task editors without rebuilding the list, so scroll position and
+  // selection survive external changes such as editing Launch Engine profiles.
+  updateItems();
+}
+
 size_t CompilationTaskListBox::itemCount() const
 {
   return m_profile ? m_profile->tasks.size() : 0;

--- a/lib/TbUiLib/src/CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/src/CompilationTaskListBox.cpp
@@ -21,16 +21,20 @@
 
 #include <QBoxLayout>
 #include <QCheckBox>
+#include <QComboBox>
 #include <QCompleter>
 #include <QFileDialog>
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QSignalBlocker>
 
 #include "el/Interpolate.h"
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
+#include "mdl/GameInfo.h"
+#include "mdl/Map.h"
 #include "ui/BorderLine.h"
 #include "ui/CompilationVariables.h"
 #include "ui/FileDialogDefaultDir.h"
@@ -567,6 +571,97 @@ void CompilationRunToolTaskEditor::treatNonZeroResultCodeAsErrorChanged(const in
   task().treatNonZeroResultCodeAsError = value;
 }
 
+// CompilationLaunchEngineTaskEditor
+
+CompilationLaunchEngineTaskEditor::CompilationLaunchEngineTaskEditor(
+  MapDocument& document,
+  mdl::CompilationProfile& profile,
+  mdl::CompilationTask& task,
+  QWidget* parent)
+  : CompilationTaskEditorBase{"Launch Engine", document, profile, task, parent}
+{
+  contract_pre(std::holds_alternative<mdl::CompilationLaunchEngine>(task));
+
+  auto* formLayout = new QFormLayout{};
+  formLayout->setContentsMargins(
+    LayoutConstants::WideHMargin,
+    LayoutConstants::WideVMargin,
+    LayoutConstants::WideHMargin,
+    LayoutConstants::WideVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
+  addMainLayout(formLayout);
+
+  m_engineProfileEditor = new QComboBox{};
+  m_engineProfileEditor->setToolTip(
+    tr("The Launch Engine profile to start when this task runs"));
+  formLayout->addRow("Engine Profile", m_engineProfileEditor);
+
+  m_treatLaunchFailureAsError = new QCheckBox{"Stop on launch failure"};
+  m_treatLaunchFailureAsError->setToolTip(
+    tr("Stop compilation if the engine cannot be launched"));
+  formLayout->addRow("", m_treatLaunchFailureAsError);
+
+  connect(
+    m_engineProfileEditor,
+    QOverload<int>::of(&QComboBox::currentIndexChanged),
+    this,
+    &CompilationLaunchEngineTaskEditor::engineProfileChanged);
+  connect(
+    m_treatLaunchFailureAsError,
+    &QCheckBox::checkStateChanged,
+    this,
+    &CompilationLaunchEngineTaskEditor::treatLaunchFailureAsErrorChanged);
+}
+
+void CompilationLaunchEngineTaskEditor::updateItem()
+{
+  CompilationTaskEditorBase::updateItem();
+
+  const auto signalBlocker = QSignalBlocker{m_engineProfileEditor};
+  m_engineProfileEditor->clear();
+
+  const auto& engineProfiles = m_document.map().gameInfo().gameEngineConfig.profiles;
+  for (const auto& engineProfile : engineProfiles)
+  {
+    m_engineProfileEditor->addItem(
+      QString::fromStdString(engineProfile.name),
+      QString::fromStdString(engineProfile.id));
+  }
+
+  m_engineProfileEditor->setCurrentIndex(
+    m_engineProfileEditor->findData(QString::fromStdString(task().engineProfileId)));
+
+  if (m_treatLaunchFailureAsError->isChecked() != task().treatLaunchFailureAsError)
+  {
+    m_treatLaunchFailureAsError->setCheckState(
+      task().treatLaunchFailureAsError ? Qt::CheckState::Checked
+                                       : Qt::CheckState::Unchecked);
+  }
+}
+
+mdl::CompilationLaunchEngine& CompilationLaunchEngineTaskEditor::task()
+{
+  // This is safe because we know what type of task the editor was initialized with.
+  // We have to do this to avoid using a template as the base class.
+  return std::get<mdl::CompilationLaunchEngine>(m_task);
+}
+
+void CompilationLaunchEngineTaskEditor::engineProfileChanged(const int index)
+{
+  if (index >= 0)
+  {
+    task().engineProfileId =
+      m_engineProfileEditor->itemData(index).toString().toStdString();
+  }
+}
+
+void CompilationLaunchEngineTaskEditor::treatLaunchFailureAsErrorChanged(const int state)
+{
+  const auto value = (state == Qt::Checked);
+  task().treatLaunchFailureAsError = value;
+}
+
 // CompilationTaskListBox
 
 CompilationTaskListBox::CompilationTaskListBox(MapDocument& document, QWidget* parent)
@@ -620,6 +715,10 @@ ControlListBoxItemRenderer* CompilationTaskListBox::createItemRenderer(
       },
       [&](const mdl::CompilationRunTool&) -> ControlListBoxItemRenderer* {
         return new CompilationRunToolTaskEditor{m_document, *m_profile, task, parent};
+      },
+      [&](const mdl::CompilationLaunchEngine&) -> ControlListBoxItemRenderer* {
+        return new CompilationLaunchEngineTaskEditor{
+          m_document, *m_profile, task, parent};
       }),
     task);
 

--- a/lib/TbUiLib/src/GameEngineProfileManager.cpp
+++ b/lib/TbUiLib/src/GameEngineProfileManager.cpp
@@ -106,7 +106,11 @@ const mdl::GameEngineConfig& GameEngineProfileManager::config() const
 
 void GameEngineProfileManager::addProfile()
 {
-  m_config.profiles.push_back(mdl::GameEngineProfile{"", {}, ""});
+  m_config.profiles.push_back(mdl::GameEngineProfile{
+    .name = "",
+    .path = {},
+    .parameterSpec = "",
+  });
   m_profileList->reloadProfiles();
   m_profileList->setCurrentRow(int(m_config.profiles.size() - 1));
 }

--- a/lib/TbUiLib/src/GameEngineProfileManager.cpp
+++ b/lib/TbUiLib/src/GameEngineProfileManager.cpp
@@ -22,6 +22,7 @@
 #include <QBoxLayout>
 #include <QToolButton>
 
+#include "Uuid.h"
 #include "mdl/GameEngineConfig.h"
 #include "mdl/GameEngineProfile.h"
 #include "ui/BitmapButton.h"
@@ -107,6 +108,7 @@ const mdl::GameEngineConfig& GameEngineProfileManager::config() const
 void GameEngineProfileManager::addProfile()
 {
   m_config.profiles.push_back(mdl::GameEngineProfile{
+    .id = generateUuid(),
     .name = "",
     .path = {},
     .parameterSpec = "",

--- a/lib/TbUiLib/test/src/tst_CompilationProfileManager.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationProfileManager.cpp
@@ -25,6 +25,7 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 #include "mdl/CompilationConfig.h"
 #include "mdl/CompilationProfile.h"
+#include "ui/AppControllerFixture.h"
 #include "ui/CatchConfig.h"
 #include "ui/CompilationProfileListBox.h"
 #include "ui/CompilationProfileManager.h"
@@ -39,6 +40,9 @@ namespace tb::ui
 
 TEST_CASE("CompilationProfileManager")
 {
+  auto appControllerFixture = AppControllerFixture{};
+  auto& appController = appControllerFixture.appController();
+
   auto fixture = MapDocumentFixture{};
   auto& document = fixture.create();
 
@@ -48,7 +52,8 @@ TEST_CASE("CompilationProfileManager")
   {
     SECTION("returns null when no profile is selected")
     {
-      auto manager = std::make_unique<CompilationProfileManager>(document, config);
+      auto manager =
+        std::make_unique<CompilationProfileManager>(appController, document, config);
 
       CHECK(manager->selectedProfile() == nullptr);
     }
@@ -58,7 +63,8 @@ TEST_CASE("CompilationProfileManager")
       config.profiles.push_back(mdl::CompilationProfile{"test 1", "", {}});
       config.profiles.push_back(mdl::CompilationProfile{"test 2", "", {}});
 
-      auto manager = std::make_unique<CompilationProfileManager>(document, config);
+      auto manager =
+        std::make_unique<CompilationProfileManager>(appController, document, config);
 
       auto* profileListBox = manager->findChild<CompilationProfileListBox*>();
       REQUIRE(profileListBox != nullptr);
@@ -82,7 +88,8 @@ TEST_CASE("CompilationProfileManager")
       config.profiles.push_back(mdl::CompilationProfile{"test 1", "", {}});
       config.profiles.push_back(mdl::CompilationProfile{"test 2", "", {}});
 
-      auto manager = std::make_unique<CompilationProfileManager>(document, config);
+      auto manager =
+        std::make_unique<CompilationProfileManager>(appController, document, config);
 
       REQUIRE(manager->selectedProfile() != nullptr);
       CHECK(manager->selectedProfile()->name == "test 1");
@@ -99,7 +106,8 @@ TEST_CASE("CompilationProfileManager")
       config.profiles.push_back(mdl::CompilationProfile{"test 1", "", {}});
       config.profiles.push_back(mdl::CompilationProfile{"test 2", "", {}});
 
-      auto manager = std::make_unique<CompilationProfileManager>(document, config);
+      auto manager =
+        std::make_unique<CompilationProfileManager>(appController, document, config);
 
       REQUIRE(manager->selectedProfile() != nullptr);
       CHECK(manager->selectedProfile()->name == "test 1");
@@ -121,7 +129,8 @@ TEST_CASE("CompilationProfileManager")
       config.profiles.push_back(mdl::CompilationProfile{"test 2", "", {}});
       config.profiles.push_back(mdl::CompilationProfile{"test 3", "", {}});
 
-      auto manager = std::make_unique<CompilationProfileManager>(document, config);
+      auto manager =
+        std::make_unique<CompilationProfileManager>(appController, document, config);
 
       manager->selectProfile(config.profiles[2]);
       REQUIRE(manager->selectedProfile() != nullptr);
@@ -135,7 +144,8 @@ TEST_CASE("CompilationProfileManager")
 
     SECTION("does nothing when there are no profiles")
     {
-      auto manager = std::make_unique<CompilationProfileManager>(document, config);
+      auto manager =
+        std::make_unique<CompilationProfileManager>(appController, document, config);
 
       manager->selectFirstProfile();
 
@@ -147,7 +157,8 @@ TEST_CASE("CompilationProfileManager")
   {
     config.profiles.push_back(mdl::CompilationProfile{"test 1", "", {}});
 
-    auto manager = std::make_unique<CompilationProfileManager>(document, config);
+    auto manager =
+      std::make_unique<CompilationProfileManager>(appController, document, config);
 
     manager->resize(700, 400);
     manager->show();
@@ -178,7 +189,8 @@ TEST_CASE("CompilationProfileManager")
     config.profiles.push_back(mdl::CompilationProfile{"test 1", "", {}});
     config.profiles.push_back(mdl::CompilationProfile{"test 2", "", {}});
 
-    auto manager = std::make_unique<CompilationProfileManager>(document, config);
+    auto manager =
+      std::make_unique<CompilationProfileManager>(appController, document, config);
 
     manager->resize(700, 400);
     manager->show();
@@ -215,7 +227,8 @@ TEST_CASE("CompilationProfileManager")
 
   SECTION("add profile by clicking button")
   {
-    auto manager = std::make_unique<CompilationProfileManager>(document, config);
+    auto manager =
+      std::make_unique<CompilationProfileManager>(appController, document, config);
 
     manager->resize(700, 400);
     manager->show();
@@ -239,7 +252,8 @@ TEST_CASE("CompilationProfileManager")
     config.profiles.push_back(mdl::CompilationProfile{"test 1", "", {}});
     config.profiles.push_back(mdl::CompilationProfile{"test 2", "", {}});
 
-    auto manager = std::make_unique<CompilationProfileManager>(document, config);
+    auto manager =
+      std::make_unique<CompilationProfileManager>(appController, document, config);
 
     manager->resize(700, 400);
     manager->show();

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -29,6 +29,7 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
 #include "mdl/EntityNode.h"
+#include "mdl/GameEngineProfile.h"
 #include "mdl/Map.h"
 #include "mdl/MapFixture.h"
 #include "mdl/Map_Nodes.h"
@@ -292,6 +293,121 @@ escaped str)"));
 #endif
 }
 
+TEST_CASE("CompilationLaunchEngineTaskRunner")
+{
+  auto fixtureConfig = mdl::MapFixtureConfig{};
+  fixtureConfig.gameInfo.gameEngineConfig.profiles = {
+    mdl::GameEngineProfile{
+      .id = "quakespasm-id",
+      .name = "Quakespasm",
+      .path = CMD_TOOL_PATH,
+      .parameterSpec = "--exit 0"},
+    mdl::GameEngineProfile{
+      .id = "missing-engine-id",
+      .name = "Missing Engine",
+      .path = "/does/not/exist",
+      .parameterSpec = ""},
+  };
+
+  auto fixture = mdl::MapFixture{};
+  auto& map = fixture.create(fixtureConfig);
+
+  SECTION("launchEngine")
+  {
+    auto variables = el::NullVariableStore{};
+    auto output = QTextEdit{};
+    auto outputAdapter = TextOutputAdapter{&output};
+
+    auto context = CompilationContext{map, variables, outputAdapter, false};
+
+    auto task = mdl::CompilationLaunchEngine{
+      K(enabled), "quakespasm-id", !K(treatLaunchFailureAsError)};
+    auto runner = CompilationLaunchEngineTaskRunner{context, task};
+
+    auto exec = ExecuteTask{runner};
+    REQUIRE(exec.executeAndWait(5000ms));
+
+    CHECK(exec.started);
+    CHECK_FALSE(exec.errored);
+    CHECK(exec.ended);
+    CHECK_THAT(
+      output.toPlainText().toStdString(),
+      ContainsSubstring("#### Launching engine profile 'Quakespasm' at '"));
+  }
+
+  SECTION("invalidEngineProfile")
+  {
+    auto variables = el::NullVariableStore{};
+    auto output = QTextEdit{};
+    auto outputAdapter = TextOutputAdapter{&output};
+
+    auto context = CompilationContext{map, variables, outputAdapter, false};
+
+    const auto engineProfileId = GENERATE(""s, "deleted-profile-id"s);
+    const auto treatLaunchFailureAsError = GENERATE(true, false);
+    CAPTURE(engineProfileId, treatLaunchFailureAsError);
+    auto task = mdl::CompilationLaunchEngine{
+      K(enabled), engineProfileId, treatLaunchFailureAsError};
+    auto runner = CompilationLaunchEngineTaskRunner{context, task};
+
+    auto exec = ExecuteTask{runner};
+    REQUIRE(exec.executeAndWait(5000ms));
+
+    CHECK(exec.started);
+    CHECK(exec.errored == treatLaunchFailureAsError);
+    CHECK(exec.ended == !treatLaunchFailureAsError);
+    CHECK_THAT(
+      output.toPlainText().toStdString(), ContainsSubstring("#### Launch failed: "));
+  }
+
+  SECTION("launchFailure")
+  {
+    auto variables = el::NullVariableStore{};
+    auto output = QTextEdit{};
+    auto outputAdapter = TextOutputAdapter{&output};
+
+    auto context = CompilationContext{map, variables, outputAdapter, false};
+
+    const auto treatLaunchFailureAsError = GENERATE(true, false);
+    CAPTURE(treatLaunchFailureAsError);
+    auto task = mdl::CompilationLaunchEngine{
+      K(enabled), "missing-engine-id", treatLaunchFailureAsError};
+    auto runner = CompilationLaunchEngineTaskRunner{context, task};
+
+    auto exec = ExecuteTask{runner};
+    REQUIRE(exec.executeAndWait(5000ms));
+
+    CHECK(exec.started);
+    CHECK(exec.errored == treatLaunchFailureAsError);
+    CHECK(exec.ended == !treatLaunchFailureAsError);
+    CHECK_THAT(
+      output.toPlainText().toStdString(), ContainsSubstring("#### Launch failed: "));
+  }
+
+  SECTION("testModeDoesNotLaunch")
+  {
+    auto variables = el::NullVariableStore{};
+    auto output = QTextEdit{};
+    auto outputAdapter = TextOutputAdapter{&output};
+
+    auto context = CompilationContext{map, variables, outputAdapter, true};
+
+    auto task = mdl::CompilationLaunchEngine{
+      K(enabled), "missing-engine-id", K(treatLaunchFailureAsError)};
+    auto runner = CompilationLaunchEngineTaskRunner{context, task};
+
+    auto exec = ExecuteTask{runner};
+    REQUIRE(exec.executeAndWait(5000ms));
+
+    CHECK(exec.started);
+    CHECK_FALSE(exec.errored);
+    CHECK(exec.ended);
+    CHECK_THAT(
+      output.toPlainText().toStdString(),
+      ContainsSubstring("#### Launching engine profile 'Missing Engine' at '"));
+  }
+}
+
 TEST_CASE("CompilationExportMapTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
@@ -515,6 +631,13 @@ TEST_CASE("CompilationRunner")
   fixtureConfig.gameInfo.gameConfig.fileFormats = std::vector<mdl::MapFormatConfig>{
     {"Valve", {}},
   };
+  fixtureConfig.gameInfo.gameEngineConfig.profiles = {
+    mdl::GameEngineProfile{
+      .id = "quakespasm-id",
+      .name = "Quakespasm",
+      .path = CMD_TOOL_PATH,
+      .parameterSpec = "--exit 0"},
+  };
 
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.load(
@@ -560,6 +683,60 @@ TEST_CASE("CompilationRunner")
     REQUIRE(compilationEndedSpy.count() == 1);
 
     CHECK_FALSE(testEnvironment.fileExists(should_not_exist));
+  }
+
+  SECTION("runLaunchEngineTask")
+  {
+    auto compilationProfile = mdl::CompilationProfile{
+      "name",
+      testEnvironment.dir().string(),
+      {
+        mdl::CompilationLaunchEngine{
+          K(enabled), "quakespasm-id", !K(treatLaunchFailureAsError)},
+      }};
+
+    auto runner = CompilationRunner{
+      CompilationContext{map, variables, outputAdapter, false}, compilationProfile};
+
+    auto compilationStartedSpy = QSignalSpy{&runner, SIGNAL(compilationStarted())};
+    auto compilationEndedSpy = QSignalSpy{&runner, SIGNAL(compilationEnded())};
+
+    REQUIRE(compilationStartedSpy.isValid());
+    REQUIRE(compilationEndedSpy.isValid());
+
+    runner.execute();
+    REQUIRE(!runner.running());
+    REQUIRE(compilationStartedSpy.count() == 1);
+    REQUIRE(compilationEndedSpy.count() == 1);
+
+    CHECK_THAT(
+      output.toPlainText().toStdString(),
+      ContainsSubstring("#### Launching engine profile 'Quakespasm' at '"));
+  }
+
+  SECTION("disabledLaunchEngineTaskIsIgnored")
+  {
+    auto compilationProfile = mdl::CompilationProfile{
+      "name",
+      testEnvironment.dir().string(),
+      {
+        mdl::CompilationLaunchEngine{!K(enabled), "", K(treatLaunchFailureAsError)},
+      }};
+
+    auto runner = CompilationRunner{
+      CompilationContext{map, variables, outputAdapter, false}, compilationProfile};
+
+    auto compilationStartedSpy = QSignalSpy{&runner, SIGNAL(compilationStarted())};
+    auto compilationEndedSpy = QSignalSpy{&runner, SIGNAL(compilationEnded())};
+
+    REQUIRE(compilationStartedSpy.isValid());
+    REQUIRE(compilationEndedSpy.isValid());
+
+    runner.execute();
+    REQUIRE(!runner.running());
+    REQUIRE(compilationStartedSpy.count() == 0);
+    REQUIRE(compilationEndedSpy.count() == 0);
+    CHECK(output.toPlainText().isEmpty());
   }
 
   SECTION("interpolateToolsVariables")

--- a/lib/TbUiLib/test/src/tst_LaunchGameEngine.cpp
+++ b/lib/TbUiLib/test/src/tst_LaunchGameEngine.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "CmdTool.h"
+#include "Uuid.h"
 #include "el/VariableStore.h"
 #include "mdl/GameEngineProfile.h"
 #include "ui/CatchConfig.h"
@@ -39,6 +40,7 @@ TEST_CASE("launchGameEngineProfile")
   SECTION("return an error if engine doesn't exist")
   {
     auto profile = mdl::GameEngineProfile{
+      .id = generateUuid(),
       .name = "some_name",
       .path = "/does/not/exist",
       .parameterSpec = "",
@@ -50,6 +52,7 @@ TEST_CASE("launchGameEngineProfile")
   SECTION("passes arguments correctly to the engine")
   {
     auto profile = mdl::GameEngineProfile{
+      .id = generateUuid(),
       .name = "some_name",
       .path = CMD_TOOL_PATH,
       .parameterSpec = R"(--printArgs 1 2 str "string with spaces")",

--- a/lib/TbUiLib/test/src/tst_LaunchGameEngine.cpp
+++ b/lib/TbUiLib/test/src/tst_LaunchGameEngine.cpp
@@ -39,9 +39,9 @@ TEST_CASE("launchGameEngineProfile")
   SECTION("return an error if engine doesn't exist")
   {
     auto profile = mdl::GameEngineProfile{
-      "some_name",
-      "/does/not/exist",
-      "",
+      .name = "some_name",
+      .path = "/does/not/exist",
+      .parameterSpec = "",
     };
 
     CHECK(launchGameEngineProfile(profile, variables).is_error());
@@ -50,9 +50,9 @@ TEST_CASE("launchGameEngineProfile")
   SECTION("passes arguments correctly to the engine")
   {
     auto profile = mdl::GameEngineProfile{
-      "some_name",
-      CMD_TOOL_PATH,
-      R"(--printArgs 1 2 str "string with spaces")",
+      .name = "some_name",
+      .path = CMD_TOOL_PATH,
+      .parameterSpec = R"(--printArgs 1 2 str "string with spaces")",
     };
 
     auto logFile = kdl::tmp_file{};


### PR DESCRIPTION
Adds a new `Launch Engine` compile task that starts one of the current game’s configured engine profiles as part of a compile profile. This lets users export, compile, copy files, and launch the game from one profile. 
The task supports optional failure handling, is editable in the compile profile UI, is covered by parser/runner tests, and is documented in the manual.

Fixes #1891

Screenshots:
<img width="352" height="334" alt="image" src="https://github.com/user-attachments/assets/81d7fa10-19fa-467b-b11a-930b87bfef30" />
<img width="1074" height="382" alt="image" src="https://github.com/user-attachments/assets/fe78ace1-f5af-4a46-9ccb-d3d570d215c9" />
