### PR TITLE
Add export option to drop entity at camera

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -1658,6 +1658,9 @@ Target
 Strip TB specific entity properties
 :    Strip any entity properties starting with _tb_ from the exported map file. Some compilers cannot handle these properties.
 
+Drop entity at camera
+:    Remove exported point entities with the given classname and add one replacement point entity at the active camera position. The open document is not modified.
+
 ### Run Tool
 
 Runs an external tool and captures its output. Note that for the Tool parameter's value, you can use a compilation tool variable defined in the [game configuration](#game_configuration), as discussed below.

--- a/lib/TbMdlLib/include/mdl/CompilationTask.h
+++ b/lib/TbMdlLib/include/mdl/CompilationTask.h
@@ -32,8 +32,16 @@ struct CompilationExportMap
   bool enabled;
   bool stripTbProperties;
   std::string targetSpec;
+  bool dropEntityAtCamera = false;
+  std::string dropEntityClassname = "info_player_start";
 
-  kdl_reflect_decl(CompilationExportMap, enabled, stripTbProperties, targetSpec);
+  kdl_reflect_decl(
+    CompilationExportMap,
+    enabled,
+    stripTbProperties,
+    targetSpec,
+    dropEntityAtCamera,
+    dropEntityClassname);
 };
 
 struct CompilationCopyFiles

--- a/lib/TbMdlLib/include/mdl/ExportOptions.h
+++ b/lib/TbMdlLib/include/mdl/ExportOptions.h
@@ -22,18 +22,34 @@
 
 #include "kd/reflection_decl.h"
 
+#include "vm/vec.h"
+
 #include <filesystem>
+#include <optional>
+#include <string>
 #include <variant>
 
 namespace tb::mdl
 {
 
+struct ReplacementPointEntityAtCamera
+{
+  std::string classname;
+  vm::vec3d origin;
+  int angle;
+
+  kdl_reflect_decl(ReplacementPointEntityAtCamera, classname, origin, angle);
+};
+
 struct MapExportOptions
 {
   std::filesystem::path exportPath;
   bool stripTbProperties;
+  std::optional<ReplacementPointEntityAtCamera> replacementPointEntityAtCamera =
+    std::nullopt;
 
-  kdl_reflect_decl(MapExportOptions, exportPath, stripTbProperties);
+  kdl_reflect_decl(
+    MapExportOptions, exportPath, stripTbProperties, replacementPointEntityAtCamera);
 };
 
 enum class ObjMtlPathMode

--- a/lib/TbMdlLib/include/mdl/NodeWriter.h
+++ b/lib/TbMdlLib/include/mdl/NodeWriter.h
@@ -19,8 +19,11 @@
 
 #pragma once
 
+#include "mdl/ExportOptions.h"
+
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace kdl
@@ -47,6 +50,7 @@ private:
 
   const WorldNode& m_world;
   std::unique_ptr<NodeSerializer> m_serializer;
+  std::optional<ReplacementPointEntityAtCamera> m_replacementPointEntityAtCamera;
 
 public:
   NodeWriter(const WorldNode& world, std::ostream& stream);
@@ -55,12 +59,15 @@ public:
 
   void setExporting(bool exporting);
   void setStripTbProperties(bool stripTbProperties);
+  void setReplacementPointEntityAtCamera(
+    std::optional<ReplacementPointEntityAtCamera> replacementPointEntityAtCamera);
   void writeMap(kdl::task_manager& taskManager);
 
 private:
   void writeDefaultLayer();
   void writeCustomLayers();
   void writeCustomLayer(const LayerNode& layer);
+  void writeReplacementPointEntityAtCamera();
 
 public:
   void writeNodes(const std::vector<Node*>& nodes, kdl::task_manager& taskManager);

--- a/lib/TbMdlLib/src/CompilationConfig.cpp
+++ b/lib/TbMdlLib/src/CompilationConfig.cpp
@@ -38,6 +38,8 @@ el::Value toValue(const CompilationTask& task)
         map["enabled"] = el::Value{exportMap.enabled};
         map["stripTbProperties"] = el::Value{exportMap.stripTbProperties};
         map["target"] = el::Value{exportMap.targetSpec};
+        map["dropEntityAtCamera"] = el::Value{exportMap.dropEntityAtCamera};
+        map["dropEntityClassname"] = el::Value{exportMap.dropEntityClassname};
         return map;
       },
       [](const CompilationCopyFiles& copyFiles) {

--- a/lib/TbMdlLib/src/ExportOptions.cpp
+++ b/lib/TbMdlLib/src/ExportOptions.cpp
@@ -24,12 +24,15 @@
 
 #include "kd/reflection_impl.h"
 
+#include "vm/vec_io.h" // IWYU pragma: keep
+
 #include <ostream>
 
 
 namespace tb::mdl
 {
 
+kdl_reflect_impl(ReplacementPointEntityAtCamera);
 kdl_reflect_impl(MapExportOptions);
 
 std::ostream& operator<<(std::ostream& lhs, const ObjMtlPathMode rhs)

--- a/lib/TbMdlLib/src/Map.cpp
+++ b/lib/TbMdlLib/src/Map.cpp
@@ -901,6 +901,8 @@ Result<void> Map::exportAs(const ExportOptions& options) const
           auto writer = NodeWriter{*m_worldNode, stream};
           writer.setExporting(true);
           writer.setStripTbProperties(mapOptions.stripTbProperties);
+          writer.setReplacementPointEntityAtCamera(
+            mapOptions.replacementPointEntityAtCamera);
           writer.writeMap(m_taskManager);
         });
       }),

