### PR TITLE
Cache DiskFileSystem contents

### DIFF
--- a/lib/KdLib/src/path_utils.cpp
+++ b/lib/KdLib/src/path_utils.cpp
@@ -58,7 +58,19 @@ std::filesystem::path path_front(const std::filesystem::path& path)
 
 std::filesystem::path path_to_lower(const std::filesystem::path& path)
 {
+#ifdef _WIN32
+  // path.string() narrows through the process's codepage and throws if the path
+  // contains a character the codepage can't represent - operate on the native UTF-16
+  // form instead, which round-trips losslessly and never throws; str_to_lower only
+  // touches ASCII 'A'-'Z' anyway, so per-code-unit lowering is equivalent.
+  auto native = path.native();
+  std::ranges::transform(native, native.begin(), [](const wchar_t c) {
+    return (c < L'A' || c > L'Z') ? c : static_cast<wchar_t>(c + L'a' - L'A');
+  });
+  return std::filesystem::path{std::move(native)};
+#else
   return std::filesystem::path{str_to_lower(path.string())};
+#endif
 }
 
 std::filesystem::path path_clip(

--- a/lib/KdLib/test/src/tst_path_utils.cpp
+++ b/lib/KdLib/test/src/tst_path_utils.cpp
@@ -136,6 +136,19 @@ TEST_CASE("path_to_lower")
   CHECK(path_to_lower(path{"/THIS/that"}) == path{"/this/that"});
   CHECK(path_to_lower(path{"/THIS/THAT"}) == path{"/this/that"});
   CHECK(path_to_lower(path{"C:\\THIS\\THAT"}) == path{"c:\\this\\that"});
+
+  SECTION("characters outside the codepage are preserved and don't throw")
+  {
+    // U+3041 HIRAGANA LETTER SMALL A, not representable in common Windows ANSI
+    // codepages - path_to_lower used to throw here on Windows (it round-tripped
+    // through a codepage-dependent narrow encoding); it must now leave such
+    // characters untouched instead of throwing.
+    const auto nonAsciiPath = parse_utf8_path("THIS/\xE3\x81\x81/THAT");
+    const auto expected = parse_utf8_path("this/\xE3\x81\x81/that");
+
+    CHECK_NOTHROW(path_to_lower(nonAsciiPath));
+    CHECK(path_to_lower(nonAsciiPath) == expected);
+  }
 }
 
 TEST_CASE("PathTest.path_clip")

--- a/lib/TbFsLib/include/fs/CachedFileTree.h
+++ b/lib/TbFsLib/include/fs/CachedFileTree.h
@@ -1,0 +1,245 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "fs/TraversalMode.h"
+
+#include "kd/overload.h"
+#include "kd/path_hash.h"
+#include "kd/path_utils.h"
+
+#include <filesystem>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace tb::fs
+{
+
+/** A cached, case-insensitively-searchable directory tree, shared by all FileSystem
+ * implementations that build their whole directory structure once (on construction or
+ * reload()) and answer queries from that cache instead of the backing storage. `Payload`
+ * is whatever a leaf (file) entry needs to carry to answer an open request later - e.g.
+ * a lazy loader for archive-backed file systems, or nothing at all
+ * (`std::monostate`) for file systems that just reconstruct a real path and reopen it.
+ */
+template <typename Payload>
+struct CachedFileEntry
+{
+  std::filesystem::path name;
+  Payload payload;
+};
+
+template <typename Payload>
+struct CachedDirectoryEntry;
+
+template <typename Payload>
+using CachedEntry = std::variant<CachedDirectoryEntry<Payload>, CachedFileEntry<Payload>>;
+
+template <typename Payload>
+struct CachedDirectoryEntry
+{
+  std::filesystem::path name;
+  std::vector<CachedEntry<Payload>> entries;
+  std::unordered_map<std::filesystem::path, size_t, kdl::path_hash> entryMapLC;
+};
+
+template <typename Payload>
+const std::filesystem::path& getEntryName(const CachedEntry<Payload>& entry)
+{
+  return std::visit(
+    [](const auto& x) -> const std::filesystem::path& { return x.name; }, entry);
+}
+
+template <typename Payload>
+bool isDirectoryEntry(const CachedEntry<Payload>& entry)
+{
+  return std::visit(
+    kdl::overload(
+      [](const CachedDirectoryEntry<Payload>&) { return true; },
+      [](const CachedFileEntry<Payload>&) { return false; }),
+    entry);
+}
+
+template <typename Payload>
+CachedEntry<Payload>& addCachedEntry(
+  CachedDirectoryEntry<Payload>& parent,
+  std::type_identity_t<CachedEntry<Payload>>&& entry)
+{
+  parent.entryMapLC[kdl::path_to_lower(getEntryName(entry))] = parent.entries.size();
+  parent.entries.push_back(std::move(entry));
+  return parent.entries.back();
+}
+
+template <typename DirEntry>
+auto findChildEntry(DirEntry& directoryEntry, const std::filesystem::path& nameLC)
+{
+  using difftype =
+    typename std::decay_t<decltype(directoryEntry.entries)>::difference_type;
+
+  const auto entryIndexIt = directoryEntry.entryMapLC.find(nameLC);
+  return entryIndexIt != directoryEntry.entryMapLC.end()
+           ? std::next(directoryEntry.entries.begin(), difftype(entryIndexIt->second))
+           : directoryEntry.entries.end();
+}
+
+template <typename Payload, typename F>
+auto withCachedEntry(
+  const std::filesystem::path& searchPathLC,
+  const CachedEntry<Payload>& currentEntry,
+  const std::filesystem::path& currentPath,
+  const F& f,
+  decltype(f(
+    std::declval<const CachedEntry<Payload>&>(),
+    std::declval<const std::filesystem::path&>())) defaultResult)
+{
+  if (searchPathLC.empty())
+  {
+    return f(currentEntry, currentPath);
+  }
+
+  return std::visit(
+    kdl::overload(
+      [&](const CachedDirectoryEntry<Payload>& directoryEntry) {
+        const auto nameLC = kdl::path_front(searchPathLC);
+        const auto entryIt = findChildEntry(directoryEntry, nameLC);
+
+        return entryIt != directoryEntry.entries.end()
+                 ? withCachedEntry(
+                     kdl::path_pop_front(searchPathLC),
+                     *entryIt,
+                     currentPath / getEntryName(*entryIt),
+                     f,
+                     defaultResult)
+                 : defaultResult;
+      },
+      [&](const CachedFileEntry<Payload>&) { return defaultResult; }),
+    currentEntry);
+}
+
+template <typename Payload, typename F>
+void withCachedEntry(
+  const std::filesystem::path& searchPathLC,
+  const CachedEntry<Payload>& currentEntry,
+  const std::filesystem::path& currentPath,
+  const F& f)
+{
+  if (searchPathLC.empty())
+  {
+    f(currentEntry, currentPath);
+  }
+  else
+  {
+    std::visit(
+      kdl::overload(
+        [&](const CachedDirectoryEntry<Payload>& directoryEntry) {
+          const auto nameLC = kdl::path_front(searchPathLC);
+          const auto entryIt = findChildEntry(directoryEntry, nameLC);
+
+          if (entryIt != directoryEntry.entries.end())
+          {
+            withCachedEntry(
+              kdl::path_pop_front(searchPathLC),
+              *entryIt,
+              currentPath / getEntryName(*entryIt),
+              f);
+          }
+        },
+        [&](const CachedFileEntry<Payload>&) {}),
+      currentEntry);
+  }
+}
+
+template <typename Payload>
+const CachedEntry<Payload>* findCachedEntry(
+  const std::filesystem::path& pathLC, const CachedEntry<Payload>& parent)
+{
+  return withCachedEntry(
+    pathLC,
+    parent,
+    std::filesystem::path{},
+    [](
+      const CachedEntry<Payload>& entry, const std::filesystem::path&) { return &entry; },
+    nullptr);
+}
+
+template <typename Payload>
+CachedDirectoryEntry<Payload>& findOrCreateCachedDirectory(
+  const std::filesystem::path& path, CachedDirectoryEntry<Payload>& parent)
+{
+  if (path.empty())
+  {
+    return parent;
+  }
+
+  auto name = kdl::path_front(path);
+  auto nameLC = kdl::path_to_lower(name);
+  auto entryIt = findChildEntry(parent, nameLC);
+  if (entryIt != parent.entries.end())
+  {
+    return std::visit(
+      kdl::overload(
+        [&](CachedDirectoryEntry<Payload>& directoryEntry)
+          -> CachedDirectoryEntry<Payload>& {
+          return findOrCreateCachedDirectory(kdl::path_pop_front(path), directoryEntry);
+        },
+        [&](CachedFileEntry<Payload>&) -> CachedDirectoryEntry<Payload>& {
+          *entryIt = CachedDirectoryEntry<Payload>{std::move(name), {}, {}};
+          return findOrCreateCachedDirectory(
+            kdl::path_pop_front(path), std::get<CachedDirectoryEntry<Payload>>(*entryIt));
+        }),
+      *entryIt);
+  }
+  else
+  {
+    return findOrCreateCachedDirectory(
+      kdl::path_pop_front(path),
+      std::get<CachedDirectoryEntry<Payload>>(
+        addCachedEntry(parent, CachedDirectoryEntry<Payload>{std::move(name), {}, {}})));
+  }
+}
+
+template <typename Payload>
+void collectCachedEntries(
+  const CachedEntry<Payload>& entry,
+  const std::filesystem::path& entryPath,
+  const size_t depth,
+  const TraversalMode& traversalMode,
+  std::vector<std::filesystem::path>& result)
+{
+  if (!traversalMode.depth || depth <= *traversalMode.depth)
+  {
+    std::visit(
+      kdl::overload(
+        [&](const CachedDirectoryEntry<Payload>& directoryEntry) {
+          for (const auto& childEntry : directoryEntry.entries)
+          {
+            const auto childPath = entryPath / getEntryName(childEntry);
+            result.push_back(childPath);
+            collectCachedEntries(childEntry, childPath, depth + 1, traversalMode, result);
+          }
+        },
+        [](const CachedFileEntry<Payload>&) {}),
+      entry);
+  }
+}
+
+} // namespace tb::fs

