### PR TITLE
Improve handling of relative paths in compilation tasks

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -1655,7 +1655,7 @@ Name
 :    The name of this compilation profile. Need not be unique and can even be empty.
 
 Working directory
-:   A working directory for the compilation profile. This is optional, but very useful because it can be referred to as a variable when specifying the parameters of each task (see below). Variables are allowed (see below).
+:   A working directory for the compilation profile. This is optional, but very useful because it can be referred to as a variable when specifying the parameters of each task (see below). Variables are allowed (see below). Furthermore, relative paths will be interpreted as relative to this directory.
 
 Tasks
 :   A list of tasks which are executed sequentially when the compilation profile is run.
@@ -1673,7 +1673,7 @@ Layers marked "Omit From Export" will not be present in the exported map.
 #### Parameters
 
 Target
-:    The path of the exported file. Variables are allowed.
+:    The path of the exported file. Variables are allowed. Relative paths are implicitly relative to the working directory.
 
 Strip TB specific entity properties
 :    Strip any entity properties starting with _tb_ from the exported map file. Some compilers cannot handle these properties.
@@ -1695,7 +1695,7 @@ Stop on nonzero error code
 
 ### Copy Files
 
-Copies one or more files.
+Copies one or more files. Relative paths are implicitly relative to the working directory.
 
 #### Parameters
 
@@ -1707,7 +1707,7 @@ Target
 
 ### Rename File
 
-Renames or moves one file.
+Renames or moves one file. Relative paths are implicitly relative to the working directory.
 
 #### Parameters
 
@@ -1719,7 +1719,7 @@ Target
 
 ### Delete Files
 
-Deletes one or more files.
+Deletes one or more files. Relative paths are implicitly relative to the working directory.
 
 #### Parameters
 
@@ -1748,11 +1748,11 @@ If the [game configuration](#game_configuration) for the current game includes c
 It is recommended to use the following general process for compiling maps and to adapt it to your specified needs:
 
 1. Set the working directory to `${MAP_DIR_PATH}`.
-2. Add an *Export Map* task and set its target to `${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.map`.
+2. Add an *Export Map* task and set its target to `${MAP_BASE_NAME}-compile.map`.
 3. Add *Run Tool* tasks for the compilation tools that you wish to run. Use the expressions `${MAP_BASE_NAME}-compile.map` and `${MAP_BASE_NAME}.bsp` to specify the input and output files for the tools. Since you have set a working directory, you don't need to specify absolute paths here.
-4. Finally, add a *Copy Files* task and set its source to `${WORK_DIR_PATH}/${MAP_BASE_NAME}.bsp` and its target to `${GAME_DIR_PATH}/${MODS[-1]}/maps`. This copies the file to the maps directory within the last enabled mod.
+4. Finally, add a *Copy Files* task and set its source to `${MAP_BASE_NAME}.bsp` and its target to `${GAME_DIR_PATH}/${MODS[-1]}/maps`. This copies the file to the maps directory within the last enabled mod.
 
-The last step will copy the bsp file to the appropriate directory within the game path. You can add more *Copy Files* tasks if the compilation produces more than just a bsp file (e.g. lightmap files). Alternatively, you can use a wildcard expression such as `${WORK_DIR_PATH}/${MAP_BASE_NAME}.*` to copy related files.
+The last step will copy the bsp file to the appropriate directory within the game path. You can add more *Copy Files* tasks if the compilation produces more than just a bsp file (e.g. lightmap files). Alternatively, you can use a wildcard expression such as `${MAP_BASE_NAME}.*` to copy related files.
 
 To run a compilation profile, click the 'Run' button in the compilation dialog. Note that the 'Run' button changes into a 'Stop' button once the compilation profile is running. If you click on this button again, TrenchBroom will terminate the currently running tool. A running compilation will also be terminated if you close the compilation dialog or if you close the main window, but TrenchBroom will ask you before this happens. Note that the compilation tools are run in the background. You can keep working on your map if you wish.
 

--- a/lib/TbUiLib/src/CompilationRunner.cpp
+++ b/lib/TbUiLib/src/CompilationRunner.cpp
@@ -70,6 +70,11 @@ Result<std::string> workDir(const CompilationContext& context)
   }
 }
 
+auto makeAbsolute(const std::filesystem::path& path, const std::filesystem::path& workDir)
+{
+  return path.is_absolute() ? path : workDir / path;
+}
+
 } // namespace
 
 CompilationTaskRunner::CompilationTaskRunner(CompilationContext& context)