--- a/lib/TbMdlLib/src/NodeWriter.cpp
+++ b/lib/TbMdlLib/src/NodeWriter.cpp
@@ -22,6 +22,8 @@
 #include "mdl/BrushNode.h"
 #include "mdl/Entity.h"
 #include "mdl/EntityNode.h"
+#include "mdl/EntityProperties.h"
+#include "mdl/ExportOptions.h"
 #include "mdl/GroupNode.h"
 #include "mdl/LayerNode.h"
 #include "mdl/MapFileSerializer.h"
@@ -37,6 +39,10 @@
 #include "kd/string_utils.h"
 #include "kd/vector_utils.h"
 
+#include "vm/vec_io.h" // IWYU pragma: keep
+
+#include <fmt/format.h>
+
 #include <vector>
 
 namespace tb::mdl
@@ -47,6 +53,7 @@ namespace
 void doWriteNodes(
   NodeSerializer& serializer,
   const std::vector<Node*>& nodes,
+  const std::optional<ReplacementPointEntityAtCamera>& replacementPointEntityAtCamera,
   const Node* parent = nullptr)
 {
   auto parentStack = std::vector<const Node*>{parent};
@@ -69,6 +76,12 @@ void doWriteNodes(
         parentStack.pop_back();
       },
       [&](const EntityNode& entityNode) {
+        if (
+          replacementPointEntityAtCamera && !entityNode.hasChildren()
+          && entityNode.entity().classname() == replacementPointEntityAtCamera->classname)
+        {
+          return;
+        }
         auto extraProperties = parentProperties();
         const auto& protectedProperties = entityNode.entity().protectedProperties();
         if (!protectedProperties.empty())
@@ -115,11 +128,18 @@ void NodeWriter::setStripTbProperties(const bool stripTbProperties)
   m_serializer->setStripTbProperties(stripTbProperties);
 }
 
+void NodeWriter::setReplacementPointEntityAtCamera(
+  std::optional<ReplacementPointEntityAtCamera> replacementPointEntityAtCamera)
+{
+  m_replacementPointEntityAtCamera = std::move(replacementPointEntityAtCamera);
+}
+
 void NodeWriter::writeMap(kdl::task_manager& taskManager)
 {
   m_serializer->beginFile({&m_world}, taskManager);
   writeDefaultLayer();
   writeCustomLayers();
+  writeReplacementPointEntityAtCamera();
   m_serializer->endFile();
 }
 
@@ -129,7 +149,10 @@ void NodeWriter::writeDefaultLayer()
 
   if (!(m_serializer->exporting() && m_world.defaultLayer()->layer().omitFromExport()))
   {
-    doWriteNodes(*m_serializer, m_world.defaultLayer()->children());
+    doWriteNodes(
+      *m_serializer,
+      m_world.defaultLayer()->children(),
+      m_replacementPointEntityAtCamera);
   }
 }
 
@@ -146,8 +169,26 @@ void NodeWriter::writeCustomLayer(const LayerNode& layerNode)
   if (!(m_serializer->exporting() && layerNode.layer().omitFromExport()))
   {
     m_serializer->customLayer(layerNode);
-    doWriteNodes(*m_serializer, layerNode.children(), &layerNode);
+    doWriteNodes(
+      *m_serializer, layerNode.children(), m_replacementPointEntityAtCamera, &layerNode);
   }
