### PR TITLE
Add UE1 package/texture loader for Unreal 1/UT99 support (Seam 1)

### DIFF
--- a/lib/TbMdlLib/CMakeLists.txt
+++ b/lib/TbMdlLib/CMakeLists.txt
@@ -101,6 +101,8 @@ target_sources(TbMdlLib
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LoadSkin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LoadSpriteModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LoadTexture.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/LoadUnrealPackage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/LoadUnrealTexture.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LoadWalTexture.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LockState.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/LongPropertyKeyValidator.cpp

--- a/lib/TbMdlLib/include/mdl/LoadUnrealPackage.h
+++ b/lib/TbMdlLib/include/mdl/LoadUnrealPackage.h
@@ -1,0 +1,171 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Result.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace tb::fs
+{
+class Reader;
+}
+
+namespace tb::mdl
+{
+
+/**
+ * UE1 (Unreal/UT99) package reader.
+ *
+ * This is a direct port of `uepkg.py` (the validated reference implementation).
+ * It implements the UE1/UE2 path extracted from UModel's `UnPackage.cpp`:
+ * `FPackageFileSummary`, the name/import/export tables, and the primitives
+ * they are built from (`FCompactIndex`, `FString`).
+ *
+ * Validated FileVersions: 61 (Unreal, no GUID/heritage path) and 68 (UT99,
+ * GUID/generations path). See uepkg.py for the field layouts this ports.
+ */
+inline constexpr uint32_t UnrealPackageFileTag = 0x9E2A83C1u;
+
+struct UnrealObjectImport
+{
+  std::string classPackage;
+  std::string className;
+  int32_t packageIndex;
+  std::string objectName;
+};
+
+struct UnrealObjectExport
+{
+  int32_t classIndex;
+  int32_t superIndex;
+  int32_t packageIndex;
+  std::string objectName;
+  uint32_t objectFlags;
+  int32_t serialSize;
+  int32_t serialOffset;
+};
+
+/**
+ * UE1 tagged property types (EPropType), as read from FPropertyTag.
+ */
+enum class UnrealPropertyType : uint8_t
+{
+  Byte = 1,
+  Int = 2,
+  Bool = 3,
+  Float = 4,
+  Object = 5,
+  Name = 6,
+  String = 7,
+  Class = 8,
+  Array = 9,
+  Struct = 10,
+  Vector = 11,
+  Rotator = 12,
+  Str = 13,
+  Map = 14,
+  FixedArray = 15,
+};
+
+/**
+ * A single entry from a UE1 tagged-property list (FPropertyTag).
+ *
+ * Only the fields needed by the current integration seams are decoded
+ * (Bool, Object/Class references, and Name/Str/String values); all other
+ * payloads are consumed from the reader but discarded. Extend this as
+ * later seams (e.g. actor class defaults) need more property types.
+ */
+struct UnrealProperty
+{
+  std::string name;
+  UnrealPropertyType type;
+  bool boolValue = false;
+  std::optional<std::string> objectRef;
+  std::string stringValue;
+};
+
+class UnrealPackage
+{
+public:
+  uint16_t fileVersion = 0;
+  uint16_t licenseeVersion = 0;
+  uint32_t packageFlags = 0;
+  std::vector<std::string> names;
+  std::vector<UnrealObjectImport> imports;
+  std::vector<UnrealObjectExport> exports;
+
+  /**
+   * Resolves the class name of the given export. A `classIndex` of 0 means
+   * the export is itself a UClass; negative indices reference the import
+   * table, positive indices reference the export table (both 1-based).
+   */
+  std::string classNameOfExport(const UnrealObjectExport& e) const;
+
+  /**
+   * Resolves an Object/Class property reference (a signed FCompactIndex):
+   * 0 is `None`, negative indices reference imports, positive indices
+   * reference exports (both 1-based).
+   */
+  std::optional<std::string> resolveObjectRef(int32_t index) const;
+
+  /**
+   * Finds an export by object name. UE1 packages used by Phase 1 are
+   * self-contained (a Texture's Palette lives in the same package), so this
+   * is sufficient for resolving property references within one package.
+   */
+  const UnrealObjectExport* findExport(const std::string& objectName) const;
+};
+
+/**
+ * Reads an FCompactIndex: a signed varint used throughout UE1 packages for
+ * name/object indices and sizes. Exact port of UModel's
+ * `FArchive::operator<<(FCompactIndex&)` (see `Reader.cindex()` in uepkg.py).
+ */
+int32_t readUnrealCompactIndex(fs::Reader& reader);
+
+/**
+ * Reads an FString: a compact-index length prefix followed by that many
+ * bytes. A positive length is an ANSI string including its trailing NUL; a
+ * negative length is a UTF-16 string (not expected in UE1 .utx/.u/.unr
+ * packages, but consumed correctly to keep the reader in sync).
+ */
+std::string readUnrealString(fs::Reader& reader);
+
+/**
+ * Reads the UE1 tagged-property list that begins every object's serial
+ * data (FPropertyTag, UObject::Serialize), stopping at the terminating
+ * `None` name. `reader` must be positioned at the start of the object's
+ * serial data.
+ */
+std::vector<UnrealProperty> readUnrealPropertyList(
+  const UnrealPackage& package, fs::Reader& reader);
+
+/**
+ * Parses a UE1 package (.utx/.u/.unr) from `reader`, covering the entire
+ * package file: FPackageFileSummary, name table, import table, and export
+ * table.
+ */
+Result<UnrealPackage> loadUnrealPackage(fs::Reader& reader);
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/LoadUnrealTexture.h
+++ b/lib/TbMdlLib/include/mdl/LoadUnrealTexture.h
@@ -1,0 +1,55 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Result.h"
+
+#include <string>
+
+namespace tb::gl
+{
+class Texture;
+}
+
+namespace tb::fs
+{
+class Reader;
+}
+
+namespace tb::mdl
+{
+
+/**
+ * Loads a UE1 (Unreal/UT99) Texture object named `textureName` out of a
+ * package. Direct port of `uetex.py` (the validated reference implementation)
+ * for the P8-indexed decode path: tagged property list, TArray<FMipmap> mip
+ * chain, and TArray<FColor> palette.
+ *
+ * `reader` must cover the entire package file (.utx), not just one object's
+ * serial data: the Texture's `Palette` property is an object reference that
+ * is resolved by name against the same package's export table, matching the
+ * self-contained .utx files Phase 1 targets (Crypt.utx, NBSpecialT.utx).
+ *
+ * Phase 1 scope: FileVersion 61 (Unreal) and 68 (UT99).
+ */
+Result<gl::Texture> loadUnrealTexture(
+  fs::Reader& reader, const std::string& packageName, const std::string& textureName);
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/src/LoadUnrealPackage.cpp
+++ b/lib/TbMdlLib/src/LoadUnrealPackage.cpp
@@ -1,0 +1,371 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mdl/LoadUnrealPackage.h"
+
+#include "fs/Reader.h"
+#include "fs/ReaderException.h"
+
+#include <fmt/format.h>
+
+#include <array>
+
+namespace tb::mdl
+{
+namespace
+{
+
+/**
+ * NUL-terminated ANSI string, used for the name table when FileVersion < 64.
+ * Not expected in Phase 1 (Unreal 61 / UT99 68 both have ArVer >= 64), but
+ * ported from uepkg.py's `_read_names` for completeness.
+ */
+std::string readUnrealAnsiCString(fs::Reader& reader)
+{
+  auto result = std::string{};
+  while (true)
+  {
+    const auto c = reader.readUnsignedChar<uint8_t>();
+    if (c == 0)
+    {
+      break;
+    }
+    result.push_back(char(c));
+  }
+  return result;
+}
+
+std::string resolveFName(const std::vector<std::string>& names, const int32_t index)
+{
+  return index >= 0 && size_t(index) < names.size() ? names[size_t(index)]
+                                                      : fmt::format("<name#{}>", index);
+}
+
+std::string readFName(const std::vector<std::string>& names, fs::Reader& reader)
+{
+  return resolveFName(names, readUnrealCompactIndex(reader));
+}
+
+} // namespace
+
+std::string UnrealPackage::classNameOfExport(const UnrealObjectExport& e) const
+{
+  if (e.classIndex == 0)
+  {
+    return "Class";
+  }
+  if (e.classIndex < 0)
+  {
+    return imports[size_t(-e.classIndex - 1)].objectName;
+  }
+  return exports[size_t(e.classIndex - 1)].objectName;
+}
+
+std::optional<std::string> UnrealPackage::resolveObjectRef(const int32_t index) const
+{
+  if (index == 0)
+  {
+    return std::nullopt;
+  }
+  if (index < 0)
+  {
+    return imports[size_t(-index - 1)].objectName;
+  }
+  return exports[size_t(index - 1)].objectName;
+}
+
+const UnrealObjectExport* UnrealPackage::findExport(const std::string& objectName) const
+{
+  for (const auto& e : exports)
+  {
+    if (e.objectName == objectName)
+    {
+      return &e;
+    }
+  }
+  return nullptr;
+}
+
+int32_t readUnrealCompactIndex(fs::Reader& reader)
+{
+  auto b = reader.readUnsignedChar<uint8_t>();
+  const auto sign = (b & 0x80) != 0;
+  auto r = int64_t(b & 0x3F);
+  auto shift = 6;
+  if (b & 0x40)
+  {
+    while (true)
+    {
+      b = reader.readUnsignedChar<uint8_t>();
+      r |= int64_t(b & 0x7F) << shift;
+      shift += 7;
+      if (!(b & 0x80))
+      {
+        break;
+      }
+    }
+  }
+  return int32_t(sign ? -r : r);
+}
+
+std::string readUnrealString(fs::Reader& reader)
+{
+  const auto len = readUnrealCompactIndex(reader);
+  if (len == 0)
+  {
+    return "";
+  }
+  if (len > 0)
+  {
+    // ANSI string: length includes the trailing NUL. Reader::readString()
+    // already truncates at the first embedded NUL byte, matching the
+    // behavior of uepkg.py's `raw.split(b'\x00', 1)[0]`.
+    return reader.readString(size_t(len));
+  }
+
+  // Unicode string (negative length) -- not expected in UE1 .utx/.u/.unr
+  // packages, but the bytes must still be consumed to keep the reader in
+  // sync (uepkg.py: `raw = self.bytes(-ln * 2); raw.decode('utf-16-le')`).
+  const auto charCount = size_t(-len);
+  auto raw = std::vector<unsigned char>(charCount * 2);
+  reader.read(raw.data(), raw.size());
+
+  auto result = std::string{};
+  result.reserve(charCount);
+  for (size_t i = 0; i < charCount; ++i)
+  {
+    const auto lo = raw[i * 2];
+    const auto hi = raw[i * 2 + 1];
+    if (lo == 0 && hi == 0)
+    {
+      break;
+    }
+    result.push_back(char(lo));
+  }
+  return result;
+}
+
+std::vector<UnrealProperty> readUnrealPropertyList(
+  const UnrealPackage& package, fs::Reader& reader)
+{
+  auto props = std::vector<UnrealProperty>{};
+  while (true)
+  {
+    const auto name = readFName(package.names, reader);
+    if (name == "None")
+    {
+      break;
+    }
+
+    const auto info = reader.readUnsignedChar<uint8_t>();
+    const auto isArray = (info & 0x80) != 0;
+    const auto ptype = UnrealPropertyType(info & 0x0F);
+
+    if (ptype == UnrealPropertyType::Struct)
+    {
+      readUnrealCompactIndex(reader); // struct name, unused by current seams
+    }
+
+    const auto sizeClass = (info >> 4) & 0x07;
+    auto dataSize = int32_t{0};
+    switch (sizeClass)
+    {
+    case 0:
+      dataSize = 1;
+      break;
+    case 1:
+      dataSize = 2;
+      break;
+    case 2:
+      dataSize = 4;
+      break;
+    case 3:
+      dataSize = 12;
+      break;
+    case 4:
+      dataSize = 16;
+      break;
+    case 5:
+      dataSize = reader.readUnsignedChar<uint8_t>();
+      break;
+    case 6:
+      dataSize = reader.readUnsignedInt<uint16_t>();
+      break;
+    case 7:
+      dataSize = reader.readInt<int32_t>();
+      break;
+    }
+
+    if (ptype != UnrealPropertyType::Bool && isArray)
+    {
+      // Variable-length array index. Exact port of PropReader._read_value's
+      // encoding; current seams don't need per-element array indices, but
+      // the bytes must still be consumed to keep the reader in sync.
+      const auto b0 = reader.readUnsignedChar<uint8_t>();
+      if (b0 >= 128)
+      {
+        reader.readUnsignedChar<uint8_t>();
+        if (b0 & 0x40)
+        {
+          reader.readUnsignedChar<uint8_t>();
+          reader.readUnsignedChar<uint8_t>();
+        }
+      }
+    }
+
+    auto prop = UnrealProperty{};
+    prop.name = name;
+    prop.type = ptype;
+
+    switch (ptype)
+    {
+    case UnrealPropertyType::Bool:
+      prop.boolValue = isArray;
+      break;
+    case UnrealPropertyType::Byte:
+      reader.readUnsignedChar<uint8_t>();
+      break;
+    case UnrealPropertyType::Int:
+      reader.readInt<int32_t>();
+      break;
+    case UnrealPropertyType::Float:
+      reader.readFloat<float>();
+      break;
+    case UnrealPropertyType::Object:
+    case UnrealPropertyType::Class:
+      prop.objectRef = package.resolveObjectRef(readUnrealCompactIndex(reader));
+      break;
+    case UnrealPropertyType::Name:
+      prop.stringValue = readFName(package.names, reader);
+      break;
+    case UnrealPropertyType::Str:
+    case UnrealPropertyType::String:
+      prop.stringValue = readUnrealString(reader);
+      break;
+    case UnrealPropertyType::Vector:
+    case UnrealPropertyType::Rotator:
+      reader.seekForward(12);
+      break;
+    default:
+      // Struct, Array, Map, FixedArray: raw payload, not decoded by current
+      // seams.
+      reader.seekForward(size_t(dataSize));
+      break;
+    }
+
+    props.push_back(std::move(prop));
+  }
+  return props;
+}
+
+Result<UnrealPackage> loadUnrealPackage(fs::Reader& reader)
+{
+  try
+  {
+    auto pkg = UnrealPackage{};
+
+    const auto tag = reader.readUnsignedInt<uint32_t>();
+    if (tag != UnrealPackageFileTag)
+    {
+      return Error{fmt::format(
+        "Bad package tag {:#010x} (expected {:#010x})", tag, UnrealPackageFileTag)};
+    }
+
+    const auto version = reader.readUnsignedInt<uint32_t>();
+    pkg.fileVersion = uint16_t(version & 0xFFFFu);
+    pkg.licenseeVersion = uint16_t(version >> 16);
+    pkg.packageFlags = reader.readUnsignedInt<uint32_t>();
+
+    const auto nameCount = reader.readInt<int32_t>();
+    const auto nameOffset = reader.readInt<int32_t>();
+    const auto exportCount = reader.readInt<int32_t>();
+    const auto exportOffset = reader.readInt<int32_t>();
+    const auto importCount = reader.readInt<int32_t>();
+    const auto importOffset = reader.readInt<int32_t>();
+
+    if (pkg.fileVersion < 68)
+    {
+      // old heritage path, no GUID
+      reader.readInt<int32_t>(); // heritageCount
+      reader.readInt<int32_t>(); // heritageOffset
+    }
+    else
+    {
+      auto guid = std::array<unsigned char, 16>{};
+      reader.read(guid.data(), guid.size());
+      const auto generationCount = reader.readInt<int32_t>();
+      for (int32_t i = 0; i < generationCount; ++i)
+      {
+        reader.readInt<int32_t>(); // export count
+        reader.readInt<int32_t>(); // name count
+      }
+    }
+
+    reader.seekFromBegin(size_t(nameOffset));
+    pkg.names.reserve(size_t(nameCount));
+    for (int32_t i = 0; i < nameCount; ++i)
+    {
+      auto name = pkg.fileVersion < 64 ? readUnrealAnsiCString(reader)
+                                        : readUnrealString(reader);
+      reader.readUnsignedInt<uint32_t>(); // object flags, discarded
+      pkg.names.push_back(std::move(name));
+    }
+
+    reader.seekFromBegin(size_t(importOffset));
+    pkg.imports.reserve(size_t(importCount));
+    for (int32_t i = 0; i < importCount; ++i)
+    {
+      auto classPackage = readFName(pkg.names, reader);
+      auto className = readFName(pkg.names, reader);
+      const auto packageIndex = reader.readInt<int32_t>();
+      auto objectName = readFName(pkg.names, reader);
+      pkg.imports.push_back(UnrealObjectImport{
+        std::move(classPackage), std::move(className), packageIndex, std::move(objectName)});
+    }
+
+    reader.seekFromBegin(size_t(exportOffset));
+    pkg.exports.reserve(size_t(exportCount));
+    for (int32_t i = 0; i < exportCount; ++i)
+    {
+      const auto classIndex = readUnrealCompactIndex(reader);
+      const auto superIndex = readUnrealCompactIndex(reader);
+      const auto packageIndex = reader.readInt<int32_t>();
+      auto objectName = readFName(pkg.names, reader);
+      const auto objectFlags = reader.readUnsignedInt<uint32_t>();
+      const auto serialSize = readUnrealCompactIndex(reader);
+      const auto serialOffset = serialSize != 0 ? readUnrealCompactIndex(reader) : 0;
+      pkg.exports.push_back(UnrealObjectExport{
+        classIndex,
+        superIndex,
+        packageIndex,
+        std::move(objectName),
+        objectFlags,
+        serialSize,
+        serialOffset});
+    }
+
+    return pkg;
+  }
+  catch (const fs::ReaderException& e)
+  {
+    return Error{e.what()};
+  }
+}
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/src/LoadUnrealTexture.cpp
+++ b/lib/TbMdlLib/src/LoadUnrealTexture.cpp
@@ -1,0 +1,259 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mdl/LoadUnrealTexture.h"
+
+#include "Color.h"
+#include "fs/Reader.h"
+#include "fs/ReaderException.h"
+#include "gl/Texture.h"
+#include "gl/TextureBuffer.h"
+#include "mdl/LoadUnrealPackage.h"
+#include "mdl/MaterialUtils.h"
+
+#include "kd/result.h"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+
+namespace tb::mdl
+{
+namespace
+{
+
+struct UnrealMip
+{
+  std::vector<unsigned char> data;
+  int32_t uSize;
+  int32_t vSize;
+  uint8_t uBits;
+  uint8_t vBits;
+};
+
+/**
+ * TLazyArray<byte>. Port of uetex.py's `read_lazy_array_bytes`: the
+ * SkipOffset is present only when FileVersion > 61 (strictly greater) -- the
+ * exact boundary between Unreal (61) and UT99 (68). We always read
+ * sequentially, so the skip offset itself is unused.
+ */
+std::vector<unsigned char> readUnrealLazyArrayBytes(
+  const UnrealPackage& package, fs::Reader& reader)
+{
+  if (package.fileVersion > 61)
+  {
+    reader.readInt<int32_t>(); // SkipOffset, unused
+  }
+  const auto count = readUnrealCompactIndex(reader);
+  auto data = std::vector<unsigned char>(size_t(count));
+  reader.read(data.data(), data.size());
+  return data;
+}
+
+/**
+ * TArray<FMipmap>. Port of uetex.py's `read_mips`.
+ */
+std::vector<UnrealMip> readUnrealMips(const UnrealPackage& package, fs::Reader& reader)
+{
+  const auto count = readUnrealCompactIndex(reader);
+  auto mips = std::vector<UnrealMip>{};
+  mips.reserve(size_t(count));
+  for (int32_t i = 0; i < count; ++i)
+  {
+    auto data = readUnrealLazyArrayBytes(package, reader);
+    const auto uSize = reader.readInt<int32_t>();
+    const auto vSize = reader.readInt<int32_t>();
+    const auto uBits = reader.readUnsignedChar<uint8_t>();
+    const auto vBits = reader.readUnsignedChar<uint8_t>();
+    mips.push_back(UnrealMip{std::move(data), uSize, vSize, uBits, vBits});
+  }
+  return mips;
+}
+
+/**
+ * UPalette body: TArray<FColor>, always 256 entries for a standard palette.
+ * On-disk order is R, G, B, A (confirmed from UModel's FColor serializer);
+ * a previous version of this port had B and R swapped -- don't repeat that.
+ * Port of uetex.py's `read_fcolor_array`.
+ */
+std::vector<unsigned char> readUnrealPaletteColors(fs::Reader& reader)
+{
+  const auto count = readUnrealCompactIndex(reader);
+  auto colors = std::vector<unsigned char>(size_t(count) * 4);
+  reader.read(colors.data(), colors.size());
+  return colors;
+}
+
+const UnrealProperty* findUnrealProperty(
+  const std::vector<UnrealProperty>& props, const std::string& name)
+{
+  const auto it = std::find_if(
+    props.begin(), props.end(), [&](const auto& p) { return p.name == name; });
+  return it != props.end() ? &*it : nullptr;
+}
+
+/**
+ * P8 decode. Unlike Quake's palette convention (index 255 transparent), UE1
+ * masked textures treat palette index 0 as the transparent index, so this
+ * writes RGBA directly from the package's own palette bytes instead of
+ * going through mdl::Palette (whose Index255Transparent handling doesn't
+ * match this convention). Port of uetex.py's per-pixel decode loop in
+ * `main()`.
+ */
+Result<gl::Texture> decodeUnrealTexture(
+  fs::Reader& reader,
+  const UnrealPackage& package,
+  const std::string& packageName,
+  const std::string& textureName)
+{
+  try
+  {
+    const auto* texExport = package.findExport(textureName);
+    if (!texExport || package.classNameOfExport(*texExport) != "Texture")
+    {
+      return Error{fmt::format("{}: texture '{}' not found", packageName, textureName)};
+    }
+
+    auto texReader = reader.subReaderFromBegin(
+      size_t(texExport->serialOffset), size_t(texExport->serialSize));
+    const auto props = readUnrealPropertyList(package, texReader);
+
+    const auto* paletteProp = findUnrealProperty(props, "Palette");
+    if (!paletteProp || !paletteProp->objectRef)
+    {
+      return Error{fmt::format(
+        "{}: texture '{}' has no Palette property", packageName, textureName)};
+    }
+
+    const auto* palExport = package.findExport(*paletteProp->objectRef);
+    if (!palExport || package.classNameOfExport(*palExport) != "Palette")
+    {
+      return Error{fmt::format(
+        "{}: palette '{}' referenced by texture '{}' not found",
+        packageName,
+        *paletteProp->objectRef,
+        textureName)};
+    }
+
+    auto palReader = reader.subReaderFromBegin(
+      size_t(palExport->serialOffset), size_t(palExport->serialSize));
+    readUnrealPropertyList(package, palReader); // usually just "None"
+    const auto paletteColors = readUnrealPaletteColors(palReader);
+    if (paletteColors.size() != 256 * 4)
+    {
+      return Error{fmt::format(
+        "{}: palette '{}' does not have 256 entries",
+        packageName,
+        *paletteProp->objectRef)};
+    }
+
+    const auto mips = readUnrealMips(package, texReader);
+    if (mips.empty())
+    {
+      return Error{
+        fmt::format("{}: texture '{}' has no mips", packageName, textureName)};
+    }
+
+    const auto width = size_t(mips.front().uSize);
+    const auto height = size_t(mips.front().vSize);
+    if (!checkTextureDimensions(width, height))
+    {
+      return Error{fmt::format("Invalid texture dimensions: {}*{}", width, height)};
+    }
+
+    const auto* maskedProp = findUnrealProperty(props, "bMasked");
+    const auto bMasked = maskedProp != nullptr && maskedProp->boolValue;
+    const auto mask = bMasked ? gl::TextureMask::On : gl::TextureMask::Off;
+
+    auto buffers = gl::TextureBufferList{};
+    buffers.reserve(mips.size());
+    auto averageColor = Color{RgbaF{}};
+
+    for (size_t level = 0; level < mips.size(); ++level)
+    {
+      const auto& mip = mips[level];
+      const auto pixelCount = size_t(mip.uSize) * size_t(mip.vSize);
+      if (mip.data.size() != pixelCount)
+      {
+        return Error{fmt::format(
+          "{}: texture '{}' mip {} has {} index bytes, expected {}",
+          packageName,
+          textureName,
+          level,
+          mip.data.size(),
+          pixelCount)};
+      }
+
+      auto buffer = gl::TextureBuffer{pixelCount * 4};
+      auto* dst = buffer.data();
+
+      auto colorSum = std::array<uint32_t, 3>{0, 0, 0};
+      for (size_t p = 0; p < pixelCount; ++p)
+      {
+        const auto index = size_t(mip.data[p]);
+        const auto* color = &paletteColors[index * 4];
+        dst[p * 4 + 0] = color[0];
+        dst[p * 4 + 1] = color[1];
+        dst[p * 4 + 2] = color[2];
+        dst[p * 4 + 3] = (bMasked && index == 0) ? 0 : 255;
+
+        colorSum[0] += uint32_t(color[0]);
+        colorSum[1] += uint32_t(color[1]);
+        colorSum[2] += uint32_t(color[2]);
+      }
+
+      if (level == 0 && pixelCount > 0)
+      {
+        averageColor = RgbaF{
+          float(colorSum[0]) / (255.0f * float(pixelCount)),
+          float(colorSum[1]) / (255.0f * float(pixelCount)),
+          float(colorSum[2]) / (255.0f * float(pixelCount)),
+          1.0f};
+      }
+
+      buffers.push_back(std::move(buffer));
+    }
+
+    return gl::Texture{
+      width,
+      height,
+      averageColor,
+      GL_RGBA,
+      mask,
+      gl::NoEmbeddedDefaults{},
+      std::move(buffers)};
+  }
+  catch (const fs::ReaderException& e)
+  {
+    return Error{e.what()};
+  }
+}
+
+} // namespace
+
+Result<gl::Texture> loadUnrealTexture(
+  fs::Reader& reader, const std::string& packageName, const std::string& textureName)
+{
+  return loadUnrealPackage(reader) | kdl::and_then([&](const auto& package) {
+           return decodeUnrealTexture(reader, package, packageName, textureName);
+         });
+}
+
+} // namespace tb::mdl


### PR DESCRIPTION
Ports the validated uepkg.py/uetex.py reference scripts to C++ for the first integration seam of Unreal (1998)/UT99 support: reading .utx package tables and decoding P8-indexed Texture objects to gl::Texture.

- LoadUnrealPackage: FPackageFileSummary, name/import/export tables, FCompactIndex/FString primitives, and the tagged-property list reader shared with the future actor-class-defaults seam.
- LoadUnrealTexture: TLazyArray mip chain (with the FileVersion > 61 skip-offset boundary), FColor palette (R,G,B,A order), and P8->RGBA decode.

Palette decode does not go through mdl::Palette::indexedToRgba, since that hard-codes Quake's index-255-transparent convention; UE1 masked textures treat index 0 as transparent instead, so decodeUnrealTexture writes RGBA directly from the package's palette bytes and applies that rule per pixel.

Targets FileVersion 61 (Unreal) and 68 (UT99), validated against Crypt.utx and NBSpecialT.utx.