### PR TITLE
Strip entities matching a pattern and drop an entity on export

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -1678,6 +1678,9 @@ Target
 Strip Entities
 :    Set a GLOB pattern to strip any entities with a matching classname. Example: 'info_player_*' to strip all info_player_start and all info_player_deatchmatch entities.
 
+Add Entity
+:    Set the classname of an entity that will be added to the exported map. Example: 'info_player_start'. This entity will have its 'origin' property set to the position of the 3D camera, and its 'angle' property set to the yaw angle of the camera. Useful when testing maps.
+
 Strip TB specific entity properties
 :    Strip any entity properties starting with _tb_ from the exported map file. Some compilers cannot handle these properties.
 

--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -1675,6 +1675,9 @@ Layers marked "Omit From Export" will not be present in the exported map.
 Target
 :    The path of the exported file. Variables are allowed. Relative paths are implicitly relative to the working directory.
 
+Strip Entities
+:    Set a GLOB pattern to strip any entities with a matching classname. Example: 'info_player_*' to strip all info_player_start and all info_player_deatchmatch entities.
+
 Strip TB specific entity properties
 :    Strip any entity properties starting with _tb_ from the exported map file. Some compilers cannot handle these properties.
 

--- a/lib/TbGlLib/include/gl/PerspectiveCamera.h
+++ b/lib/TbGlLib/include/gl/PerspectiveCamera.h
@@ -40,6 +40,10 @@ public:
     const vm::vec3f& direction,
     const vm::vec3f& up);
 
+  float pitch() const;
+  float yaw() const;
+
+
   float fov() const;
   float zoomedFov() const;
   void setFov(float fov);

--- a/lib/TbGlLib/src/PerspectiveCamera.cpp
+++ b/lib/TbGlLib/src/PerspectiveCamera.cpp
@@ -26,6 +26,7 @@
 #include "vm/mat_ext.h"
 #include "vm/vec.h"
 
+#include <cmath>
 #include <limits>
 
 namespace tb::gl
@@ -45,6 +46,18 @@ PerspectiveCamera::PerspectiveCamera(
   , m_fov{fov}
 {
   contract_pre(m_fov > 0.0f);
+}
+
+float PerspectiveCamera::pitch() const
+{
+  const auto& d = direction();
+  return std::atan2(d.z(), vm::length(vm::vec2f{d.x(), d.y()}));
+}
+
+float PerspectiveCamera::yaw() const
+{
+  const auto& d = direction();
+  return std::atan2(d.y(), d.x());
 }
 
 float PerspectiveCamera::fov() const

--- a/lib/TbGlLib/test/src/tst_PerspectiveCamera.cpp
+++ b/lib/TbGlLib/test/src/tst_PerspectiveCamera.cpp
@@ -19,7 +19,12 @@
 
 #include "gl/PerspectiveCamera.h"
 
+#include "vm/scalar.h"
+#include "vm/vec.h"
+
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 namespace tb::gl
 {
@@ -71,6 +76,44 @@ TEST_CASE("PerspectiveCamera")
     CHECK_FALSE(vm::is_nan(c.direction()));
     CHECK_FALSE(vm::is_nan(c.right()));
     CHECK_FALSE(vm::is_nan(c.up()));
+  }
+
+  SECTION("yaw")
+  {
+    const auto [direction, up, expectedYaw] =
+      GENERATE(table<vm::vec3f, vm::vec3f, float>({
+        {vm::vec3f{1, 0, 0}, vm::vec3f{0, 0, 1}, 0.0f},
+        {vm::vec3f{0, 1, 0}, vm::vec3f{0, 0, 1}, 90.0f},
+        {vm::vec3f{-1, 0, 0}, vm::vec3f{0, 0, 1}, 180.0f},
+        {vm::vec3f{0, -1, 0}, vm::vec3f{0, 0, 1}, -90.0f},
+        {vm::normalize(vm::vec3f{1, 1, 0}), vm::vec3f{0, 0, 1}, 45.0f},
+        // yaw ignores the pitch component of the direction
+        {vm::normalize(vm::vec3f{0, 1, 1}), vm::vec3f{0, 0, 1}, 90.0f},
+      }));
+
+    CAPTURE(direction, up);
+
+    camera.setDirection(direction, up);
+    CHECK(vm::to_degrees(camera.yaw()) == Catch::Approx{expectedYaw});
+  }
+
+  SECTION("pitch")
+  {
+    const auto [direction, up, expectedPitch] =
+      GENERATE(table<vm::vec3f, vm::vec3f, float>({
+        {vm::vec3f{1, 0, 0}, vm::vec3f{0, 0, 1}, 0.0f},
+        {vm::normalize(vm::vec3f{1, 0, 1}), vm::vec3f{0, 0, 1}, 45.0f},
+        {vm::normalize(vm::vec3f{1, 0, -1}), vm::vec3f{0, 0, 1}, -45.0f},
+        {vm::vec3f{0, 0, 1}, vm::vec3f{1, 0, 0}, 90.0f},
+        {vm::vec3f{0, 0, -1}, vm::vec3f{1, 0, 0}, -90.0f},
+        // pitch ignores the yaw component of the direction
+        {vm::normalize(vm::vec3f{0, 1, 1}), vm::vec3f{0, 0, 1}, 45.0f},
+      }));
+
+    CAPTURE(direction, up);
+
+    camera.setDirection(direction, up);
+    CHECK(vm::to_degrees(camera.pitch()) == Catch::Approx{expectedPitch});
   }
 }
 

--- a/lib/TbMdlLib/include/mdl/CompilationTask.h
+++ b/lib/TbMdlLib/include/mdl/CompilationTask.h
@@ -22,6 +22,7 @@
 #include "kd/reflection_decl.h"
 
 #include <iosfwd>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -31,9 +32,11 @@ struct CompilationExportMap
 {
   bool enabled;
   bool stripTbProperties;
+  std::optional<std::string> stripEntityPattern;
   std::string targetSpec;
 
-  kdl_reflect_decl(CompilationExportMap, enabled, stripTbProperties, targetSpec);
+  kdl_reflect_decl(
+    CompilationExportMap, enabled, stripTbProperties, stripEntityPattern, targetSpec);
 };
 
 struct CompilationCopyFiles

--- a/lib/TbMdlLib/include/mdl/CompilationTask.h
+++ b/lib/TbMdlLib/include/mdl/CompilationTask.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "mdl/Entity.h"
+
 #include "kd/reflection_decl.h"
 
 #include <iosfwd>
@@ -33,10 +35,16 @@ struct CompilationExportMap
   bool enabled;
   bool stripTbProperties;
   std::optional<std::string> stripEntityPattern;
+  std::optional<Entity> entityToAdd;
   std::string targetSpec;
 
   kdl_reflect_decl(
-    CompilationExportMap, enabled, stripTbProperties, stripEntityPattern, targetSpec);
+    CompilationExportMap,
+    enabled,
+    stripTbProperties,
+    stripEntityPattern,
+    entityToAdd,
+    targetSpec);
 };
 
 struct CompilationCopyFiles

--- a/lib/TbMdlLib/include/mdl/ExportOptions.h
+++ b/lib/TbMdlLib/include/mdl/ExportOptions.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "mdl/Entity.h"
+
 #include "kd/reflection_decl.h"
 
 #include <filesystem>
@@ -35,8 +37,10 @@ struct MapExportOptions
   std::filesystem::path exportPath;
   bool stripTbProperties;
   std::optional<std::string> stripEntityPattern;
+  std::optional<Entity> entityToAdd;
 
-  kdl_reflect_decl(MapExportOptions, exportPath, stripTbProperties, stripEntityPattern);
+  kdl_reflect_decl(
+    MapExportOptions, exportPath, stripTbProperties, stripEntityPattern, entityToAdd);
 };
 
 enum class ObjMtlPathMode

--- a/lib/TbMdlLib/include/mdl/ExportOptions.h
+++ b/lib/TbMdlLib/include/mdl/ExportOptions.h
@@ -23,6 +23,8 @@
 #include "kd/reflection_decl.h"
 
 #include <filesystem>
+#include <optional>
+#include <string>
 #include <variant>
 
 namespace tb::mdl
@@ -32,8 +34,9 @@ struct MapExportOptions
 {
   std::filesystem::path exportPath;
   bool stripTbProperties;
+  std::optional<std::string> stripEntityPattern;
 
-  kdl_reflect_decl(MapExportOptions, exportPath, stripTbProperties);
+  kdl_reflect_decl(MapExportOptions, exportPath, stripTbProperties, stripEntityPattern);
 };
 
 enum class ObjMtlPathMode