+}
+
+void NodeWriter::writeReplacementPointEntityAtCamera()
+{
+  if (!m_replacementPointEntityAtCamera)
+  {
+    return;
+  }
+
+  auto entityNode = EntityNode{Entity{{
+    {EntityPropertyKeys::Classname, m_replacementPointEntityAtCamera->classname},
+    {EntityPropertyKeys::Origin,
+     kdl::str_to_string(vm::correct(m_replacementPointEntityAtCamera->origin))},
+    {EntityPropertyKeys::Angle,
+     fmt::format("{}", m_replacementPointEntityAtCamera->angle)},
+  }}};
+  m_serializer->entity(entityNode, entityNode.entity().properties(), {}, entityNode);
 }
 
 void NodeWriter::writeNodes(
@@ -185,8 +226,8 @@ void NodeWriter::writeNodes(
   writeWorldBrushes(worldBrushes);
   writeEntityBrushes(entityBrushes);
 
-  doWriteNodes(*m_serializer, groups);
-  doWriteNodes(*m_serializer, entities);
+  doWriteNodes(*m_serializer, groups, std::nullopt);
+  doWriteNodes(*m_serializer, entities, std::nullopt);
 
   m_serializer->endFile();
 }

--- a/lib/TbMdlLib/src/ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/src/ParseCompilationConfig.cpp
@@ -53,6 +53,10 @@ CompilationExportMap toExportTask(
     enabled,
     stripTbProperties,
     value.at(context, "target").stringValue(context),
+    value.atOrDefault(context, "dropEntityAtCamera", el::Value{false})
+      .booleanValue(context),
+    value.atOrDefault(context, "dropEntityClassname", el::Value{"info_player_start"})
+      .stringValue(context),
   };
 }
 

--- a/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
@@ -99,7 +99,9 @@ TEST_CASE("toValue")
                 "type": "export",
                 "enabled": {},
                 "stripTbProperties": {},
-                "target": "targetSpec"
+                "target": "targetSpec",
+                "dropEntityAtCamera": false,
+                "dropEntityClassname": "info_player_start"
               }}
             ]
           }}

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -25,6 +25,7 @@
 #include "mdl/CatchConfig.h"
 #include "mdl/Entity.h"
 #include "mdl/EntityNode.h"
+#include "mdl/ExportOptions.h"
 #include "mdl/GroupNode.h"
 #include "mdl/LayerNode.h"
 #include "mdl/LockState.h"
@@ -40,6 +41,7 @@
 #include <fmt/format.h>
 
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
@@ -757,6 +759,65 @@ TEST_CASE("NodeWriter")
 }
 )";
     CHECK_THAT(actual, MatchesGlob(expected));
+  }
+
+  SECTION("dropPointEntityAtCamera")
+  {
+    const auto worldBounds = vm::bbox3d{8192.0};
+
+    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+
+    auto* matchingPointEntityNode = new mdl::EntityNode{mdl::Entity{{
+      {"classname", "info_player_start"},
+      {"origin", "1 2 3"},
+    }}};
+    map.defaultLayer()->addChild(matchingPointEntityNode);
+
+    auto* otherPointEntityNode = new mdl::EntityNode{mdl::Entity{{
+      {"classname", "info_player_deathmatch"},
+      {"origin", "4 5 6"},
+    }}};
+    map.defaultLayer()->addChild(otherPointEntityNode);
+
+    auto* matchingBrushEntityNode =
+      new mdl::EntityNode{mdl::Entity{{{"classname", "info_player_start"}}}};
+    matchingBrushEntityNode->addChild(
+      new mdl::BrushNode{builder.createCube(64.0, "brushMaterial") | kdl::value()});
+    map.defaultLayer()->addChild(matchingBrushEntityNode);
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{map, str};
+    writer.setExporting(true);
+    writer.setReplacementPointEntityAtCamera(mdl::ReplacementPointEntityAtCamera{
+      "info_player_start", vm::vec3d{16.0, 32.0, 48.0}, 90});
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+    const auto count = [&](const std::string_view str) {
+      auto result = size_t{0};
+      auto pos = size_t{0};
+      while ((pos = actual.find(str, pos)) != std::string::npos)
+      {
+        ++result;
+        pos += str.size();
+      }
+      return result;
+    };
+
+    CHECK(count(R"("classname" "info_player_start")") == 2u);
+    CHECK(actual.find(R"("origin" "1 2 3")") == std::string::npos);
+    CHECK(actual.find(R"("classname" "info_player_deathmatch")") != std::string::npos);
+    CHECK(actual.find("brushMaterial") != std::string::npos);
+
+    const auto classnamePos = actual.rfind(R"("classname" "info_player_start")");
+    const auto originPos = actual.rfind(R"("origin" "16 32 48")");
+    const auto anglePos = actual.rfind(R"("angle" "90")");
+    REQUIRE(classnamePos != std::string::npos);
+    REQUIRE(originPos != std::string::npos);
+    REQUIRE(anglePos != std::string::npos);
+    CHECK(classnamePos < originPos);
+    CHECK(originPos < anglePos);
   }
 
   SECTION("writeMapWithInheritedLock")

