### PR TITLE
Fix compile error in GCC 15

### DIFF
--- a/lib/KdLib/include/kd/ranges/enumerate_view.h
+++ b/lib/KdLib/include/kd/ranges/enumerate_view.h
@@ -188,7 +188,7 @@ public:
     }
 
     friend constexpr auto iter_move(const iterator& i) noexcept(
-      noexcept(std::ranges::iter_move(i.current_))
+      noexcept(std::ranges::iter_move(std::declval<iterator const&>().current_))
       and std::is_nothrow_move_constructible_v<
         std::ranges::range_rvalue_reference_t<Base>>)
     {


### PR DESCRIPTION
This just cherry-picks 8114817763e2448c31e6a1315de5266e26415075 from https://github.com/TrenchBroom/TrenchBroom/pull/4938, which was subsequently undone by https://github.com/TrenchBroom/TrenchBroom/pull/5222.

Closes #5243.