--- a/lib/TbMdlLib/include/mdl/NodeSerializer.h
+++ b/lib/TbMdlLib/include/mdl/NodeSerializer.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "mdl/Entity.h"
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -32,6 +34,7 @@ namespace tb::mdl
 {
 class BrushNode;
 class BrushFace;
+class EntityNode;
 class EntityProperty;
 class GroupNode;
 class LayerNode;
@@ -65,6 +68,7 @@ private:
   bool m_exporting = false;
   bool m_stripTbProperties = false;
   std::optional<std::string> m_stripEntityPattern;
+  std::optional<Entity> m_entityToAdd;
 
 public:
   virtual ~NodeSerializer();
@@ -82,6 +86,9 @@ public:
 
   const std::optional<std::string>& stripEntityPattern() const;
   void setStripEntityPattern(std::optional<std::string> stripEntityPattern);
+
+  const std::optional<Entity>& entityToAdd() const;
+  void setEntityToAdd(std::optional<Entity> entityToAdd);
 
 public:
   /**

--- a/lib/TbMdlLib/include/mdl/NodeSerializer.h
+++ b/lib/TbMdlLib/include/mdl/NodeSerializer.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -63,6 +64,7 @@ private:
   ObjectNo m_brushNo = 0;
   bool m_exporting = false;
   bool m_stripTbProperties = false;
+  std::optional<std::string> m_stripEntityPattern;
 
 public:
   virtual ~NodeSerializer();
@@ -77,6 +79,9 @@ public:
 
   bool stripTbProperties() const;
   void setStripTbProperties(bool stripTbProperties);
+
+  const std::optional<std::string>& stripEntityPattern() const;
+  void setStripEntityPattern(std::optional<std::string> stripEntityPattern);
 
 public:
   /**

--- a/lib/TbMdlLib/include/mdl/NodeWriter.h
+++ b/lib/TbMdlLib/include/mdl/NodeWriter.h
@@ -21,6 +21,8 @@
 
 #include <map>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace kdl
@@ -55,6 +57,7 @@ public:
 
   void setExporting(bool exporting);
   void setStripTbProperties(bool stripTbProperties);
+  void setStripEntityPattern(std::optional<std::string> stripEntityPattern);
   void writeMap(kdl::task_manager& taskManager);
 
 private:

--- a/lib/TbMdlLib/include/mdl/NodeWriter.h
+++ b/lib/TbMdlLib/include/mdl/NodeWriter.h
@@ -36,6 +36,7 @@ namespace mdl
 {
 class BrushNode;
 class BrushFace;
+class Entity;
 class EntityNode;
 class LayerNode;
 class Node;
@@ -58,6 +59,7 @@ public:
   void setExporting(bool exporting);
   void setStripTbProperties(bool stripTbProperties);
   void setStripEntityPattern(std::optional<std::string> stripEntityPattern);
+  void setEntityToAdd(std::optional<Entity> entityToAdd);
   void writeMap(kdl::task_manager& taskManager);
 
 private:

--- a/lib/TbMdlLib/src/CompilationConfig.cpp
+++ b/lib/TbMdlLib/src/CompilationConfig.cpp
@@ -37,6 +37,10 @@ el::Value toValue(const CompilationTask& task)
         map["type"] = el::Value{"export"};
         map["enabled"] = el::Value{exportMap.enabled};
         map["stripTbProperties"] = el::Value{exportMap.stripTbProperties};
+        if (const auto& stripEntityPattern = exportMap.stripEntityPattern)
+        {
+          map["stripEntityPattern"] = el::Value{*stripEntityPattern};
+        }
         map["target"] = el::Value{exportMap.targetSpec};
         return map;
       },

--- a/lib/TbMdlLib/src/CompilationConfig.cpp
+++ b/lib/TbMdlLib/src/CompilationConfig.cpp
@@ -28,6 +28,18 @@ namespace tb::mdl
 namespace
 {
 
+el::Value toValue(const Entity& entity)
+{
+  return el::Value{
+    entity.properties() | std::views::transform([](const auto& entityProperty) {
+      return el::Value{el::MapType{
+        {"key", el::Value{entityProperty.key()}},
+        {"value", el::Value{entityProperty.value()}},
+      }};
+    })
+    | kdl::ranges::to<el::ArrayType>()};
+}
+
 el::Value toValue(const CompilationTask& task)
 {
   return el::Value{std::visit(
@@ -40,6 +52,10 @@ el::Value toValue(const CompilationTask& task)
         if (const auto& stripEntityPattern = exportMap.stripEntityPattern)
         {
           map["stripEntityPattern"] = el::Value{*stripEntityPattern};
+        }
+        if (const auto& entityToAdd = exportMap.entityToAdd)
+        {
+          map["entityToAdd"] = toValue(*entityToAdd);
         }
         map["target"] = el::Value{exportMap.targetSpec};
         return map;

--- a/lib/TbMdlLib/src/Map.cpp
+++ b/lib/TbMdlLib/src/Map.cpp
@@ -902,6 +902,7 @@ Result<void> Map::exportAs(const ExportOptions& options) const
           writer.setExporting(true);
           writer.setStripTbProperties(mapOptions.stripTbProperties);
           writer.setStripEntityPattern(mapOptions.stripEntityPattern);
+          writer.setEntityToAdd(mapOptions.entityToAdd);
           writer.writeMap(m_taskManager);
         });
       }),

--- a/lib/TbMdlLib/src/Map.cpp
+++ b/lib/TbMdlLib/src/Map.cpp
@@ -901,6 +901,7 @@ Result<void> Map::exportAs(const ExportOptions& options) const
           auto writer = NodeWriter{*m_worldNode, stream};
           writer.setExporting(true);
           writer.setStripTbProperties(mapOptions.stripTbProperties);
+          writer.setStripEntityPattern(mapOptions.stripEntityPattern);
           writer.writeMap(m_taskManager);
         });
       }),

--- a/lib/TbMdlLib/src/NodeSerializer.cpp
+++ b/lib/TbMdlLib/src/NodeSerializer.cpp
@@ -21,6 +21,7 @@
 
 #include "mdl/BrushFace.h"
 #include "mdl/BrushNode.h"
+#include "mdl/EntityNode.h"
 #include "mdl/EntityProperties.h"
 #include "mdl/GroupNode.h"
 #include "mdl/LayerNode.h"
@@ -102,6 +103,16 @@ void NodeSerializer::setStripEntityPattern(std::optional<std::string> stripEntit
   m_stripEntityPattern = std::move(stripEntityPattern);
 }
 
+const std::optional<Entity>& NodeSerializer::entityToAdd() const
+{
+  return m_entityToAdd;
+}
+
+void NodeSerializer::setEntityToAdd(std::optional<Entity> entityToAdd)
+{
+  m_entityToAdd = std::move(entityToAdd);
+}
+
 void NodeSerializer::beginFile(
   const std::vector<const Node*>& rootNodes, kdl::task_manager& taskManager)
 {
@@ -112,6 +123,11 @@ void NodeSerializer::beginFile(
 
 void NodeSerializer::endFile()
 {
+  if (m_entityToAdd)
+  {
+    auto entityNode = EntityNode{*m_entityToAdd};
+    entity(entityNode, entityNode.entity().properties(), {}, entityNode);
+  }
   doEndFile();
 }
 

--- a/lib/TbMdlLib/src/NodeSerializer.cpp
+++ b/lib/TbMdlLib/src/NodeSerializer.cpp
@@ -41,6 +41,24 @@
 
 namespace tb::mdl
 {
+namespace
+{
+
+bool shouldStripEntity(
+  const std::vector<EntityProperty>& properties,
+  const std::optional<std::string>& classnamePattern)
+{
+  if (!classnamePattern)
+  {
+    return false;
+  }
+
+  const auto iClassname = findEntityProperty(properties, EntityPropertyKeys::Classname);
+  return iClassname != properties.end()
+         && kdl::ci::str_matches_glob(iClassname->value(), *classnamePattern);
+}
+
+} // namespace
 
 NodeSerializer::~NodeSerializer() = default;
 
@@ -72,6 +90,16 @@ bool NodeSerializer::stripTbProperties() const
 void NodeSerializer::setStripTbProperties(const bool stripTbProperties)
 {
   m_stripTbProperties = stripTbProperties;
+}
+
+const std::optional<std::string>& NodeSerializer::stripEntityPattern() const
+{
+  return m_stripEntityPattern;
+}
+
+void NodeSerializer::setStripEntityPattern(std::optional<std::string> stripEntityPattern)
+{
+  m_stripEntityPattern = std::move(stripEntityPattern);
 }
 
 void NodeSerializer::beginFile(
@@ -169,17 +197,20 @@ void NodeSerializer::entity(
   const std::vector<EntityProperty>& extraProperties,
   const Node& brushParent)
 {
-  beginEntity(node, properties, extraProperties);
+  if (!shouldStripEntity(properties, m_stripEntityPattern))
+  {
+    beginEntity(node, properties, extraProperties);
 
-  brushParent.visitChildren(kdl::overload(
-    [](const WorldNode&) {},
-    [](const LayerNode&) {},
-    [](const GroupNode&) {},
-    [](const EntityNode&) {},
-    [&](const BrushNode& brushNode) { brush(brushNode); },
-    [&](const PatchNode& patchNode) { patch(patchNode); }));
+    brushParent.visitChildren(kdl::overload(
+      [](const WorldNode&) {},
+      [](const LayerNode&) {},
+      [](const GroupNode&) {},
+      [](const EntityNode&) {},
+      [&](const BrushNode& brushNode) { brush(brushNode); },
+      [&](const PatchNode& patchNode) { patch(patchNode); }));
 
-  endEntity(node);
+    endEntity(node);
+  }
 }
 
 void NodeSerializer::entity(
@@ -188,9 +219,12 @@ void NodeSerializer::entity(
   const std::vector<EntityProperty>& extraProperties,
   const std::vector<BrushNode*>& entityBrushes)
 {
-  beginEntity(node, properties, extraProperties);
-  brushes(entityBrushes);
-  endEntity(node);
+  if (!shouldStripEntity(properties, m_stripEntityPattern))
+  {
+    beginEntity(node, properties, extraProperties);
+    brushes(entityBrushes);
+    endEntity(node);
+  }
 }
 
 void NodeSerializer::beginEntity(

--- a/lib/TbMdlLib/src/NodeWriter.cpp
+++ b/lib/TbMdlLib/src/NodeWriter.cpp
@@ -120,6 +120,11 @@ void NodeWriter::setStripEntityPattern(std::optional<std::string> stripEntityPat
   m_serializer->setStripEntityPattern(std::move(stripEntityPattern));
 }
 
+void NodeWriter::setEntityToAdd(std::optional<Entity> entityToAdd)
+{
+  m_serializer->setEntityToAdd(std::move(entityToAdd));
+}
+
 void NodeWriter::writeMap(kdl::task_manager& taskManager)
 {
   m_serializer->beginFile({&m_world}, taskManager);

--- a/lib/TbMdlLib/src/NodeWriter.cpp
+++ b/lib/TbMdlLib/src/NodeWriter.cpp
@@ -115,6 +115,11 @@ void NodeWriter::setStripTbProperties(const bool stripTbProperties)
   m_serializer->setStripTbProperties(stripTbProperties);
 }
 
+void NodeWriter::setStripEntityPattern(std::optional<std::string> stripEntityPattern)
+{
+  m_serializer->setStripEntityPattern(std::move(stripEntityPattern));
+}
+
 void NodeWriter::writeMap(kdl::task_manager& taskManager)
 {
   m_serializer->beginFile({&m_world}, taskManager);

--- a/lib/TbMdlLib/src/ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/src/ParseCompilationConfig.cpp
@@ -49,9 +49,15 @@ CompilationExportMap toExportTask(
     value.atOrDefault(context, "stripTbProperties", el::Value{false})
       .booleanValue(context);
 
+  auto stripEntityPattern =
+    value.contains(context, "stripEntityPattern")
+      ? std::optional{value.at(context, "stripEntityPattern").stringValue(context)}
+      : std::nullopt;
+
   return {
     enabled,
     stripTbProperties,
+    std::move(stripEntityPattern),
     value.at(context, "target").stringValue(context),
   };
 }

--- a/lib/TbMdlLib/src/ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/src/ParseCompilationConfig.cpp
@@ -39,6 +39,21 @@ namespace tb::mdl
 namespace
 {
 
+Entity toEntity(const el::EvaluationContext& context, const el::Value& entityValue)
+{
+  auto entityProperties = entityValue.arrayValue(context)
+                          | std::views::transform([&](const auto& propertyValue) {
+                              const auto& map = propertyValue.mapValue(context);
+                              return EntityProperty{
+                                map.at("key").stringValue(context),
+                                map.at("value").stringValue(context),
+                              };
+                            })
+                          | kdl::ranges::to<std::vector>();
+
+  return Entity{std::move(entityProperties)};
+}
+
 CompilationExportMap toExportTask(
   const el::EvaluationContext& context, const el::Value& value)
 {
@@ -54,10 +69,16 @@ CompilationExportMap toExportTask(
       ? std::optional{value.at(context, "stripEntityPattern").stringValue(context)}
       : std::nullopt;
 
+  auto entityToAdd =
+    value.contains(context, "entityToAdd")
+      ? std::optional{toEntity(context, value.at(context, "entityToAdd"))}
+      : std::nullopt;
+
   return {
     enabled,
     stripTbProperties,
     std::move(stripEntityPattern),
+    std::move(entityToAdd),
     value.at(context, "target").stringValue(context),
   };
 }

--- a/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
@@ -22,8 +22,11 @@
 #include "mdl/CatchConfig.h"
 #include "mdl/CompilationConfig.h"
 
+#include "kd/ranges/to.h"
+
 #include <fmt/format.h>
 
+#include <ranges>
 #include <string_view>
 
 #include <catch2/catch_test_macros.hpp>
@@ -31,6 +34,24 @@
 
 namespace tb::mdl
 {
+namespace
+{
+
+std::optional<std::string> entityToStr(const std::optional<Entity>& entity)
+{
+  return entity | kdl::optional_transform([](const auto& e) {
+           const auto array = el::Value{
+             e.properties() | std::views::transform([](const auto& p) {
+               return el::Value{el::MapType{
+                 {"key", el::Value{p.key()}},
+                 {"value", el::Value{p.value()}},
+               }};
+             })
+             | kdl::ranges::to<el::ArrayType>()};
+
+           return array.asString();
+         });
+}
 
 auto parse(const std::string_view str)
 {
@@ -41,6 +62,8 @@ auto parse(const std::string_view str)
            | kdl::if_error([](const auto& e) { FAIL(e); });
   });
 }
+
+} // namespace
 
 TEST_CASE("toValue")
 {
@@ -75,14 +98,22 @@ TEST_CASE("toValue")
     const auto enabled = GENERATE(true, false);
     const auto stripTbProperties = GENERATE(true, false);
     const auto stripEntityPattern = GENERATE(std::optional{"some pattern"}, std::nullopt);
-
-    CAPTURE(enabled, stripTbProperties, stripEntityPattern);
+    const auto entityToAdd =
+      GENERATE(std::optional{Entity{{{"classname", "some_class"}}}}, std::nullopt);
 
     const auto stripEntityPatternStr =
       stripEntityPattern | kdl::optional_transform([](const auto& pattern) {
         return fmt::format(R"("stripEntityPattern": "{}",)", pattern);
       })
       | kdl::optional_value_or("");
+
+    const auto entityToAddStr = entityToStr(entityToAdd)
+                                | kdl::optional_transform([](const auto& entityStr) {
+                                    return fmt::format(R"(entityToAdd: {},)", entityStr);
+                                  })
+                                | kdl::optional_value_or("");
+
+    CAPTURE(enabled, stripTbProperties, stripEntityPatternStr, entityToAddStr);
 
     CHECK(
       toValue(CompilationConfig{{
@@ -93,6 +124,7 @@ TEST_CASE("toValue")
              enabled,
              stripTbProperties,
              stripEntityPattern,
+             entityToAdd,
              "targetSpec",
            },
          }},
@@ -110,6 +142,7 @@ TEST_CASE("toValue")
                 "enabled": {},
                 "stripTbProperties": {},
                 {}
+                {}
                 "target": "targetSpec"
               }}
             ]
@@ -118,7 +151,8 @@ TEST_CASE("toValue")
       }})",
         enabled,
         stripTbProperties,
-        stripEntityPatternStr)));
+        stripEntityPatternStr,
+        entityToAddStr)));
   }
 
   SECTION("copy task")

--- a/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_CompilationConfig.cpp
@@ -74,6 +74,15 @@ TEST_CASE("toValue")
   {
     const auto enabled = GENERATE(true, false);
     const auto stripTbProperties = GENERATE(true, false);
+    const auto stripEntityPattern = GENERATE(std::optional{"some pattern"}, std::nullopt);
+
+    CAPTURE(enabled, stripTbProperties, stripEntityPattern);
+
+    const auto stripEntityPatternStr =
+      stripEntityPattern | kdl::optional_transform([](const auto& pattern) {
+        return fmt::format(R"("stripEntityPattern": "{}",)", pattern);
+      })
+      | kdl::optional_value_or("");
 
     CHECK(
       toValue(CompilationConfig{{
@@ -83,6 +92,7 @@ TEST_CASE("toValue")
            CompilationExportMap{
              enabled,
              stripTbProperties,
+             stripEntityPattern,
              "targetSpec",
            },
          }},
@@ -99,6 +109,7 @@ TEST_CASE("toValue")
                 "type": "export",
                 "enabled": {},
                 "stripTbProperties": {},
+                {}
                 "target": "targetSpec"
               }}
             ]
@@ -106,7 +117,8 @@ TEST_CASE("toValue")
         ]
       }})",
         enabled,
-        stripTbProperties)));
+        stripTbProperties,
+        stripEntityPatternStr)));
   }
 
   SECTION("copy task")

--- a/lib/TbMdlLib/test/src/tst_Map_Persistence.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Persistence.cpp
@@ -174,6 +174,7 @@ TEST_CASE("Map_Persistence")
         env.dir() / filename,
         !K(stripTbProperties),
         std::nullopt,
+        std::nullopt,
       }));
       REQUIRE(env.fileExists(filename));
       CHECK(env.loadFile(filename) == R"(// entity 0
@@ -204,6 +205,7 @@ TEST_CASE("Map_Persistence")
         env.dir() / newDocumentPath,
         !K(stripTbProperties),
         std::nullopt,
+        std::nullopt,
       }));
       REQUIRE(env.fileExists(newDocumentPath));
       CHECK(env.loadFile(newDocumentPath) == R"(// entity 0
@@ -225,6 +227,7 @@ TEST_CASE("Map_Persistence")
       REQUIRE(map.exportAs(MapExportOptions{
         env.dir() / newDocumentPath,
         K(stripTbProperties),
+        std::nullopt,
         std::nullopt,
       }));
       REQUIRE(env.fileExists(newDocumentPath));
@@ -252,11 +255,43 @@ TEST_CASE("Map_Persistence")
         env.dir() / newDocumentPath,
         !K(stripTbProperties),
         "light",
+        std::nullopt,
       }));
       REQUIRE(env.fileExists(newDocumentPath));
       CHECK(env.loadFile(newDocumentPath) == R"(// entity 0
 {
 "classname" "worldspawn"
+}
+)");
+    }
+
+    SECTION("Add entity")
+    {
+      const auto newDocumentPath = std::filesystem::path{"test.map"};
+
+      auto& map = fixture.create(QuakeFixtureConfig);
+
+      auto* entityNode = new mdl::EntityNode{mdl::Entity{{{"classname", "light"}}}};
+      addNodes(map, {{parentForNodes(map), {entityNode}}});
+
+      REQUIRE(map.exportAs(MapExportOptions{
+        env.dir() / newDocumentPath,
+        !K(stripTbProperties),
+        std::nullopt,
+        mdl::Entity{{{"classname", "info_player_start"}}},
+      }));
+      REQUIRE(env.fileExists(newDocumentPath));
+      CHECK(env.loadFile(newDocumentPath) == R"(// entity 0
+{
+"classname" "worldspawn"
+}
+// entity 1
+{
+"classname" "light"
+}
+// entity 2
+{
+"classname" "info_player_start"
 }
 )");
     }

--- a/lib/TbMdlLib/test/src/tst_Map_Persistence.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Persistence.cpp
@@ -170,8 +170,11 @@ TEST_CASE("Map_Persistence")
       addNodes(map, {{parentForNodes(map), {entityNode}}});
 
       const auto filename = "test.map";
-      REQUIRE(
-        map.exportAs(MapExportOptions{env.dir() / filename, !K(stripTbProperties)}));
+      REQUIRE(map.exportAs(MapExportOptions{
+        env.dir() / filename,
+        !K(stripTbProperties),
+        std::nullopt,
+      }));
       REQUIRE(env.fileExists(filename));
       CHECK(env.loadFile(filename) == R"(// entity 0
 {
@@ -197,8 +200,11 @@ TEST_CASE("Map_Persistence")
       auto* layerNode = new mdl::LayerNode{std::move(layer)};
       addNodes(map, {{&map.worldNode(), {layerNode}}});
 
-      REQUIRE(map.exportAs(
-        MapExportOptions{env.dir() / newDocumentPath, !K(stripTbProperties)}));
+      REQUIRE(map.exportAs(MapExportOptions{
+        env.dir() / newDocumentPath,
+        !K(stripTbProperties),
+        std::nullopt,
+      }));
       REQUIRE(env.fileExists(newDocumentPath));
       CHECK(env.loadFile(newDocumentPath) == R"(// entity 0
 {
@@ -216,8 +222,11 @@ TEST_CASE("Map_Persistence")
       auto* layerNode = new mdl::LayerNode{mdl::Layer{"Layer"}};
       addNodes(map, {{&map.worldNode(), {layerNode}}});
 
-      REQUIRE(map.exportAs(
-        MapExportOptions{env.dir() / newDocumentPath, K(stripTbProperties)}));
+      REQUIRE(map.exportAs(MapExportOptions{
+        env.dir() / newDocumentPath,
+        K(stripTbProperties),
+        std::nullopt,
+      }));
       REQUIRE(env.fileExists(newDocumentPath));
       CHECK(env.loadFile(newDocumentPath) == R"(// entity 0
 {
@@ -226,6 +235,28 @@ TEST_CASE("Map_Persistence")
 // entity 1
 {
 "classname" "func_group"
+}
+)");
+    }
+
+    SECTION("Strip entities")
+    {
+      const auto newDocumentPath = std::filesystem::path{"test.map"};
+
+      auto& map = fixture.create(QuakeFixtureConfig);
+
+      auto* entityNode = new mdl::EntityNode{mdl::Entity{{{"classname", "light"}}}};
+      addNodes(map, {{parentForNodes(map), {entityNode}}});
+
+      REQUIRE(map.exportAs(MapExportOptions{
+        env.dir() / newDocumentPath,
+        !K(stripTbProperties),
+        "light",
+      }));
+      REQUIRE(env.fileExists(newDocumentPath));
+      CHECK(env.loadFile(newDocumentPath) == R"(// entity 0
+{
+"classname" "worldspawn"
 }
 )");
     }

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -241,6 +241,35 @@ TEST_CASE("NodeWriter")
     CHECK(actual == expected);
   }
 
+  SECTION("setEntityNodeToAdd")
+  {
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+
+    const auto entityToAdd = Entity{{
+      {"classname", "info_compile_settings"},
+      {"message", "added by export"},
+    }};
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{map, str};
+    writer.setEntityToAdd(entityToAdd);
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+    const auto expected =
+      R"(// entity 0
+{
+"classname" "worldspawn"
+}
+// entity 1
+{
+"classname" "info_compile_settings"
+"message" "added by export"
+}
+)";
+    CHECK(actual == expected);
+  }
+
   SECTION("writeDaikatanaMap")
   {
     const auto worldBounds = vm::bbox3d{8192.0};

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -46,16 +46,17 @@
 
 namespace tb::mdl
 {
+
 TEST_CASE("NodeWriter")
 {
   auto taskManager = kdl::task_manager{};
 
   SECTION("writeEmptyMap")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -70,10 +71,10 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeWorldspawn")
   {
-    auto map = WorldNode{{}, {{"message", "holy damn"}}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {{"message", "holy damn"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -89,17 +90,17 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeDefaultLayerProperties")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
-    map.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
-    map.defaultLayer()->setLockState(LockState::Locked);
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
+    worldNode.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
+    worldNode.defaultLayer()->setLockState(LockState::Locked);
 
-    auto layer = map.defaultLayer()->layer();
+    auto layer = worldNode.defaultLayer()->layer();
     layer.setColor(RgbF{0.25f, 0.75f, 1.0f});
     layer.setOmitFromExport(true);
-    map.defaultLayer()->setLayer(std::move(layer));
+    worldNode.defaultLayer()->setLayer(std::move(layer));
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -118,17 +119,17 @@ TEST_CASE("NodeWriter")
 
   SECTION("stripTbProperties")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
-    map.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
-    map.defaultLayer()->setLockState(LockState::Locked);
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
+    worldNode.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
+    worldNode.defaultLayer()->setLockState(LockState::Locked);
 
-    auto layer = map.defaultLayer()->layer();
+    auto layer = worldNode.defaultLayer()->layer();
     layer.setColor(RgbF{0.25f, 0.75f, 1.0f});
     layer.setOmitFromExport(true);
-    map.defaultLayer()->setLayer(std::move(layer));
+    worldNode.defaultLayer()->setLayer(std::move(layer));
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.setStripTbProperties(true);
     writer.writeMap(taskManager);
 
@@ -144,7 +145,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("stripEntityPattern")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto* matchingPointEntityNode = new EntityNode{Entity{{
       {"classname", "info_player_start"},
@@ -159,12 +160,12 @@ TEST_CASE("NodeWriter")
       {"origin", "128 0 0"},
     }}};
 
-    map.defaultLayer()->addChild(matchingPointEntityNode);
-    map.defaultLayer()->addChild(caseMatchingPointEntityNode);
-    map.defaultLayer()->addChild(nonMatchingPointEntityNode);
+    worldNode.defaultLayer()->addChild(matchingPointEntityNode);
+    worldNode.defaultLayer()->addChild(caseMatchingPointEntityNode);
+    worldNode.defaultLayer()->addChild(nonMatchingPointEntityNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.setStripEntityPattern("info_*");
     writer.writeMap(taskManager);
 
@@ -243,7 +244,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("setEntityNodeToAdd")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     const auto entityToAdd = Entity{{
       {"classname", "info_compile_settings"},
@@ -251,7 +252,7 @@ TEST_CASE("NodeWriter")
     }};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.setEntityToAdd(entityToAdd);
     writer.writeMap(taskManager);
 
@@ -274,9 +275,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Daikatana};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Daikatana};
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto brush1 = builder.createCube(64.0, "none") | kdl::value();
     for (auto& face : brush1.faces())
     {
@@ -285,13 +286,13 @@ TEST_CASE("NodeWriter")
       face.setAttributes(attributes);
     }
     auto* brushNode1 = new BrushNode{std::move(brush1)};
-    map.defaultLayer()->addChild(brushNode1);
+    worldNode.defaultLayer()->addChild(brushNode1);
 
     auto* brushNode2 = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
-    map.defaultLayer()->addChild(brushNode2);
+    worldNode.defaultLayer()->addChild(brushNode2);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -326,9 +327,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Quake2_Valve};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Quake2_Valve};
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto brush1 = builder.createCube(64.0, "e1u1/alarm0") | kdl::value();
 
     // set +Z face to e1u1/brwater with contents 0, flags 0, value 0
@@ -360,10 +361,10 @@ TEST_CASE("NodeWriter")
     // other faces are e1u1/alarm0 with unset contents/flags/value
 
     auto* brushNode1 = new BrushNode{std::move(brush1)};
-    map.defaultLayer()->addChild(brushNode1);
+    worldNode.defaultLayer()->addChild(brushNode1);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -390,14 +391,14 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Quake3_Valve};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Quake3_Valve};
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode1 = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
-    map.defaultLayer()->addChild(brushNode1);
+    worldNode.defaultLayer()->addChild(brushNode1);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -424,14 +425,14 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
-    map.defaultLayer()->addChild(brushNode);
+    worldNode.defaultLayer()->addChild(brushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -457,21 +458,21 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto layer = Layer{"Custom Layer"};
     REQUIRE(layer.sortIndex() == Layer::invalidSortIndex());
     layer.setSortIndex(0);
 
     auto* layerNode = new LayerNode{std::move(layer)};
-    map.addChild(layerNode);
+    worldNode.addChild(layerNode);
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     layerNode->addChild(brushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -504,7 +505,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeWorldspawnWithCustomLayerWithSortIndex")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto layer = Layer{"Custom Layer"};
     layer.setSortIndex(1);
@@ -514,10 +515,10 @@ TEST_CASE("NodeWriter")
     layerNode->setLockState(LockState::Locked);
     layerNode->setVisibilityState(VisibilityState::Hidden);
 
-    map.addChild(layerNode);
+    worldNode.addChild(layerNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -546,18 +547,18 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto* groupNode = new GroupNode{Group{"Group"}};
     setLinkId(*groupNode, "group_link_id");
-    map.defaultLayer()->addChild(groupNode);
+    worldNode.defaultLayer()->addChild(groupNode);
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     groupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -592,21 +593,21 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
-    map.addChild(layerNode);
+    worldNode.addChild(layerNode);
 
     auto* groupNode = new GroupNode{Group{"Group"}};
     setLinkId(*groupNode, "group_link_id");
     layerNode->addChild(groupNode);
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     groupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -650,10 +651,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
-    map.addChild(layerNode);
+    worldNode.addChild(layerNode);
 
     auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
     setLinkId(*outerGroupNode, "outer_group_link_id");
@@ -663,12 +664,12 @@ TEST_CASE("NodeWriter")
     setLinkId(*innerGroupNode, "inner_group_link_id");
     outerGroupNode->addChild(innerGroupNode);
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     innerGroupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -722,11 +723,11 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto* layerNode1 = new LayerNode{Layer{"Custom Layer 1"}};
     layerNode1->setPersistentId(1u);
-    map.addChild(layerNode1);
+    worldNode.addChild(layerNode1);
 
     auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
     outerGroupNode->setPersistentId(21u);
@@ -740,14 +741,14 @@ TEST_CASE("NodeWriter")
 
     auto* layerNode2 = new LayerNode{Layer{"Custom Layer 2"}};
     layerNode2->setPersistentId(12u);
-    map.addChild(layerNode2);
+    worldNode.addChild(layerNode2);
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     innerGroupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -805,28 +806,28 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
 
     // default layer (omit from export)
-    auto defaultLayer = map.defaultLayer()->layer();
+    auto defaultLayer = worldNode.defaultLayer()->layer();
     defaultLayer.setOmitFromExport(true);
-    map.defaultLayer()->setLayer(std::move(defaultLayer));
+    worldNode.defaultLayer()->setLayer(std::move(defaultLayer));
 
     auto* defaultLayerPointEntityNode =
       new EntityNode{Entity{{{"classname", "defaultLayerPointEntity"}}}};
 
     auto* defaultLayerBrushNode =
       new BrushNode{builder.createCube(64.0, "defaultMaterial") | kdl::value()};
-    map.defaultLayer()->addChild(defaultLayerPointEntityNode);
-    map.defaultLayer()->addChild(defaultLayerBrushNode);
+    worldNode.defaultLayer()->addChild(defaultLayerPointEntityNode);
+    worldNode.defaultLayer()->addChild(defaultLayerBrushNode);
 
     // layer1 (omit from export)
     auto layer1 = Layer{"Custom Layer 1"};
     layer1.setOmitFromExport(true);
 
     auto* layerNode1 = new LayerNode{std::move(layer1)};
-    map.addChild(layerNode1);
+    worldNode.addChild(layerNode1);
 
     auto* layer1PointEntityNode =
       new EntityNode{Entity{{{"classname", "layer1PointEntity"}}}};
@@ -838,7 +839,7 @@ TEST_CASE("NodeWriter")
 
     // layer2
     auto* layerNode2 = new LayerNode{Layer{"Custom Layer 2"}};
-    map.addChild(layerNode2);
+    worldNode.addChild(layerNode2);
 
     auto* layer2PointEntityNode =
       new EntityNode{Entity{{{"classname", "layer2PointEntity"}}}};
@@ -849,7 +850,7 @@ TEST_CASE("NodeWriter")
     layerNode2->addChild(layer2BrushNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.setExporting(true);
     writer.writeMap(taskManager);
 
@@ -887,22 +888,22 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeMapWithInheritedLock")
   {
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
-    map.addChild(layerNode);
+    worldNode.addChild(layerNode);
 
     // WorldNode's lock state is not persisted.
     // TB uses it e.g. for locking everything when opening a group.
     // So this should result in both the default layer and custom layer being written
     // unlocked.
 
-    map.setLockState(LockState::Locked);
-    map.defaultLayer()->setLockState(LockState::Inherited);
+    worldNode.setLockState(LockState::Locked);
+    worldNode.defaultLayer()->setLockState(LockState::Inherited);
     layerNode->setLockState(LockState::Inherited);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -926,9 +927,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
 
     auto* worldBrushNode = new BrushNode{builder.createCube(64.0, "some") | kdl::value()};
     auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
@@ -940,11 +941,11 @@ TEST_CASE("NodeWriter")
 
     innerGroupNode->addChild(innerBrushNode);
     outerGroupNode->addChild(innerGroupNode);
-    map.defaultLayer()->addChild(worldBrushNode);
-    map.defaultLayer()->addChild(outerGroupNode);
+    worldNode.defaultLayer()->addChild(worldBrushNode);
+    worldNode.defaultLayer()->addChild(outerGroupNode);
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeNodes({innerGroupNode, worldBrushNode}, taskManager);
 
     const auto actual = str.str();
@@ -1138,12 +1139,12 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = WorldNode{{}, {}, MapFormat::Standard};
-    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeBrushFaces(brushNode->brush().faces(), taskManager);
 
     const auto actual = str.str();
@@ -1163,10 +1164,11 @@ TEST_CASE("NodeWriter")
 
   SECTION("writePropertiesWithQuotationMarks")
   {
-    WorldNode map({}, {{"message", "\"holy damn\", he said"}}, MapFormat::Standard);
+    const auto worldNode =
+      WorldNode{{}, {{"message", "\"holy damn\", he said"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -1183,11 +1185,11 @@ TEST_CASE("NodeWriter")
 
   SECTION("writePropertiesWithEscapedQuotationMarks")
   {
-    auto map =
+    auto worldNode =
       WorldNode{{}, {{"message", R"(\"holy damn\", he said)"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -1205,10 +1207,11 @@ TEST_CASE("NodeWriter")
   // https://github.com/TrenchBroom/TrenchBroom/issues/1739
   SECTION("writePropertiesWithNewlineEscapeSequence")
   {
-    auto map = WorldNode{{}, {{"message", "holy damn\\nhe said"}}, MapFormat::Standard};
+    auto worldNode =
+      WorldNode{{}, {{"message", "holy damn\\nhe said"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();
@@ -1226,7 +1229,7 @@ TEST_CASE("NodeWriter")
   // https://github.com/TrenchBroom/TrenchBroom/issues/2556
   SECTION("writePropertiesWithTrailingBackslash")
   {
-    auto map = WorldNode{
+    auto worldNode = WorldNode{
       {},
       {
         {R"(message\)", R"(holy damn\)"},
@@ -1236,7 +1239,7 @@ TEST_CASE("NodeWriter")
       MapFormat::Standard};
 
     auto str = std::stringstream{};
-    auto writer = NodeWriter{map, str};
+    auto writer = NodeWriter{worldNode, str};
     writer.writeMap(taskManager);
 
     const auto actual = str.str();

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -52,7 +52,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeEmptyMap")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -70,7 +70,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeWorldspawn")
   {
-    auto map = mdl::WorldNode{{}, {{"message", "holy damn"}}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {{"message", "holy damn"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -89,9 +89,9 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeDefaultLayerProperties")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    map.defaultLayer()->setVisibilityState(mdl::VisibilityState::Hidden);
-    map.defaultLayer()->setLockState(mdl::LockState::Locked);
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    map.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
+    map.defaultLayer()->setLockState(LockState::Locked);
 
     auto layer = map.defaultLayer()->layer();
     layer.setColor(RgbF{0.25f, 0.75f, 1.0f});
@@ -118,9 +118,9 @@ TEST_CASE("NodeWriter")
 
   SECTION("stripTbProperties")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    map.defaultLayer()->setVisibilityState(mdl::VisibilityState::Hidden);
-    map.defaultLayer()->setLockState(mdl::LockState::Locked);
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    map.defaultLayer()->setVisibilityState(VisibilityState::Hidden);
+    map.defaultLayer()->setLockState(LockState::Locked);
 
     auto layer = map.defaultLayer()->layer();
     layer.setColor(RgbF{0.25f, 0.75f, 1.0f});
@@ -146,9 +146,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Daikatana};
+    auto map = WorldNode{{}, {}, MapFormat::Daikatana};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
     auto brush1 = builder.createCube(64.0, "none") | kdl::value();
     for (auto& face : brush1.faces())
     {
@@ -156,11 +156,10 @@ TEST_CASE("NodeWriter")
       attributes.setColor(RgbF{1.0f, 0.5f, 0.25f});
       face.setAttributes(attributes);
     }
-    auto* brushNode1 = new mdl::BrushNode{std::move(brush1)};
+    auto* brushNode1 = new BrushNode{std::move(brush1)};
     map.defaultLayer()->addChild(brushNode1);
 
-    auto* brushNode2 =
-      new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto* brushNode2 = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     map.defaultLayer()->addChild(brushNode2);
 
     auto str = std::stringstream{};
@@ -199,9 +198,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake2_Valve};
+    auto map = WorldNode{{}, {}, MapFormat::Quake2_Valve};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
     auto brush1 = builder.createCube(64.0, "e1u1/alarm0") | kdl::value();
 
     // set +Z face to e1u1/brwater with contents 0, flags 0, value 0
@@ -232,7 +231,7 @@ TEST_CASE("NodeWriter")
     }
     // other faces are e1u1/alarm0 with unset contents/flags/value
 
-    auto* brushNode1 = new mdl::BrushNode{std::move(brush1)};
+    auto* brushNode1 = new BrushNode{std::move(brush1)};
     map.defaultLayer()->addChild(brushNode1);
 
     auto str = std::stringstream{};
@@ -263,11 +262,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Quake3_Valve};
+    auto map = WorldNode{{}, {}, MapFormat::Quake3_Valve};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode1 =
-      new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode1 = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     map.defaultLayer()->addChild(brushNode1);
 
     auto str = std::stringstream{};
@@ -298,10 +296,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     map.defaultLayer()->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -331,17 +329,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto layer = mdl::Layer{"Custom Layer"};
-    REQUIRE(layer.sortIndex() == mdl::Layer::invalidSortIndex());
+    auto layer = Layer{"Custom Layer"};
+    REQUIRE(layer.sortIndex() == Layer::invalidSortIndex());
     layer.setSortIndex(0);
 
-    auto* layerNode = new mdl::LayerNode{std::move(layer)};
+    auto* layerNode = new LayerNode{std::move(layer)};
     map.addChild(layerNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     layerNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -378,15 +376,15 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeWorldspawnWithCustomLayerWithSortIndex")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto layer = mdl::Layer{"Custom Layer"};
+    auto layer = Layer{"Custom Layer"};
     layer.setSortIndex(1);
     layer.setOmitFromExport(true);
 
-    auto* layerNode = new mdl::LayerNode{std::move(layer)};
-    layerNode->setLockState(mdl::LockState::Locked);
-    layerNode->setVisibilityState(mdl::VisibilityState::Hidden);
+    auto* layerNode = new LayerNode{std::move(layer)};
+    layerNode->setLockState(LockState::Locked);
+    layerNode->setVisibilityState(VisibilityState::Hidden);
 
     map.addChild(layerNode);
 
@@ -420,14 +418,14 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "group_link_id");
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "group_link_id");
     map.defaultLayer()->addChild(groupNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     groupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -466,17 +464,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode = new mdl::LayerNode{mdl::Layer{"Custom Layer"}};
+    auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
     map.addChild(layerNode);
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "group_link_id");
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "group_link_id");
     layerNode->addChild(groupNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     groupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -524,21 +522,21 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode = new mdl::LayerNode{mdl::Layer{"Custom Layer"}};
+    auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
     map.addChild(layerNode);
 
-    auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"Outer Group"}};
-    mdl::setLinkId(*outerGroupNode, "outer_group_link_id");
+    auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
+    setLinkId(*outerGroupNode, "outer_group_link_id");
     layerNode->addChild(outerGroupNode);
 
-    auto* innerGroupNode = new mdl::GroupNode{mdl::Group{"Inner Group"}};
-    mdl::setLinkId(*innerGroupNode, "inner_group_link_id");
+    auto* innerGroupNode = new GroupNode{Group{"Inner Group"}};
+    setLinkId(*innerGroupNode, "inner_group_link_id");
     outerGroupNode->addChild(innerGroupNode);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     innerGroupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -596,28 +594,28 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode1 = new mdl::LayerNode{mdl::Layer{"Custom Layer 1"}};
+    auto* layerNode1 = new LayerNode{Layer{"Custom Layer 1"}};
     layerNode1->setPersistentId(1u);
     map.addChild(layerNode1);
 
-    auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"Outer Group"}};
+    auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
     outerGroupNode->setPersistentId(21u);
-    mdl::setLinkId(*outerGroupNode, "outer_group_link_id");
+    setLinkId(*outerGroupNode, "outer_group_link_id");
     layerNode1->addChild(outerGroupNode);
 
-    auto* innerGroupNode = new mdl::GroupNode{mdl::Group{"Inner Group"}};
+    auto* innerGroupNode = new GroupNode{Group{"Inner Group"}};
     innerGroupNode->setPersistentId(7u);
-    mdl::setLinkId(*innerGroupNode, "inner_group_link_id");
+    setLinkId(*innerGroupNode, "inner_group_link_id");
     outerGroupNode->addChild(innerGroupNode);
 
-    auto* layerNode2 = new mdl::LayerNode{mdl::Layer{"Custom Layer 2"}};
+    auto* layerNode2 = new LayerNode{Layer{"Custom Layer 2"}};
     layerNode2->setPersistentId(12u);
     map.addChild(layerNode2);
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
     innerGroupNode->addChild(brushNode);
 
     auto str = std::stringstream{};
@@ -679,8 +677,8 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
 
     // default layer (omit from export)
     auto defaultLayer = map.defaultLayer()->layer();
@@ -688,38 +686,38 @@ TEST_CASE("NodeWriter")
     map.defaultLayer()->setLayer(std::move(defaultLayer));
 
     auto* defaultLayerPointEntityNode =
-      new mdl::EntityNode{mdl::Entity{{{"classname", "defaultLayerPointEntity"}}}};
+      new EntityNode{Entity{{{"classname", "defaultLayerPointEntity"}}}};
 
     auto* defaultLayerBrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "defaultMaterial") | kdl::value()};
+      new BrushNode{builder.createCube(64.0, "defaultMaterial") | kdl::value()};
     map.defaultLayer()->addChild(defaultLayerPointEntityNode);
     map.defaultLayer()->addChild(defaultLayerBrushNode);
 
     // layer1 (omit from export)
-    auto layer1 = mdl::Layer{"Custom Layer 1"};
+    auto layer1 = Layer{"Custom Layer 1"};
     layer1.setOmitFromExport(true);
 
-    auto* layerNode1 = new mdl::LayerNode{std::move(layer1)};
+    auto* layerNode1 = new LayerNode{std::move(layer1)};
     map.addChild(layerNode1);
 
     auto* layer1PointEntityNode =
-      new mdl::EntityNode{mdl::Entity{{{"classname", "layer1PointEntity"}}}};
+      new EntityNode{Entity{{{"classname", "layer1PointEntity"}}}};
     layerNode1->addChild(layer1PointEntityNode);
 
     auto* layer1BrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "layer1Material") | kdl::value()};
+      new BrushNode{builder.createCube(64.0, "layer1Material") | kdl::value()};
     layerNode1->addChild(layer1BrushNode);
 
     // layer2
-    auto* layerNode2 = new mdl::LayerNode{mdl::Layer{"Custom Layer 2"}};
+    auto* layerNode2 = new LayerNode{Layer{"Custom Layer 2"}};
     map.addChild(layerNode2);
 
     auto* layer2PointEntityNode =
-      new mdl::EntityNode{mdl::Entity{{{"classname", "layer2PointEntity"}}}};
+      new EntityNode{Entity{{{"classname", "layer2PointEntity"}}}};
     layerNode2->addChild(layer2PointEntityNode);
 
     auto* layer2BrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "layer2Material") | kdl::value()};
+      new BrushNode{builder.createCube(64.0, "layer2Material") | kdl::value()};
     layerNode2->addChild(layer2BrushNode);
 
     auto str = std::stringstream{};
@@ -761,9 +759,9 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeMapWithInheritedLock")
   {
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* layerNode = new mdl::LayerNode{mdl::Layer{"Custom Layer"}};
+    auto* layerNode = new LayerNode{Layer{"Custom Layer"}};
     map.addChild(layerNode);
 
     // WorldNode's lock state is not persisted.
@@ -771,9 +769,9 @@ TEST_CASE("NodeWriter")
     // So this should result in both the default layer and custom layer being written
     // unlocked.
 
-    map.setLockState(mdl::LockState::Locked);
-    map.defaultLayer()->setLockState(mdl::LockState::Inherited);
-    layerNode->setLockState(mdl::LockState::Inherited);
+    map.setLockState(LockState::Locked);
+    map.defaultLayer()->setLockState(LockState::Inherited);
+    layerNode->setLockState(LockState::Inherited);
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -800,19 +798,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
 
-    auto* worldBrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "some") | kdl::value()};
-    auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"Outer Group"}};
-    auto* innerGroupNode = new mdl::GroupNode{mdl::Group{"Inner Group"}};
-    auto* innerBrushNode =
-      new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto* worldBrushNode = new BrushNode{builder.createCube(64.0, "some") | kdl::value()};
+    auto* outerGroupNode = new GroupNode{Group{"Outer Group"}};
+    auto* innerGroupNode = new GroupNode{Group{"Inner Group"}};
+    auto* innerBrushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
 
-    mdl::setLinkId(*outerGroupNode, "outer_group_link_id");
-    mdl::setLinkId(*innerGroupNode, "inner_group_link_id");
+    setLinkId(*outerGroupNode, "outer_group_link_id");
+    setLinkId(*innerGroupNode, "inner_group_link_id");
 
     innerGroupNode->addChild(innerBrushNode);
     outerGroupNode->addChild(innerGroupNode);
@@ -864,10 +860,10 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto worldNode = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "group_link_id");
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "group_link_id");
     worldNode.defaultLayer()->addChild(groupNode);
 
     SECTION("Group node with identity transformation does not write transformation")
@@ -897,8 +893,7 @@ TEST_CASE("NodeWriter")
 
     SECTION("Group node with changed transformation writes transformation")
     {
-      mdl::transformNode(
-        *groupNode, vm::translation_matrix(vm::vec3d{32, 0, 0}), worldBounds);
+      transformNode(*groupNode, vm::translation_matrix(vm::vec3d{32, 0, 0}), worldBounds);
 
       auto str = std::stringstream{};
       auto writer = NodeWriter{worldNode, str};
@@ -929,17 +924,17 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto worldNode = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
-    auto* groupNode = new mdl::GroupNode{mdl::Group{"Group"}};
-    mdl::setLinkId(*groupNode, "asdf");
-    mdl::transformNode(
+    auto* groupNode = new GroupNode{Group{"Group"}};
+    setLinkId(*groupNode, "asdf");
+    transformNode(
       *groupNode, vm::translation_matrix(vm::vec3d(32.0, 0.0, 0.0)), worldBounds);
     worldNode.defaultLayer()->addChild(groupNode);
 
     auto* groupNodeClone =
-      static_cast<mdl::GroupNode*>(groupNode->cloneRecursively(worldBounds));
-    mdl::transformNode(
+      static_cast<GroupNode*>(groupNode->cloneRecursively(worldBounds));
+    transformNode(
       *groupNodeClone, vm::translation_matrix(vm::vec3d(0.0, 16.0, 0.0)), worldBounds);
 
     worldNode.defaultLayer()->addChild(groupNodeClone);
@@ -967,13 +962,13 @@ TEST_CASE("NodeWriter")
 
   SECTION("writeProtectedEntityProperties")
   {
-    auto worldNode = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
 
     SECTION("No protected properties")
     {
-      auto entity = mdl::Entity{};
+      auto entity = Entity{};
       entity.setProtectedProperties({});
-      auto* entityNode = new mdl::EntityNode{std::move(entity)};
+      auto* entityNode = new EntityNode{std::move(entity)};
       worldNode.defaultLayer()->addChild(entityNode);
 
       auto str = std::stringstream{};
@@ -991,9 +986,9 @@ TEST_CASE("NodeWriter")
 
     SECTION("Some protected properties")
     {
-      auto entity = mdl::Entity{};
+      auto entity = Entity{};
       entity.setProtectedProperties({"asdf", "some", "with;semicolon"});
-      auto* entityNode = new mdl::EntityNode{std::move(entity)};
+      auto* entityNode = new EntityNode{std::move(entity)};
       worldNode.defaultLayer()->addChild(entityNode);
 
       auto str = std::stringstream{};
@@ -1015,9 +1010,9 @@ TEST_CASE("NodeWriter")
   {
     const auto worldBounds = vm::bbox3d{8192.0};
 
-    auto map = mdl::WorldNode{{}, {}, mdl::MapFormat::Standard};
-    auto builder = mdl::BrushBuilder{map.mapFormat(), worldBounds};
-    auto* brushNode = new mdl::BrushNode{builder.createCube(64.0, "none") | kdl::value()};
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{map.mapFormat(), worldBounds};
+    auto* brushNode = new BrushNode{builder.createCube(64.0, "none") | kdl::value()};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1040,8 +1035,7 @@ TEST_CASE("NodeWriter")
 
   SECTION("writePropertiesWithQuotationMarks")
   {
-    mdl::WorldNode map(
-      {}, {{"message", "\"holy damn\", he said"}}, mdl::MapFormat::Standard);
+    WorldNode map({}, {{"message", "\"holy damn\", he said"}}, MapFormat::Standard);
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1061,8 +1055,8 @@ TEST_CASE("NodeWriter")
 
   SECTION("writePropertiesWithEscapedQuotationMarks")
   {
-    auto map = mdl::WorldNode{
-      {}, {{"message", R"(\"holy damn\", he said)"}}, mdl::MapFormat::Standard};
+    auto map =
+      WorldNode{{}, {{"message", R"(\"holy damn\", he said)"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1083,8 +1077,7 @@ TEST_CASE("NodeWriter")
   // https://github.com/TrenchBroom/TrenchBroom/issues/1739
   SECTION("writePropertiesWithNewlineEscapeSequence")
   {
-    auto map =
-      mdl::WorldNode{{}, {{"message", "holy damn\\nhe said"}}, mdl::MapFormat::Standard};
+    auto map = WorldNode{{}, {{"message", "holy damn\\nhe said"}}, MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};
@@ -1105,14 +1098,14 @@ TEST_CASE("NodeWriter")
   // https://github.com/TrenchBroom/TrenchBroom/issues/2556
   SECTION("writePropertiesWithTrailingBackslash")
   {
-    auto map = mdl::WorldNode{
+    auto map = WorldNode{
       {},
       {
         {R"(message\)", R"(holy damn\)"},
         {R"(message2)", R"(holy damn\\)"},
         {R"(message3)", R"(holy damn\\\)"},
       },
-      mdl::MapFormat::Standard};
+      MapFormat::Standard};
 
     auto str = std::stringstream{};
     auto writer = NodeWriter{map, str};

--- a/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeWriter.cpp
@@ -142,6 +142,105 @@ TEST_CASE("NodeWriter")
     CHECK(actual == expected);
   }
 
+  SECTION("stripEntityPattern")
+  {
+    auto map = WorldNode{{}, {}, MapFormat::Standard};
+
+    auto* matchingPointEntityNode = new EntityNode{Entity{{
+      {"classname", "info_player_start"},
+      {"origin", "0 0 0"},
+    }}};
+    auto* caseMatchingPointEntityNode = new EntityNode{Entity{{
+      {"classname", "INFO_PLAYER_DEATHMATCH"},
+      {"origin", "64 0 0"},
+    }}};
+    auto* nonMatchingPointEntityNode = new EntityNode{Entity{{
+      {"classname", "light"},
+      {"origin", "128 0 0"},
+    }}};
+
+    map.defaultLayer()->addChild(matchingPointEntityNode);
+    map.defaultLayer()->addChild(caseMatchingPointEntityNode);
+    map.defaultLayer()->addChild(nonMatchingPointEntityNode);
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{map, str};
+    writer.setStripEntityPattern("info_*");
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+    const auto expected =
+      R"(// entity 0
+{
+"classname" "worldspawn"
+}
+// entity 1
+{
+"classname" "light"
+"origin" "128 0 0"
+}
+)";
+    CHECK(actual == expected);
+  }
+
+  SECTION("stripEntityPattern strips brush entities")
+  {
+    const auto worldBounds = vm::bbox3d{8192.0};
+
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
+    auto builder = BrushBuilder{worldNode.mapFormat(), worldBounds};
+
+    auto* matchingBrushEntityNode = new EntityNode{Entity{{
+      {"classname", "info_brush_entity"},
+    }}};
+    matchingBrushEntityNode->addChild(
+      new BrushNode{builder.createCube(64.0, "none") | kdl::value()});
+
+    worldNode.defaultLayer()->addChild(matchingBrushEntityNode);
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{worldNode, str};
+    writer.setStripEntityPattern("info_*");
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+    const auto expected =
+      R"(// entity 0
+{
+"classname" "worldspawn"
+}
+)";
+    CHECK(actual == expected);
+  }
+
+  SECTION("stripEntityPattern keeps entities without a classname")
+  {
+    auto worldNode = WorldNode{{}, {}, MapFormat::Standard};
+
+    auto* entityNodeWithoutClassname = new EntityNode{Entity{{
+      {"some_key", "some_value"},
+    }}};
+    worldNode.defaultLayer()->addChild(entityNodeWithoutClassname);
+
+    auto str = std::stringstream{};
+    auto writer = NodeWriter{worldNode, str};
+    writer.setStripEntityPattern("info_*");
+    writer.writeMap(taskManager);
+
+    const auto actual = str.str();
+    const auto expected =
+      R"(// entity 0
+{
+"classname" "worldspawn"
+}
+// entity 1
+{
+"some_key" "some_value"
+}
+)";
+    CHECK(actual == expected);
+  }
+
   SECTION("writeDaikatanaMap")
   {
     const auto worldBounds = vm::bbox3d{8192.0};

--- a/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
@@ -185,7 +185,8 @@ TEST_CASE("CompilationConfigParser")
         {"A profile",
          "",
          {
-           mdl::CompilationExportMap{K(enabled), !K(stripTbProperties), "the target"},
+           mdl::CompilationExportMap{
+             K(enabled), !K(stripTbProperties), std::nullopt, "the target"},
          }},
       }});
   }
@@ -210,7 +211,34 @@ TEST_CASE("CompilationConfigParser")
         {"A profile",
          "",
          {
-           mdl::CompilationExportMap{K(enabled), K(stripTbProperties), "the target"},
+           mdl::CompilationExportMap{
+             K(enabled), K(stripTbProperties), std::nullopt, "the target"},
+         }},
+      }});
+  }
+
+  SECTION("parseOneProfileWithNameAndOneExportTaskWithStripEntityPattern")
+  {
+    const auto config = R"(
+{
+  'version': 1,
+  'profiles': [
+    {
+      'name' : 'A profile',
+      'workdir' : '',
+      'tasks' : [ { 'type' : 'export', 'stripTbProperties': true, 'stripEntityPattern': 'info_player_*', 'target' : 'the target' } ]
+    }
+  ]
+})";
+
+    CHECK(
+      parseCompilationConfig(config)
+      == mdl::CompilationConfig{{
+        {"A profile",
+         "",
+         {
+           mdl::CompilationExportMap{
+             K(enabled), K(stripTbProperties), "info_player_*", "the target"},
          }},
       }});
   }

--- a/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
+++ b/lib/TbMdlLib/test/src/tst_ParseCompilationConfig.cpp
@@ -186,7 +186,7 @@ TEST_CASE("CompilationConfigParser")
          "",
          {
            mdl::CompilationExportMap{
-             K(enabled), !K(stripTbProperties), std::nullopt, "the target"},
+             K(enabled), !K(stripTbProperties), std::nullopt, std::nullopt, "the target"},
          }},
       }});
   }
@@ -212,7 +212,7 @@ TEST_CASE("CompilationConfigParser")
          "",
          {
            mdl::CompilationExportMap{
-             K(enabled), K(stripTbProperties), std::nullopt, "the target"},
+             K(enabled), K(stripTbProperties), std::nullopt, std::nullopt, "the target"},
          }},
       }});
   }
@@ -238,7 +238,41 @@ TEST_CASE("CompilationConfigParser")
          "",
          {
            mdl::CompilationExportMap{
-             K(enabled), K(stripTbProperties), "info_player_*", "the target"},
+             K(enabled),
+             K(stripTbProperties),
+             "info_player_*",
+             std::nullopt,
+             "the target"},
+         }},
+      }});
+  }
+
+  SECTION("parseOneProfileWithNameAndOneExportTaskWithEntityToAdd")
+  {
+    const auto config = R"(
+{
+  'version': 1,
+  'profiles': [
+    {
+      'name' : 'A profile',
+      'workdir' : '',
+      'tasks' : [ { 'type' : 'export', 'stripTbProperties': true, 'entityToAdd': [ { 'key': 'classname', 'value': 'info_player_start' } ], 'target' : 'the target' } ]
+    }
+  ]
+})";
+
+    CHECK(
+      parseCompilationConfig(config)
+      == mdl::CompilationConfig{{
+        {"A profile",
+         "",
+         {
+           mdl::CompilationExportMap{
+             K(enabled),
+             K(stripTbProperties),
+             std::nullopt,
+             mdl::Entity{{{"classname", "info_player_start"}}},
+             "the target"},
          }},
       }});
   }

--- a/lib/TbUiLib/include/ui/CompilationContext.h
+++ b/lib/TbUiLib/include/ui/CompilationContext.h
@@ -28,6 +28,11 @@
 
 namespace tb
 {
+namespace gl
+{
+class PerspectiveCamera;
+}
+
 namespace mdl
 {
 class Map;
@@ -40,6 +45,7 @@ class CompilationContext
 {
 private:
   const mdl::Map& m_map;
+  const gl::PerspectiveCamera& m_camera;
   std::unique_ptr<el::VariableStore> m_variables;
 
   TextOutputAdapter m_output;
@@ -48,11 +54,13 @@ private:
 public:
   CompilationContext(
     const mdl::Map& map,
+    const gl::PerspectiveCamera& camera,
     const el::VariableStore& variables,
     TextOutputAdapter output,
     bool test);
 
   const mdl::Map& map() const;
+  const gl::PerspectiveCamera& camera() const;
   bool test() const;
 
   Result<std::string> interpolate(const std::string& input) const;

--- a/lib/TbUiLib/include/ui/CompilationDialog.h
+++ b/lib/TbUiLib/include/ui/CompilationDialog.h
@@ -29,6 +29,11 @@ class QTextEdit;
 
 namespace tb
 {
+namespace gl
+{
+class PerspectiveCamera;
+}
+
 namespace mdl
 {
 struct CompilationProfile;
@@ -46,6 +51,7 @@ class CompilationDialog : public QDialog
 private:
   AppController& m_appController;
   MapDocument& m_document;
+  const gl::PerspectiveCamera& m_camera;
 
   CompilationProfileManager* m_profileManager = nullptr;
   QPushButton* m_launchButton = nullptr;
@@ -59,7 +65,10 @@ private:
 
 public:
   explicit CompilationDialog(
-    AppController& appController, MapDocument& document, QWidget* parent = nullptr);
+    AppController& appController,
+    MapDocument& document,
+    const gl::PerspectiveCamera& camera,
+    QWidget* parent = nullptr);
 
   bool selectProfile(const mdl::CompilationProfile& profile);
   void selectFirstProfile();

--- a/lib/TbUiLib/include/ui/CompilationRun.h
+++ b/lib/TbUiLib/include/ui/CompilationRun.h
@@ -31,6 +31,11 @@ namespace tb
 {
 class VariableTable;
 
+namespace gl
+{
+class PerspectiveCamera;
+}
+
 namespace mdl
 {
 class Map;
@@ -55,10 +60,12 @@ public:
   Result<void> run(
     const mdl::CompilationProfile& profile,
     const mdl::Map& map,
+    const gl::PerspectiveCamera& camera,
     QTextEdit* currentOutput);
   Result<void> test(
     const mdl::CompilationProfile& profile,
     const mdl::Map& map,
+    const gl::PerspectiveCamera& camera,
     QTextEdit* currentOutput);
   void terminate();
 
@@ -67,6 +74,7 @@ private:
   Result<void> run(
     const mdl::CompilationProfile& profile,
     const mdl::Map& map,
+    const gl::PerspectiveCamera& camera,
     QTextEdit* currentOutput,
     bool test);
 

--- a/lib/TbUiLib/include/ui/CompilationTaskListBox.h
+++ b/lib/TbUiLib/include/ui/CompilationTaskListBox.h
@@ -82,6 +82,7 @@ class CompilationExportMapTaskEditor : public CompilationTaskEditorBase
 private:
   MultiCompletionLineEdit* m_targetEditor = nullptr;
   QLineEdit* m_stripEntityPattern = nullptr;
+  QLineEdit* m_dropEntity = nullptr;
   QCheckBox* m_stripTbProperties = nullptr;
 
 public:
@@ -98,6 +99,7 @@ private:
 private slots:
   void targetSpecChanged(const QString& text);
   void stripEntityPatternChanged(const QString& text);
+  void dropEntityChanged(const QString& text);
   void stripTbPropertiesChanged(int state);
 };
 

--- a/lib/TbUiLib/include/ui/CompilationTaskListBox.h
+++ b/lib/TbUiLib/include/ui/CompilationTaskListBox.h
@@ -66,11 +66,10 @@ protected:
     mdl::CompilationTask& task,
     QWidget* parent);
 
-protected:
   void setupCompleter(MultiCompletionLineEdit* lineEdit);
   void addMainLayout(QLayout* layout);
 
-protected:
+public:
   void updateItem() override;
 
 private:
@@ -92,8 +91,9 @@ public:
     mdl::CompilationTask& task,
     QWidget* parent = nullptr);
 
-private:
   void updateItem() override;
+
+private:
   mdl::CompilationExportMap& task();
 private slots:
   void targetSpecChanged(const QString& text);
@@ -115,8 +115,9 @@ public:
     mdl::CompilationTask& task,
     QWidget* parent = nullptr);
 
-private:
   void updateItem() override;
+
+private:
   mdl::CompilationCopyFiles& task();
 private slots:
   void sourceSpecChanged(const QString& text);
@@ -137,8 +138,9 @@ public:
     mdl::CompilationTask& task,
     QWidget* parent = nullptr);
 
-private:
   void updateItem() override;
+
+private:
   mdl::CompilationRenameFile& task();
 private slots:
   void sourceSpecChanged(const QString& text);
@@ -158,8 +160,9 @@ public:
     mdl::CompilationTask& task,
     QWidget* parent = nullptr);
 
-private:
   void updateItem() override;
+
+private:
   mdl::CompilationDeleteFiles& task();
 private slots:
   void targetSpecChanged(const QString& text);
@@ -180,8 +183,9 @@ public:
     mdl::CompilationTask& task,
     QWidget* parent = nullptr);
 
-private:
   void updateItem() override;
+
+private:
   mdl::CompilationRunTool& task();
 private slots:
   void browseTool();
@@ -204,8 +208,9 @@ public:
     mdl::CompilationTask& task,
     QWidget* parent = nullptr);
 
-private:
   void updateItem() override;
+
+private:
   mdl::CompilationLaunchEngine& task();
 private slots:
   void engineProfileChanged(int index);

--- a/lib/TbUiLib/include/ui/CompilationTaskListBox.h
+++ b/lib/TbUiLib/include/ui/CompilationTaskListBox.h
@@ -82,6 +82,7 @@ class CompilationExportMapTaskEditor : public CompilationTaskEditorBase
   Q_OBJECT
 private:
   MultiCompletionLineEdit* m_targetEditor = nullptr;
+  QLineEdit* m_stripEntityPattern = nullptr;
   QCheckBox* m_stripTbProperties = nullptr;
 
 public:
@@ -96,6 +97,7 @@ private:
   mdl::CompilationExportMap& task();
 private slots:
   void targetSpecChanged(const QString& text);
+  void stripEntityPatternChanged(const QString& text);
   void stripTbPropertiesChanged(int state);
 };
 

--- a/lib/TbUiLib/include/ui/CyclingMapView.h
+++ b/lib/TbUiLib/include/ui/CyclingMapView.h
@@ -83,6 +83,8 @@ public: // implement MapView interface
   void refreshViews() override;
 
 public: // implement MapViewContainer interface
+  const gl::PerspectiveCamera& perspectiveCamera() const override;
+
   bool canMaximizeCurrentView() const override;
   bool currentViewMaximized() const override;
   void toggleMaximizeCurrentView() override;

--- a/lib/TbUiLib/include/ui/FourPaneMapView.h
+++ b/lib/TbUiLib/include/ui/FourPaneMapView.h
@@ -60,7 +60,10 @@ private:
 private: // event handlers
   void onSplitterMoved(int pos, int index);
 
-private: // implement MultiPaneMapView subclassing interface
+public: // implement MultiPaneMapView subclassing interface
+  const gl::PerspectiveCamera& perspectiveCamera() const override;
+
+private:
   void maximizeView(MapView* view) override;
   void restoreViews() override;
 };

--- a/lib/TbUiLib/include/ui/MapView3D.h
+++ b/lib/TbUiLib/include/ui/MapView3D.h
@@ -52,6 +52,8 @@ public:
   MapView3D(AppController& appController, MapDocument& document, MapViewToolBox& toolBox);
   ~MapView3D() override;
 
+  const gl::PerspectiveCamera& perspectiveCamera() const;
+
 private:
   void initializeCamera();
   void initializeToolChain(MapViewToolBox& toolBox);

--- a/lib/TbUiLib/include/ui/MapViewContainer.h
+++ b/lib/TbUiLib/include/ui/MapViewContainer.h
@@ -23,7 +23,14 @@
 
 #include "ui/MapView.h"
 
-namespace tb::ui
+namespace tb
+{
+namespace gl
+{
+class PerspectiveCamera;
+}
+
+namespace ui
 {
 class MapViewActivationTracker;
 class MapViewBase;
@@ -36,6 +43,8 @@ public:
   ~MapViewContainer() override;
 
 public:
+  virtual const gl::PerspectiveCamera& perspectiveCamera() const = 0;
+
   virtual bool canMaximizeCurrentView() const = 0;
   virtual bool currentViewMaximized() const = 0;
   virtual void toggleMaximizeCurrentView() = 0;
@@ -55,4 +64,6 @@ public: // implement MapView interface
 public:
   virtual void cycleChildMapView(MapView* after) = 0;
 };
-} // namespace tb::ui
+
+} // namespace ui
+} // namespace tb

--- a/lib/TbUiLib/include/ui/MultiPaneMapView.h
+++ b/lib/TbUiLib/include/ui/MultiPaneMapView.h
@@ -26,7 +26,14 @@
 
 class QWidget;
 
-namespace tb::ui
+namespace tb
+{
+namespace gl
+{
+class PerspectiveCamera;
+}
+
+namespace ui
 {
 class MultiPaneMapView : public MapViewContainer
 {
@@ -76,4 +83,5 @@ private: // subclassing interface
   virtual void restoreViews() = 0;
 };
 
-} // namespace tb::ui
+} // namespace ui
+} // namespace tb

--- a/lib/TbUiLib/include/ui/OnePaneMapView.h
+++ b/lib/TbUiLib/include/ui/OnePaneMapView.h
@@ -45,7 +45,10 @@ public:
 private:
   void createGui(AppController& appController, MapViewToolBox& toolBox);
 
-private: // implement MultiPaneMapView subclassing interface
+public: // implement MultiPaneMapView subclassing interface
+  const gl::PerspectiveCamera& perspectiveCamera() const override;
+
+private:
   void maximizeView(MapView* view) override;
   void restoreViews() override;
 };

--- a/lib/TbUiLib/include/ui/SwitchableMapViewContainer.h
+++ b/lib/TbUiLib/include/ui/SwitchableMapViewContainer.h
@@ -25,7 +25,14 @@
 #include "NotifierConnection.h"
 #include "ui/MapView.h"
 
-namespace tb::ui
+namespace tb
+{
+namespace gl
+{
+class PerspectiveCamera;
+}
+
+namespace ui
 {
 class AppController;
 class ClipTool;
@@ -76,6 +83,8 @@ public:
   void moveCameraToNextTracePoint();
   void moveCameraToPreviousTracePoint();
 
+  const gl::PerspectiveCamera& perspectiveCamera() const;
+
   bool canMaximizeCurrentView() const;
   bool currentViewMaximized() const;
   void toggleMaximizeCurrentView();
@@ -103,4 +112,5 @@ public: // implement MapView interface
   deleteCopyAndMove(SwitchableMapViewContainer);
 };
 
-} // namespace tb::ui
+} // namespace ui
+} // namespace tb

--- a/lib/TbUiLib/include/ui/ThreePaneMapView.h
+++ b/lib/TbUiLib/include/ui/ThreePaneMapView.h
@@ -56,7 +56,10 @@ public:
 private:
   void createGui(AppController& appController, MapViewToolBox& toolBox);
 
-private: // implement MultiPaneMapView subclassing interface
+public: // implement MultiPaneMapView subclassing interface
+  const gl::PerspectiveCamera& perspectiveCamera() const override;
+
+private:
   void maximizeView(MapView* view) override;
   void restoreViews() override;
 };

--- a/lib/TbUiLib/include/ui/TwoPaneMapView.h
+++ b/lib/TbUiLib/include/ui/TwoPaneMapView.h
@@ -52,7 +52,10 @@ public:
 private:
   void createGui(AppController& appController, MapViewToolBox& toolBox);
 
-private: // implement MultiPaneMapView subclassing interface
+public: // implement MultiPaneMapView subclassing interface
+  const gl::PerspectiveCamera& perspectiveCamera() const override;
+
+private:
   void maximizeView(MapView* view) override;
   void restoreViews() override;
 };

--- a/lib/TbUiLib/src/CompilationContext.cpp
+++ b/lib/TbUiLib/src/CompilationContext.cpp
@@ -28,10 +28,12 @@ namespace tb::ui
 
 CompilationContext::CompilationContext(
   const mdl::Map& map,
+  const gl::PerspectiveCamera& camera,
   const el::VariableStore& variables,
   TextOutputAdapter output,
   bool test)
   : m_map{map}
+  , m_camera{camera}
   , m_variables{variables.clone()}
   , m_output{std::move(output)}
   , m_test{test}
@@ -41,6 +43,11 @@ CompilationContext::CompilationContext(
 const mdl::Map& CompilationContext::map() const
 {
   return m_map;
+}
+
+const gl::PerspectiveCamera& CompilationContext::camera() const
+{
+  return m_camera;
 }
 
 bool CompilationContext::test() const

--- a/lib/TbUiLib/src/CompilationDialog.cpp
+++ b/lib/TbUiLib/src/CompilationDialog.cpp
@@ -53,10 +53,14 @@ namespace tb::ui
 {
 
 CompilationDialog::CompilationDialog(
-  AppController& appController, MapDocument& document, QWidget* parent)
+  AppController& appController,
+  MapDocument& document,
+  const gl::PerspectiveCamera& camera,
+  QWidget* parent)
   : QDialog{parent}
   , m_appController{appController}
   , m_document{document}
+  , m_camera{camera}
 {
   createGui();
   setMinimumSize(600, 300);
@@ -222,7 +226,8 @@ Result<void> CompilationDialog::runProfile(
   const mdl::CompilationProfile& profile, const bool test)
 {
   const auto& map = m_document.map();
-  return test ? m_run.test(profile, map, m_output) : m_run.run(profile, map, m_output);
+  return test ? m_run.test(profile, map, m_camera, m_output)
+              : m_run.run(profile, map, m_camera, m_output);
 }
 
 void CompilationDialog::stopCompilation()

--- a/lib/TbUiLib/src/CompilationProfileEditor.cpp
+++ b/lib/TbUiLib/src/CompilationProfileEditor.cpp
@@ -218,6 +218,7 @@ void CompilationProfileEditor::addTask()
         K(enabled),
         !K(stripTbProperties),
         std::nullopt,
+        std::nullopt,
         "${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.map"};
     }
     if (chosenAction == copyFilesAction)

--- a/lib/TbUiLib/src/CompilationProfileEditor.cpp
+++ b/lib/TbUiLib/src/CompilationProfileEditor.cpp
@@ -217,6 +217,7 @@ void CompilationProfileEditor::addTask()
       return mdl::CompilationExportMap{
         K(enabled),
         !K(stripTbProperties),
+        std::nullopt,
         "${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.map"};
     }
     if (chosenAction == copyFilesAction)

--- a/lib/TbUiLib/src/CompilationRun.cpp
+++ b/lib/TbUiLib/src/CompilationRun.cpp
@@ -47,15 +47,21 @@ bool CompilationRun::running() const
 }
 
 Result<void> CompilationRun::run(
-  const mdl::CompilationProfile& profile, const mdl::Map& map, QTextEdit* currentOutput)
+  const mdl::CompilationProfile& profile,
+  const mdl::Map& map,
+  const gl::PerspectiveCamera& camera,
+  QTextEdit* currentOutput)
 {
-  return run(profile, map, currentOutput, false);
+  return run(profile, map, camera, currentOutput, false);
 }
 
 Result<void> CompilationRun::test(
-  const mdl::CompilationProfile& profile, const mdl::Map& map, QTextEdit* currentOutput)
+  const mdl::CompilationProfile& profile,
+  const mdl::Map& map,
+  const gl::PerspectiveCamera& camera,
+  QTextEdit* currentOutput)
 {
-  return run(profile, map, currentOutput, true);
+  return run(profile, map, camera, currentOutput, true);
 }
 
 void CompilationRun::terminate()
@@ -74,6 +80,7 @@ bool CompilationRun::doIsRunning() const
 Result<void> CompilationRun::run(
   const mdl::CompilationProfile& profile,
   const mdl::Map& map,
+  const gl::PerspectiveCamera& camera,
   QTextEdit* currentOutput,
   const bool test)
 {
@@ -85,8 +92,8 @@ Result<void> CompilationRun::run(
 
   return buildWorkDir(profile, map) | kdl::transform([&](const auto& workDir) {
            auto variables = CompilationVariables{map, workDir};
-           auto compilationContext =
-             CompilationContext{map, variables, TextOutputAdapter{currentOutput}, test};
+           auto compilationContext = CompilationContext{
+             map, camera, variables, TextOutputAdapter{currentOutput}, test};
            m_currentRun =
              new CompilationRunner{std::move(compilationContext), profile, this};
            connect(

--- a/lib/TbUiLib/src/CompilationRunner.cpp
+++ b/lib/TbUiLib/src/CompilationRunner.cpp
@@ -135,8 +135,11 @@ void CompilationExportMapTaskRunner::doExecute()
         {
           return fs::Disk::createDirectory(targetPath.parent_path())
                  | kdl::and_then([&](auto) {
-                     const auto options =
-                       mdl::MapExportOptions{targetPath, m_task.stripTbProperties};
+                     const auto options = mdl::MapExportOptions{
+                       targetPath,
+                       m_task.stripTbProperties,
+                       m_task.stripEntityPattern,
+                     };
                      return m_context.map().exportAs(options);
                    });
         }

--- a/lib/TbUiLib/src/CompilationRunner.cpp
+++ b/lib/TbUiLib/src/CompilationRunner.cpp
@@ -139,6 +139,7 @@ void CompilationExportMapTaskRunner::doExecute()
                        targetPath,
                        m_task.stripTbProperties,
                        m_task.stripEntityPattern,
+                       m_task.entityToAdd,
                      };
                      return m_context.map().exportAs(options);
                    });

--- a/lib/TbUiLib/src/CompilationRunner.cpp
+++ b/lib/TbUiLib/src/CompilationRunner.cpp
@@ -29,6 +29,7 @@
 #include "fs/PathInfo.h"
 #include "fs/PathMatcher.h"
 #include "fs/TraversalMode.h"
+#include "gl/PerspectiveCamera.h"
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
 #include "mdl/ExportOptions.h"
@@ -49,7 +50,10 @@
 #include "kd/result_fold.h"
 #include "kd/string_utils.h"
 
+#include "vm/vec_io.h" // IWYU pragma: keep
+
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <fmt/std.h>
 
 #include <algorithm>
@@ -131,6 +135,19 @@ void CompilationExportMapTaskRunner::doExecute()
         const auto targetPath = makeAbsolute(kdl::parse_path(interpolated), workDir);
         m_context << "#### Exporting map file '" << pathAsQString(targetPath) << "'\n";
 
+        auto entityToAdd = m_task.entityToAdd | kdl::optional_transform([&](auto entity) {
+                             const auto position = m_context.camera().position();
+                             const auto yaw = vm::to_degrees(m_context.camera().yaw());
+
+                             entity.addOrUpdateProperty(
+                               mdl::EntityPropertyKeys::Origin,
+                               fmt::format("{}", fmt::streamed(position)));
+                             entity.addOrUpdateProperty(
+                               mdl::EntityPropertyKeys::Angle, fmt::format("{}", yaw));
+
+                             return entity;
+                           });
+
         if (!m_context.test())
         {
           return fs::Disk::createDirectory(targetPath.parent_path())
@@ -139,7 +156,7 @@ void CompilationExportMapTaskRunner::doExecute()
                        targetPath,
                        m_task.stripTbProperties,
                        m_task.stripEntityPattern,
-                       m_task.entityToAdd,
+                       std::move(entityToAdd),
                      };
                      return m_context.map().exportAs(options);
                    });

--- a/lib/TbUiLib/src/CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/src/CompilationTaskListBox.cpp
@@ -161,6 +161,13 @@ Variables are allowed.)");
   m_stripEntityPattern->setPlaceholderText("enter GLOB pattern");
   formLayout->addRow("Strip Entities", m_stripEntityPattern);
 
+  m_dropEntity = new QLineEdit{};
+  m_dropEntity->setToolTip(tr(
+    "Set the classname of an entity that will be added to the map. The entities' origin "
+    "and angles will be set to the camera position and view direction, respectively."));
+  m_dropEntity->setPlaceholderText("enter classname");
+  formLayout->addRow("Add Entity", m_dropEntity);
+
   m_stripTbProperties = new QCheckBox{"Strip TrenchBroom specific entity properties"};
   m_stripTbProperties->setToolTip(
     tr("Set this checkbox to strip any entity properties starting with _tb_ from the "
@@ -177,6 +184,11 @@ Variables are allowed.)");
     &QLineEdit::textChanged,
     this,
     &CompilationExportMapTaskEditor::stripEntityPatternChanged);
+  connect(
+    m_dropEntity,
+    &QLineEdit::textChanged,
+    this,
+    &CompilationExportMapTaskEditor::dropEntityChanged);
   connect(
     m_stripTbProperties,
     &QCheckBox::checkStateChanged,
@@ -206,6 +218,13 @@ void CompilationExportMapTaskEditor::updateItem()
   {
     m_stripEntityPattern->setText(stripEntityPattern);
   }
+
+  const auto dropEntity =
+    QString::fromStdString(task().entityToAdd ? task().entityToAdd->classname() : "");
+  if (m_dropEntity->text() != dropEntity)
+  {
+    m_dropEntity->setText(dropEntity);
+  }
 }
 
 mdl::CompilationExportMap& CompilationExportMapTaskEditor::task()
@@ -218,6 +237,20 @@ mdl::CompilationExportMap& CompilationExportMapTaskEditor::task()
 void CompilationExportMapTaskEditor::targetSpecChanged(const QString& text)
 {
   task().targetSpec = text.toStdString();
+}
+
+void CompilationExportMapTaskEditor::dropEntityChanged(const QString& text)
+{
+  if (text.isEmpty())
+  {
+    task().entityToAdd = std::nullopt;
+  }
+  else
+  {
+    task().entityToAdd = mdl::Entity{{
+      {mdl::EntityPropertyKeys::Classname, text.toStdString()},
+    }};
+  }
 }
 
 void CompilationExportMapTaskEditor::stripEntityPatternChanged(const QString& text)

--- a/lib/TbUiLib/src/CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/src/CompilationTaskListBox.cpp
@@ -142,7 +142,7 @@ CompilationExportMapTaskEditor::CompilationExportMapTaskEditor(
     LayoutConstants::WideVMargin,
     LayoutConstants::WideHMargin,
     LayoutConstants::WideVMargin);
-  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
   formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
   addMainLayout(formLayout);
 
@@ -253,7 +253,7 @@ CompilationCopyFilesTaskEditor::CompilationCopyFilesTaskEditor(
     LayoutConstants::WideVMargin,
     LayoutConstants::WideHMargin,
     LayoutConstants::WideVMargin);
-  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
   formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
   addMainLayout(formLayout);
 
@@ -337,7 +337,7 @@ CompilationRenameFileTaskEditor::CompilationRenameFileTaskEditor(
     LayoutConstants::WideVMargin,
     LayoutConstants::WideHMargin,
     LayoutConstants::WideVMargin);
-  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
   formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
   addMainLayout(formLayout);
 
@@ -422,7 +422,7 @@ CompilationDeleteFilesTaskEditor::CompilationDeleteFilesTaskEditor(
     LayoutConstants::WideVMargin,
     LayoutConstants::WideHMargin,
     LayoutConstants::WideVMargin);
-  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
   formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
   addMainLayout(formLayout);
 
@@ -482,7 +482,7 @@ CompilationRunToolTaskEditor::CompilationRunToolTaskEditor(
     LayoutConstants::WideVMargin,
     LayoutConstants::WideHMargin,
     LayoutConstants::WideVMargin);
-  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
   formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
   addMainLayout(formLayout);
 
@@ -620,7 +620,7 @@ CompilationLaunchEngineTaskEditor::CompilationLaunchEngineTaskEditor(
     LayoutConstants::WideVMargin,
     LayoutConstants::WideHMargin,
     LayoutConstants::WideVMargin);
-  formLayout->setVerticalSpacing(LayoutConstants::NarrowVMargin);
+  formLayout->setVerticalSpacing(LayoutConstants::MediumVMargin);
   formLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
   addMainLayout(formLayout);
 

--- a/lib/TbUiLib/src/CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/src/CompilationTaskListBox.cpp
@@ -153,6 +153,14 @@ Variables are allowed.)");
   setupCompleter(m_targetEditor);
   formLayout->addRow("File Path", m_targetEditor);
 
+  m_stripEntityPattern = new QLineEdit{};
+  m_stripEntityPattern->setToolTip(
+    tr("Set a GLOB pattern to strip any entities with a matching classname. Example: "
+       "'info_player_*' to strip all info_player_start and all info_player_deatchmatch "
+       "entities."));
+  m_stripEntityPattern->setPlaceholderText("enter GLOB pattern");
+  formLayout->addRow("Strip Entities", m_stripEntityPattern);
+
   m_stripTbProperties = new QCheckBox{"Strip TrenchBroom specific entity properties"};
   m_stripTbProperties->setToolTip(
     tr("Set this checkbox to strip any entity properties starting with _tb_ from the "
@@ -164,6 +172,11 @@ Variables are allowed.)");
     &QLineEdit::textChanged,
     this,
     &CompilationExportMapTaskEditor::targetSpecChanged);
+  connect(
+    m_stripEntityPattern,
+    &QLineEdit::textChanged,
+    this,
+    &CompilationExportMapTaskEditor::stripEntityPatternChanged);
   connect(
     m_stripTbProperties,
     &QCheckBox::checkStateChanged,
@@ -186,6 +199,13 @@ void CompilationExportMapTaskEditor::updateItem()
     m_stripTbProperties->setCheckState(
       task().stripTbProperties ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
   }
+
+  const auto stripEntityPattern =
+    QString::fromStdString(task().stripEntityPattern.value_or(""));
+  if (m_stripEntityPattern->text() != stripEntityPattern)
+  {
+    m_stripEntityPattern->setText(stripEntityPattern);
+  }
 }
 
 mdl::CompilationExportMap& CompilationExportMapTaskEditor::task()
@@ -198,6 +218,18 @@ mdl::CompilationExportMap& CompilationExportMapTaskEditor::task()
 void CompilationExportMapTaskEditor::targetSpecChanged(const QString& text)
 {
   task().targetSpec = text.toStdString();
+}
+
+void CompilationExportMapTaskEditor::stripEntityPatternChanged(const QString& text)
+{
+  if (text.isEmpty())
+  {
+    task().stripEntityPattern = std::nullopt;
+  }
+  else
+  {
+    task().stripEntityPattern = text.toStdString();
+  }
 }
 
 void CompilationExportMapTaskEditor::stripTbPropertiesChanged(const int state)

--- a/lib/TbUiLib/src/CyclingMapView.cpp
+++ b/lib/TbUiLib/src/CyclingMapView.cpp
@@ -183,6 +183,25 @@ void CyclingMapView::refreshViews()
   }
 }
 
+const gl::PerspectiveCamera& CyclingMapView::perspectiveCamera() const
+{
+  const auto* mapView3D = [&]() -> const MapView3D* {
+    for (const auto* mapView : m_mapViews)
+    {
+      if (const auto* candidate = dynamic_cast<const MapView3D*>(mapView))
+      {
+        return candidate;
+      }
+    }
+
+    return nullptr;
+  }();
+
+  contract_assert(mapView3D != nullptr);
+
+  return mapView3D->perspectiveCamera();
+}
+
 bool CyclingMapView::canMaximizeCurrentView() const
 {
   return false;

--- a/lib/TbUiLib/src/FourPaneMapView.cpp
+++ b/lib/TbUiLib/src/FourPaneMapView.cpp
@@ -127,6 +127,11 @@ void FourPaneMapView::onSplitterMoved(
   other->setSizes(moved->sizes());
 }
 
+const gl::PerspectiveCamera& FourPaneMapView::perspectiveCamera() const
+{
+  return m_mapView3D->perspectiveCamera();
+}
+
 void FourPaneMapView::maximizeView(MapView* view)
 {
   contract_pre(

--- a/lib/TbUiLib/src/MapView3D.cpp
+++ b/lib/TbUiLib/src/MapView3D.cpp
@@ -93,6 +93,11 @@ MapView3D::MapView3D(
 
 MapView3D::~MapView3D() = default;
 
+const gl::PerspectiveCamera& MapView3D::perspectiveCamera() const
+{
+  return *m_camera;
+}
+
 void MapView3D::initializeCamera()
 {
   m_camera->moveTo(vm::vec3f{-80.0f, -128.0f, 96.0f});

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -1096,6 +1096,7 @@ bool MapWindow::exportDocumentAsMap()
     pathFromQString(newFileName),
     !K(stripTbProperties),
     std::nullopt,
+    std::nullopt,
   };
   return exportDocument(options);
 }

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -2085,7 +2085,10 @@ void MapWindow::showCompileDialog()
 {
   if (!m_compilationDialog)
   {
-    m_compilationDialog = new CompilationDialog{m_appController, *m_document, this};
+    const auto& camera = m_mapView->perspectiveCamera();
+
+    m_compilationDialog =
+      new CompilationDialog{m_appController, *m_document, camera, this};
     connect(
       m_compilationDialog,
       &CompilationDialog::compilationProfileStarted,

--- a/lib/TbUiLib/src/MapWindow.cpp
+++ b/lib/TbUiLib/src/MapWindow.cpp
@@ -1092,8 +1092,11 @@ bool MapWindow::exportDocumentAsMap()
     return false;
   }
 
-  const auto options =
-    mdl::MapExportOptions{pathFromQString(newFileName), !K(stripTbProperties)};
+  const auto options = mdl::MapExportOptions{
+    pathFromQString(newFileName),
+    !K(stripTbProperties),
+    std::nullopt,
+  };
   return exportDocument(options);
 }
 

--- a/lib/TbUiLib/src/OnePaneMapView.cpp
+++ b/lib/TbUiLib/src/OnePaneMapView.cpp
@@ -49,6 +49,11 @@ void OnePaneMapView::createGui(AppController& appController, MapViewToolBox& too
   setLayout(layout);
 }
 
+const gl::PerspectiveCamera& OnePaneMapView::perspectiveCamera() const
+{
+  return m_mapView->perspectiveCamera();
+}
+
 void OnePaneMapView::maximizeView(MapView*)
 {
   // nothing to do

--- a/lib/TbUiLib/src/SwitchableMapViewContainer.cpp
+++ b/lib/TbUiLib/src/SwitchableMapViewContainer.cpp
@@ -168,6 +168,11 @@ void SwitchableMapViewContainer::moveCameraToPreviousTracePoint()
   }
 }
 
+const gl::PerspectiveCamera& SwitchableMapViewContainer::perspectiveCamera() const
+{
+  return m_mapView->perspectiveCamera();
+}
+
 bool SwitchableMapViewContainer::canMaximizeCurrentView() const
 {
   return m_mapView->canMaximizeCurrentView();

--- a/lib/TbUiLib/src/ThreePaneMapView.cpp
+++ b/lib/TbUiLib/src/ThreePaneMapView.cpp
@@ -98,6 +98,11 @@ void ThreePaneMapView::createGui(AppController& appController, MapViewToolBox& t
   restoreWidgetState(m_vSplitter);
 }
 
+const gl::PerspectiveCamera& ThreePaneMapView::perspectiveCamera() const
+{
+  return m_mapView3D->perspectiveCamera();
+}
+
 void ThreePaneMapView::maximizeView(MapView* view)
 {
   contract_pre(view == m_mapView3D || view == m_mapViewXY || view == m_mapViewZZ);

--- a/lib/TbUiLib/src/TwoPaneMapView.cpp
+++ b/lib/TbUiLib/src/TwoPaneMapView.cpp
@@ -80,6 +80,11 @@ void TwoPaneMapView::createGui(AppController& appController, MapViewToolBox& too
   restoreWidgetState(m_splitter);
 }
 
+const gl::PerspectiveCamera& TwoPaneMapView::perspectiveCamera() const
+{
+  return m_mapView3D->perspectiveCamera();
+}
+
 void TwoPaneMapView::maximizeView(MapView* view)
 {
   contract_pre(view == m_mapView2D || view == m_mapView3D);

--- a/lib/TbUiLib/test/CMakeLists.txt
+++ b/lib/TbUiLib/test/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(TbUiLibTest
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CompilationDialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CompilationProfileManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CompilationRunner.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CompilationTaskListBox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_DrawShapeToolExtensions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ViewEditor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_EntityPropertyModel.cpp

--- a/lib/TbUiLib/test/src/tst_CompilationDialog.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationDialog.cpp
@@ -21,6 +21,7 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include <QPushButton>
 #include <QtTest/QSignalSpy>
 
+#include "gl/PerspectiveCamera.h"
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
 #include "mdl/Map.h"
@@ -65,8 +66,9 @@ TEST_CASE("CompilationDialog")
     auto documentFixture = MapDocumentFixture{};
     auto& document =
       documentFixture.create(fixtureConfigWithCompilationProfiles(profiles));
+    auto camera = gl::PerspectiveCamera{};
 
-    auto dialog = CompilationDialog{appController, document};
+    auto dialog = CompilationDialog{appController, document, camera};
 
     auto* profileManager = dialog.findChild<CompilationProfileManager*>();
     REQUIRE(profileManager != nullptr);
@@ -100,8 +102,9 @@ TEST_CASE("CompilationDialog")
       {"profile 2", "${MAP_DIR_PATH}", {}},
       {"profile 3", "${MAP_DIR_PATH}", {}},
     }));
+    auto camera = gl::PerspectiveCamera{};
 
-    auto dialog = CompilationDialog{appController, document};
+    auto dialog = CompilationDialog{appController, document, camera};
 
     auto* profileManager = dialog.findChild<CompilationProfileManager*>();
     REQUIRE(profileManager != nullptr);
@@ -121,8 +124,9 @@ TEST_CASE("CompilationDialog")
     {
       auto documentFixture = MapDocumentFixture{};
       auto& document = documentFixture.create();
+      auto camera = gl::PerspectiveCamera{};
 
-      auto dialog = CompilationDialog{appController, document};
+      auto dialog = CompilationDialog{appController, document, camera};
       auto spy = QSignalSpy{&dialog, &CompilationDialog::compilationProfileStarted};
 
       dialog.runSelectedProfile();
@@ -141,8 +145,9 @@ TEST_CASE("CompilationDialog")
           {mdl::CompilationRunTool{true, "/does/not/exist", "", true}},
         },
       }));
+      auto camera = gl::PerspectiveCamera{};
 
-      auto dialog = CompilationDialog{appController, document};
+      auto dialog = CompilationDialog{appController, document, camera};
       auto spy = QSignalSpy{&dialog, &CompilationDialog::compilationProfileStarted};
 
       dialog.runSelectedProfile();

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -441,6 +441,7 @@ TEST_CASE("CompilationExportMapTaskRunner")
       K(enabled),
       !K(stripTbProperties),
       std::nullopt,
+      std::nullopt,
       exportSpec,
     };
 
@@ -458,6 +459,7 @@ TEST_CASE("CompilationExportMapTaskRunner")
     auto task = mdl::CompilationExportMap{
       K(enabled),
       !K(stripTbProperties),
+      std::nullopt,
       std::nullopt,
       "${WORK_DIR_PATH/exported.map",
     };

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -29,7 +29,9 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include "gl/PerspectiveCamera.h"
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
+#include "mdl/Entity.h"
 #include "mdl/EntityNode.h"
+#include "mdl/EntityProperties.h"
 #include "mdl/GameEngineProfile.h"
 #include "mdl/Map.h"
 #include "mdl/MapFixture.h"
@@ -415,7 +417,14 @@ TEST_CASE("CompilationExportMapTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
-  auto camera = gl::PerspectiveCamera{};
+  auto camera = gl::PerspectiveCamera{
+    90.0f,
+    1.0f,
+    65536.0f,
+    gl::Camera::Viewport{0, 0, 1024, 768},
+    vm::vec3f{1, 2, 3},
+    vm::vec3f{0, 1, 0},
+    vm::vec3f{0, 0, 1}};
 
   auto testEnvironment = fs::TestEnvironment{};
 
@@ -453,6 +462,34 @@ TEST_CASE("CompilationExportMapTaskRunner")
     REQUIRE_NOTHROW(runner.execute());
 
     CHECK(testEnvironment.fileExists(expectedFilePath));
+  }
+
+  SECTION("addEntity")
+  {
+    auto task = mdl::CompilationExportMap{
+      K(enabled),
+      !K(stripTbProperties),
+      std::nullopt,
+      mdl::Entity{{{mdl::EntityPropertyKeys::Classname, "info_player_start"}}},
+      "exported.map",
+    };
+
+    auto runner = CompilationExportMapTaskRunner{context, task};
+    REQUIRE_NOTHROW(runner.execute());
+
+    REQUIRE(testEnvironment.fileExists("exported.map"));
+    REQUIRE(vm::to_degrees(camera.yaw()) == 90.0f);
+    CHECK(testEnvironment.loadFile("exported.map") == R"(// entity 0
+{
+"classname" "worldspawn"
+}
+// entity 1
+{
+"classname" "info_player_start"
+"origin" "1 2 3"
+"angle" "90"
+}
+)");
   }
 
   SECTION("variable interpolation error")

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -437,7 +437,12 @@ TEST_CASE("CompilationExportMapTaskRunner")
     auto node = new mdl::EntityNode{mdl::Entity{}};
     addNodes(map, {{parentForNodes(map), {node}}});
 
-    auto task = mdl::CompilationExportMap{K(enabled), !K(stripTbProperties), exportSpec};
+    auto task = mdl::CompilationExportMap{
+      K(enabled),
+      !K(stripTbProperties),
+      std::nullopt,
+      exportSpec,
+    };
 
     auto runner = CompilationExportMapTaskRunner{context, task};
     REQUIRE_NOTHROW(runner.execute());
@@ -451,7 +456,11 @@ TEST_CASE("CompilationExportMapTaskRunner")
     addNodes(map, {{parentForNodes(map), {node}}});
 
     auto task = mdl::CompilationExportMap{
-      K(enabled), !K(stripTbProperties), "${WORK_DIR_PATH/exported.map"};
+      K(enabled),
+      !K(stripTbProperties),
+      std::nullopt,
+      "${WORK_DIR_PATH/exported.map",
+    };
 
     auto runner = CompilationExportMapTaskRunner{context, task};
     REQUIRE_NOTHROW(runner.execute());

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -26,6 +26,7 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 #include "CmdTool.h"
 #include "el/VariableStore.h"
 #include "fs/TestEnvironment.h"
+#include "gl/PerspectiveCamera.h"
 #include "mdl/CompilationProfile.h"
 #include "mdl/CompilationTask.h"
 #include "mdl/EntityNode.h"
@@ -119,6 +120,7 @@ TEST_CASE("CompilationRunToolTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
+  auto camera = gl::PerspectiveCamera{};
 
   SECTION("runMissingTool")
   {
@@ -126,7 +128,7 @@ TEST_CASE("CompilationRunToolTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     auto task = mdl::CompilationRunTool{K(enabled), "", "", false};
     auto runner = CompilationRunToolTaskRunner{context, task};
@@ -156,7 +158,7 @@ TEST_CASE("CompilationRunToolTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto treatNonZeroResultCodeAsError = GENERATE(true, false);
     auto task = mdl::CompilationRunTool{
@@ -177,7 +179,7 @@ TEST_CASE("CompilationRunToolTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto treatNonZeroResultCodeAsError = GENERATE(true, false);
     auto task = mdl::CompilationRunTool{
@@ -198,7 +200,7 @@ TEST_CASE("CompilationRunToolTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto treatNonZeroResultCodeAsError = GENERATE(true, false);
     auto task = mdl::CompilationRunTool{
@@ -219,7 +221,7 @@ TEST_CASE("CompilationRunToolTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     auto task = mdl::CompilationRunTool{
       true, CMD_TOOL_PATH, R"(--printArgs 1 2 str "escaped str")", false};
@@ -246,7 +248,7 @@ escaped str)"));
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto treatNonZeroResultCodeAsError = GENERATE(true, false);
     auto task = mdl::CompilationRunTool{
@@ -270,7 +272,7 @@ escaped str)"));
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto treatNonZeroResultCodeAsError = GENERATE(true, false);
     auto task = mdl::CompilationRunTool{
@@ -311,6 +313,7 @@ TEST_CASE("CompilationLaunchEngineTaskRunner")
 
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create(fixtureConfig);
+  auto camera = gl::PerspectiveCamera{};
 
   SECTION("launchEngine")
   {
@@ -318,7 +321,7 @@ TEST_CASE("CompilationLaunchEngineTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     auto task = mdl::CompilationLaunchEngine{
       K(enabled), "quakespasm-id", !K(treatLaunchFailureAsError)};
@@ -341,7 +344,7 @@ TEST_CASE("CompilationLaunchEngineTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto engineProfileId = GENERATE(""s, "deleted-profile-id"s);
     const auto treatLaunchFailureAsError = GENERATE(true, false);
@@ -366,7 +369,7 @@ TEST_CASE("CompilationLaunchEngineTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, false};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
     const auto treatLaunchFailureAsError = GENERATE(true, false);
     CAPTURE(treatLaunchFailureAsError);
@@ -390,7 +393,7 @@ TEST_CASE("CompilationLaunchEngineTaskRunner")
     auto output = QTextEdit{};
     auto outputAdapter = TextOutputAdapter{&output};
 
-    auto context = CompilationContext{map, variables, outputAdapter, true};
+    auto context = CompilationContext{map, camera, variables, outputAdapter, true};
 
     auto task = mdl::CompilationLaunchEngine{
       K(enabled), "missing-engine-id", K(treatLaunchFailureAsError)};
@@ -412,6 +415,7 @@ TEST_CASE("CompilationExportMapTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
+  auto camera = gl::PerspectiveCamera{};
 
   auto testEnvironment = fs::TestEnvironment{};
 
@@ -420,7 +424,7 @@ TEST_CASE("CompilationExportMapTaskRunner")
   auto output = QTextEdit{};
   auto outputAdapter = TextOutputAdapter{&output};
 
-  auto context = CompilationContext{map, variables, outputAdapter, false};
+  auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
   SECTION("exportMap")
   {
@@ -475,6 +479,7 @@ TEST_CASE("CompilationCopyFilesTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
+  auto camera = gl::PerspectiveCamera{};
 
   auto testEnvironment = fs::TestEnvironment{};
 
@@ -483,7 +488,7 @@ TEST_CASE("CompilationCopyFilesTaskRunner")
   auto output = QTextEdit{};
   auto outputAdapter = TextOutputAdapter{&output};
 
-  auto context = CompilationContext{map, variables, outputAdapter, false};
+  auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
   SECTION("createTargetDirectories")
   {
@@ -527,6 +532,7 @@ TEST_CASE("CompilationRenameFileTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
+  auto camera = gl::PerspectiveCamera{};
 
   auto testEnvironment = fs::TestEnvironment{};
 
@@ -535,7 +541,7 @@ TEST_CASE("CompilationRenameFileTaskRunner")
   auto output = QTextEdit{};
   auto outputAdapter = TextOutputAdapter{&output};
 
-  auto context = CompilationContext{map, variables, outputAdapter, false};
+  auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
   SECTION("renameFile")
   {
@@ -588,6 +594,7 @@ TEST_CASE("CompilationDeleteFilesTaskRunner")
 {
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.create();
+  auto camera = gl::PerspectiveCamera{};
 
   auto testEnvironment = fs::TestEnvironment{};
 
@@ -596,7 +603,7 @@ TEST_CASE("CompilationDeleteFilesTaskRunner")
   auto output = QTextEdit{};
   auto outputAdapter = TextOutputAdapter{&output};
 
-  auto context = CompilationContext{map, variables, outputAdapter, false};
+  auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
   SECTION("deleteTargetPattern")
   {
@@ -653,13 +660,14 @@ TEST_CASE("CompilationRunner")
   auto fixture = mdl::MapFixture{};
   auto& map = fixture.load(
     "test/ui/CompilationRunner/valveFormatMapWithoutFormatTag.map", fixtureConfig);
+  auto camera = gl::PerspectiveCamera{};
 
   const auto testWorkDir = std::string{"/some/path"};
   auto variables = CompilationVariables{map, testWorkDir};
   auto output = QTextEdit{};
   auto outputAdapter = TextOutputAdapter{&output};
 
-  auto context = CompilationContext{map, variables, outputAdapter, false};
+  auto context = CompilationContext{map, camera, variables, outputAdapter, false};
 
   auto testEnvironment = fs::TestEnvironment{};
 
@@ -680,7 +688,8 @@ TEST_CASE("CompilationRunner")
       }};
 
     auto runner = CompilationRunner{
-      CompilationContext{map, variables, outputAdapter, false}, compilationProfile};
+      CompilationContext{map, camera, variables, outputAdapter, false},
+      compilationProfile};
 
     auto compilationStartedSpy = QSignalSpy{&runner, SIGNAL(compilationStarted())};
     auto compilationEndedSpy = QSignalSpy{&runner, SIGNAL(compilationEnded())};
@@ -707,7 +716,8 @@ TEST_CASE("CompilationRunner")
       }};
 
     auto runner = CompilationRunner{
-      CompilationContext{map, variables, outputAdapter, false}, compilationProfile};
+      CompilationContext{map, camera, variables, outputAdapter, false},
+      compilationProfile};
 
     auto compilationStartedSpy = QSignalSpy{&runner, SIGNAL(compilationStarted())};
     auto compilationEndedSpy = QSignalSpy{&runner, SIGNAL(compilationEnded())};
@@ -735,7 +745,8 @@ TEST_CASE("CompilationRunner")
       }};
 
     auto runner = CompilationRunner{
-      CompilationContext{map, variables, outputAdapter, false}, compilationProfile};
+      CompilationContext{map, camera, variables, outputAdapter, false},
+      compilationProfile};
 
     auto compilationStartedSpy = QSignalSpy{&runner, SIGNAL(compilationStarted())};
     auto compilationEndedSpy = QSignalSpy{&runner, SIGNAL(compilationEnded())};

--- a/lib/TbUiLib/test/src/tst_CompilationTaskListBox.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationTaskListBox.cpp
@@ -1,0 +1,100 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QLineEdit>
+
+#include "mdl/CompilationProfile.h"
+#include "mdl/CompilationTask.h"
+#include "mdl/Entity.h"
+#include "mdl/EntityProperties.h"
+#include "ui/CatchConfig.h"
+#include "ui/CompilationTaskListBox.h"
+#include "ui/ControlListBox.h"
+#include "ui/MapDocument.h"
+#include "ui/MapDocumentFixture.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb::ui
+{
+namespace
+{
+
+QLineEdit* findLineEditByPlaceholder(const QWidget& widget, const QString& placeholder)
+{
+  for (auto* lineEdit : widget.findChildren<QLineEdit*>())
+  {
+    if (lineEdit->placeholderText() == placeholder)
+    {
+      return lineEdit;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace
+
+TEST_CASE("CompilationExportMapTaskEditor")
+{
+  auto documentFixture = MapDocumentFixture{};
+  auto& document = documentFixture.create();
+
+  auto profile = mdl::CompilationProfile{"profile", "", {}};
+
+  SECTION("updateItem")
+  {
+    SECTION("syncs the drop entity classname from the task")
+    {
+      auto task = mdl::CompilationTask{mdl::CompilationExportMap{
+        true,
+        false,
+        std::nullopt,
+        mdl::Entity{{{mdl::EntityPropertyKeys::Classname, "info_player_start"}}},
+        "target",
+      }};
+
+      auto editor = CompilationExportMapTaskEditor{document, profile, task};
+      editor.updateItem();
+
+      auto* dropEntity = findLineEditByPlaceholder(editor, "enter classname");
+      REQUIRE(dropEntity != nullptr);
+      CHECK(dropEntity->text() == "info_player_start");
+    }
+
+    SECTION("clears the drop entity classname when the task has none")
+    {
+      auto task = mdl::CompilationTask{mdl::CompilationExportMap{
+        true,
+        false,
+        std::nullopt,
+        std::nullopt,
+        "target",
+      }};
+
+      auto editor = CompilationExportMapTaskEditor{document, profile, task};
+      editor.updateItem();
+
+      auto* dropEntity = findLineEditByPlaceholder(editor, "enter classname");
+      REQUIRE(dropEntity != nullptr);
+      CHECK(dropEntity->text().isEmpty());
+    }
+  }
+}
+
+} // namespace tb::ui


### PR DESCRIPTION
This PR adds to features to the export map task. First, users can now enter a GLOB pattern to the task to strip all entities matching that pattern on export. This can be used to strip all `info_player_*` entities for example. Second, this option is complemented by another option that allows to add an entity to the exported map. The `origin` of the added entity is set to the position of the 3D camera, and its `angle` property is set to the camera's yaw angle. This is useful when testing maps because the player is spawned exactly where the camera is positioned.

Replaces #5310.