--- a/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
@@ -185,7 +185,12 @@ TEST_CASE("CompilationConfigParser")
         {"A profile",
          "",
          {
-           mdl::CompilationExportMap{K(enabled), !K(stripTbProperties), "the target"},
+           mdl::CompilationExportMap{
+             K(enabled),
+             !K(stripTbProperties),
+             "the target",
+             !K(dropEntityAtCamera),
+             "info_player_start"},
          }},
       }});
   }
@@ -211,6 +216,43 @@ TEST_CASE("CompilationConfigParser")
          "",
          {
            mdl::CompilationExportMap{K(enabled), K(stripTbProperties), "the target"},
+         }},
+      }});
+  }
+
+  SECTION("parseOneProfileWithNameAndOneExportTaskWithDropEntityAtCamera")
+  {
+    const auto config = R"(
+{
+  'version': 1,
+  'profiles': [
+    {
+      'name' : 'A profile',
+      'workdir' : '',
+      'tasks' : [
+        {
+          'type' : 'export',
+          'target' : 'the target',
+          'dropEntityAtCamera' : true,
+          'dropEntityClassname' : 'deathmatch_start'
+        }
+      ]
+    }
+  ]
+})";
+
+    CHECK(
+      parseCompilationConfig(config)
+      == mdl::CompilationConfig{{
+        {"A profile",
+         "",
+         {
+           mdl::CompilationExportMap{
+             K(enabled),
+             !K(stripTbProperties),
+             "the target",
+             K(dropEntityAtCamera),
+             "deathmatch_start"},
          }},
       }});
   }

--- a/lib/TbUiLib/include/ui/CompilationContext.h
+++ b/lib/TbUiLib/include/ui/CompilationContext.h
@@ -23,7 +23,10 @@
 #include "el/VariableStore.h"
 #include "ui/TextOutputAdapter.h"
 
+#include "vm/vec.h"
+
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace tb
@@ -36,6 +39,12 @@ class Map;
 namespace ui
 {
 
+struct CompilationCameraSnapshot
+{
+  vm::vec3d position;
+  vm::vec3d direction;
+};
+
 class CompilationContext
 {
 private:
@@ -44,16 +53,19 @@ private:
 
   TextOutputAdapter m_output;
   bool m_test;
+  std::optional<CompilationCameraSnapshot> m_cameraSnapshot;
 
 public:
   CompilationContext(
     const mdl::Map& map,
     const el::VariableStore& variables,
     TextOutputAdapter output,
-    bool test);
+    bool test,
+    std::optional<CompilationCameraSnapshot> cameraSnapshot = std::nullopt);
 
   const mdl::Map& map() const;
   bool test() const;
+  const std::optional<CompilationCameraSnapshot>& cameraSnapshot() const;
 
   Result<std::string> interpolate(const std::string& input) const;
   Result<std::string> variableValue(const std::string& variableName) const;

--- a/lib/TbUiLib/include/ui/CompilationDialog.h
+++ b/lib/TbUiLib/include/ui/CompilationDialog.h
@@ -23,6 +23,8 @@
 
 #include "ui/CompilationRun.h"
 
+#include <optional>
+
 class QLabel;
 class QPushButton;
 class QTextEdit;
@@ -77,6 +79,7 @@ private:
   void updateCompileButtons();
   void startCompilation(bool test);
   Result<void> runProfile(const mdl::CompilationProfile& profile, bool test);
+  std::optional<CompilationCameraSnapshot> currentCameraSnapshot() const;
   void stopCompilation();
   void closeEvent(QCloseEvent* event) override;
 private slots:

--- a/lib/TbUiLib/include/ui/CompilationRun.h
+++ b/lib/TbUiLib/include/ui/CompilationRun.h
@@ -22,7 +22,9 @@
 #include <QObject>
 
 #include "Result.h"
+#include "ui/CompilationContext.h"
 
+#include <optional>
 #include <string>
 
 class QTextEdit;
@@ -55,11 +57,13 @@ public:
   Result<void> run(
     const mdl::CompilationProfile& profile,
     const mdl::Map& map,
-    QTextEdit* currentOutput);
+    QTextEdit* currentOutput,
+    std::optional<CompilationCameraSnapshot> cameraSnapshot = std::nullopt);
   Result<void> test(
     const mdl::CompilationProfile& profile,
     const mdl::Map& map,
-    QTextEdit* currentOutput);
+    QTextEdit* currentOutput,
+    std::optional<CompilationCameraSnapshot> cameraSnapshot = std::nullopt);
   void terminate();
 
 private:
