### PR TITLE
Add "All" and "None" buttons to flags editor

### DIFF
--- a/lib/TbUiLib/include/ui/FlagsEditor.h
+++ b/lib/TbUiLib/include/ui/FlagsEditor.h
@@ -36,6 +36,8 @@ private:
   using CheckBoxList = std::vector<QCheckBox*>;
   using ValueList = std::vector<int>;
 
+  QWidget* m_checkBoxContainer = nullptr;
+
   size_t m_numCols;
   CheckBoxList m_checkBoxes;
   ValueList m_values;

--- a/lib/TbUiLib/src/FlagsEditor.cpp
+++ b/lib/TbUiLib/src/FlagsEditor.cpp
@@ -19,6 +19,7 @@
 
 #include "ui/FlagsEditor.h"
 
+#include <QBoxLayout>
 #include <QCheckBox>
 #include <QGridLayout>
 
@@ -32,9 +33,16 @@ namespace tb::ui
 
 FlagsEditor::FlagsEditor(const size_t numCols, QWidget* parent)
   : QWidget{parent}
+  , m_checkBoxContainer{new QWidget{this}}
   , m_numCols{numCols}
 {
   contract_pre(m_numCols > 0);
+
+  auto* layout = new QVBoxLayout{};
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setSpacing(0);
+  layout->addWidget(m_checkBoxContainer);
+  setLayout(layout);
 }
 
 void FlagsEditor::setFlags(const QStringList& labels, const QStringList& tooltips)
@@ -62,7 +70,7 @@ void FlagsEditor::setFlags(
   m_checkBoxes.resize(count, nullptr);
   m_values.resize(count, 0);
 
-  deleteChildWidgetsLaterAndDeleteLayout(this);
+  deleteChildWidgetsLaterAndDeleteLayout(m_checkBoxContainer);
 
   auto* layout = new QGridLayout{};
   layout->setHorizontalSpacing(LayoutConstants::WideHMargin);
@@ -101,7 +109,7 @@ void FlagsEditor::setFlags(
   contract_post(std::ranges::all_of(
     m_checkBoxes, [](const auto* checkBox) { return checkBox != nullptr; }));
 
-  setLayout(layout);
+  m_checkBoxContainer->setLayout(layout);
 }
 
 void FlagsEditor::setFlagValue(const int on, const int mixed)

--- a/lib/TbUiLib/src/FlagsEditor.cpp
+++ b/lib/TbUiLib/src/FlagsEditor.cpp
@@ -74,7 +74,11 @@ void FlagsEditor::setFlags(
 
   auto* layout = new QGridLayout{};
   layout->setHorizontalSpacing(LayoutConstants::WideHMargin);
-  layout->setVerticalSpacing(0);
+#if defined(Q_OS_MACOS)
+  layout->setVerticalSpacing(LayoutConstants::WideVMargin);
+#else
+  layout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+#endif
   layout->setSizeConstraint(QLayout::SetMinimumSize);
 
   for (size_t row = 0; row < numRows; ++row)

--- a/lib/TbUiLib/src/FlagsEditor.cpp
+++ b/lib/TbUiLib/src/FlagsEditor.cpp
@@ -22,7 +22,9 @@
 #include <QBoxLayout>
 #include <QCheckBox>
 #include <QGridLayout>
+#include <QPushButton>
 
+#include "ui/QStyleUtils.h"
 #include "ui/QWidgetUtils.h"
 #include "ui/ViewConstants.h"
 
@@ -38,10 +40,40 @@ FlagsEditor::FlagsEditor(const size_t numCols, QWidget* parent)
 {
   contract_pre(m_numCols > 0);
 
+  auto* allButton = new QPushButton{tr("All")};
+  setEmphasizedStyle(allButton);
+  auto* noneButton = new QPushButton{tr("None")};
+  setEmphasizedStyle(noneButton);
+
+  connect(allButton, &QAbstractButton::clicked, this, [this]() {
+    for (size_t i = 0u; i < m_checkBoxes.size(); ++i)
+    {
+      m_checkBoxes[i]->setCheckState(Qt::CheckState::Checked);
+      emit flagChanged(i, 1, ~0, ~0);
+    }
+  });
+  connect(noneButton, &QAbstractButton::clicked, this, [this]() {
+    for (size_t i = 0u; i < m_checkBoxes.size(); ++i)
+    {
+      m_checkBoxes[i]->setCheckState(Qt::CheckState::Unchecked);
+      emit flagChanged(i, 0, 0, 0);
+    }
+  });
+
+  auto* buttonLayout = new QHBoxLayout{};
+  buttonLayout->setContentsMargins(0, 0, 0, 0);
+  buttonLayout->setSpacing(LayoutConstants::NarrowHMargin);
+  buttonLayout->addStretch(1);
+  buttonLayout->addWidget(allButton);
+  buttonLayout->addWidget(noneButton);
+  buttonLayout->addStretch(1);
+
+
   auto* layout = new QVBoxLayout{};
-  layout->setContentsMargins(0, 0, 0, 0);
-  layout->setSpacing(0);
+  layout->setSpacing(LayoutConstants::MediumVMargin);
+  layout->setSizeConstraint(QLayout::SetMinimumSize);
   layout->addWidget(m_checkBoxContainer);
+  layout->addLayout(buttonLayout);
   setLayout(layout);
 }
 
@@ -79,6 +111,7 @@ void FlagsEditor::setFlags(
 #else
   layout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
 #endif
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSizeConstraint(QLayout::SetMinimumSize);
 
   for (size_t row = 0; row < numRows; ++row)

--- a/lib/TbUiLib/src/PopupButton.cpp
+++ b/lib/TbUiLib/src/PopupButton.cpp
@@ -58,12 +58,14 @@ void PopupButton::buttonClicked(bool checked)
 {
   if (checked)
   {
-    // TODO: unfortunately it seems like we need to show the popup first, before
-    // m_window->size() contains useful data, and we need the size to position the popup.
-    // This show() puts the window at (0, 0) on Ubuntu, but positionTouchingWidget() is
-    // able to move it without any flicker. Need to confirm on other OS'es.
-    m_window->show();
+    // Compute the popup's size and position it before showing it. Under Wayland,
+    // top-level (and popup) windows cannot be moved to an arbitrary screen position
+    // once shown, so showing first and repositioning afterwards is unreliable there.
+    m_window->adjustSize();
     m_window->positionTouchingWidget(this);
+    m_window->show();
+    m_window->raise();
+    m_window->activateWindow();
   }
   else
   {

--- a/lib/TbUiLib/src/PopupWindow.cpp
+++ b/lib/TbUiLib/src/PopupWindow.cpp
@@ -73,7 +73,9 @@ PopupWindow::PopupWindow(QWidget* parent)
 
 void PopupWindow::positionTouchingWidget(QWidget* refWidget)
 {
-  const auto screenGeom = QGuiApplication::primaryScreen()->availableGeometry();
+  auto* screen = refWidget->screen();
+  const auto screenGeom = screen ? screen->availableGeometry()
+                                 : QGuiApplication::primaryScreen()->availableGeometry();
   const auto refWidgetRectOnScreen =
     QRect{refWidget->mapToGlobal(QPoint{0, 0}), refWidget->size()};
   const auto ourSize = size();


### PR DESCRIPTION
The new buttons allow a user to quickly set all or no flags. This is useful for the issue filters, but also for spawnflags.

<img width="285" height="525" alt="Screenshot 2026-07-02 at 19 37 32" src="https://github.com/user-attachments/assets/b4706e46-41eb-409b-a6b2-9c5cd6d28dc2" />

Closes #5246