### PR TITLE
fix: uuid regenerated on every call, perf fix

### DIFF
--- a/lib/TbBaseLib/src/Uuid.cpp
+++ b/lib/TbBaseLib/src/Uuid.cpp
@@ -22,19 +22,30 @@
 #include "stduuid/uuid.h"
 
 #include <algorithm>
+#include <array>
+#include <functional>
+#include <random>
 
 namespace tb
 {
 
 std::string generateUuid()
 {
-  std::random_device rd;
-  auto seed_data = std::array<int, std::mt19937::state_size>{};
-  std::ranges::generate(seed_data, std::ref(rd));
-  std::seed_seq seq(std::begin(seed_data), std::end(seed_data));
-  std::mt19937 generator(seq);
-  uuids::uuid_random_generator gen{generator};
+  // Seed the Mersenne Twister once per thread and reuse it. Seeding pulls
+  // std::mt19937::state_size (624) values from std::random_device, which is very expensive
+  // (each draw may hit the OS entropy source). Doing this on every call made node creation
+  // dominate map load times, since every node generates a UUID in its constructor. The
+  // engine is thread_local so parallel node creation needs no synchronization; advancing
+  // its state on each call still yields unique UUIDs.
+  static thread_local auto generator = [] {
+    auto rd = std::random_device{};
+    auto seedData = std::array<int, std::mt19937::state_size>{};
+    std::ranges::generate(seedData, std::ref(rd));
+    auto seq = std::seed_seq(std::begin(seedData), std::end(seedData));
+    return std::mt19937{seq};
+  }();
 
+  auto gen = uuids::uuid_random_generator{generator};
   return uuids::to_string(gen());
 }
 

--- a/lib/TbBaseLib/test/CMakeLists.txt
+++ b/lib/TbBaseLib/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(TbBaseLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Notifier.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_PreferenceManager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Tokenizer.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Uuid.cpp
 )
 
 add_compile_definitions(CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS=1)

--- a/lib/TbBaseLib/test/src/tst_Uuid.cpp
+++ b/lib/TbBaseLib/test/src/tst_Uuid.cpp
@@ -1,0 +1,128 @@
+/*
+ Copyright (C) 2025 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Uuid.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb
+{
+
+namespace
+{
+
+bool hasValidUuidFormat(const std::string& uuid)
+{
+  // Canonical form: 8-4-4-4-12 lower-case hex digits separated by hyphens.
+  if (uuid.size() != 36u)
+  {
+    return false;
+  }
+
+  for (size_t i = 0u; i < uuid.size(); ++i)
+  {
+    if (i == 8u || i == 13u || i == 18u || i == 23u)
+    {
+      if (uuid[i] != '-')
+      {
+        return false;
+      }
+    }
+    else if (std::isxdigit(static_cast<unsigned char>(uuid[i])) == 0)
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace
+
+TEST_CASE("generateUuid")
+{
+  SECTION("produces canonically formatted UUIDs")
+  {
+    for (auto i = 0; i < 1000; ++i)
+    {
+      const auto uuid = generateUuid();
+      CAPTURE(uuid);
+      CHECK(hasValidUuidFormat(uuid));
+    }
+  }
+
+  SECTION("produces unique UUIDs on a single thread")
+  {
+    constexpr auto count = 100'000u;
+
+    auto seen = std::unordered_set<std::string>{};
+    seen.reserve(count);
+    for (auto i = 0u; i < count; ++i)
+    {
+      CHECK(seen.insert(generateUuid()).second);
+    }
+    CHECK(seen.size() == count);
+  }
+
+  SECTION("produces unique UUIDs across concurrent threads")
+  {
+    // The generator is seeded once per thread (thread_local). This is the case that would
+    // break if two threads happened to seed identical engines, so exercise it directly.
+    const auto threadCount = std::max(4u, std::thread::hardware_concurrency());
+    constexpr auto perThread = 50'000u;
+
+    auto perThreadResults = std::vector<std::vector<std::string>>(threadCount);
+    auto threads = std::vector<std::thread>{};
+    for (auto t = 0u; t < threadCount; ++t)
+    {
+      threads.emplace_back([&, t]() {
+        auto& out = perThreadResults[t];
+        out.reserve(perThread);
+        for (auto i = 0u; i < perThread; ++i)
+        {
+          out.push_back(generateUuid());
+        }
+      });
+    }
+    for (auto& thread : threads)
+    {
+      thread.join();
+    }
+
+    auto seen = std::unordered_set<std::string>{};
+    seen.reserve(threadCount * perThread);
+    for (const auto& out : perThreadResults)
+    {
+      for (const auto& uuid : out)
+      {
+        CHECK(seen.insert(uuid).second);
+      }
+    }
+    CHECK(seen.size() == threadCount * perThread);
+  }
+}
+
+} // namespace tb


### PR DESCRIPTION
**Problem:** Opening a map was slow, took ~17 seconds just to build its objects, pinning every CPU core and making the whole system stutter (laggy mouse, brief freezes).

**Cause:** Every object in a map gets a unique ID when it's created. The code that generated those IDs was rebuilding and re-seeding a random number generator from scratch on every single call, an expensive operation that pulls from the operating system's randomness source hundreds of times. With thousands of objects in a map, this added up to seconds of wasted work, spread across all cores.

**Fix:** Set up the random number generator once per thread and reuse it, instead of rebuilding it for every object. Same quality of unique IDs, a tiny fraction of the cost.

**Result:** That step of loading dropped from **~17 seconds to ~500 milliseconds** on one of my maps roughly 35× faster. The system-wide slowdown during load is gone.

**Testing:** Added a test that generates ~1.3 million IDs across many threads at once and confirms every one is valid and unique. Covers the exact concurrent scenario the map loader uses.

---

**Additional information:** This PR was reviewed and tested on a Linux based machine. I don't foresee any issues as this is similar code to what already existed. Code was also written by Claude but made sure that it made minimal changes to the UUID generator.