@@ -68,6 +72,7 @@ private:
     const mdl::CompilationProfile& profile,
     const mdl::Map& map,
     QTextEdit* currentOutput,
+    std::optional<CompilationCameraSnapshot> cameraSnapshot,
     bool test);
 
 private:

--- a/lib/TbUiLib/include/ui/CompilationTaskListBox.h
+++ b/lib/TbUiLib/include/ui/CompilationTaskListBox.h
@@ -82,6 +82,8 @@ class CompilationExportMapTaskEditor : public CompilationTaskEditorBase
 private:
   MultiCompletionLineEdit* m_targetEditor = nullptr;
   QCheckBox* m_stripTbProperties = nullptr;
+  QCheckBox* m_dropEntityAtCamera = nullptr;
+  QLineEdit* m_dropEntityClassname = nullptr;
 
 public:
   CompilationExportMapTaskEditor(
@@ -96,6 +98,8 @@ private:
 private slots:
   void targetSpecChanged(const QString& text);
   void stripTbPropertiesChanged(int state);
+  void dropEntityAtCameraChanged(int state);
+  void dropEntityClassnameChanged(const QString& text);
 };
 
 class CompilationCopyFilesTaskEditor : public CompilationTaskEditorBase

--- a/lib/TbUiLib/src/CompilationContext.cpp
+++ b/lib/TbUiLib/src/CompilationContext.cpp
@@ -23,6 +23,8 @@
 #include "el/Interpolate.h"
 #include "el/Types.h"
 
+#include <utility>
+
 namespace tb::ui
 {
 
@@ -30,11 +32,13 @@ CompilationContext::CompilationContext(
   const mdl::Map& map,
   const el::VariableStore& variables,
   TextOutputAdapter output,
-  bool test)
+  const bool test,
+  std::optional<CompilationCameraSnapshot> cameraSnapshot)
   : m_map{map}
   , m_variables{variables.clone()}
   , m_output{std::move(output)}
   , m_test{test}
+  , m_cameraSnapshot{std::move(cameraSnapshot)}
 {
 }
 
@@ -46,6 +50,11 @@ const mdl::Map& CompilationContext::map() const
 bool CompilationContext::test() const
 {
   return m_test;
+}
+
+const std::optional<CompilationCameraSnapshot>& CompilationContext::cameraSnapshot() const
+{
+  return m_cameraSnapshot;
 }
 
 Result<std::string> CompilationContext::interpolate(const std::string& input) const

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -30,6 +30,7 @@
 #include <QTextEdit>
 
 #include "Logger.h"
+#include "gl/Camera.h"
 #include "mdl/CompilationProfile.h"
 #include "mdl/GameInfo.h"
 #include "mdl/GameManager.h"
@@ -41,6 +42,8 @@
 #include "ui/FixedWidthFont.h"
 #include "ui/LaunchGameEngineDialog.h"
 #include "ui/MapDocument.h" // IWYU pragma: keep
+#include "ui/MapView3D.h"
+#include "ui/MapViewBase.h"
 #include "ui/MapWindow.h"
 #include "ui/QStyleUtils.h"
 #include "ui/Splitter.h"