--- a/lib/TbFsLib/include/fs/DiskFileSystem.h
+++ b/lib/TbFsLib/include/fs/DiskFileSystem.h
@@ -25,22 +25,46 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <variant>
 
 namespace tb::fs
 {
+
+template <typename Payload>
+struct CachedFileEntry;
+template <typename Payload>
+struct CachedDirectoryEntry;
+
+using DiskFileEntry = CachedFileEntry<std::monostate>;
+using DiskDirectoryEntry = CachedDirectoryEntry<std::monostate>;
+using DiskEntry = std::variant<DiskDirectoryEntry, DiskFileEntry>;
 
 class DiskFileSystem : public virtual FileSystem
 {
 protected:
   std::filesystem::path m_root;
 
+  /**
+   * The cached directory tree, or null if m_root did not denote a directory as of the
+   * last reload() - a nullable field expresses "root doesn't exist" directly, rather
+   * than needing a separate flag alongside an always-present (but then meaningless)
+   * empty tree.
+   */
+  std::unique_ptr<DiskEntry> m_cacheRoot;
+
 public:
   explicit DiskFileSystem(const std::filesystem::path& root);
+  ~DiskFileSystem() override;
 
   const std::filesystem::path& root() const;
 
   Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const override;
+
+  /**
+   * Reload this file system's cached directory tree from disk.
+   */
+  Result<void> reload();
 
   PathInfo pathInfo(const std::filesystem::path& path) const override;
 
@@ -80,6 +104,14 @@ private:
   Result<void> doRenameDirectory(
     const std::filesystem::path& sourcePath,
     const std::filesystem::path& destPath) override;
+
+  /**
+   * On success, reloads the cached directory tree before returning the wrapped
+   * result unchanged; on failure, returns the error without reloading, since nothing
+   * changed on disk.
+   */
+  Result<bool> reloadAfterWrite(Result<bool> result);
+  Result<void> reloadAfterWrite(Result<void> result);
 };
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/lib/TbFsLib/include/fs/DiskFileSystem.h
+++ b/lib/TbFsLib/include/fs/DiskFileSystem.h
@@ -24,6 +24,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <variant>
 
@@ -51,6 +52,11 @@ protected:
    * empty tree.
    */
   std::unique_ptr<DiskEntry> m_cacheRoot;
+
+  /**
+   * Guards m_cacheRoot against concurrent reload() and reads.
+   */
+  mutable std::shared_mutex m_mutex;
 
 public:
   explicit DiskFileSystem(const std::filesystem::path& root);

--- a/lib/TbFsLib/include/fs/DiskFileSystem.h
+++ b/lib/TbFsLib/include/fs/DiskFileSystem.h
@@ -67,10 +67,7 @@ public:
   Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const override;
 
-  /**
-   * Reload this file system's cached directory tree from disk.
-   */
-  Result<void> reload();
+  Result<void> reload() override;
 
   PathInfo pathInfo(const std::filesystem::path& path) const override;
 

--- a/lib/TbFsLib/include/fs/FileSystem.h
+++ b/lib/TbFsLib/include/fs/FileSystem.h
@@ -64,6 +64,11 @@ public:
    */
   virtual PathInfo pathInfo(const std::filesystem::path& path) const = 0;
 
+  /** Reloads this file system, refreshing any cached view of its contents from the
+   * underlying storage.
+   */
+  virtual Result<void> reload() = 0;
+
   /** Returns the meta data associated with the given path and key, or null if no metadata
    * is associated with the given path and key.
    */

--- a/lib/TbFsLib/include/fs/FileSystem.h
+++ b/lib/TbFsLib/include/fs/FileSystem.h
@@ -34,6 +34,18 @@ namespace tb::fs
 enum class PathInfo;
 struct TraversalMode;
 
+/** A FileSystem provides access to a hierarchy of files and directories, abstracting
+ * over how they are physically stored, e.g. on disk or inside an archive.
+ *
+ * Every FileSystem implementation is case insensitive in one direction only: paths
+ * passed *into* pathInfo(), find(), openFile() and path matchers are matched without
+ * regard to case, but paths returned *from* find() always reflect the true stored
+ * case of every path component - the on-disk case for DiskFileSystem, the in-archive
+ * case for ImageFileSystemBase-derived filesystems - never the case the caller
+ * queried with, and never all-lowercase. This holds even for the portion of a
+ * returned path that was already covered by a case-mismatched search path passed to
+ * find().
+ */
 class FileSystem
 {
 public:
@@ -47,7 +59,8 @@ public:
   virtual Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const = 0;
 
-  /** Indicates whether the given path denotes a file, a directory, or is unknown.
+  /** Indicates whether the given path denotes a file, a directory, or is unknown. The
+   * given path is matched case insensitively.
    */
   virtual PathInfo pathInfo(const std::filesystem::path& path) const = 0;
 
@@ -59,7 +72,9 @@ public:
 
   /** Returns a vector of paths listing the contents of the directory  at the given path
    * that satisfy the given path matcher. The returned paths are relative to the root of
-   * this file system.
+   * this file system. The given path is matched case insensitively, but every returned
+   * path reflects the true stored case of each of its components, regardless of the
+   * case of the given path.
    *
    * @param path the path to the directory to search
    * @param traversalMode the traversal mode
@@ -70,7 +85,8 @@ public:
     const TraversalMode& traversalMode,
     const PathMatcher& pathMatcher = matchAnyPath) const;
 
-  /** Open a file at the given path and return it.
+  /** Open a file at the given path and return it. The given path is matched case
+   * insensitively.
    */
   Result<std::shared_ptr<File>> openFile(const std::filesystem::path& path) const;
 

--- a/lib/TbFsLib/include/fs/ImageFileSystem.h
+++ b/lib/TbFsLib/include/fs/ImageFileSystem.h
@@ -73,10 +73,7 @@ public:
   Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const override;
 
-  /**
-   * Reload this file system.
-   */
-  Result<void> reload();
+  Result<void> reload() override;
 
   void setMetadata(std::unordered_map<std::string, FileSystemMetadata> metadata);
 

--- a/lib/TbFsLib/include/fs/ImageFileSystem.h
+++ b/lib/TbFsLib/include/fs/ImageFileSystem.h
@@ -30,6 +30,7 @@
 #include <filesystem>
 #include <functional>
 #include <memory>
+#include <shared_mutex>
 #include <unordered_map>
 
 namespace tb::fs
@@ -49,9 +50,24 @@ protected:
   ImageEntry m_root;
   std::unordered_map<std::string, FileSystemMetadata> m_metadata;
 
+  /**
+   * Guards m_root and m_metadata against concurrent reload() and reads. Only reload()
+   * and the read-only pathInfo/metadata/doFind/doOpenFile paths take this lock -
+   * addFile() runs solely from within doReadDirectory(), itself only ever called from
+   * reload() while the exclusive lock is already held, so it needs no lock of its own.
+   *
+   * unique_ptr, not a plain std::shared_mutex member, because ImageFileSystemBase must
+   * stay movable.
+   */
+  mutable std::unique_ptr<std::shared_mutex> m_mutex =
+    std::make_unique<std::shared_mutex>();
+
   ImageFileSystemBase();
 
 public:
+  ImageFileSystemBase(ImageFileSystemBase&&) noexcept;
+  ImageFileSystemBase& operator=(ImageFileSystemBase&&) noexcept;
+
   ~ImageFileSystemBase() override;
 
   Result<std::filesystem::path> makeAbsolute(

--- a/lib/TbFsLib/include/fs/ImageFileSystem.h
+++ b/lib/TbFsLib/include/fs/ImageFileSystem.h
@@ -20,18 +20,17 @@
 #pragma once
 
 #include "Result.h"
+#include "fs/CachedFileTree.h"
 #include "fs/FileSystem.h"
 #include "fs/FileSystemMetadata.h"
 
 #include "kd/contracts.h"
-#include "kd/path_hash.h"
 #include "kd/result.h"
 
 #include <filesystem>
 #include <functional>
 #include <memory>
 #include <unordered_map>
-#include <variant>
 
 namespace tb::fs
 {
@@ -40,21 +39,9 @@ class File;
 
 using GetImageFile = std::function<Result<std::shared_ptr<File>>()>;
 
-struct ImageFileEntry
-{
-  std::filesystem::path name;
-  GetImageFile getFile;
-};
-
-struct ImageDirectoryEntry;
-using ImageEntry = std::variant<ImageDirectoryEntry, ImageFileEntry>;
-
-struct ImageDirectoryEntry
-{
-  std::filesystem::path name;
-  std::vector<ImageEntry> entries;
-  std::unordered_map<std::filesystem::path, size_t, kdl::path_hash> entryMapLC;
-};
+using ImageFileEntry = CachedFileEntry<GetImageFile>;
+using ImageDirectoryEntry = CachedDirectoryEntry<GetImageFile>;
+using ImageEntry = CachedEntry<GetImageFile>;
 
 class ImageFileSystemBase : public FileSystem
 {

--- a/lib/TbFsLib/include/fs/VirtualFileSystem.h
+++ b/lib/TbFsLib/include/fs/VirtualFileSystem.h
@@ -24,6 +24,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <shared_mutex>
 #include <vector>
 
 namespace tb::fs
@@ -54,6 +55,14 @@ class VirtualFileSystem : public FileSystem
 {
 private:
   std::vector<VirtualMountPoint> m_mountPoints;
+
+  /** Guards m_mountPoints against concurrent writes (mount, unmount) vs. reads
+   * (makeAbsolute, pathInfo, metadata, doFind, doOpenFile) from other threads. This can
+   * occur via GameFileSystem::reloadWads() racing with background material/model loading.
+   * Allocated on the heap because VirtualFileSystem must stay movable.
+   */
+  mutable std::unique_ptr<std::shared_mutex> m_mutex =
+    std::make_unique<std::shared_mutex>();
 
 public:
   Result<std::filesystem::path> makeAbsolute(

--- a/lib/TbFsLib/include/fs/VirtualFileSystem.h
+++ b/lib/TbFsLib/include/fs/VirtualFileSystem.h
@@ -67,6 +67,9 @@ private:
 public:
   Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const override;
+
+  Result<void> reload() override;
+
   PathInfo pathInfo(const std::filesystem::path& path) const override;
   const FileSystemMetadata* metadata(
     const std::filesystem::path& path, const std::string& key) const override;
@@ -97,6 +100,9 @@ public:
 
   Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const override;
+
+  Result<void> reload() override;
+
   PathInfo pathInfo(const std::filesystem::path& path) const override;
   const FileSystemMetadata* metadata(
     const std::filesystem::path& path, const std::string& key) const override;

--- a/lib/TbFsLib/src/DiskFileSystem.cpp
+++ b/lib/TbFsLib/src/DiskFileSystem.cpp
@@ -19,13 +19,13 @@
 
 #include "fs/DiskFileSystem.h"
 
+#include "fs/CachedFileTree.h"
 #include "fs/DiskIO.h"
 #include "fs/File.h"
 #include "fs/PathInfo.h"
 #include "fs/TraversalMode.h"
 
 #include "kd/path_utils.h"
-#include "kd/ranges/to.h"
 #include "kd/result.h"
 
 #include <fmt/format.h>
@@ -33,14 +33,32 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 
 namespace tb::fs
 {
+namespace
+{
+
+// "." lexically normalizes to itself rather than to an empty path, but the cached tree
+// treats an empty path as a lookup of the root itself - so it needs to be collapsed
+// explicitly here.
+std::filesystem::path cacheLookupKey(const std::filesystem::path& normalizedPath)
+{
+  return kdl::path_to_lower(
+    normalizedPath == std::filesystem::path{"."} ? std::filesystem::path{}
+                                                 : normalizedPath);
+}
+
+} // namespace
 
 DiskFileSystem::DiskFileSystem(const std::filesystem::path& root)
   : m_root{root.lexically_normal()}
 {
+  std::ignore = reload();
 }
+
+DiskFileSystem::~DiskFileSystem() = default;
 
 const std::filesystem::path& DiskFileSystem::root() const
 {
@@ -58,12 +76,77 @@ Result<std::filesystem::path> DiskFileSystem::makeAbsolute(
   return canonicalPath.empty() ? m_root : m_root / canonicalPath;
 }
 
+Result<void> DiskFileSystem::reload()
+{
+  auto error = std::error_code{};
+  auto it = std::filesystem::recursive_directory_iterator{
+    m_root, std::filesystem::directory_options::follow_directory_symlink, error};
+  const auto end = std::filesystem::recursive_directory_iterator{};
+
+  if (error)
+  {
+    m_cacheRoot = nullptr;
+    return kdl::void_success;
+  }
+
+  // build into a local tree and only publish it below once the scan completes fully -
+  // otherwise a permission error, symlink loop, or race encountered partway through
+  // would silently leave m_cacheRoot holding an incomplete tree while still reporting
+  // success
+  auto newCacheRoot = std::make_unique<DiskEntry>(DiskDirectoryEntry{{}, {}, {}});
+  auto& rootDir = std::get<DiskDirectoryEntry>(*newCacheRoot);
+
+  try
+  {
+    while (it != end)
+    {
+      const auto relativePath = it->path().lexically_relative(m_root);
+      if (it->is_directory())
+      {
+        findOrCreateCachedDirectory(relativePath, rootDir);
+      }
+      else if (it->is_regular_file())
+      {
+        auto& directoryEntry =
+          findOrCreateCachedDirectory(relativePath.parent_path(), rootDir);
+        addCachedEntry(directoryEntry, DiskFileEntry{relativePath.filename(), {}});
+      }
+      // else: neither a directory nor a regular file (e.g. a FIFO, device, socket, or
+      // broken symlink) - skip it, matching Disk::pathInfo's PathInfo::Unknown for such
+      // entries instead of caching it as a file
+      ++it;
+    }
+  }
+  catch (const std::filesystem::filesystem_error& e)
+  {
+    // leave the previous cache (if any) in place rather than publishing a partial scan
+    return Error{fmt::format("Failed to reload {}: {}", m_root, e.what())};
+  }
+
+  m_cacheRoot = std::move(newCacheRoot);
+  return kdl::void_success;
+}
+
 PathInfo DiskFileSystem::pathInfo(const std::filesystem::path& path) const
 {
-  return makeAbsolute(path)
-         | kdl::transform([](const auto& absPath) { return Disk::pathInfo(absPath); })
-         | kdl::transform_error([](const auto&) { return PathInfo::Unknown; })
-         | kdl::value();
+  const auto normalized = path.lexically_normal();
+  if (normalized.is_absolute())
+  {
+    return Disk::pathInfo(normalized);
+  }
+  if (kdl::path_front(normalized) == "..")
+  {
+    return PathInfo::Unknown;
+  }
+
+  if (!m_cacheRoot)
+  {
+    return PathInfo::Unknown;
+  }
+
+  const auto* entry = findCachedEntry(cacheLookupKey(normalized), *m_cacheRoot);
+  return entry ? isDirectoryEntry(*entry) ? PathInfo::Directory : PathInfo::File
+               : PathInfo::Unknown;
 }
 
 const FileSystemMetadata* DiskFileSystem::metadata(
@@ -75,25 +158,42 @@ const FileSystemMetadata* DiskFileSystem::metadata(
 Result<std::vector<std::filesystem::path>> DiskFileSystem::doFind(
   const std::filesystem::path& path, const TraversalMode& traversalMode) const
 {
-  const auto makeLexicallyRelative = [&](const auto& p) {
-    return p.lexically_relative(m_root);
-  };
-
-  return makeAbsolute(path) | kdl::and_then([&](const auto& absPath) {
-           return Disk::find(absPath, traversalMode);
-         })
-         | kdl::transform([&](const auto& paths) {
-             return paths | std::views::transform(makeLexicallyRelative)
-                    | kdl::ranges::to<std::vector>();
-           });
+  auto result = std::vector<std::filesystem::path>{};
+  // guards against a reload() racing between the base find() wrapper's pathInfo()
+  // check and this call clearing the cache out from under it
+  if (m_cacheRoot)
+  {
+    withCachedEntry(
+      cacheLookupKey(path.lexically_normal()),
+      *m_cacheRoot,
+      {},
+      [&](const DiskEntry& entry, const std::filesystem::path& entryPath) {
+        collectCachedEntries(entry, entryPath, 0, traversalMode, result);
+      });
+  }
+  return result;
 }
 
 Result<std::shared_ptr<File>> DiskFileSystem::doOpenFile(
   const std::filesystem::path& path) const
 {
-  return makeAbsolute(path) | kdl::and_then(Disk::openFile)
-         | kdl::transform(
-           [](auto cFile) { return std::static_pointer_cast<File>(cFile); });
+  // guards against a reload() racing between the base openFile() wrapper's
+  // pathInfo() check and this call clearing the cache out from under it
+  if (!m_cacheRoot)
+  {
+    return Result<std::shared_ptr<File>>{Error{fmt::format("{} not found", path)}};
+  }
+
+  return withCachedEntry(
+    cacheLookupKey(path.lexically_normal()),
+    *m_cacheRoot,
+    std::filesystem::path{},
+    [&](const DiskEntry&, const std::filesystem::path& entryPath) {
+      return Disk::openFile(m_root / entryPath) | kdl::transform([](auto cFile) {
+               return std::static_pointer_cast<File>(cFile);
+             });
+    },
+    Result<std::shared_ptr<File>>{Error{fmt::format("{} not found", path)}});
 }
 
 WritableDiskFileSystem::WritableDiskFileSystem(const std::filesystem::path& root)
@@ -104,41 +204,57 @@ WritableDiskFileSystem::WritableDiskFileSystem(const std::filesystem::path& root
 Result<void> WritableDiskFileSystem::doCreateFile(
   const std::filesystem::path& path, const std::string& contents)
 {
-  return makeAbsolute(path) | kdl::and_then([&](const auto& absPath) {
-           return Disk::withOutputStream(
-             absPath, [&](auto& stream) { stream << contents; });
-         });
+  return reloadAfterWrite(makeAbsolute(path) | kdl::and_then([&](const auto& absPath) {
+                            return Disk::withOutputStream(
+                              absPath, [&](auto& stream) { stream << contents; });
+                          }));
 }
 
 Result<bool> WritableDiskFileSystem::doCreateDirectory(const std::filesystem::path& path)
 {
-  return makeAbsolute(path) | kdl::and_then(Disk::createDirectory);
+  return reloadAfterWrite(makeAbsolute(path) | kdl::and_then(Disk::createDirectory));
 }
 
 Result<bool> WritableDiskFileSystem::doDeleteFile(const std::filesystem::path& path)
 {
-  return makeAbsolute(path) | kdl::and_then(Disk::deleteFile);
+  return reloadAfterWrite(makeAbsolute(path) | kdl::and_then(Disk::deleteFile));
 }
 
 Result<void> WritableDiskFileSystem::doCopyFile(
   const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
 {
-  return makeAbsolute(sourcePath).join(makeAbsolute(destPath))
-         | kdl::and_then(Disk::copyFile);
+  return reloadAfterWrite(
+    makeAbsolute(sourcePath).join(makeAbsolute(destPath))
+    | kdl::and_then(Disk::copyFile));
 }
 
 Result<void> WritableDiskFileSystem::doMoveFile(
   const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
 {
-  return makeAbsolute(sourcePath).join(makeAbsolute(destPath))
-         | kdl::and_then(Disk::moveFile);
+  return reloadAfterWrite(
+    makeAbsolute(sourcePath).join(makeAbsolute(destPath))
+    | kdl::and_then(Disk::moveFile));
 }
 
 Result<void> WritableDiskFileSystem::doRenameDirectory(
   const std::filesystem::path& sourcePath, const std::filesystem::path& destPath)
 {
-  return makeAbsolute(sourcePath).join(makeAbsolute(destPath))
-         | kdl::and_then(Disk::renameDirectory);
+  return reloadAfterWrite(
+    makeAbsolute(sourcePath).join(makeAbsolute(destPath))
+    | kdl::and_then(Disk::renameDirectory));
+}
+
+Result<bool> WritableDiskFileSystem::reloadAfterWrite(Result<bool> result)
+{
+  return std::move(result) | kdl::transform([&](const bool value) {
+           std::ignore = reload();
+           return value;
+         });
+}
+
+Result<void> WritableDiskFileSystem::reloadAfterWrite(Result<void> result)
+{
+  return std::move(result) | kdl::transform([&]() { std::ignore = reload(); });
 }
 
 } // namespace tb::fs

--- a/lib/TbFsLib/src/DiskFileSystem.cpp
+++ b/lib/TbFsLib/src/DiskFileSystem.cpp
@@ -32,6 +32,8 @@
 #include <fmt/std.h>
 
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <tuple>
 
@@ -78,6 +80,8 @@ Result<std::filesystem::path> DiskFileSystem::makeAbsolute(
 
 Result<void> DiskFileSystem::reload()
 {
+  const auto lock = std::unique_lock{m_mutex};
+
   auto error = std::error_code{};
   auto it = std::filesystem::recursive_directory_iterator{
     m_root, std::filesystem::directory_options::follow_directory_symlink, error};
@@ -139,6 +143,7 @@ PathInfo DiskFileSystem::pathInfo(const std::filesystem::path& path) const
     return PathInfo::Unknown;
   }
 
+  const auto lock = std::shared_lock{m_mutex};
   if (!m_cacheRoot)
   {
     return PathInfo::Unknown;
@@ -158,6 +163,8 @@ const FileSystemMetadata* DiskFileSystem::metadata(
 Result<std::vector<std::filesystem::path>> DiskFileSystem::doFind(
   const std::filesystem::path& path, const TraversalMode& traversalMode) const
 {
+  const auto lock = std::shared_lock{m_mutex};
+
   auto result = std::vector<std::filesystem::path>{};
   // guards against a reload() racing between the base find() wrapper's pathInfo()
   // check and this call clearing the cache out from under it
@@ -177,6 +184,8 @@ Result<std::vector<std::filesystem::path>> DiskFileSystem::doFind(
 Result<std::shared_ptr<File>> DiskFileSystem::doOpenFile(
   const std::filesystem::path& path) const
 {
+  const auto lock = std::shared_lock{m_mutex};
+
   // guards against a reload() racing between the base openFile() wrapper's
   // pathInfo() check and this call clearing the cache out from under it
   if (!m_cacheRoot)

--- a/lib/TbFsLib/src/ImageFileSystem.cpp
+++ b/lib/TbFsLib/src/ImageFileSystem.cpp
@@ -34,153 +34,6 @@
 
 namespace tb::fs
 {
-namespace
-{
-
-const std::filesystem::path& getName(const ImageEntry& entry)
-{
-  return std::visit(
-    [](const auto& x) -> const std::filesystem::path& { return x.name; }, entry);
-}
-
-bool isDirectory(const ImageEntry& entry)
-{
-  return std::visit(
-    kdl::overload(
-      [](const ImageDirectoryEntry&) { return true; },
-      [](const ImageFileEntry&) { return false; }),
-    entry);
-}
-
-auto& addEntry(ImageDirectoryEntry& parent, ImageEntry&& entry)
-{
-  parent.entryMapLC[kdl::path_to_lower(getName(entry))] = parent.entries.size();
-  parent.entries.push_back(std::move(entry));
-  return parent.entries.back();
-}
-
-template <typename Entry>
-auto findEntry(Entry& directoryEntry, const std::filesystem::path& nameLC)
-{
-  using difftype = std::vector<ImageEntry>::difference_type;
-
-  const auto entryIndexIt = directoryEntry.entryMapLC.find(nameLC);
-  return entryIndexIt != directoryEntry.entryMapLC.end()
-           ? std::next(directoryEntry.entries.begin(), difftype(entryIndexIt->second))
-           : directoryEntry.entries.end();
-}
-
-template <typename F>
-auto withEntry(
-  const std::filesystem::path& searchPathLC,
-  const ImageEntry& currentEntry,
-  const std::filesystem::path& currentPath,
-  const F& f,
-  decltype(f(
-    std::declval<const ImageEntry&>(),
-    std::declval<const std::filesystem::path&>())) defaultResult)
-{
-  if (searchPathLC.empty())
-  {
-    return f(currentEntry, currentPath);
-  }
-
-  return std::visit(
-    kdl::overload(
-      [&](const ImageDirectoryEntry& directoryEntry) {
-        const auto nameLC = kdl::path_front(searchPathLC);
-        const auto entryIt = findEntry(directoryEntry, nameLC);
-
-        return entryIt != directoryEntry.entries.end()
-                 ? withEntry(
-                     kdl::path_pop_front(searchPathLC),
-                     *entryIt,
-                     currentPath / getName(*entryIt),
-                     f,
-                     defaultResult)
-                 : defaultResult;
-      },
-      [&](const ImageFileEntry&) { return defaultResult; }),
-    currentEntry);
-}
-
-template <typename F>
-void withEntry(
-  const std::filesystem::path& searchPathLC,
-  const ImageEntry& currentEntry,
-  const std::filesystem::path& currentPath,
-  const F& f)
-{
-  if (searchPathLC.empty())
-  {
-    f(currentEntry, currentPath);
-  }
-  else
-  {
-    std::visit(
-      kdl::overload(
-        [&](const ImageDirectoryEntry& directoryEntry) {
-          const auto nameLC = kdl::path_front(searchPathLC);
-          const auto entryIt = findEntry(directoryEntry, nameLC);
-
-          if (entryIt != directoryEntry.entries.end())
-          {
-            withEntry(
-              kdl::path_pop_front(searchPathLC),
-              *entryIt,
-              currentPath / getName(*entryIt),
-              f);
-          }
-        },
-        [&](const ImageFileEntry&) {}),
-      currentEntry);
-  }
-}
-
-const ImageEntry* findEntry(const std::filesystem::path& path, const ImageEntry& parent)
-{
-  return withEntry(
-    path,
-    parent,
-    std::filesystem::path{},
-    [](const ImageEntry& entry, const std::filesystem::path&) { return &entry; },
-    nullptr);
-}
-
-ImageDirectoryEntry& findOrCreateDirectory(
-  const std::filesystem::path& path, ImageDirectoryEntry& parent)
-{
-  if (path.empty())
-  {
-    return parent;
-  }
-
-  auto name = kdl::path_front(path);
-  auto nameLC = kdl::path_to_lower(name);
-  auto entryIt = findEntry(parent, nameLC);
-  if (entryIt != parent.entries.end())
-  {
-    return std::visit(
-      kdl::overload(
-        [&](ImageDirectoryEntry& directoryEntry) -> ImageDirectoryEntry& {
-          return findOrCreateDirectory(kdl::path_pop_front(path), directoryEntry);
-        },
-        [&](ImageFileEntry&) -> ImageDirectoryEntry& {
-          *entryIt = ImageDirectoryEntry{std::move(name), {}, {}};
-          return findOrCreateDirectory(
-            kdl::path_pop_front(path), std::get<ImageDirectoryEntry>(*entryIt));
-        }),
-      *entryIt);
-  }
-  else
-  {
-    return findOrCreateDirectory(
-      kdl::path_pop_front(path),
-      std::get<ImageDirectoryEntry>(
-        addEntry(parent, ImageDirectoryEntry{std::move(name), {}, {}})));
-  }
-}
-} // namespace
 
 ImageFileSystemBase::ImageFileSystemBase()
   : m_root{ImageDirectoryEntry{{}, {}, {}}}
@@ -209,33 +62,33 @@ void ImageFileSystemBase::setMetadata(
 
 void ImageFileSystemBase::addFile(const std::filesystem::path& path, GetImageFile getFile)
 {
-  auto& directoryEntry =
-    findOrCreateDirectory(path.parent_path(), std::get<ImageDirectoryEntry>(m_root));
+  auto& directoryEntry = findOrCreateCachedDirectory(
+    path.parent_path(), std::get<ImageDirectoryEntry>(m_root));
 
   auto name = path.filename();
   auto nameLC = kdl::path_to_lower(name);
-  if (const auto entryIt = findEntry(directoryEntry, nameLC);
+  if (const auto entryIt = findChildEntry(directoryEntry, nameLC);
       entryIt != directoryEntry.entries.end())
   {
     *entryIt = ImageFileEntry{std::move(name), std::move(getFile)};
   }
   else
   {
-    addEntry(directoryEntry, ImageFileEntry{std::move(name), std::move(getFile)});
+    addCachedEntry(directoryEntry, ImageFileEntry{std::move(name), std::move(getFile)});
   }
 }
 
 PathInfo ImageFileSystemBase::pathInfo(const std::filesystem::path& path) const
 {
-  const auto* entry = findEntry(kdl::path_to_lower(path), m_root);
-  return entry ? isDirectory(*entry) ? PathInfo::Directory : PathInfo::File
+  const auto* entry = findCachedEntry(kdl::path_to_lower(path), m_root);
+  return entry ? isDirectoryEntry(*entry) ? PathInfo::Directory : PathInfo::File
                : PathInfo::Unknown;
 }
 
 const FileSystemMetadata* ImageFileSystemBase::metadata(
   const std::filesystem::path& path, const std::string& key) const
 {
-  if (findEntry(kdl::path_to_lower(path), m_root))
+  if (findCachedEntry(kdl::path_to_lower(path), m_root))
   {
     if (const auto it = m_metadata.find(key); it != m_metadata.end())
     {
@@ -245,43 +98,16 @@ const FileSystemMetadata* ImageFileSystemBase::metadata(
   return nullptr;
 }
 
-namespace
-{
-void doFindImpl(
-  const ImageEntry& entry,
-  const std::filesystem::path& entryPath,
-  const size_t depth,
-  const TraversalMode& traversalMode,
-  std::vector<std::filesystem::path>& result)
-{
-  if (!traversalMode.depth || depth <= *traversalMode.depth)
-  {
-    std::visit(
-      kdl::overload(
-        [&](const ImageDirectoryEntry& directoryEntry) {
-          for (const auto& childEntry : directoryEntry.entries)
-          {
-            const auto childPath = entryPath / getName(childEntry);
-            result.push_back(childPath);
-            doFindImpl(childEntry, childPath, depth + 1, traversalMode, result);
-          }
-        },
-        [](const ImageFileEntry&) {}),
-      entry);
-  }
-}
-} // namespace
-
 Result<std::vector<std::filesystem::path>> ImageFileSystemBase::doFind(
   const std::filesystem::path& path, const TraversalMode& traversalMode) const
 {
   auto result = std::vector<std::filesystem::path>{};
-  withEntry(
+  withCachedEntry(
     kdl::path_to_lower(path),
     m_root,
     {},
     [&](const ImageEntry& entry, const std::filesystem::path& entryPath) {
-      doFindImpl(entry, entryPath, 0, traversalMode, result);
+      collectCachedEntries(entry, entryPath, 0, traversalMode, result);
     });
   return result;
 }
@@ -289,7 +115,7 @@ Result<std::vector<std::filesystem::path>> ImageFileSystemBase::doFind(
 Result<std::shared_ptr<File>> ImageFileSystemBase::doOpenFile(
   const std::filesystem::path& path) const
 {
-  return withEntry(
+  return withCachedEntry(
     kdl::path_to_lower(path),
     m_root,
     std::filesystem::path{},
@@ -300,7 +126,7 @@ Result<std::shared_ptr<File>> ImageFileSystemBase::doOpenFile(
             return Result<std::shared_ptr<File>>{
               Error{fmt::format("Cannot open directory entry at {}", path)}};
           },
-          [](const ImageFileEntry& fileEntry) { return fileEntry.getFile(); }),
+          [](const ImageFileEntry& fileEntry) { return fileEntry.payload(); }),
         entry);
     },
     Result<std::shared_ptr<File>>{Error{fmt::format("{} not found", path)}});

--- a/lib/TbFsLib/src/ImageFileSystem.cpp
+++ b/lib/TbFsLib/src/ImageFileSystem.cpp
@@ -95,7 +95,7 @@ auto withEntry(
                  ? withEntry(
                      kdl::path_pop_front(searchPathLC),
                      *entryIt,
-                     currentPath / nameLC,
+                     currentPath / getName(*entryIt),
                      f,
                      defaultResult)
                  : defaultResult;
@@ -126,7 +126,10 @@ void withEntry(
           if (entryIt != directoryEntry.entries.end())
           {
             withEntry(
-              kdl::path_pop_front(searchPathLC), *entryIt, currentPath / nameLC, f);
+              kdl::path_pop_front(searchPathLC),
+              *entryIt,
+              currentPath / getName(*entryIt),
+              f);
           }
         },
         [&](const ImageFileEntry&) {}),

--- a/lib/TbFsLib/src/ImageFileSystem.cpp
+++ b/lib/TbFsLib/src/ImageFileSystem.cpp
@@ -31,6 +31,8 @@
 
 #include <cassert>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 
 namespace tb::fs
 {
@@ -39,6 +41,10 @@ ImageFileSystemBase::ImageFileSystemBase()
   : m_root{ImageDirectoryEntry{{}, {}, {}}}
 {
 }
+
+ImageFileSystemBase::ImageFileSystemBase(ImageFileSystemBase&&) noexcept = default;
+ImageFileSystemBase& ImageFileSystemBase::operator=(ImageFileSystemBase&&) noexcept =
+  default;
 
 ImageFileSystemBase::~ImageFileSystemBase() = default;
 
@@ -50,6 +56,7 @@ Result<std::filesystem::path> ImageFileSystemBase::makeAbsolute(
 
 Result<void> ImageFileSystemBase::reload()
 {
+  const auto lock = std::unique_lock{*m_mutex};
   m_root = ImageDirectoryEntry{{}, {}, {}};
   return doReadDirectory();
 }
@@ -80,6 +87,7 @@ void ImageFileSystemBase::addFile(const std::filesystem::path& path, GetImageFil
 
 PathInfo ImageFileSystemBase::pathInfo(const std::filesystem::path& path) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   const auto* entry = findCachedEntry(kdl::path_to_lower(path), m_root);
   return entry ? isDirectoryEntry(*entry) ? PathInfo::Directory : PathInfo::File
                : PathInfo::Unknown;
@@ -88,6 +96,7 @@ PathInfo ImageFileSystemBase::pathInfo(const std::filesystem::path& path) const
 const FileSystemMetadata* ImageFileSystemBase::metadata(
   const std::filesystem::path& path, const std::string& key) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   if (findCachedEntry(kdl::path_to_lower(path), m_root))
   {
     if (const auto it = m_metadata.find(key); it != m_metadata.end())
@@ -101,6 +110,7 @@ const FileSystemMetadata* ImageFileSystemBase::metadata(
 Result<std::vector<std::filesystem::path>> ImageFileSystemBase::doFind(
   const std::filesystem::path& path, const TraversalMode& traversalMode) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   auto result = std::vector<std::filesystem::path>{};
   withCachedEntry(
     kdl::path_to_lower(path),
@@ -115,6 +125,7 @@ Result<std::vector<std::filesystem::path>> ImageFileSystemBase::doFind(
 Result<std::shared_ptr<File>> ImageFileSystemBase::doOpenFile(
   const std::filesystem::path& path) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   return withCachedEntry(
     kdl::path_to_lower(path),
     m_root,

--- a/lib/TbFsLib/src/VirtualFileSystem.cpp
+++ b/lib/TbFsLib/src/VirtualFileSystem.cpp
@@ -106,6 +106,15 @@ Result<std::filesystem::path> VirtualFileSystem::makeAbsolute(
   return Error{fmt::format("Failed to make absolute path of {}", path)};
 }
 
+Result<void> VirtualFileSystem::reload()
+{
+  const auto lock = std::shared_lock{*m_mutex};
+  return m_mountPoints | std::views::transform([](const auto& mountPoint) {
+           return mountPoint.mountedFileSystem->reload();
+         })
+         | kdl::fold;
+}
+
 PathInfo VirtualFileSystem::pathInfo(const std::filesystem::path& path) const
 {
   const auto lock = std::shared_lock{*m_mutex};
@@ -340,6 +349,11 @@ Result<std::filesystem::path> WritableVirtualFileSystem::makeAbsolute(
   const std::filesystem::path& path) const
 {
   return m_virtualFs.makeAbsolute(path);
+}
+
+Result<void> WritableVirtualFileSystem::reload()
+{
+  return m_virtualFs.reload();
 }
 
 PathInfo WritableVirtualFileSystem::pathInfo(const std::filesystem::path& path) const

--- a/lib/TbFsLib/src/VirtualFileSystem.cpp
+++ b/lib/TbFsLib/src/VirtualFileSystem.cpp
@@ -35,6 +35,7 @@
 #include <fmt/std.h>
 
 #include <algorithm>
+#include <mutex>
 #include <optional>
 #include <ranges>
 #include <unordered_map>
@@ -85,6 +86,7 @@ bool operator!=(const VirtualMountPointId& lhs, const VirtualMountPointId& rhs)
 Result<std::filesystem::path> VirtualFileSystem::makeAbsolute(
   const std::filesystem::path& path) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   for (auto it = m_mountPoints.rbegin(); it != m_mountPoints.rend(); ++it)
   {
     const auto& mountPoint = *it;
@@ -106,6 +108,7 @@ Result<std::filesystem::path> VirtualFileSystem::makeAbsolute(
 
 PathInfo VirtualFileSystem::pathInfo(const std::filesystem::path& path) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   for (auto it = m_mountPoints.rbegin(); it != m_mountPoints.rend(); ++it)
   {
     const auto& mountPoint = *it;
@@ -133,6 +136,7 @@ PathInfo VirtualFileSystem::pathInfo(const std::filesystem::path& path) const
 const FileSystemMetadata* VirtualFileSystem::metadata(
   const std::filesystem::path& path, const std::string& key) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   for (auto it = m_mountPoints.rbegin(); it != m_mountPoints.rend(); ++it)
   {
     const auto& mountPoint = *it;
@@ -153,6 +157,7 @@ const FileSystemMetadata* VirtualFileSystem::metadata(
 VirtualMountPointId VirtualFileSystem::mount(
   const std::filesystem::path& path, std::unique_ptr<FileSystem> fs)
 {
+  const auto lock = std::unique_lock{*m_mutex};
   const auto id = VirtualMountPointId{};
   m_mountPoints.push_back({id, path, std::move(fs)});
   return id;
@@ -160,6 +165,7 @@ VirtualMountPointId VirtualFileSystem::mount(
 
 bool VirtualFileSystem::unmount(const VirtualMountPointId& id)
 {
+  const auto lock = std::unique_lock{*m_mutex};
   if (const auto it = std::ranges::find_if(
         m_mountPoints, [&](const auto& mountPoint) { return mountPoint.id == id; });
       it != m_mountPoints.end())
@@ -172,6 +178,7 @@ bool VirtualFileSystem::unmount(const VirtualMountPointId& id)
 
 void VirtualFileSystem::unmountAll()
 {
+  const auto lock = std::unique_lock{*m_mutex};
   m_mountPoints.clear();
 }
 
@@ -258,6 +265,7 @@ Result<std::vector<std::filesystem::path>> findMatchesForMountedFileSystem(
 Result<std::vector<std::filesystem::path>> VirtualFileSystem::doFind(
   const std::filesystem::path& path, const TraversalMode& traversalMode) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   return m_mountPoints | std::views::transform([&](const auto& mountPoint) {
            return findMatchesForMountedFileSystem(mountPoint, path, traversalMode);
          })
@@ -303,6 +311,7 @@ Result<std::vector<std::filesystem::path>> VirtualFileSystem::doFind(
 Result<std::shared_ptr<File>> VirtualFileSystem::doOpenFile(
   const std::filesystem::path& path) const
 {
+  const auto lock = std::shared_lock{*m_mutex};
   for (auto it = m_mountPoints.rbegin(); it != m_mountPoints.rend(); ++it)
   {
     const auto& mountPoint = *it;

--- a/lib/TbFsLib/test-utils/include/fs/TestFileSystem.h
+++ b/lib/TbFsLib/test-utils/include/fs/TestFileSystem.h
@@ -76,6 +76,9 @@ public:
 
   Result<std::filesystem::path> makeAbsolute(
     const std::filesystem::path& path) const override;
+
+  Result<void> reload() override;
+
   PathInfo pathInfo(const std::filesystem::path& path) const override;
   const FileSystemMetadata* metadata(
     const std::filesystem::path& path, const std::string& key) const override;

--- a/lib/TbFsLib/test-utils/src/TestFileSystem.cpp
+++ b/lib/TbFsLib/test-utils/src/TestFileSystem.cpp
@@ -110,6 +110,11 @@ Result<std::filesystem::path> TestFileSystem::makeAbsolute(
   return m_absolutePathPrefix / path;
 }
 
+Result<void> TestFileSystem::reload()
+{
+  return kdl::void_success;
+}
+
 namespace
 {
 void doFindImpl(

--- a/lib/TbFsLib/test-utils/test/src/tst_TestFileSystem.cpp
+++ b/lib/TbFsLib/test-utils/test/src/tst_TestFileSystem.cpp
@@ -182,6 +182,13 @@ TEST_CASE("TestFileSystem")
     CHECK(fs.openFile("some_dir/some_dir_file_1") == some_dir_file_1);
     CHECK(fs.openFile("some_dir/nested_dir/nested_dir_file_1") == nested_dir_file_1);
   }
+
+  SECTION("reload")
+  {
+    // no-op: the tree is supplied directly by the test author, never scanned
+    CHECK(fs.reload() == Result<void>{});
+    CHECK(fs.pathInfo("root_file_1") == fs::PathInfo::File);
+  }
 }
 
 } // namespace tb::fs

--- a/lib/TbFsLib/test/CMakeLists.txt
+++ b/lib/TbFsLib/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(TbFsLibTest)
 
 target_sources(TbFsLibTest PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CachedFileTree.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_DiskFileSystem.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_DiskIO.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_FileSystem.cpp

--- a/lib/TbFsLib/test/src/tst_CachedFileTree.cpp
+++ b/lib/TbFsLib/test/src/tst_CachedFileTree.cpp
@@ -1,0 +1,270 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fs/CachedFileTree.h"
+#include "fs/TraversalMode.h"
+
+#include "kd/path_utils.h"
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+
+namespace tb::fs
+{
+namespace
+{
+
+using TestFileEntry = CachedFileEntry<int>;
+using TestDirectoryEntry = CachedDirectoryEntry<int>;
+using TestEntry = CachedEntry<int>;
+
+TestEntry makeRoot()
+{
+  return TestDirectoryEntry{{}, {}, {}};
+}
+
+void insertFile(TestEntry& root, const std::filesystem::path& path, const int payload)
+{
+  auto& directoryEntry =
+    findOrCreateCachedDirectory(path.parent_path(), std::get<TestDirectoryEntry>(root));
+  addCachedEntry(directoryEntry, TestFileEntry{path.filename(), payload});
+}
+
+} // namespace
+
+TEST_CASE("CachedFileTree")
+{
+  SECTION("findOrCreateCachedDirectory")
+  {
+    SECTION("builds intermediate directories")
+    {
+      auto root = makeRoot();
+      auto& dir =
+        findOrCreateCachedDirectory("a/b/c", std::get<TestDirectoryEntry>(root));
+      CHECK(dir.name == "c");
+
+      const auto* aEntry = findCachedEntry(kdl::path_to_lower("a"), root);
+      REQUIRE(aEntry != nullptr);
+      CHECK(isDirectoryEntry(*aEntry));
+
+      const auto* bEntry = findCachedEntry(kdl::path_to_lower("a/b"), root);
+      REQUIRE(bEntry != nullptr);
+      CHECK(isDirectoryEntry(*bEntry));
+
+      const auto* cEntry = findCachedEntry(kdl::path_to_lower("a/b/c"), root);
+      REQUIRE(cEntry != nullptr);
+      CHECK(isDirectoryEntry(*cEntry));
+    }
+
+    SECTION("is idempotent")
+    {
+      auto root = makeRoot();
+      findOrCreateCachedDirectory("a/b", std::get<TestDirectoryEntry>(root));
+      findOrCreateCachedDirectory("a/b", std::get<TestDirectoryEntry>(root));
+
+      const auto& rootDir = std::get<TestDirectoryEntry>(root);
+      REQUIRE(rootDir.entries.size() == 1);
+
+      const auto& aDir = std::get<TestDirectoryEntry>(rootDir.entries.front());
+      CHECK(aDir.entries.size() == 1);
+    }
+
+    SECTION("replaces a file entry that collides with a directory path")
+    {
+      auto root = makeRoot();
+      insertFile(root, "a", 1);
+
+      const auto* fileEntry = findCachedEntry(kdl::path_to_lower("a"), root);
+      REQUIRE(fileEntry != nullptr);
+      CHECK_FALSE(isDirectoryEntry(*fileEntry));
+
+      findOrCreateCachedDirectory("a/b", std::get<TestDirectoryEntry>(root));
+
+      const auto* dirEntry = findCachedEntry(kdl::path_to_lower("a"), root);
+      REQUIRE(dirEntry != nullptr);
+      CHECK(isDirectoryEntry(*dirEntry));
+
+      const auto* bEntry = findCachedEntry(kdl::path_to_lower("a/b"), root);
+      REQUIRE(bEntry != nullptr);
+      CHECK(isDirectoryEntry(*bEntry));
+    }
+  }
+
+  SECTION("findCachedEntry")
+  {
+    auto root = makeRoot();
+    insertFile(root, "SomeDir/File.txt", 1);
+
+    const auto* entry = findCachedEntry(kdl::path_to_lower("somedir/file.txt"), root);
+    REQUIRE(entry != nullptr);
+    CHECK(getEntryName(*entry) == "File.txt");
+
+    CHECK(findCachedEntry(kdl::path_to_lower("somedir/missing.txt"), root) == nullptr);
+  }
+
+  SECTION("findChildEntry")
+  {
+    auto root = makeRoot();
+    insertFile(root, "File.txt", 1);
+
+    auto& rootDir = std::get<TestDirectoryEntry>(root);
+    const auto entryIt = findChildEntry(rootDir, std::filesystem::path{"file.txt"});
+    REQUIRE(entryIt != rootDir.entries.end());
+    CHECK(getEntryName(*entryIt) == "File.txt");
+
+    CHECK(
+      findChildEntry(rootDir, std::filesystem::path{"missing.txt"})
+      == rootDir.entries.end());
+  }
+
+  SECTION("withCacheEntry")
+  {
+    SECTION("locates an entry and reports its payload")
+    {
+      auto root = makeRoot();
+      insertFile(root, "a/File.txt", 42);
+
+      const auto payload = withCachedEntry(
+        kdl::path_to_lower("a/file.txt"),
+        root,
+        std::filesystem::path{},
+        [](const TestEntry& entry, const std::filesystem::path&) {
+          return std::get<TestFileEntry>(entry).payload;
+        },
+        -1);
+
+      CHECK(payload == 42);
+    }
+
+    SECTION("accumulates the true stored case")
+    {
+      auto root = makeRoot();
+      insertFile(root, "SomeDir/File.txt", 1);
+
+      const auto path = withCachedEntry(
+        kdl::path_to_lower("somedir/file.txt"),
+        root,
+        std::filesystem::path{},
+        [](
+          const TestEntry&, const std::filesystem::path& entryPath) { return entryPath; },
+        std::filesystem::path{});
+
+      CHECK(path == "SomeDir/File.txt");
+    }
+
+    SECTION("yields the default result for a missing path")
+    {
+      auto root = makeRoot();
+      insertFile(root, "a/file.txt", 1);
+
+      const auto payload = withCachedEntry(
+        kdl::path_to_lower("a/missing.txt"),
+        root,
+        std::filesystem::path{},
+        [](const TestEntry& entry, const std::filesystem::path&) {
+          return std::get<TestFileEntry>(entry).payload;
+        },
+        -1);
+
+      CHECK(payload == -1);
+    }
+
+    SECTION("invokes the callback for a case-mismatched path with the true stored case")
+    {
+      auto root = makeRoot();
+      insertFile(root, "SomeDir/File.txt", 1);
+
+      auto calledPath = std::optional<std::filesystem::path>{};
+      withCachedEntry(
+        kdl::path_to_lower("SOMEDIR/FILE.TXT"),
+        root,
+        std::filesystem::path{},
+        [&](const TestEntry&, const std::filesystem::path& entryPath) {
+          calledPath = entryPath;
+        });
+
+      REQUIRE(calledPath.has_value());
+      CHECK(*calledPath == "SomeDir/File.txt");
+    }
+
+    SECTION("does not invoke the callback for a missing path")
+    {
+      auto root = makeRoot();
+      insertFile(root, "a/file.txt", 1);
+
+      auto called = false;
+      withCachedEntry(
+        kdl::path_to_lower("a/missing.txt"),
+        root,
+        std::filesystem::path{},
+        [&](const TestEntry&, const std::filesystem::path&) { called = true; });
+
+      CHECK_FALSE(called);
+    }
+  }
+
+  SECTION("collectCachedEntries")
+  {
+    SECTION("recursively enumerates with true-cased paths")
+    {
+      auto root = makeRoot();
+      insertFile(root, "SomeDir/File1.txt", 1);
+      insertFile(root, "SomeDir/NestedDir/File2.txt", 2);
+      insertFile(root, "OtherFile.txt", 3);
+
+      auto result = std::vector<std::filesystem::path>{};
+      collectCachedEntries(root, {}, 0, TraversalMode::Recursive, result);
+
+      CHECK_THAT(
+        result,
+        Catch::Matchers::UnorderedEquals(std::vector<std::filesystem::path>{
+          "SomeDir",
+          "SomeDir/File1.txt",
+          "SomeDir/NestedDir",
+          "SomeDir/NestedDir/File2.txt",
+          "OtherFile.txt",
+        }));
+    }
+
+    SECTION("respects TraversalMode::Flat / depth limits")
+    {
+      auto root = makeRoot();
+      insertFile(root, "SomeDir/File1.txt", 1);
+      insertFile(root, "SomeDir/NestedDir/File2.txt", 2);
+      insertFile(root, "OtherFile.txt", 3);
+
+      auto result = std::vector<std::filesystem::path>{};
+      collectCachedEntries(root, {}, 0, TraversalMode::Flat, result);
+
+      CHECK_THAT(
+        result,
+        Catch::Matchers::UnorderedEquals(std::vector<std::filesystem::path>{
+          "SomeDir",
+          "OtherFile.txt",
+        }));
+    }
+  }
+}
+
+} // namespace tb::fs

--- a/lib/TbFsLib/test/src/tst_DiskFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_DiskFileSystem.cpp
@@ -33,6 +33,10 @@
 #include <fmt/std.h>
 
 #include <filesystem>
+#include <functional>
+#include <thread>
+#include <tuple>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -525,6 +529,53 @@ TEST_CASE("DiskFileSystem reload")
 
     CHECK(fs.pathInfo("brokenLink") == fs::PathInfo::Unknown);
   }
+}
+
+TEST_CASE("DiskFileSystem concurrent reload vs. reads")
+{
+  using ThreadFunc = std::function<void()>;
+
+  // WritableDiskFileSystem's reload-after-write firing on a potentially-live
+  // DiskFileSystem instance while other threads read from it. Not a deterministic
+  // assertion of absence-of-race (that's what running this under -DTB_ENABLE_TSAN=ON is
+  // for) - this just exercises the pattern under contention, with a fixed iteration count
+  // so it terminates (a lock-ordering bug here would hang or crash rather than fail an
+  // assertion).
+  const auto env = makeTestEnvironment();
+
+  auto fs = DiskFileSystem{env.dir()};
+
+  constexpr auto numReaderThreads = 4;
+  constexpr auto numIterations = 500;
+
+  auto reloader = ThreadFunc{[&]() {
+    for (auto i = 0; i < numIterations; ++i)
+    {
+      std::ignore = fs.reload();
+    }
+  }};
+
+  auto reader = ThreadFunc{[&]() {
+    for (auto i = 0; i < numIterations; ++i)
+    {
+      static_cast<void>(fs.pathInfo("anotherDir"));
+      static_cast<void>(fs.find("anotherDir", fs::TraversalMode::Flat));
+      static_cast<void>(fs.openFile("test.txt"));
+    }
+  }};
+
+  auto threads =
+    kdl::views::concat(
+      std::views::single(reloader), kdl::views::repeat(reader, numReaderThreads))
+    | std::views::transform([](auto func) { return std::thread{std::move(func)}; })
+    | kdl::ranges::to<std::vector>();
+
+  for (auto& thread : threads)
+  {
+    thread.join();
+  }
+
+  CHECK(fs.pathInfo("anotherDir") == fs::PathInfo::Directory);
 }
 
 } // namespace tb::fs

--- a/lib/TbFsLib/test/src/tst_DiskFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_DiskFileSystem.cpp
@@ -25,6 +25,10 @@
 #include "fs/TestEnvironment.h"
 #include "fs/TraversalMode.h"
 
+#include "kd/ranges/concat_view.h"
+#include "kd/ranges/repeat_view.h"
+#include "kd/ranges/to.h"
+
 #include <fmt/format.h>
 #include <fmt/std.h>
 
@@ -430,6 +434,84 @@ TEST_CASE("WritableDiskFileSystemTest")
     CHECK(fs.copyFile("test2.map", "dir1/test2.map") == Result<void>{});
     CHECK(fs.pathInfo("test2.map") == fs::PathInfo::File);
     CHECK(fs.pathInfo("dir1/test2.map") == fs::PathInfo::File);
+  }
+}
+
+TEST_CASE("DiskFileSystem reload")
+{
+  SECTION("reload picks up changes made directly to the backing directory")
+  {
+    auto env = makeTestEnvironment();
+    auto fs = DiskFileSystem{env.dir()};
+
+    CHECK(fs.pathInfo("newDir") == fs::PathInfo::Unknown);
+
+    // bypass DiskFileSystem and mutate the backing directory directly
+    env.createDirectory("newDir");
+    env.createFile("newDir/newFile.txt", "some content");
+
+    // the cache is stale until reload() is called
+    CHECK(fs.pathInfo("newDir") == fs::PathInfo::Unknown);
+    CHECK(fs.pathInfo("newDir/newFile.txt") == fs::PathInfo::Unknown);
+
+    CHECK(fs.reload() == Result<void>{});
+    CHECK(fs.pathInfo("newDir") == fs::PathInfo::Directory);
+    CHECK(fs.pathInfo("newDir/newFile.txt") == fs::PathInfo::File);
+  }
+
+  SECTION("constructing over a non-existent root does not error")
+  {
+    auto env = makeTestEnvironment();
+    const auto rootPath = env.dir() / "doesNotExistYet";
+
+    auto fs = DiskFileSystem{rootPath};
+    CHECK(fs.pathInfo(".") == fs::PathInfo::Unknown);
+    CHECK(fs.pathInfo("anything") == fs::PathInfo::Unknown);
+    CHECK(
+      fs.find(".", fs::TraversalMode::Flat)
+      == Result<std::vector<std::filesystem::path>>{Error{
+        fmt::format("Path {} does not denote a directory", std::filesystem::path{"."})}});
+
+    // create the root directory (with some contents) after construction
+    env.createDirectory("doesNotExistYet");
+    env.createFile("doesNotExistYet/file.txt", "some content");
+
+    CHECK(fs.reload() == Result<void>{});
+    CHECK(fs.pathInfo(".") == fs::PathInfo::Directory);
+    CHECK(fs.pathInfo("file.txt") == fs::PathInfo::File);
+    CHECK_THAT(fs.find(".", fs::TraversalMode::Flat), MatchesPathsResult({"file.txt"}));
+  }
+
+  SECTION("find/pathInfo/openFile behave consistently through a symlinked directory")
+  {
+    auto env = makeTestEnvironment();
+    env.createDirectory("realDir");
+    env.createFile("realDir/realFile.txt", "some content");
+    env.createSymLink("realDir", "linkedDir");
+
+    auto fs = DiskFileSystem{env.dir()};
+
+    CHECK(fs.pathInfo("linkedDir") == fs::PathInfo::Directory);
+    CHECK(fs.pathInfo("linkedDir/realFile.txt") == fs::PathInfo::File);
+
+    CHECK_THAT(
+      fs.find("linkedDir", fs::TraversalMode::Flat),
+      MatchesPathsResult({
+        "linkedDir/realFile.txt",
+      }));
+
+    const auto file = fs.openFile("linkedDir/realFile.txt") | kdl::value();
+    CHECK(file->reader().readString(file->size()) == "some content");
+  }
+
+  SECTION("a broken symlink is neither a directory nor a file")
+  {
+    auto env = makeTestEnvironment();
+    env.createSymLink("doesNotExist", "brokenLink");
+
+    auto fs = DiskFileSystem{env.dir()};
+
+    CHECK(fs.pathInfo("brokenLink") == fs::PathInfo::Unknown);
   }
 }
 

--- a/lib/TbFsLib/test/src/tst_DiskFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_DiskFileSystem.cpp
@@ -154,6 +154,15 @@ TEST_CASE("DiskFileSystemTest")
         "anotherDir/test3.map",
       }));
 
+    // querying with mismatched case must still return paths with the true on-disk
+    // case, including the portion covered by the search path itself
+    CHECK_THAT(
+      fs.find("ANOTHerDir", fs::TraversalMode::Flat),
+      MatchesPathsResult({
+        "anotherDir/subDirTest",
+        "anotherDir/test3.map",
+      }));
+
     CHECK_THAT(
       fs.find(".", fs::TraversalMode::Recursive),
       MatchesPathsResult({
@@ -218,6 +227,9 @@ TEST_CASE("DiskFileSystemTest")
     checkOpenFile("test.txt");
     checkOpenFile("anotherDir/test3.map");
     checkOpenFile("anotherDir/../anotherDir/./test3.map");
+
+    // opening a file with mismatched case must still succeed
+    checkOpenFile("ANOTHerDir/TEST3.MAP");
   }
 }
 

--- a/lib/TbFsLib/test/src/tst_ImageFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_ImageFileSystem.cpp
@@ -857,6 +857,15 @@ TEST_CASE("Hierarchical ImageFileSystems")
         "pics/tag1.pcx",
       }));
 
+    // querying with mismatched case must still return paths with the true on-disk /
+    // in-archive case, including the portion covered by the search path itself
+    CHECK_THAT(
+      fs->find("PICS", fs::TraversalMode::Flat),
+      MatchesPathsResult({
+        "pics/tag2.pcx",
+        "pics/tag1.pcx",
+      }));
+
     CHECK_THAT(
       fs->find("", fs::TraversalMode::Recursive),
       MatchesPathsResult({

--- a/lib/TbFsLib/test/src/tst_ImageFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_ImageFileSystem.cpp
@@ -913,10 +913,7 @@ TEST_CASE("Hierarchical ImageFileSystems")
 
   SECTION("openFile")
   {
-    const auto amnet_cfg = fs->openFile("amnet.cfg") | kdl::value();
-
-    auto reader = amnet_cfg->reader();
-    CHECK(reader.readString(reader.size()) == R"(//
+    const auto expectedContents = std::string{R"(//
 // my stuff
 //
 
@@ -944,7 +941,16 @@ bind mouse1 v30
 
 alias v30 "fov 30; sensitivity 7; bind mouse1 v90"
 alias v90 "fov 90; sensitivity 13; bind mouse1 v30"
-)");
+)"};
+
+    const auto amnet_cfg = fs->openFile("amnet.cfg") | kdl::value();
+    auto reader = amnet_cfg->reader();
+    CHECK(reader.readString(reader.size()) == expectedContents);
+
+    // opening a file with mismatched case must still succeed
+    const auto amnet_cfg_mismatched = fs->openFile("AMNET.CFG") | kdl::value();
+    auto mismatchedReader = amnet_cfg_mismatched->reader();
+    CHECK(mismatchedReader.readString(mismatchedReader.size()) == expectedContents);
   }
 }
 

--- a/lib/TbFsLib/test/src/tst_VirtualFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_VirtualFileSystem.cpp
@@ -784,6 +784,34 @@ TEST_CASE("VirtualFileSystem")
   }
 }
 
+TEST_CASE("VirtualFileSystem reload")
+{
+  // TestFileSystem has no mutable backing state to observe a reload against, so this
+  // uses real DiskFileSystem mounts to confirm reload() propagates to every mount
+  // point, not just the first one.
+  auto env1 = TestEnvironment{[](auto& e) { e.createDirectory("dir"); }};
+  auto env2 = TestEnvironment{[](auto& e) { e.createDirectory("dir"); }};
+
+  auto vfs = VirtualFileSystem{};
+  vfs.mount("fs1", std::make_unique<DiskFileSystem>(env1.dir()));
+  vfs.mount("fs2", std::make_unique<DiskFileSystem>(env2.dir()));
+
+  CHECK(vfs.pathInfo("fs1/newFile.txt") == fs::PathInfo::Unknown);
+  CHECK(vfs.pathInfo("fs2/newFile.txt") == fs::PathInfo::Unknown);
+
+  // bypass the mounted DiskFileSystems and mutate their backing directories directly
+  env1.createFile("newFile.txt", "content1");
+  env2.createFile("newFile.txt", "content2");
+
+  // the mounted DiskFileSystems' caches are stale until reload() is called
+  CHECK(vfs.pathInfo("fs1/newFile.txt") == fs::PathInfo::Unknown);
+  CHECK(vfs.pathInfo("fs2/newFile.txt") == fs::PathInfo::Unknown);
+
+  CHECK(vfs.reload() == Result<void>{});
+  CHECK(vfs.pathInfo("fs1/newFile.txt") == fs::PathInfo::File);
+  CHECK(vfs.pathInfo("fs2/newFile.txt") == fs::PathInfo::File);
+}
+
 TEST_CASE("VirtualFileSystem concurrent mount/unmount vs. reads")
 {
   using ThreadFunc = std::function<void()>;

--- a/lib/TbFsLib/test/src/tst_VirtualFileSystem.cpp
+++ b/lib/TbFsLib/test/src/tst_VirtualFileSystem.cpp
@@ -18,16 +18,25 @@
  */
 
 #include "Matchers.h"
+#include "fs/DiskFileSystem.h"
 #include "fs/File.h"
 #include "fs/FileSystemMetadata.h"
+#include "fs/PathInfo.h"
+#include "fs/TestEnvironment.h"
 #include "fs/TestFileSystem.h"
 #include "fs/TraversalMode.h"
 #include "fs/VirtualFileSystem.h"
 
+#include "kd/ranges/concat_view.h"
+#include "kd/ranges/repeat_view.h"
+#include "kd/ranges/to.h"
 #include "kd/result.h"
 
 #include <fmt/format.h>
 #include <fmt/std.h>
+
+#include <thread>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -773,6 +782,62 @@ TEST_CASE("VirtualFileSystem")
       CHECK(vfs.openFile("foo/bar/g") == Result<std::shared_ptr<File>>{fs2_foo_bar_g});
     }
   }
+}
+
+TEST_CASE("VirtualFileSystem concurrent mount/unmount vs. reads")
+{
+  using ThreadFunc = std::function<void()>;
+
+  // Reproduces the shape of the reachable race this test protects against:
+  // GameFileSystem::reloadWads() (mount()/unmount() from one thread) racing with
+  // background material/model loading (pathInfo()/find()/openFile() from other threads)
+  // on the same VirtualFileSystem. Not a deterministic assertion of absence-of-race
+  // (that's what running this under -DTB_ENABLE_TSAN=ON is for) - this just exercises the
+  // pattern under contention, with a fixed iteration count so it terminates (a
+  // lock-ordering bug here would hang or crash rather than fail an assertion).
+  auto env = TestEnvironment{[](auto& e) {
+    e.createDirectory("dir");
+    e.createFile("dir/file.txt", "some content");
+  }};
+
+  auto vfs = VirtualFileSystem{};
+  vfs.mount("", std::make_unique<DiskFileSystem>(env.dir()));
+
+  constexpr auto numReaderThreads = 4;
+  constexpr auto numIterations = 500;
+
+  auto writer = ThreadFunc{[&]() {
+    for (auto i = 0; i < numIterations; ++i)
+    {
+      auto fs = std::make_unique<DiskFileSystem>(env.dir());
+      const auto id = vfs.mount("mnt", std::move(fs));
+      vfs.unmount(id);
+    }
+  }};
+
+  auto reader = ThreadFunc{[&]() {
+    for (auto i = 0; i < numIterations; ++i)
+    {
+      static_cast<void>(vfs.pathInfo("dir"));
+      static_cast<void>(vfs.find("dir", fs::TraversalMode::Flat));
+      static_cast<void>(vfs.openFile("dir/file.txt"));
+    }
+  }};
+
+  auto threads =
+    kdl::views::concat(
+      std::views::single(writer), kdl::views::repeat(reader, numReaderThreads))
+    | std::views::transform([](auto func) { return std::thread{std::move(func)}; })
+    | kdl::ranges::to<std::vector>();
+
+  for (auto& thread : threads)
+  {
+    thread.join();
+  }
+
+  // the mount()/unmount() pairs in the writer thread should have left the original
+  // mount point as the only one remaining
+  CHECK(vfs.pathInfo("dir") == fs::PathInfo::Directory);
 }
 
 } // namespace tb::fs

--- a/lib/TbMdlLib/include/mdl/FgdParser.h
+++ b/lib/TbMdlLib/include/mdl/FgdParser.h
@@ -27,7 +27,6 @@
 #include "vm/bbox.h"
 
 #include <filesystem>
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -37,11 +36,6 @@ namespace tb
 class ParserStatus;
 
 struct FileLocation;
-
-namespace fs
-{
-class FileSystem;
-} // namespace fs
 
 namespace mdl
 {
@@ -92,7 +86,7 @@ private:
   using Token = FgdTokenizer::Token;
 
   std::vector<std::filesystem::path> m_paths;
-  std::unique_ptr<fs::FileSystem> m_fs;
+  std::filesystem::path m_basePath;
 
   FgdTokenizer m_tokenizer;
 

--- a/lib/TbMdlLib/src/Autosaver.cpp
+++ b/lib/TbMdlLib/src/Autosaver.cpp
@@ -20,9 +20,7 @@
 #include "mdl/Autosaver.h"
 
 #include "Logger.h"
-#include "fs/DiskFileSystem.h"
 #include "fs/DiskIO.h"
-#include "fs/FileSystem.h"
 #include "fs/PathInfo.h"
 #include "fs/TraversalMode.h"
 #include "mdl/CommandProcessor.h"
@@ -48,27 +46,27 @@ namespace tb::mdl
 namespace
 {
 
-Result<fs::WritableDiskFileSystem> createBackupFileSystem(
+Result<std::filesystem::path> ensureAutosaveDirectory(
   const std::filesystem::path& mapPath)
 {
   const auto basePath = mapPath.parent_path();
   const auto autosavePath = basePath / "autosave";
 
   return fs::Disk::createDirectory(autosavePath)
-         | kdl::transform([&](auto) { return fs::WritableDiskFileSystem{autosavePath}; });
+         | kdl::transform([&](auto) { return autosavePath; });
 }
 
 Result<std::vector<std::filesystem::path>> collectBackups(
-  const fs::FileSystem& fs, const std::filesystem::path& mapBasename)
+  const std::filesystem::path& autosavePath, const std::filesystem::path& mapBasename)
 {
-  return fs.find({}, fs::TraversalMode::Flat, makeBackupPathMatcher(mapBasename))
+  return fs::Disk::find(
+           autosavePath, fs::TraversalMode::Flat, makeBackupPathMatcher(mapBasename))
          | kdl::transform(
            [](auto backupPaths) { return kdl::vec_sort(std::move(backupPaths)); });
 }
 
 Result<std::vector<std::filesystem::path>> thinBackups(
   Logger& logger,
-  fs::WritableDiskFileSystem& fs,
   const std::vector<std::filesystem::path>& backups,
   const size_t maxBackups)
 {
@@ -80,12 +78,13 @@ Result<std::vector<std::filesystem::path>> thinBackups(
   const auto numToDelete = backups.size() - maxBackups + 1;
   const auto toDelete = backups | std::views::take(numToDelete);
   return toDelete | std::views::transform([&](auto filename) {
-           return fs.deleteFile(filename) | kdl::transform([&](const auto deleted) {
-                    if (deleted)
-                    {
-                      logger.debug() << "Deleted autosave backup " << filename;
-                    }
-                  });
+           return fs::Disk::deleteFile(filename)
+                  | kdl::transform([&](const auto deleted) {
+                      if (deleted)
+                      {
+                        logger.debug() << "Deleted autosave backup " << filename;
+                      }
+                    });
          })
          | kdl::fold | kdl::transform([&]() {
              return backups | std::views::drop(numToDelete)
@@ -100,15 +99,16 @@ std::filesystem::path makeBackupName(
 }
 
 Result<void> cleanBackups(
-  fs::WritableDiskFileSystem& fs,
   const std::vector<std::filesystem::path>& backups,
-  const std::filesystem::path& mapBasename)
+  const std::filesystem::path& mapBasename,
+  const std::filesystem::path& autosavePath)
 {
   const auto cleanBackup = [&](const auto i, const auto& backup) {
     const auto& oldName = backup.filename();
     const auto newName = makeBackupName(mapBasename, size_t(i) + 1);
 
-    return oldName != newName ? fs.moveFile(oldName, newName) : Result<void>{};
+    return oldName != newName ? fs::Disk::moveFile(backup, autosavePath / newName)
+                              : Result<void>{};
   };
 
   return backups | kdl::views::enumerate | std::views::transform([&](const auto& pair) {
@@ -164,17 +164,17 @@ void Autosaver::autosave()
   const auto mapFilename = mapPath.filename();
   const auto mapBasename = mapPath.stem();
 
-  createBackupFileSystem(mapPath) | kdl::and_then([&](auto fs) {
-    return collectBackups(fs, mapBasename) | kdl::and_then([&](auto backups) {
-             return thinBackups(m_map.logger(), fs, backups, m_maxBackups);
+  ensureAutosaveDirectory(mapPath) | kdl::and_then([&](const auto& autosavePath) {
+    return collectBackups(autosavePath, mapBasename) | kdl::and_then([&](auto backups) {
+             return thinBackups(m_map.logger(), backups, m_maxBackups);
            })
            | kdl::and_then([&](auto remainingBackups) {
-               return cleanBackups(fs, remainingBackups, mapBasename)
-                      | kdl::and_then([&]() {
+               return cleanBackups(remainingBackups, mapBasename, autosavePath)
+                      | kdl::and_then([&]() -> Result<std::filesystem::path> {
                           contract_assert(remainingBackups.size() < m_maxBackups);
 
                           const auto backupNo = remainingBackups.size() + 1;
-                          return fs.makeAbsolute(makeBackupName(mapBasename, backupNo));
+                          return autosavePath / makeBackupName(mapBasename, backupNo);
                         });
              });
   }) | kdl::and_then([&](const auto& backupFilePath) {

--- a/lib/TbMdlLib/src/FgdParser.cpp
+++ b/lib/TbMdlLib/src/FgdParser.cpp
@@ -22,7 +22,7 @@
 #include "ParserException.h"
 #include "ParserStatus.h"
 #include "el/Expression.h"
-#include "fs/DiskFileSystem.h"
+#include "fs/DiskIO.h"
 #include "mdl/EntityDefinitionClassInfo.h"
 #include "mdl/LegacyModelDefinitionParser.h"
 #include "mdl/ParseModelDefinition.h"
@@ -30,6 +30,7 @@
 
 #include "kd/contracts.h"
 #include "kd/invoke.h"
+#include "kd/path_utils.h"
 #include "kd/result.h"
 #include "kd/string_compare.h"
 #include "kd/string_format.h"
@@ -212,7 +213,7 @@ FgdParser::FgdParser(
 {
   if (!path.empty() && path.is_absolute())
   {
-    m_fs = std::make_unique<fs::DiskFileSystem>(path.parent_path());
+    m_basePath = path.parent_path();
     pushIncludePath(path.filename());
   }
 }
@@ -1128,7 +1129,7 @@ std::vector<EntityDefinitionClassInfo> FgdParser::parseInclude(ParserStatus& sta
 std::vector<EntityDefinitionClassInfo> FgdParser::handleInclude(
   ParserStatus& status, const std::filesystem::path& path)
 {
-  if (!m_fs)
+  if (m_basePath.empty())
   {
     status.error(
       m_tokenizer.location(),
@@ -1144,7 +1145,18 @@ std::vector<EntityDefinitionClassInfo> FgdParser::handleInclude(
   status.debug(m_tokenizer.location(), fmt::format("Parsing included file '{}'", path));
 
   const auto filePath = currentRoot() / path;
-  return m_fs->openFile(filePath) | kdl::transform([&](auto file) {
+  const auto normalizedFilePath = filePath.lexically_normal();
+  if (
+    filePath.is_absolute()
+    || (!normalizedFilePath.empty() && kdl::path_front(normalizedFilePath) == ".."))
+  {
+    status.error(
+      m_tokenizer.location(),
+      fmt::format("Skipping include file outside of base path: {} ({})", path, filePath));
+    return {};
+  }
+
+  return fs::Disk::openFile(m_basePath / filePath) | kdl::transform([&](auto file) {
            status.debug(
              m_tokenizer.location(),
              fmt::format("Resolved '{}' to '{}'", path, filePath));

--- a/lib/TbMdlLib/src/GameFileSystem.cpp
+++ b/lib/TbMdlLib/src/GameFileSystem.cpp
@@ -169,23 +169,19 @@ void GameFileSystem::addFileSystemPackages(
 
   if (fs::Disk::pathInfo(searchPath) == fs::PathInfo::Directory)
   {
-    const auto diskFS = fs::DiskFileSystem{searchPath};
-    diskFS.find(
-      std::filesystem::path{},
+    fs::Disk::find(
+      searchPath,
       fs::TraversalMode::Flat,
       fs::makeExtensionPathMatcher(packageExtensions))
       | kdl::and_then([&](auto packagePaths) {
           std::ranges::sort(packagePaths);
           return packagePaths | kdl::views::as_rvalue
-                 | std::views::transform([&](auto packagePath) {
-                     return diskFS.makeAbsolute(packagePath)
-                            | kdl::and_then([&](const auto& absPackagePath) {
-                                return createImageFileSystem(
-                                  packageFormat, absPackagePath);
-                              })
+                 | std::views::transform([&](auto absPackagePath) {
+                     return createImageFileSystem(packageFormat, absPackagePath)
                             | kdl::transform([&](auto fs) {
                                 logger.info()
-                                  << "Adding file system package " << packagePath;
+                                  << "Adding file system package "
+                                  << absPackagePath.lexically_relative(searchPath);
                                 mount("", std::move(fs));
                               });
                    })

--- a/lib/TbMdlLib/src/GameManager.cpp
+++ b/lib/TbMdlLib/src/GameManager.cpp
@@ -37,6 +37,8 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <tuple>
+#include <utility>
 
 namespace tb::mdl
 {
@@ -47,7 +49,11 @@ const auto gameConfigFilename = "GameConfig.cfg";
 const auto compilationConfigFilename = "CompilationProfiles.cfg";
 const auto gameEngineConfigFilename = "GameEngineProfiles.cfg";
 
-Result<std::unique_ptr<fs::WritableVirtualFileSystem>> createFileSystem(
+// The second element points at the WritableDiskFileSystem mounted at userGameDir - it
+// is used by migrateConfigFiles to refresh that filesystem's cached directory tree
+// after migrating files with a raw Disk:: call that bypasses it.
+Result<std::pair<std::unique_ptr<fs::WritableVirtualFileSystem>, fs::DiskFileSystem*>>
+createFileSystem(
   const std::vector<std::filesystem::path>& gameConfigSearchDirs,
   const std::filesystem::path& userGameDir)
 {
@@ -61,14 +67,20 @@ Result<std::unique_ptr<fs::WritableVirtualFileSystem>> createFileSystem(
   }
 
   return fs::Disk::createDirectory(userGameDir) | kdl::transform([&](auto) {
-           return std::make_unique<fs::WritableVirtualFileSystem>(
-             std::move(virtualFs),
-             std::make_unique<fs::WritableDiskFileSystem>(userGameDir));
+           auto userGameDirFs = std::make_unique<fs::WritableDiskFileSystem>(userGameDir);
+           auto* const userGameDirFsPtr = userGameDirFs.get();
+           return std::
+             pair<std::unique_ptr<fs::WritableVirtualFileSystem>, fs::DiskFileSystem*>{
+               std::make_unique<fs::WritableVirtualFileSystem>(
+                 std::move(virtualFs), std::move(userGameDirFs)),
+               userGameDirFsPtr};
          });
 }
 
 Result<void> migrateConfigFiles(
-  const std::filesystem::path& userGameDir, const GameConfig& config)
+  fs::DiskFileSystem& userGameDirFs,
+  const std::filesystem::path& userGameDir,
+  const GameConfig& config)
 {
   const auto legacyDir = userGameDir / config.name;
   const auto newDir = userGameDir / config.configFileFolder();
@@ -82,7 +94,8 @@ Result<void> migrateConfigFiles(
     case fs::PathInfo::Directory:
       break;
     case fs::PathInfo::Unknown:
-      return fs::Disk::renameDirectory(legacyDir, newDir);
+      return fs::Disk::renameDirectory(legacyDir, newDir)
+             | kdl::transform([&]() { std::ignore = userGameDirFs.reload(); });
     }
   }
   return Result<void>{};
@@ -127,6 +140,7 @@ Result<void> loadGameEngineConfig(const fs::FileSystem& fs, GameInfo& gameInfo)
 }
 
 Result<GameConfig> loadGameConfig(
+  fs::DiskFileSystem& userGameDirFs,
   const fs::FileSystem& fs,
   const std::filesystem::path& userGameDir,
   const std::filesystem::path& path)
@@ -137,14 +151,16 @@ Result<GameConfig> loadGameConfig(
              return parseGameConfig(reader.stringView(), absolutePath);
            })
          | kdl::transform([&](auto config) {
-             migrateConfigFiles(userGameDir, config) | kdl::transform_error([&](auto e) {
-               std::cerr << "Could not migrate user config files: '" << e.msg << "\n";
-             });
+             migrateConfigFiles(userGameDirFs, userGameDir, config)
+               | kdl::transform_error([&](auto e) {
+                   std::cerr << "Could not migrate user config files: '" << e.msg << "\n";
+                 });
              return config;
            });
 }
 
 Result<GameInfo> loadGameInfo(
+  fs::DiskFileSystem& userGameDirFs,
   const fs::FileSystem& fs,
   const std::filesystem::path& userGameDir,
   const std::filesystem::path& path,
@@ -152,17 +168,19 @@ Result<GameInfo> loadGameInfo(
 {
   const auto saveWarning = [&](const auto& e) { warnings.push_back(e.msg); };
 
-  return loadGameConfig(fs, userGameDir, path) | kdl::transform([&](auto gameConfig) {
-           auto gameInfo = makeGameInfo(std::move(gameConfig));
+  return loadGameConfig(userGameDirFs, fs, userGameDir, path)
+         | kdl::transform([&](auto gameConfig) {
+             auto gameInfo = makeGameInfo(std::move(gameConfig));
 
-           loadCompilationConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
-           loadGameEngineConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
+             loadCompilationConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
+             loadGameEngineConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
 
-           return gameInfo;
-         });
+             return gameInfo;
+           });
 }
 
 Result<std::vector<GameInfo>> loadGameInfos(
+  fs::DiskFileSystem& userGameDirFs,
   const fs::FileSystem& fs,
   const std::filesystem::path& userGameDir,
   std::vector<std::string>& warnings)
@@ -174,7 +192,8 @@ Result<std::vector<GameInfo>> loadGameInfos(
          | kdl::transform([&](auto configFiles) {
              auto [gameInfos, errors] =
                configFiles | std::views::transform([&](const auto& configFilePath) {
-                 return loadGameInfo(fs, userGameDir, configFilePath, warnings);
+                 return loadGameInfo(
+                   userGameDirFs, fs, userGameDir, configFilePath, warnings);
                })
                | kdl::collect();
 
@@ -337,9 +356,12 @@ Result<kdl::multi_value<GameManager, std::vector<std::string>>> initializeGameMa
   const std::filesystem::path& userGameDir)
 {
   return createFileSystem(gameConfigSearchDirs, userGameDir)
-         | kdl::and_then([&](auto fs) {
+         | kdl::and_then([&](auto fsAndUserGameDirFs) {
+             auto fs = std::move(fsAndUserGameDirFs.first);
+             auto* userGameDirFs = fsAndUserGameDirFs.second;
+
              auto warnings = std::vector<std::string>{};
-             return loadGameInfos(*fs, userGameDir, warnings)
+             return loadGameInfos(*userGameDirFs, *fs, userGameDir, warnings)
                     | kdl::transform([&](auto gameInfos) {
                         return kdl::multi_value{
                           GameManager{std::move(fs), std::move(gameInfos)},

--- a/lib/TbMdlLib/src/GameManager.cpp
+++ b/lib/TbMdlLib/src/GameManager.cpp
@@ -38,7 +38,6 @@
 #include <iostream>
 #include <sstream>
 #include <tuple>
-#include <utility>
 
 namespace tb::mdl
 {
@@ -49,11 +48,7 @@ const auto gameConfigFilename = "GameConfig.cfg";
 const auto compilationConfigFilename = "CompilationProfiles.cfg";
 const auto gameEngineConfigFilename = "GameEngineProfiles.cfg";
 
-// The second element points at the WritableDiskFileSystem mounted at userGameDir - it
-// is used by migrateConfigFiles to refresh that filesystem's cached directory tree
-// after migrating files with a raw Disk:: call that bypasses it.
-Result<std::pair<std::unique_ptr<fs::WritableVirtualFileSystem>, fs::DiskFileSystem*>>
-createFileSystem(
+Result<std::unique_ptr<fs::WritableVirtualFileSystem>> createFileSystem(
   const std::vector<std::filesystem::path>& gameConfigSearchDirs,
   const std::filesystem::path& userGameDir)
 {
@@ -67,20 +62,14 @@ createFileSystem(
   }
 
   return fs::Disk::createDirectory(userGameDir) | kdl::transform([&](auto) {
-           auto userGameDirFs = std::make_unique<fs::WritableDiskFileSystem>(userGameDir);
-           auto* const userGameDirFsPtr = userGameDirFs.get();
-           return std::
-             pair<std::unique_ptr<fs::WritableVirtualFileSystem>, fs::DiskFileSystem*>{
-               std::make_unique<fs::WritableVirtualFileSystem>(
-                 std::move(virtualFs), std::move(userGameDirFs)),
-               userGameDirFsPtr};
+           return std::make_unique<fs::WritableVirtualFileSystem>(
+             std::move(virtualFs),
+             std::make_unique<fs::WritableDiskFileSystem>(userGameDir));
          });
 }
 
 Result<void> migrateConfigFiles(
-  fs::DiskFileSystem& userGameDirFs,
-  const std::filesystem::path& userGameDir,
-  const GameConfig& config)
+  fs::FileSystem& fs, const std::filesystem::path& userGameDir, const GameConfig& config)
 {
   const auto legacyDir = userGameDir / config.name;
   const auto newDir = userGameDir / config.configFileFolder();
@@ -95,7 +84,7 @@ Result<void> migrateConfigFiles(
       break;
     case fs::PathInfo::Unknown:
       return fs::Disk::renameDirectory(legacyDir, newDir)
-             | kdl::transform([&]() { std::ignore = userGameDirFs.reload(); });
+             | kdl::transform([&]() { std::ignore = fs.reload(); });
     }
   }
   return Result<void>{};
@@ -140,8 +129,7 @@ Result<void> loadGameEngineConfig(const fs::FileSystem& fs, GameInfo& gameInfo)
 }
 
 Result<GameConfig> loadGameConfig(
-  fs::DiskFileSystem& userGameDirFs,
-  const fs::FileSystem& fs,
+  fs::FileSystem& fs,
   const std::filesystem::path& userGameDir,
   const std::filesystem::path& path)
 {
@@ -151,7 +139,7 @@ Result<GameConfig> loadGameConfig(
              return parseGameConfig(reader.stringView(), absolutePath);
            })
          | kdl::transform([&](auto config) {
-             migrateConfigFiles(userGameDirFs, userGameDir, config)
+             migrateConfigFiles(fs, userGameDir, config)
                | kdl::transform_error([&](auto e) {
                    std::cerr << "Could not migrate user config files: '" << e.msg << "\n";
                  });
@@ -160,28 +148,25 @@ Result<GameConfig> loadGameConfig(
 }
 
 Result<GameInfo> loadGameInfo(
-  fs::DiskFileSystem& userGameDirFs,
-  const fs::FileSystem& fs,
+  fs::FileSystem& fs,
   const std::filesystem::path& userGameDir,
   const std::filesystem::path& path,
   std::vector<std::string>& warnings)
 {
   const auto saveWarning = [&](const auto& e) { warnings.push_back(e.msg); };
 
-  return loadGameConfig(userGameDirFs, fs, userGameDir, path)
-         | kdl::transform([&](auto gameConfig) {
-             auto gameInfo = makeGameInfo(std::move(gameConfig));
+  return loadGameConfig(fs, userGameDir, path) | kdl::transform([&](auto gameConfig) {
+           auto gameInfo = makeGameInfo(std::move(gameConfig));
 
-             loadCompilationConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
-             loadGameEngineConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
+           loadCompilationConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
+           loadGameEngineConfig(fs, gameInfo) | kdl::transform_error(saveWarning);
 
-             return gameInfo;
-           });
+           return gameInfo;
+         });
 }
 
 Result<std::vector<GameInfo>> loadGameInfos(
-  fs::DiskFileSystem& userGameDirFs,
-  const fs::FileSystem& fs,
+  fs::FileSystem& fs,
   const std::filesystem::path& userGameDir,
   std::vector<std::string>& warnings)
 {
@@ -192,8 +177,7 @@ Result<std::vector<GameInfo>> loadGameInfos(
          | kdl::transform([&](auto configFiles) {
              auto [gameInfos, errors] =
                configFiles | std::views::transform([&](const auto& configFilePath) {
-                 return loadGameInfo(
-                   userGameDirFs, fs, userGameDir, configFilePath, warnings);
+                 return loadGameInfo(fs, userGameDir, configFilePath, warnings);
                })
                | kdl::collect();
 
@@ -356,12 +340,9 @@ Result<kdl::multi_value<GameManager, std::vector<std::string>>> initializeGameMa
   const std::filesystem::path& userGameDir)
 {
   return createFileSystem(gameConfigSearchDirs, userGameDir)
-         | kdl::and_then([&](auto fsAndUserGameDirFs) {
-             auto fs = std::move(fsAndUserGameDirFs.first);
-             auto* userGameDirFs = fsAndUserGameDirFs.second;
-
+         | kdl::and_then([&](auto fs) {
              auto warnings = std::vector<std::string>{};
-             return loadGameInfos(*userGameDirFs, *fs, userGameDir, warnings)
+             return loadGameInfos(*fs, userGameDir, warnings)
                     | kdl::transform([&](auto gameInfos) {
                         return kdl::multi_value{
                           GameManager{std::move(fs), std::move(gameInfos)},

--- a/lib/TbMdlLib/test/fixture/mdl/FgdParser/parseIncludeEscapingBasePath/host.fgd
+++ b/lib/TbMdlLib/test/fixture/mdl/FgdParser/parseIncludeEscapingBasePath/host.fgd
@@ -1,0 +1,4 @@
+@SolidClass = worldspawn : "World entity"
+[]
+
+@include "../parseInclude/include.fgd"

--- a/lib/TbMdlLib/test/src/tst_FgdParser.cpp
+++ b/lib/TbMdlLib/test/src/tst_FgdParser.cpp
@@ -1251,6 +1251,28 @@ model({"path"
       defs.value(), [](const auto& def) { return def.name == "worldspawn"; }));
   }
 
+  SECTION("parseIncludeEscapingBasePath")
+  {
+    // an @include path that escapes the host file's directory (here, into the sibling
+    // parseInclude fixture directory) must be rejected rather than followed - the host
+    // file's own definitions should still parse
+    const auto path =
+      getFixtureRoot() / "test/mdl/FgdParser/parseIncludeEscapingBasePath/host.fgd";
+    auto file = fs::Disk::openFile(path) | kdl::value();
+    auto reader = file->reader().buffer();
+
+    auto parser = FgdParser{reader.stringView(), RgbaF{1.0f, 1.0f, 1.0f, 1.0f}, path};
+
+    auto status = TestParserStatus{};
+    auto defs = parser.parseDefinitions(status);
+    REQUIRE(defs);
+    CHECK(defs.value().size() == 1u);
+    CHECK(std::ranges::any_of(
+      defs.value(), [](const auto& def) { return def.name == "worldspawn"; }));
+    CHECK(std::ranges::none_of(
+      defs.value(), [](const auto& def) { return def.name == "info_player_start"; }));
+  }
+
   SECTION("parseStringContinuations")
   {
     const auto file = R"(

--- a/lib/TbMdlLib/test/src/tst_GameFileSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_GameFileSystem.cpp
@@ -19,15 +19,26 @@
 
 #include "Logger.h"
 #include "TestEnvironment.h"
+#include "fs/DiskFileSystem.h"
 #include "fs/PathInfo.h"
+#include "fs/TestEnvironment.h"
 #include "fs/TestUtils.h"
+#include "fs/TraversalMode.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/EnvironmentConfig.h"
 #include "mdl/GameConfig.h"
 #include "mdl/GameFileSystem.h"
 #include "mdl/TestUtils.h"
 
+#include "kd/ranges/concat_view.h"
+#include "kd/ranges/repeat_view.h"
+#include "kd/ranges/to.h"
+
 #include <filesystem>
+#include <functional>
+#include <thread>
+#include <tuple>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -152,6 +163,62 @@ TEST_CASE("GameFileSystem")
     CHECK(fs.pathInfo("id1_pak0_loose_file.txt") == fs::PathInfo::File);
     CHECK(fs.pathInfo("mod1_pak0_1.txt") == fs::PathInfo::Unknown);
   }
+}
+
+TEST_CASE("GameFileSystem concurrent reload/mount/unmount vs. reads")
+{
+  using ThreadFunc = std::function<void()>;
+
+  // Confirms VirtualFileSystem's mount-point lock and DiskFileSystem's cache lock
+  // compose correctly together: one thread repeatedly reloads and remounts a
+  // DiskFileSystem while other threads concurrently read through the same
+  // GameFileSystem. Not a deterministic assertion of absence-of-race (that's what
+  // running this under -DTB_ENABLE_TSAN=ON is for) - this just exercises the pattern
+  // under contention, with a fixed iteration count so it terminates (a lock-ordering
+  // bug here would hang or crash rather than fail an assertion).
+  auto env = fs::TestEnvironment{[](auto& e) {
+    e.createDirectory("dir");
+    e.createFile("dir/file.txt", "some content");
+  }};
+
+  auto gfs = GameFileSystem{};
+  gfs.mount("", std::make_unique<fs::DiskFileSystem>(env.dir()));
+
+  constexpr auto numReaderThreads = 4;
+  constexpr auto numIterations = 500;
+
+  auto writer = ThreadFunc{[&]() {
+    for (auto i = 0; i < numIterations; ++i)
+    {
+      std::ignore = gfs.reload();
+
+      auto diskFs = std::make_unique<fs::DiskFileSystem>(env.dir());
+      const auto id = gfs.mount("mnt", std::move(diskFs));
+      gfs.unmount(id);
+    }
+  }};
+
+  auto reader = ThreadFunc{[&]() {
+    for (auto i = 0; i < numIterations; ++i)
+    {
+      static_cast<void>(gfs.pathInfo("dir"));
+      static_cast<void>(gfs.find("dir", fs::TraversalMode::Flat));
+      static_cast<void>(gfs.openFile("dir/file.txt"));
+    }
+  }};
+
+  auto threads =
+    kdl::views::concat(
+      std::views::single(writer), kdl::views::repeat(reader, numReaderThreads))
+    | std::views::transform([](auto func) { return std::thread{std::move(func)}; })
+    | kdl::ranges::to<std::vector>();
+
+  for (auto& thread : threads)
+  {
+    thread.join();
+  }
+
+  CHECK(gfs.pathInfo("dir") == fs::PathInfo::Directory);
 }
 
 } // namespace tb::mdl

--- a/lib/TbUiLib/src/ModEditor.cpp
+++ b/lib/TbUiLib/src/ModEditor.cpp
@@ -28,7 +28,6 @@
 #include "Logger.h"
 #include "Notifier.h"
 #include "PreferenceManager.h"
-#include "fs/DiskFileSystem.h"
 #include "fs/DiskIO.h"
 #include "fs/PathInfo.h"
 #include "fs/TraversalMode.h"
@@ -68,9 +67,8 @@ Result<std::vector<std::string>> findAvailableMods(const mdl::GameInfo& gameInfo
 
   const auto defaultMod =
     gameInfo.gameConfig.fileSystemConfig.searchPath.filename().string();
-  const auto fs = fs::DiskFileSystem{gamePath};
-  return fs.find(
-           "",
+  return fs::Disk::find(
+           gamePath,
            fs::TraversalMode::Flat,
            fs::makePathInfoPathMatcher({fs::PathInfo::Directory}))
          | kdl::transform([&](const auto& subDirs) {


### PR DESCRIPTION
This PR changes how DiskFileSystem works internally. Instead of accessing the filesystem directly for every call, it reads the root directory recursively when constructed and reloaded and answers all queries except for opening files from the cached data. This makes it consistent with the image-based filesystems, and makes the virtual file system also behave consistently. On top of that, it will improve performance when scanning for textures and other resources.

Furthermore, we make the case (in)sensitivity of the filesystem abstraction explicit: All paths going into `FileSystem` are case insensitive, but all paths going out are case sensitive.

On top of that, this PR also fixes a few existing issues, mostly related to synchronization of access to DiskFileSystem and VirtualFileSystem when they are reloaded while other threads still access them.

Improvements

macOS (case insensitive file system): 340ms vs. 470ms
Linux (case sensitive file system): 270ms vs 1500ms