@@ -115,22 +120,25 @@ void CompilationExportMapTaskRunner::doExecute()
 {
   emit start();
 
-  interpolate(m_task.targetSpec).and_then([&](const auto& interpolated) {
-    const auto targetPath = kdl::parse_path(interpolated);
-    m_context << "#### Exporting map file '" << pathAsQString(targetPath) << "'\n";
 
-    if (!m_context.test())
-    {
-      return fs::Disk::createDirectory(targetPath.parent_path())
-             | kdl::and_then([&](auto) {
-                 const auto options =
-                   mdl::MapExportOptions{targetPath, m_task.stripTbProperties};
-                 return m_context.map().exportAs(options);
-               });
-    }
-    return Result<void>{};
-  }) | kdl::transform([&]() { emit end(); })
-    | kdl::transform_error([&](auto e) {
+  workDir(m_context)
+      .join(interpolate(m_task.targetSpec))
+      .and_then([&](const auto& workDir, const auto& interpolated) {
+        const auto targetPath = makeAbsolute(kdl::parse_path(interpolated), workDir);
+        m_context << "#### Exporting map file '" << pathAsQString(targetPath) << "'\n";
+
+        if (!m_context.test())
+        {
+          return fs::Disk::createDirectory(targetPath.parent_path())
+                 | kdl::and_then([&](auto) {
+                     const auto options =
+                       mdl::MapExportOptions{targetPath, m_task.stripTbProperties};
+                     return m_context.map().exportAs(options);
+                   });
+        }
+        return Result<void>{};
+      })
+    | kdl::transform([&]() { emit end(); }) | kdl::transform_error([&](auto e) {
         m_context << "#### Export failed: " << QString::fromStdString(e.msg) << "\n";
         emit error();
       });
@@ -151,11 +159,17 @@ void CompilationCopyFilesTaskRunner::doExecute()
 {
   emit start();
 
-  interpolate(m_task.sourceSpec)
+  workDir(m_context)
+      .join(interpolate(m_task.sourceSpec))
       .join(interpolate(m_task.targetSpec))
-      .and_then([&](const auto& interpolatedSource, const auto& interpolatedTarget) {
-        const auto sourcePath = kdl::parse_path(interpolatedSource);
-        const auto targetPath = kdl::parse_path(interpolatedTarget);
+      .and_then([&](
+                  const auto& workDir,
+                  const auto& interpolatedSource,
+                  const auto& interpolatedTarget) {
+        const auto sourcePath =
+          makeAbsolute(kdl::parse_path(interpolatedSource), workDir);
+        const auto targetPath =
+          makeAbsolute(kdl::parse_path(interpolatedTarget), workDir);
 
         const auto sourceDirPath = sourcePath.parent_path();
         const auto sourcePathMatcher = kdl::logical_and(
@@ -211,11 +225,17 @@ void CompilationRenameFileTaskRunner::doExecute()
 {
   emit start();
 
-  interpolate(m_task.sourceSpec)
+  workDir(m_context)
+      .join(interpolate(m_task.sourceSpec))
       .join(interpolate(m_task.targetSpec))
-      .and_then([&](const auto& interpolatedSource, const auto& interpolatedTarget) {
-        const auto sourcePath = kdl::parse_path(interpolatedSource);
-        const auto targetPath = kdl::parse_path(interpolatedTarget);
+      .and_then([&](
+                  const auto& workDir,
+                  const auto& interpolatedSource,
+                  const auto& interpolatedTarget) {
+        const auto sourcePath =
+          makeAbsolute(kdl::parse_path(interpolatedSource), workDir);
+        const auto targetPath =
+          makeAbsolute(kdl::parse_path(interpolatedTarget), workDir);
 
         m_context << "#### Renaming '" << pathAsQString(sourcePath) << "' to '"
                   << pathAsQString(targetPath) << "'\n";
@@ -248,35 +268,39 @@ void CompilationDeleteFilesTaskRunner::doExecute()
 {
   emit start();
 
-  interpolate(m_task.targetSpec).and_then([&](const auto& interpolated) {
-    const auto targetPath = kdl::parse_path(interpolated);
+  workDir(m_context)
+      .join(interpolate(m_task.targetSpec))
+      .and_then([&](const auto& workDir, const auto& interpolated) {
+        const auto targetPath = makeAbsolute(kdl::parse_path(interpolated), workDir);
 
-    const auto targetDirPath = targetPath.parent_path();
-    const auto targetPathMatcher = kdl::logical_and(
-      fs::makePathInfoPathMatcher({fs::PathInfo::File}),
-      fs::makeFilenamePathMatcher(targetPath.filename().string()));
+        const auto targetDirPath = targetPath.parent_path();
+        const auto targetPathMatcher = kdl::logical_and(
+          fs::makePathInfoPathMatcher({fs::PathInfo::File}),
+          fs::makeFilenamePathMatcher(targetPath.filename().string()));
 
-    return fs::Disk::find(targetDirPath, fs::TraversalMode::Recursive, targetPathMatcher)
-           | kdl::transform([&](const auto& pathsToDelete) {
-               const auto pathStrsToDelete =
-                 pathsToDelete | std::views::transform([](const auto& path) {
-                   return fmt::format("{}", path);
-                 })
-                 | kdl::ranges::to<std::vector>();
+        return fs::Disk::find(
+                 targetDirPath, fs::TraversalMode::Recursive, targetPathMatcher)
+               | kdl::transform([&](const auto& pathsToDelete) {
+                   const auto pathStrsToDelete =
+                     pathsToDelete | std::views::transform([](const auto& path) {
+                       return fmt::format("{}", path);
+                     })
+                     | kdl::ranges::to<std::vector>();
 
-               m_context << "#### Deleting: "
-                         << QString::fromStdString(kdl::str_join(pathStrsToDelete, ", "))
-                         << "\n";
+                   m_context << "#### Deleting: "
+                             << QString::fromStdString(
+                                  kdl::str_join(pathStrsToDelete, ", "))
+                             << "\n";
 
-               if (!m_context.test())
-               {
-                 return pathsToDelete | std::views::transform(fs::Disk::deleteFile)
-                        | kdl::fold;
-               }
-               return Result<std::vector<bool>>{std::vector<bool>{}};
-             });
-  }) | kdl::transform([&](auto) { emit end(); })
-    | kdl::transform_error([&](auto e) {
+                   if (!m_context.test())
+                   {
+                     return pathsToDelete | std::views::transform(fs::Disk::deleteFile)
+                            | kdl::fold;
+                   }
+                   return Result<std::vector<bool>>{std::vector<bool>{}};
+                 });
+      })
+    | kdl::transform([&](auto) { emit end(); }) | kdl::transform_error([&](auto e) {
         m_context << "#### Delete failed: " << QString::fromStdString(e.msg) << "\n";
         emit error();
       });

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -39,7 +39,6 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include "ui/TextOutputAdapter.h"
 
 #include "kd/k.h"
-#include "kd/path_utils.h"
 #include "kd/string_utils.h"
 
 #include <chrono>
@@ -309,20 +308,25 @@ TEST_CASE("CompilationExportMapTaskRunner")
 
   SECTION("exportMap")
   {
-    const auto exportPath =
-      GENERATE("${WORK_DIR_PATH}/exported.map", "${WORK_DIR_PATH}\\exported.map");
+    const auto [exportSpec, expectedFilePath] =
+      GENERATE(table<std::string, std::filesystem::path>({
+        {"${WORK_DIR_PATH}/exported.map", "exported.map"},
+        {"${WORK_DIR_PATH}\\exported.map", "exported.map"},
+        {"exported.map", "exported.map"},
+        {"some/nested/exported.map", "some/nested/exported.map"},
+      }));
 
-    CAPTURE(exportPath);
+    CAPTURE(exportSpec);
 
     auto node = new mdl::EntityNode{mdl::Entity{}};
     addNodes(map, {{parentForNodes(map), {node}}});
 
-    auto task = mdl::CompilationExportMap{K(enabled), !K(stripTbProperties), exportPath};
+    auto task = mdl::CompilationExportMap{K(enabled), !K(stripTbProperties), exportSpec};
 
     auto runner = CompilationExportMapTaskRunner{context, task};
     REQUIRE_NOTHROW(runner.execute());
 
-    CHECK(testEnvironment.fileExists("exported.map"));
+    CHECK(testEnvironment.fileExists(expectedFilePath));
   }
 
   SECTION("variable interpolation error")
@@ -359,20 +363,23 @@ TEST_CASE("CompilationCopyFilesTaskRunner")
     const auto sourcePath = "my_map.map";
     testEnvironment.createFile(sourcePath, "{}");
 
-    const auto targetPath = GENERATE("some/other/path"s, "some\\other\\path"s);
+    const auto [targetSpec, expectedTargetPath] =
+      GENERATE(table<std::string, std::filesystem::path>({
+        {"${WORK_DIR_PATH}/some/other/path", "some/other/path"},
+        {"${WORK_DIR_PATH}\\some\\other\\path", "some/other/path"},
+        {"some/other/path", "some/other/path"},
+        {"some\\other\\path", "some/other/path"},
+      }));
 
-    CAPTURE(targetPath);
+    CAPTURE(targetSpec);
 
-    auto task = mdl::CompilationCopyFiles{
-      true,
-      (testEnvironment.dir() / sourcePath).string(),
-      (testEnvironment.dir() / targetPath).string()};
+    auto task = mdl::CompilationCopyFiles{true, sourcePath, targetSpec};
     auto runner = CompilationCopyFilesTaskRunner{context, task};
 
     REQUIRE_NOTHROW(runner.execute());
 
-    CHECK(testEnvironment.directoryExists(kdl::parse_path(targetPath)));
-    CHECK(testEnvironment.loadFile(kdl::parse_path(targetPath) / sourcePath) == "{}");
+    CHECK(testEnvironment.directoryExists(expectedTargetPath));
+    CHECK(testEnvironment.loadFile(expectedTargetPath / sourcePath) == "{}");
   }
 
   SECTION("variable interpolation errors")
@@ -410,28 +417,30 @@ TEST_CASE("CompilationRenameFileTaskRunner")
     const auto sourcePath = "my_map.map";
     testEnvironment.createFile(sourcePath, "{}");
 
-    const auto targetPathStr =
-      GENERATE("some/other/path/your_map.map"s, "some\\other\\path\\your_map.map"s);
+    const auto [targetSpec, expectedTargetPath] =
+      GENERATE(table<std::string, std::filesystem::path>({
+        {"${WORK_DIR_PATH}/some/other/path/your_map.map", "some/other/path/your_map.map"},
+        {"${WORK_DIR_PATH}\\some\\other\\path\\your_map.map",
+         "some/other/path/your_map.map"},
+        {"some/other/path/your_map.map", "some/other/path/your_map.map"},
+        {"some\\other\\path\\your_map.map", "some/other/path/your_map.map"},
+      }));
 
-    CAPTURE(targetPathStr);
+    CAPTURE(targetSpec);
 
-    const auto targetPath = kdl::parse_path(targetPathStr);
     if (overwrite)
     {
-      testEnvironment.createDirectory(targetPath.parent_path());
-      testEnvironment.createFile(targetPath, "{...}");
-      REQUIRE(testEnvironment.loadFile(targetPath) == "{...}");
+      testEnvironment.createDirectory(expectedTargetPath.parent_path());
+      testEnvironment.createFile(expectedTargetPath, "{...}");
+      REQUIRE(testEnvironment.loadFile(expectedTargetPath) == "{...}");
     }
 
-    auto task = mdl::CompilationRenameFile{
-      true,
-      (testEnvironment.dir() / sourcePath).string(),
-      (testEnvironment.dir() / targetPathStr).string()};
+    auto task = mdl::CompilationRenameFile{true, sourcePath, targetSpec};
     auto runner = CompilationRenameFileTaskRunner{context, task};
 
     REQUIRE_NOTHROW(runner.execute());
 
-    CHECK(testEnvironment.loadFile(targetPath) == "{}");
+    CHECK(testEnvironment.loadFile(expectedTargetPath) == "{}");
   }
 
   SECTION("variable interpolation errors")
@@ -453,13 +462,14 @@ TEST_CASE("CompilationDeleteFilesTaskRunner")
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
 
-  auto variables = el::NullVariableStore{};
+  auto testEnvironment = fs::TestEnvironment{};
+
+  const auto testWorkDir = testEnvironment.dir().string();
+  auto variables = CompilationVariables{map, testWorkDir};
   auto output = QTextEdit{};
   auto outputAdapter = TextOutputAdapter{&output};
 
   auto context = CompilationContext{map, variables, outputAdapter, false};
-
-  auto testEnvironment = fs::TestEnvironment{};
 
   SECTION("deleteTargetPattern")
   {
@@ -473,8 +483,12 @@ TEST_CASE("CompilationDeleteFilesTaskRunner")
     testEnvironment.createFile(file3, "");
     testEnvironment.createDirectory(dir);
 
-    auto task =
-      mdl::CompilationDeleteFiles{K(enabled), (testEnvironment.dir() / "*.lit").string()};
+    const auto targetSpec = GENERATE(
+      std::filesystem::path{"${WORK_DIR_PATH}/*.lit"}, std::filesystem::path{"*.lit"});
+
+    CAPTURE(targetSpec);
+
+    auto task = mdl::CompilationDeleteFiles{K(enabled), targetSpec.string()};
     auto runner = CompilationDeleteFilesTaskRunner{context, task};
 
     REQUIRE_NOTHROW(runner.execute());


### PR DESCRIPTION
Relative paths are now interpreted as being relative to the working directory, so it's no longer necessary to use the corresponding variable everywhere.