@@ -221,7 +224,32 @@ Result<void> CompilationDialog::runProfile(
   const mdl::CompilationProfile& profile, const bool test)
 {
   const auto& map = m_document.map();
-  return test ? m_run.test(profile, map, m_output) : m_run.run(profile, map, m_output);
+  const auto cameraSnapshot = currentCameraSnapshot();
+  return test ? m_run.test(profile, map, m_output, cameraSnapshot)
+              : m_run.run(profile, map, m_output, cameraSnapshot);
+}
+
+std::optional<CompilationCameraSnapshot> CompilationDialog::currentCameraSnapshot() const
+{
+  auto* mapWindow = dynamic_cast<MapWindow*>(parentWidget());
+  if (!mapWindow)
+  {
+    return std::nullopt;
+  }
+
+  auto* mapView = mapWindow->currentMapViewBase();
+  if (!dynamic_cast<MapView3D*>(mapView))
+  {
+    mapView = mapWindow->findChild<MapView3D*>();
+  }
+  if (!mapView)
+  {
+    return std::nullopt;
+  }
+
+  const auto& camera = mapView->camera();
+  return CompilationCameraSnapshot{
+    vm::vec3d{camera.position()}, vm::vec3d{camera.direction()}};
 }
 
 void CompilationDialog::stopCompilation()

--- a/lib/TbUiLib/src/CompilationRun.cpp
+++ b/lib/TbUiLib/src/CompilationRun.cpp
@@ -29,6 +29,7 @@
 #include "kd/contracts.h"
 
 #include <string>
+#include <utility>
 
 namespace tb::ui
 {
@@ -47,15 +48,21 @@ bool CompilationRun::running() const
 }
 
 Result<void> CompilationRun::run(
-  const mdl::CompilationProfile& profile, const mdl::Map& map, QTextEdit* currentOutput)
+  const mdl::CompilationProfile& profile,
+  const mdl::Map& map,
+  QTextEdit* currentOutput,
+  std::optional<CompilationCameraSnapshot> cameraSnapshot)
 {
-  return run(profile, map, currentOutput, false);
+  return run(profile, map, currentOutput, std::move(cameraSnapshot), false);
 }
 
 Result<void> CompilationRun::test(
-  const mdl::CompilationProfile& profile, const mdl::Map& map, QTextEdit* currentOutput)
+  const mdl::CompilationProfile& profile,
+  const mdl::Map& map,
+  QTextEdit* currentOutput,
+  std::optional<CompilationCameraSnapshot> cameraSnapshot)
 {
-  return run(profile, map, currentOutput, true);
+  return run(profile, map, currentOutput, std::move(cameraSnapshot), true);
 }
 
 void CompilationRun::terminate()
@@ -75,6 +82,7 @@ Result<void> CompilationRun::run(
   const mdl::CompilationProfile& profile,
   const mdl::Map& map,
   QTextEdit* currentOutput,
+  std::optional<CompilationCameraSnapshot> cameraSnapshot,
   const bool test)
 {
   contract_pre(!profile.tasks.empty());
@@ -85,8 +93,12 @@ Result<void> CompilationRun::run(
 
   return buildWorkDir(profile, map) | kdl::transform([&](const auto& workDir) {
            auto variables = CompilationVariables{map, workDir};
-           auto compilationContext =
-             CompilationContext{map, variables, TextOutputAdapter{currentOutput}, test};
+           auto compilationContext = CompilationContext{
+             map,
+             variables,
+             TextOutputAdapter{currentOutput},
+             test,
+             std::move(cameraSnapshot)};
            m_currentRun =
              new CompilationRunner{std::move(compilationContext), profile, this};
            connect(

--- a/lib/TbUiLib/src/CompilationRunner.cpp
+++ b/lib/TbUiLib/src/CompilationRunner.cpp
@@ -44,13 +44,19 @@
 #include "kd/path_utils.h"
 #include "kd/ranges/to.h"
 #include "kd/result_fold.h"
+#include "kd/string_format.h"
 #include "kd/string_utils.h"
+
+#include "vm/scalar.h"
 
 #include <fmt/format.h>
 #include <fmt/std.h>
 
+#include <cmath>
+#include <optional>
 #include <ranges>
 #include <string>
+#include <utility>
 
 namespace tb::ui
 {
@@ -68,6 +74,17 @@ Result<std::string> workDir(const CompilationContext& context)
   {
     return Error{e.what()};
   }
+}
+
+int cameraYawAngle(const vm::vec3d& direction)
+{
+  if (direction.x() == 0.0 && direction.y() == 0.0)
+  {
+    return 0;
+  }
+
+  return static_cast<int>(vm::normalize_degrees(
+    std::round(vm::to_degrees(std::atan2(direction.y(), direction.x())))));
 }
 
 } // namespace
@@ -119,12 +136,33 @@ void CompilationExportMapTaskRunner::doExecute()
     const auto targetPath = kdl::parse_path(interpolated);
     m_context << "#### Exporting map file '" << pathAsQString(targetPath) << "'\n";
 
+    auto replacementPointEntityAtCamera =
+      std::optional<mdl::ReplacementPointEntityAtCamera>{};
+    if (m_task.dropEntityAtCamera)
+    {
+      auto classname = kdl::str_trim(m_task.dropEntityClassname);
+      if (classname.empty())
+      {
+        return Result<void>{Error{"Drop entity classname must not be empty"}};
+      }
+      if (!m_context.cameraSnapshot())
+      {
+        return Result<void>{Error{"Could not get 3D camera position"}};
+      }
+
+      replacementPointEntityAtCamera = mdl::ReplacementPointEntityAtCamera{
+        std::move(classname),
+        m_context.cameraSnapshot()->position,
+        cameraYawAngle(m_context.cameraSnapshot()->direction),
+      };
+    }
+
     if (!m_context.test())
     {
       return fs::Disk::createDirectory(targetPath.parent_path())
              | kdl::and_then([&](auto) {
-                 const auto options =
-                   mdl::MapExportOptions{targetPath, m_task.stripTbProperties};
+                 const auto options = mdl::MapExportOptions{
+                   targetPath, m_task.stripTbProperties, replacementPointEntityAtCamera};
                  return m_context.map().exportAs(options);
                });
     }

--- a/lib/TbUiLib/src/CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/src/CompilationTaskListBox.cpp
@@ -155,6 +155,22 @@ Variables are allowed.)");
        "exported map file. Some compilers cannot handle these properties."));
   formLayout->addRow("", m_stripTbProperties);
 
+  m_dropEntityAtCamera = new QCheckBox{"Drop entity at camera"};
+  m_dropEntityAtCamera->setToolTip(
+    tr("On export, remove matching point entities and add one replacement at the "
+       "active camera position. The document is not modified."));
+
+  m_dropEntityClassname = new QLineEdit{};
+  m_dropEntityClassname->setFont(Fonts::fixedWidthFont());
+  m_dropEntityClassname->setToolTip(m_dropEntityAtCamera->toolTip());
+
+  auto* dropEntityLayout = new QHBoxLayout{};
+  dropEntityLayout->setContentsMargins(0, 0, 0, 0);
+  dropEntityLayout->setSpacing(LayoutConstants::NarrowHMargin);
+  dropEntityLayout->addWidget(m_dropEntityAtCamera);
+  dropEntityLayout->addWidget(m_dropEntityClassname, 1);
+  formLayout->addRow("", dropEntityLayout);
+
   connect(
     m_targetEditor,
     &QLineEdit::textChanged,
@@ -165,6 +181,16 @@ Variables are allowed.)");
     &QCheckBox::checkStateChanged,
     this,
     &CompilationExportMapTaskEditor::stripTbPropertiesChanged);
+  connect(
+    m_dropEntityAtCamera,
+    &QCheckBox::checkStateChanged,
+    this,
+    &CompilationExportMapTaskEditor::dropEntityAtCameraChanged);
+  connect(
+    m_dropEntityClassname,
+    &QLineEdit::textChanged,
+    this,
+    &CompilationExportMapTaskEditor::dropEntityClassnameChanged);
 }
 
 void CompilationExportMapTaskEditor::updateItem()
@@ -181,6 +207,19 @@ void CompilationExportMapTaskEditor::updateItem()
   {
     m_stripTbProperties->setCheckState(
       task().stripTbProperties ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
+  }
+
+  if (m_dropEntityAtCamera->isChecked() != task().dropEntityAtCamera)
+  {
+    m_dropEntityAtCamera->setCheckState(
+      task().dropEntityAtCamera ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
+  }
+  m_dropEntityClassname->setEnabled(task().dropEntityAtCamera);
+
+  const auto classname = QString::fromStdString(task().dropEntityClassname);
+  if (m_dropEntityClassname->text() != classname)
+  {
+    m_dropEntityClassname->setText(classname);
   }
 }
 
@@ -200,6 +239,18 @@ void CompilationExportMapTaskEditor::stripTbPropertiesChanged(const int state)
 {
   const auto value = (state == Qt::Checked);
   task().stripTbProperties = value;
+}
+
+void CompilationExportMapTaskEditor::dropEntityAtCameraChanged(const int state)
+{
+  const auto value = (state == Qt::Checked);
+  task().dropEntityAtCamera = value;
+  m_dropEntityClassname->setEnabled(value);
+}
+
+void CompilationExportMapTaskEditor::dropEntityClassnameChanged(const QString& text)
+{
+  task().dropEntityClassname = text.toStdString();
 }
 
 CompilationCopyFilesTaskEditor::CompilationCopyFilesTaskEditor(

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -337,6 +337,65 @@ TEST_CASE("CompilationExportMapTaskRunner")
 
     CHECK(!testEnvironment.fileExists("exported.map"));
   }
+
+  SECTION("dropEntityAtCamera")
+  {
+    auto node = new mdl::EntityNode{mdl::Entity{{
+      {"classname", "info_player_start"},
+      {"origin", "1 2 3"},
+    }}};
+    addNodes(map, {{parentForNodes(map), {node}}});
+
+    auto contextWithCamera = CompilationContext{
+      map,
+      variables,
+      outputAdapter,
+      false,
+      CompilationCameraSnapshot{
+        vm::vec3d{16.0, 32.0, 48.0},
+        vm::vec3d{0.0, 1.0, 0.0},
+      }};
+    auto task = mdl::CompilationExportMap{
+      K(enabled),
+      !K(stripTbProperties),
+      "${WORK_DIR_PATH}/exported.map",
+      K(dropEntityAtCamera),
+      " info_player_start "};
+
+    auto runner = CompilationExportMapTaskRunner{contextWithCamera, task};
+    REQUIRE_NOTHROW(runner.execute());
+
+    const auto exportedMap = testEnvironment.loadFile("exported.map");
+    CHECK(exportedMap.find(R"("origin" "1 2 3")") == std::string::npos);
+    CHECK(exportedMap.find(R"("classname" "info_player_start")") != std::string::npos);
+    CHECK(exportedMap.find(R"("origin" "16 32 48")") != std::string::npos);
+    CHECK(exportedMap.find(R"("angle" "90")") != std::string::npos);
+  }
+
+  SECTION("dropEntityAtCameraWithEmptyClassname")
+  {
+    auto contextWithCamera = CompilationContext{
+      map,
+      variables,
+      outputAdapter,
+      false,
+      CompilationCameraSnapshot{
+        vm::vec3d{16.0, 32.0, 48.0},
+        vm::vec3d{0.0, 1.0, 0.0},
+      }};
+    auto task = mdl::CompilationExportMap{
+      K(enabled),
+      !K(stripTbProperties),
+      "${WORK_DIR_PATH}/nested/exported.map",
+      K(dropEntityAtCamera),
+      "  "};
+
+    auto runner = CompilationExportMapTaskRunner{contextWithCamera, task};
+    REQUIRE_NOTHROW(runner.execute());
+
+    CHECK_FALSE(testEnvironment.directoryExists("nested"));
+    CHECK_FALSE(testEnvironment.fileExists("nested/exported.map"));
+  }
 }
 
 TEST_CASE("CompilationCopyFilesTaskRunner")


### PR DESCRIPTION
Adds a new `Export Map` task option, `Drop entity at camera`, which lets users replace exported point entities  of a chosen classname with a single point entity at the current 3D camera position. This is useful for quick compile/test workflows where the player start should follow the editor camera without modifying the open map. 

  ### Technical changes

  - Added `dropEntityAtCamera` and `dropEntityClassname` to Export Map task config.
  - Default classname is `info_player_start` - supported by all Quake / Quake 2 engines (i.e. looks like [`testplayerstart`](https://quakewiki.org/wiki/testplayerstart) is not supported widely)
  - Writer removes matching point entities only, preserves matching brush entities, and appends one replacement  with classname, origin, and angle.
  - UI uses a compact single-row checkbox + classname field; the field is visible but disabled when unchecked.

<img width="952" height="194" alt="image" src="https://github.com/user-attachments/assets/d740cbac-8e97-4b31-b854-1c4f0d763136" />

Fixes https://github.com/TrenchBroom/TrenchBroom/issues/3518
