### PR TITLE
Extrude opposite coplanar faces

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -729,7 +729,7 @@ When starting a drag with #key(Ctrl) you can also drag inward to split the origi
 
 ![Splitting a brush inward in the 3D viewport](images/ExtrudeTool3DSplitInwardMode.gif)
 
-You can also extrude several brushes at the same time by moving their faces using the extrude tool, but only if these faces line up perfectly. As the following animation illustrates, it's not enough that the faces are parallel - they have to be identical. Note however that their normals can be opposing, so you can also resize the faces where two brushes touch. In that case, splitting is disabled, however.
+You can also extrude several brushes at the same time by moving their faces using the extrude tool, but only if these faces line up perfectly. As the following animation illustrates, it's not enough that the faces are parallel - they have to be identical. Note however that their normals can be opposing, so you can also resize the faces where two brushes touch. If the two faces have the exact same vertices, you can pick the shared face(s) for extrusion by hovering over a shared edge. Splitting is disabled when extruding opposing faces to avoid creating overlapping brushes.
 
 ![Extruding multiple brushes](images/ExtrudeTool3DMultipleBrushes.gif)
 

--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -729,7 +729,7 @@ When starting a drag with #key(Ctrl) you can also drag inward to split the origi
 
 ![Splitting a brush inward in the 3D viewport](images/ExtrudeTool3DSplitInwardMode.gif)
 
-You can also extrude several brushes at the same time by moving their faces using the extrude tool, but only if these faces line up perfectly. As the following animation illustrates, it's not enough that the faces are parallel - they have to be identical.
+You can also extrude several brushes at the same time by moving their faces using the extrude tool, but only if these faces line up perfectly. As the following animation illustrates, it's not enough that the faces are parallel - they have to be identical. Note however that their normals can be opposing, so you can also resize the faces where two brushes touch. In that case, splitting is disabled, however.
 
 ![Extruding multiple brushes](images/ExtrudeTool3DMultipleBrushes.gif)
 

--- a/lib/TbUiLib/include/ui/ExtrudeTool.h
+++ b/lib/TbUiLib/include/ui/ExtrudeTool.h
@@ -129,8 +129,14 @@ public:
 
   const mdl::Grid& grid() const;
 
-  mdl::Hit pick2D(const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const;
-  mdl::Hit pick3D(const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const;
+  mdl::Hit pick2D(
+    const vm::ray3d& pickRay,
+    const gl::Camera& camera,
+    const mdl::PickResult& pickResult) const;
+  mdl::Hit pick3D(
+    const vm::ray3d& pickRay,
+    const gl::Camera& camera,
+    const mdl::PickResult& pickResult) const;
 
   /**
    * Returns the current proposed drag handles as per the last call to

--- a/lib/TbUiLib/include/ui/ExtrudeToolController.h
+++ b/lib/TbUiLib/include/ui/ExtrudeToolController.h
@@ -23,6 +23,11 @@
 
 namespace tb
 {
+namespace gl
+{
+class Camera;
+}
+
 namespace render
 {
 class RenderBatch;
@@ -69,7 +74,9 @@ private:
 private:
   virtual bool doHandleInput(const InputState& inputState) const = 0;
   virtual mdl::Hit doPick(
-    const vm::ray3d& pickRay, const mdl::PickResult& pickResult) = 0;
+    const vm::ray3d& pickRay,
+    const gl::Camera& camera,
+    const mdl::PickResult& pickResult) = 0;
 };
 
 class ExtrudeToolController2D : public ExtrudeToolController
@@ -78,7 +85,10 @@ public:
   explicit ExtrudeToolController2D(ExtrudeTool& tool);
 
 private:
-  mdl::Hit doPick(const vm::ray3d& pickRay, const mdl::PickResult& pickResult) override;
+  mdl::Hit doPick(
+    const vm::ray3d& pickRay,
+    const gl::Camera& camera,
+    const mdl::PickResult& pickResult) override;
   bool doHandleInput(const InputState& inputState) const override;
 };
 
@@ -88,7 +98,10 @@ public:
   explicit ExtrudeToolController3D(ExtrudeTool& tool);
 
 private:
-  mdl::Hit doPick(const vm::ray3d& pickRay, const mdl::PickResult& pickResult) override;
+  mdl::Hit doPick(
+    const vm::ray3d& pickRay,
+    const gl::Camera& camera,
+    const mdl::PickResult& pickResult) override;
   bool doHandleInput(const InputState& inputState) const override;
 };
 

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -191,6 +191,32 @@ std::optional<EdgeInfo> findClosestHorizonEdge(
   return result;
 }
 
+/**
+ * Returns true if the horizon edge's cylindrical handle (with the same radius as the
+ * vertex handles) is grabbed and should take priority over the given direct brush face
+ * hit. The edge's own adjacent face never steals the handle; a different, occluding face
+ * only wins if it is nearer along the ray than the edge.
+ */
+bool preferEdgeHandle(
+  const gl::Camera& camera,
+  const vm::ray3d& pickRay,
+  const EdgeInfo& edgeInfo,
+  const mdl::Hit& faceHit)
+{
+  const auto edgeDistance = camera.pickLineSegmentHandle(
+    pickRay, edgeInfo.segment, pref(Preferences::HandleRadius));
+  if (!edgeDistance)
+  {
+    return false;
+  }
+
+  const auto faceHandle = hitToFaceHandle(faceHit);
+  const auto hitIsAdjacentFace =
+    faceHandle
+    && (*faceHandle == edgeInfo.leftFaceHandle || *faceHandle == edgeInfo.rightFaceHandle);
+  return hitIsAdjacentFace || *edgeDistance <= faceHit.distance();
+}
+
 std::vector<ExtrudeDragHandle> getDragHandles(
   const std::vector<mdl::Node*>& nodes, const mdl::Hit& hit)
 {
@@ -447,7 +473,7 @@ const mdl::Grid& ExtrudeTool::grid() const
 
 mdl::Hit ExtrudeTool::pick2D(
   const vm::ray3d& pickRay,
-  const gl::Camera& /* camera */,
+  const gl::Camera& camera,
   const mdl::PickResult& pickResult) const
 {
   using namespace mdl::HitFilters;
@@ -481,24 +507,29 @@ mdl::Hit ExtrudeTool::pick2D(
   };
 
   const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
+  const auto edgeInfo =
+    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
+
   if (hit.isMatch())
   {
+    // The cursor is over a brush face. Only engage if a horizon edge handle is grabbed.
+    if (edgeInfo && preferEdgeHandle(camera, pickRay, *edgeInfo, hit))
+    {
+      return makeEdgeHit(*edgeInfo);
+    }
     return mdl::Hit::NoHit;
   }
 
-  const auto edgeInfo =
-    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
   if (!edgeInfo)
   {
     return mdl::Hit::NoHit;
   }
-
   return makeEdgeHit(*edgeInfo);
 }
 
 mdl::Hit ExtrudeTool::pick3D(
   const vm::ray3d& pickRay,
-  const gl::Camera& /* camera */,
+  const gl::Camera& camera,
   const mdl::PickResult& pickResult) const
 {
   using namespace mdl::HitFilters;
@@ -525,8 +556,17 @@ mdl::Hit ExtrudeTool::pick3D(
   };
 
   const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
-  if (const auto faceHandle = hitToFaceHandle(hit))
+  const auto faceHandle = hitToFaceHandle(hit);
+  const auto edgeInfo =
+    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
+
+  if (faceHandle)
   {
+    // The cursor is over a brush face. Prefer it unless a horizon edge handle is grabbed.
+    if (edgeInfo && preferEdgeHandle(camera, pickRay, *edgeInfo, hit))
+    {
+      return makeEdgeHit(*edgeInfo);
+    }
     return {
       ExtrudeHitType,
       hit.distance(),
@@ -537,13 +577,10 @@ mdl::Hit ExtrudeTool::pick3D(
         hit.hitPoint()}};
   }
 
-  const auto edgeInfo =
-    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
   if (!edgeInfo)
   {
     return mdl::Hit::NoHit;
   }
-
   return makeEdgeHit(*edgeInfo);
 }
 

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -116,6 +116,38 @@ std::optional<EdgeInfo> getEdgeInfo(
   return {{leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, dist}};
 }
 
+std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
+  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
+{
+  auto result = std::vector<mdl::BrushFaceHandle>{};
+
+  const auto& referenceFace = faceHandle.face();
+  for (auto* node : nodes)
+  {
+    node->accept(kdl::overload(
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [](mdl::GroupNode&) {},
+      [](mdl::EntityNode&) {},
+      [&](mdl::BrushNode& brushNode) {
+        const auto& brush = brushNode.brush();
+        for (size_t i = 0; i < brush.faceCount(); ++i)
+        {
+          const auto& face = brush.face(i);
+          if (!face.coplanarWith(referenceFace.boundary()))
+          {
+            continue;
+          }
+
+          result.emplace_back(&brushNode, i);
+        }
+      },
+      [](mdl::PatchNode&) {}));
+  }
+
+  return result;
+}
+
 std::optional<EdgeInfo> findClosestHorizonEdge(
   const std::vector<mdl::Node*>& nodes, const vm::ray3d& pickRay)
 {
@@ -136,6 +168,23 @@ std::optional<EdgeInfo> findClosestHorizonEdge(
       [](mdl::PatchNode&) {}));
   }
   return result;
+}
+
+std::vector<ExtrudeDragHandle> getDragHandles(
+  const std::vector<mdl::Node*>& nodes, const mdl::Hit& hit)
+{
+  if (!hit.isMatch())
+  {
+    return {};
+  }
+
+  contract_assert(hit.hasType(ExtrudeTool::ExtrudeHitType));
+  const auto& data = hit.target<const ExtrudeHitData&>();
+
+  return collectCoplanarFaces(nodes, data.face)
+         | std::views::transform(
+           [](const auto& faceHandle) { return ExtrudeDragHandle{faceHandle}; })
+         | kdl::ranges::to<std::vector>();
 }
 
 /**
@@ -323,55 +372,6 @@ std::vector<vm::polygon3d> getPolygons(const std::vector<ExtrudeDragHandle>& dra
            return dragHandle.brushAtDragStart.face(dragHandle.faceHandle.faceIndex())
              .polygon();
          })
-         | kdl::ranges::to<std::vector>();
-}
-
-std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
-  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
-{
-  auto result = std::vector<mdl::BrushFaceHandle>{};
-
-  const auto& referenceFace = faceHandle.face();
-  for (auto* node : nodes)
-  {
-    node->accept(kdl::overload(
-      [](mdl::WorldNode&) {},
-      [](mdl::LayerNode&) {},
-      [](mdl::GroupNode&) {},
-      [](mdl::EntityNode&) {},
-      [&](mdl::BrushNode& brushNode) {
-        const auto& brush = brushNode.brush();
-        for (size_t i = 0; i < brush.faceCount(); ++i)
-        {
-          const auto& face = brush.face(i);
-          if (!face.coplanarWith(referenceFace.boundary()))
-          {
-            continue;
-          }
-
-          result.emplace_back(&brushNode, i);
-        }
-      },
-      [](mdl::PatchNode&) {}));
-  }
-
-  return result;
-}
-
-std::vector<ExtrudeDragHandle> getDragHandles(
-  const std::vector<mdl::Node*>& nodes, const mdl::Hit& hit)
-{
-  if (!hit.isMatch())
-  {
-    return {};
-  }
-
-  contract_assert(hit.hasType(ExtrudeTool::ExtrudeHitType));
-  const auto& data = hit.target<const ExtrudeHitData&>();
-
-  return collectCoplanarFaces(nodes, data.face)
-         | std::views::transform(
-           [](const auto& faceHandle) { return ExtrudeDragHandle{faceHandle}; })
          | kdl::ranges::to<std::vector>();
 }
 

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -58,55 +58,9 @@
 
 namespace tb::ui
 {
-
-// DragHandle
-
-ExtrudeDragHandle::ExtrudeDragHandle(mdl::BrushFaceHandle i_faceHandle)
-  : faceHandle{std::move(i_faceHandle)}
-  , brushAtDragStart{faceHandle.node()->brush()}
-{
-}
-
-const mdl::BrushFace& ExtrudeDragHandle::faceAtDragStart() const
-{
-  return brushAtDragStart.face(faceHandle.faceIndex());
-}
-
-vm::vec3d ExtrudeDragHandle::faceNormal() const
-{
-  return faceAtDragStart().normal();
-}
-
-kdl_reflect_impl(ExtrudeDragHandle);
-
-kdl_reflect_impl(ExtrudeDragState);
-
-kdl_reflect_impl(ExtrudeHitData);
-
-// ExtrudeTool
-
-const mdl::HitType::Type ExtrudeTool::ExtrudeHitType = mdl::HitType::freeType();
-
-ExtrudeTool::ExtrudeTool(MapDocument& document)
-  : Tool{true}
-  , m_document{document}
-  , m_dragging{false}
-{
-  connectObservers();
-}
-
-bool ExtrudeTool::applies() const
-{
-  return m_document.map().selection().hasBrushes();
-}
-
-const mdl::Grid& ExtrudeTool::grid() const
-{
-  return m_document.map().grid();
-}
-
 namespace
 {
+
 struct EdgeInfo
 {
   mdl::BrushFaceHandle leftFaceHandle;
@@ -183,207 +137,6 @@ std::optional<EdgeInfo> findClosestHorizonEdge(
   }
   return result;
 }
-} // namespace
-
-mdl::Hit ExtrudeTool::pick2D(
-  const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const
-{
-  using namespace mdl::HitFilters;
-
-  const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
-  if (hit.isMatch())
-  {
-    return mdl::Hit::NoHit;
-  }
-
-  const auto edgeInfo =
-    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
-  if (!edgeInfo)
-  {
-    return mdl::Hit::NoHit;
-  }
-
-  const auto [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
-    *edgeInfo;
-  const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
-  const auto handlePosition = vm::point_at_distance(segment, distance.position2);
-
-  // Select the face that is perpendicular to the view direction or the back facing one.
-  if (leftDot >= -vm::Cd::almost_zero() && !vm::is_zero(rightDot, vm::Cd::almost_zero()))
-  {
-    return {
-      ExtrudeHitType,
-      distance.position1,
-      hitPoint,
-      ExtrudeHitData{
-        leftFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
-  }
-  return {
-    ExtrudeHitType,
-    distance.position1,
-    hitPoint,
-    ExtrudeHitData{
-      rightFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
-}
-
-mdl::Hit ExtrudeTool::pick3D(
-  const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const
-{
-  using namespace mdl::HitFilters;
-
-  const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
-  if (const auto faceHandle = hitToFaceHandle(hit))
-  {
-    return {
-      ExtrudeHitType,
-      hit.distance(),
-      hit.hitPoint(),
-      ExtrudeHitData{
-        *faceHandle,
-        vm::line3d{hit.hitPoint(), faceHandle->face().normal()},
-        hit.hitPoint()}};
-  }
-
-  const auto edgeInfo =
-    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
-  if (!edgeInfo)
-  {
-    return mdl::Hit::NoHit;
-  }
-
-  const auto [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
-    *edgeInfo;
-  const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
-  const auto handlePosition = vm::point_at_distance(segment, distance.position2);
-
-  // choose the face that we are seeing from behind
-  const auto dragFaceHandle = leftDot > rightDot ? leftFaceHandle : rightFaceHandle;
-  const auto referenceFaceHandle = leftDot > rightDot ? rightFaceHandle : leftFaceHandle;
-
-  return {
-    ExtrudeHitType,
-    distance.position1,
-    hitPoint,
-    ExtrudeHitData{
-      dragFaceHandle,
-      vm::plane3d{handlePosition, referenceFaceHandle.face().normal()},
-      handlePosition}};
-}
-
-const std::vector<ExtrudeDragHandle>& ExtrudeTool::proposedDragHandles() const
-{
-  return m_proposedDragHandles;
-}
-
-namespace
-{
-std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
-  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
-{
-  auto result = std::vector<mdl::BrushFaceHandle>{};
-
-  const auto& referenceFace = faceHandle.face();
-  for (auto* node : nodes)
-  {
-    node->accept(kdl::overload(
-      [](mdl::WorldNode&) {},
-      [](mdl::LayerNode&) {},
-      [](mdl::GroupNode&) {},
-      [](mdl::EntityNode&) {},
-      [&](mdl::BrushNode& brushNode) {
-        const auto& brush = brushNode.brush();
-        for (size_t i = 0; i < brush.faceCount(); ++i)
-        {
-          const auto& face = brush.face(i);
-          if (!face.coplanarWith(referenceFace.boundary()))
-          {
-            continue;
-          }
-
-          result.emplace_back(&brushNode, i);
-        }
-      },
-      [](mdl::PatchNode&) {}));
-  }
-
-  return result;
-}
-
-std::vector<ExtrudeDragHandle> getDragHandles(
-  const std::vector<mdl::Node*>& nodes, const mdl::Hit& hit)
-{
-  if (!hit.isMatch())
-  {
-    return {};
-  }
-
-  contract_assert(hit.hasType(ExtrudeTool::ExtrudeHitType));
-  const auto& data = hit.target<const ExtrudeHitData&>();
-
-  return collectCoplanarFaces(nodes, data.face)
-         | std::views::transform(
-           [](const auto& faceHandle) { return ExtrudeDragHandle{faceHandle}; })
-         | kdl::ranges::to<std::vector>();
-}
-} // namespace
-
-void ExtrudeTool::updateProposedDragHandles(const mdl::PickResult& pickResult)
-{
-  using namespace mdl::HitFilters;
-
-  auto& map = m_document.map();
-  if (m_dragging)
-  {
-    // FIXME: this should be turned into an ensure failure, but it's easy to make it
-    // fail currently by spamming drags/modifiers. Indicates a bug in
-    // ExtrudeToolController thinking we are not dragging when we actually still are.
-    map.logger().error() << "updateProposedDragHandles called during a drag";
-    return;
-  }
-
-  const auto& hit = pickResult.first(type(ExtrudeHitType));
-  const auto& nodes = map.selection().nodes;
-
-  auto newDragHandles = getDragHandles(nodes, hit);
-  if (newDragHandles != m_proposedDragHandles)
-  {
-    m_proposedDragHandles = std::move(newDragHandles);
-    refreshViews();
-  }
-}
-
-std::vector<mdl::BrushFaceHandle> ExtrudeTool::getDragFaces(
-  const std::vector<ExtrudeDragHandle>& dragHandles)
-{
-  auto dragFaces = std::vector<mdl::BrushFaceHandle>{};
-  dragFaces.reserve(dragHandles.size());
-
-  for (const auto& dragHandle : dragHandles)
-  {
-    const auto& brush = dragHandle.faceHandle.node()->brush();
-    if (const auto faceIndex = brush.findFace(dragHandle.faceNormal()))
-    {
-      dragFaces.emplace_back(dragHandle.faceHandle.node(), *faceIndex);
-    }
-  }
-
-  return dragFaces;
-}
-
-/**
- * Starts resizing the faces determined by the previous call to
- * updateProposedDragHandles
- */
-void ExtrudeTool::beginExtrude()
-{
-  contract_pre(!m_dragging);
-
-  m_dragging = true;
-  m_document.map().startTransaction("Resize Brushes", mdl::TransactionScope::LongRunning);
-}
-
-namespace
-{
 
 /**
  * Splits off new brush "outward" from the drag handles.
@@ -572,7 +325,248 @@ std::vector<vm::polygon3d> getPolygons(const std::vector<ExtrudeDragHandle>& dra
          })
          | kdl::ranges::to<std::vector>();
 }
+
+std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
+  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
+{
+  auto result = std::vector<mdl::BrushFaceHandle>{};
+
+  const auto& referenceFace = faceHandle.face();
+  for (auto* node : nodes)
+  {
+    node->accept(kdl::overload(
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [](mdl::GroupNode&) {},
+      [](mdl::EntityNode&) {},
+      [&](mdl::BrushNode& brushNode) {
+        const auto& brush = brushNode.brush();
+        for (size_t i = 0; i < brush.faceCount(); ++i)
+        {
+          const auto& face = brush.face(i);
+          if (!face.coplanarWith(referenceFace.boundary()))
+          {
+            continue;
+          }
+
+          result.emplace_back(&brushNode, i);
+        }
+      },
+      [](mdl::PatchNode&) {}));
+  }
+
+  return result;
+}
+
+std::vector<ExtrudeDragHandle> getDragHandles(
+  const std::vector<mdl::Node*>& nodes, const mdl::Hit& hit)
+{
+  if (!hit.isMatch())
+  {
+    return {};
+  }
+
+  contract_assert(hit.hasType(ExtrudeTool::ExtrudeHitType));
+  const auto& data = hit.target<const ExtrudeHitData&>();
+
+  return collectCoplanarFaces(nodes, data.face)
+         | std::views::transform(
+           [](const auto& faceHandle) { return ExtrudeDragHandle{faceHandle}; })
+         | kdl::ranges::to<std::vector>();
+}
+
 } // namespace
+
+// DragHandle
+
+ExtrudeDragHandle::ExtrudeDragHandle(mdl::BrushFaceHandle i_faceHandle)
+  : faceHandle{std::move(i_faceHandle)}
+  , brushAtDragStart{faceHandle.node()->brush()}
+{
+}
+
+const mdl::BrushFace& ExtrudeDragHandle::faceAtDragStart() const
+{
+  return brushAtDragStart.face(faceHandle.faceIndex());
+}
+
+vm::vec3d ExtrudeDragHandle::faceNormal() const
+{
+  return faceAtDragStart().normal();
+}
+
+kdl_reflect_impl(ExtrudeDragHandle);
+
+kdl_reflect_impl(ExtrudeDragState);
+
+kdl_reflect_impl(ExtrudeHitData);
+
+// ExtrudeTool
+
+const mdl::HitType::Type ExtrudeTool::ExtrudeHitType = mdl::HitType::freeType();
+
+ExtrudeTool::ExtrudeTool(MapDocument& document)
+  : Tool{true}
+  , m_document{document}
+  , m_dragging{false}
+{
+  connectObservers();
+}
+
+bool ExtrudeTool::applies() const
+{
+  return m_document.map().selection().hasBrushes();
+}
+
+const mdl::Grid& ExtrudeTool::grid() const
+{
+  return m_document.map().grid();
+}
+
+mdl::Hit ExtrudeTool::pick2D(
+  const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const
+{
+  using namespace mdl::HitFilters;
+
+  const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
+  if (hit.isMatch())
+  {
+    return mdl::Hit::NoHit;
+  }
+
+  const auto edgeInfo =
+    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
+  if (!edgeInfo)
+  {
+    return mdl::Hit::NoHit;
+  }
+
+  const auto [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
+    *edgeInfo;
+  const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
+  const auto handlePosition = vm::point_at_distance(segment, distance.position2);
+
+  // Select the face that is perpendicular to the view direction or the back facing one.
+  if (leftDot >= -vm::Cd::almost_zero() && !vm::is_zero(rightDot, vm::Cd::almost_zero()))
+  {
+    return {
+      ExtrudeHitType,
+      distance.position1,
+      hitPoint,
+      ExtrudeHitData{
+        leftFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
+  }
+  return {
+    ExtrudeHitType,
+    distance.position1,
+    hitPoint,
+    ExtrudeHitData{
+      rightFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
+}
+
+mdl::Hit ExtrudeTool::pick3D(
+  const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const
+{
+  using namespace mdl::HitFilters;
+
+  const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
+  if (const auto faceHandle = hitToFaceHandle(hit))
+  {
+    return {
+      ExtrudeHitType,
+      hit.distance(),
+      hit.hitPoint(),
+      ExtrudeHitData{
+        *faceHandle,
+        vm::line3d{hit.hitPoint(), faceHandle->face().normal()},
+        hit.hitPoint()}};
+  }
+
+  const auto edgeInfo =
+    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
+  if (!edgeInfo)
+  {
+    return mdl::Hit::NoHit;
+  }
+
+  const auto [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
+    *edgeInfo;
+  const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
+  const auto handlePosition = vm::point_at_distance(segment, distance.position2);
+
+  // choose the face that we are seeing from behind
+  const auto dragFaceHandle = leftDot > rightDot ? leftFaceHandle : rightFaceHandle;
+  const auto referenceFaceHandle = leftDot > rightDot ? rightFaceHandle : leftFaceHandle;
+
+  return {
+    ExtrudeHitType,
+    distance.position1,
+    hitPoint,
+    ExtrudeHitData{
+      dragFaceHandle,
+      vm::plane3d{handlePosition, referenceFaceHandle.face().normal()},
+      handlePosition}};
+}
+
+const std::vector<ExtrudeDragHandle>& ExtrudeTool::proposedDragHandles() const
+{
+  return m_proposedDragHandles;
+}
+
+void ExtrudeTool::updateProposedDragHandles(const mdl::PickResult& pickResult)
+{
+  using namespace mdl::HitFilters;
+
+  auto& map = m_document.map();
+  if (m_dragging)
+  {
+    // FIXME: this should be turned into an ensure failure, but it's easy to make it
+    // fail currently by spamming drags/modifiers. Indicates a bug in
+    // ExtrudeToolController thinking we are not dragging when we actually still are.
+    map.logger().error() << "updateProposedDragHandles called during a drag";
+    return;
+  }
+
+  const auto& hit = pickResult.first(type(ExtrudeHitType));
+  const auto& nodes = map.selection().nodes;
+
+  auto newDragHandles = getDragHandles(nodes, hit);
+  if (newDragHandles != m_proposedDragHandles)
+  {
+    m_proposedDragHandles = std::move(newDragHandles);
+    refreshViews();
+  }
+}
+
+std::vector<mdl::BrushFaceHandle> ExtrudeTool::getDragFaces(
+  const std::vector<ExtrudeDragHandle>& dragHandles)
+{
+  auto dragFaces = std::vector<mdl::BrushFaceHandle>{};
+  dragFaces.reserve(dragHandles.size());
+
+  for (const auto& dragHandle : dragHandles)
+  {
+    const auto& brush = dragHandle.faceHandle.node()->brush();
+    if (const auto faceIndex = brush.findFace(dragHandle.faceNormal()))
+    {
+      dragFaces.emplace_back(dragHandle.faceHandle.node(), *faceIndex);
+    }
+  }
+
+  return dragFaces;
+}
+
+/**
+ * Starts resizing the faces determined by the previous call to
+ * updateProposedDragHandles
+ */
+void ExtrudeTool::beginExtrude()
+{
+  contract_pre(!m_dragging);
+
+  m_dragging = true;
+  m_document.map().startTransaction("Resize Brushes", mdl::TransactionScope::LongRunning);
+}
 
 bool ExtrudeTool::extrude(const vm::vec3d& handleDelta, ExtrudeDragState& dragState)
 {

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -22,6 +22,7 @@
 #include "Logger.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
+#include "gl/Camera.h"
 #include "mdl/BrushFace.h"
 #include "mdl/BrushGeometry.h"
 #include "mdl/BrushNode.h"
@@ -445,7 +446,9 @@ const mdl::Grid& ExtrudeTool::grid() const
 }
 
 mdl::Hit ExtrudeTool::pick2D(
-  const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const
+  const vm::ray3d& pickRay,
+  const gl::Camera& /* camera */,
+  const mdl::PickResult& pickResult) const
 {
   using namespace mdl::HitFilters;
 
@@ -486,7 +489,9 @@ mdl::Hit ExtrudeTool::pick2D(
 }
 
 mdl::Hit ExtrudeTool::pick3D(
-  const vm::ray3d& pickRay, const mdl::PickResult& pickResult) const
+  const vm::ray3d& pickRay,
+  const gl::Camera& /* camera */,
+  const mdl::PickResult& pickResult) const
 {
   using namespace mdl::HitFilters;
 

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -42,6 +42,7 @@
 #include "kd/k.h"
 #include "kd/map_utils.h"
 #include "kd/overload.h"
+#include "kd/ranges/concat_view.h"
 #include "kd/ranges/to.h"
 #include "kd/reflection_impl.h"
 #include "kd/result.h"
@@ -160,6 +161,13 @@ std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
   return collectCoincidentFaces(nodes, faceHandle, K(normalSign));
 }
 
+
+std::vector<mdl::BrushFaceHandle> collectOpposingFaces(
+  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
+{
+  return collectCoincidentFaces(nodes, faceHandle, !K(normalSign));
+}
+
 std::optional<EdgeInfo> findClosestHorizonEdge(
   const std::vector<mdl::Node*>& nodes, const vm::ray3d& pickRay)
 {
@@ -193,7 +201,8 @@ std::vector<ExtrudeDragHandle> getDragHandles(
   contract_assert(hit.hasType(ExtrudeTool::ExtrudeHitType));
   const auto& data = hit.target<const ExtrudeHitData&>();
 
-  return collectCoplanarFaces(nodes, data.face)
+  return kdl::views::concat(
+           collectCoplanarFaces(nodes, data.face), collectOpposingFaces(nodes, data.face))
          | std::views::transform(
            [](const auto& faceHandle) { return ExtrudeDragHandle{faceHandle}; })
          | kdl::ranges::to<std::vector>();

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -39,6 +39,7 @@
 #include "ui/MapDocument.h"
 
 #include "kd/contracts.h"
+#include "kd/k.h"
 #include "kd/map_utils.h"
 #include "kd/overload.h"
 #include "kd/ranges/to.h"
@@ -116,12 +117,17 @@ std::optional<EdgeInfo> getEdgeInfo(
   return {{leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, dist}};
 }
 
-std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
-  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
+std::vector<mdl::BrushFaceHandle> collectCoincidentFaces(
+  const std::vector<mdl::Node*>& nodes,
+  const mdl::BrushFaceHandle& faceHandle,
+  const bool normalSign)
 {
   auto result = std::vector<mdl::BrushFaceHandle>{};
 
   const auto& referenceFace = faceHandle.face();
+  const auto referencePlane =
+    normalSign ? referenceFace.boundary() : referenceFace.boundary().flip();
+
   for (auto* node : nodes)
   {
     node->accept(kdl::overload(
@@ -134,7 +140,7 @@ std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
         for (size_t i = 0; i < brush.faceCount(); ++i)
         {
           const auto& face = brush.face(i);
-          if (!face.coplanarWith(referenceFace.boundary()))
+          if (!face.coplanarWith(referencePlane))
           {
             continue;
           }
@@ -146,6 +152,12 @@ std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
   }
 
   return result;
+}
+
+std::vector<mdl::BrushFaceHandle> collectCoplanarFaces(
+  const std::vector<mdl::Node*>& nodes, const mdl::BrushFaceHandle& faceHandle)
+{
+  return collectCoincidentFaces(nodes, faceHandle, K(normalSign));
 }
 
 std::optional<EdgeInfo> findClosestHorizonEdge(

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -452,6 +452,34 @@ mdl::Hit ExtrudeTool::pick2D(
 {
   using namespace mdl::HitFilters;
 
+  const auto makeEdgeHit = [&](const EdgeInfo& edgeInfo) -> mdl::Hit {
+    const auto& [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
+      edgeInfo;
+    const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
+    const auto handlePosition = vm::point_at_distance(segment, distance.position2);
+
+    // Select the face that is perpendicular to the view direction or the back facing
+    // one.
+    if (
+      leftDot >= -vm::Cd::almost_zero() && !vm::is_zero(rightDot, vm::Cd::almost_zero()))
+    {
+      return {
+        ExtrudeHitType,
+        distance.position1,
+        hitPoint,
+        ExtrudeHitData{
+          leftFaceHandle,
+          vm::plane3d{handlePosition, pickRay.direction},
+          handlePosition}};
+    }
+    return {
+      ExtrudeHitType,
+      distance.position1,
+      hitPoint,
+      ExtrudeHitData{
+        rightFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
+  };
+
   const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
   if (hit.isMatch())
   {
@@ -465,27 +493,7 @@ mdl::Hit ExtrudeTool::pick2D(
     return mdl::Hit::NoHit;
   }
 
-  const auto [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
-    *edgeInfo;
-  const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
-  const auto handlePosition = vm::point_at_distance(segment, distance.position2);
-
-  // Select the face that is perpendicular to the view direction or the back facing one.
-  if (leftDot >= -vm::Cd::almost_zero() && !vm::is_zero(rightDot, vm::Cd::almost_zero()))
-  {
-    return {
-      ExtrudeHitType,
-      distance.position1,
-      hitPoint,
-      ExtrudeHitData{
-        leftFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
-  }
-  return {
-    ExtrudeHitType,
-    distance.position1,
-    hitPoint,
-    ExtrudeHitData{
-      rightFaceHandle, vm::plane3d{handlePosition, pickRay.direction}, handlePosition}};
+  return makeEdgeHit(*edgeInfo);
 }
 
 mdl::Hit ExtrudeTool::pick3D(
@@ -494,6 +502,27 @@ mdl::Hit ExtrudeTool::pick3D(
   const mdl::PickResult& pickResult) const
 {
   using namespace mdl::HitFilters;
+
+  const auto makeEdgeHit = [&](const EdgeInfo& edgeInfo) -> mdl::Hit {
+    const auto& [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
+      edgeInfo;
+    const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
+    const auto handlePosition = vm::point_at_distance(segment, distance.position2);
+
+    // choose the face that we are seeing from behind
+    const auto dragFaceHandle = leftDot > rightDot ? leftFaceHandle : rightFaceHandle;
+    const auto referenceFaceHandle =
+      leftDot > rightDot ? rightFaceHandle : leftFaceHandle;
+
+    return {
+      ExtrudeHitType,
+      distance.position1,
+      hitPoint,
+      ExtrudeHitData{
+        dragFaceHandle,
+        vm::plane3d{handlePosition, referenceFaceHandle.face().normal()},
+        handlePosition}};
+  };
 
   const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
   if (const auto faceHandle = hitToFaceHandle(hit))
@@ -515,23 +544,7 @@ mdl::Hit ExtrudeTool::pick3D(
     return mdl::Hit::NoHit;
   }
 
-  const auto [leftFaceHandle, rightFaceHandle, leftDot, rightDot, segment, distance] =
-    *edgeInfo;
-  const auto hitPoint = vm::point_at_distance(pickRay, distance.position1);
-  const auto handlePosition = vm::point_at_distance(segment, distance.position2);
-
-  // choose the face that we are seeing from behind
-  const auto dragFaceHandle = leftDot > rightDot ? leftFaceHandle : rightFaceHandle;
-  const auto referenceFaceHandle = leftDot > rightDot ? rightFaceHandle : leftFaceHandle;
-
-  return {
-    ExtrudeHitType,
-    distance.position1,
-    hitPoint,
-    ExtrudeHitData{
-      dragFaceHandle,
-      vm::plane3d{handlePosition, referenceFaceHandle.face().normal()},
-      handlePosition}};
+  return makeEdgeHit(*edgeInfo);
 }
 
 const std::vector<ExtrudeDragHandle>& ExtrudeTool::proposedDragHandles() const

--- a/lib/TbUiLib/src/ExtrudeToolController.cpp
+++ b/lib/TbUiLib/src/ExtrudeToolController.cpp
@@ -72,7 +72,8 @@ void ExtrudeToolController::pick(
 {
   if (handleInput(inputState))
   {
-    if (const auto hit = doPick(inputState.pickRay(), pickResult); hit.isMatch())
+    if (const auto hit = doPick(inputState.pickRay(), inputState.camera(), pickResult);
+        hit.isMatch())
     {
       pickResult.addHit(hit);
     }
@@ -469,9 +470,9 @@ ExtrudeToolController2D::ExtrudeToolController2D(ExtrudeTool& tool)
 }
 
 mdl::Hit ExtrudeToolController2D::doPick(
-  const vm::ray3d& pickRay, const mdl::PickResult& pickResult)
+  const vm::ray3d& pickRay, const gl::Camera& camera, const mdl::PickResult& pickResult)
 {
-  return m_tool.pick2D(pickRay, pickResult);
+  return m_tool.pick2D(pickRay, camera, pickResult);
 }
 
 bool ExtrudeToolController2D::doHandleInput(const InputState& inputState) const
@@ -488,9 +489,9 @@ ExtrudeToolController3D::ExtrudeToolController3D(ExtrudeTool& tool)
 }
 
 mdl::Hit ExtrudeToolController3D::doPick(
-  const vm::ray3d& pickRay, const mdl::PickResult& pickResult)
+  const vm::ray3d& pickRay, const gl::Camera& camera, const mdl::PickResult& pickResult)
 {
-  return m_tool.pick3D(pickRay, pickResult);
+  return m_tool.pick3D(pickRay, camera, pickResult);
 }
 
 bool ExtrudeToolController3D::doHandleInput(const InputState& inputState) const

--- a/lib/TbUiLib/src/ExtrudeToolController.cpp
+++ b/lib/TbUiLib/src/ExtrudeToolController.cpp
@@ -38,6 +38,7 @@
 #include "ui/InputState.h"
 
 #include "kd/contracts.h"
+#include "kd/ranges/adjacent_transform_view.h"
 #include "kd/ranges/to.h"
 
 #include "vm/distance.h" // IWYU pragma: keep
@@ -282,14 +283,28 @@ struct ExtrudeDragDelegate : public HandleDragTrackerDelegate
 auto createExtrudeDragTracker(
   ExtrudeTool& tool, const InputState& inputState, const mdl::Hit& hit, const bool split)
 {
+  const auto toNormal = [](const auto& proposedDragHandle) {
+    return proposedDragHandle.faceHandle.face().boundary().normal;
+  };
+
+  const auto equalNormals = [](const auto& lhs, const auto& rhs) {
+    // normals are either identical or opposing
+    return vm::dot(lhs, rhs) > 0.0;
+  };
+
   const auto initialHandlePosition = hit.target<ExtrudeHitData>().initialHandlePosition;
+
+  const auto proposedDragHandles = tool.proposedDragHandles();
+  const auto pairwiseEqual = proposedDragHandles | std::views::transform(toNormal)
+                             | kdl::views::pairwise_transform(equalNormals);
+  const auto canSplit = split && std::ranges::all_of(pairwiseEqual, std::identity{});
 
   return createHandleDragTracker(
     ExtrudeDragDelegate{
       tool,
       {tool.proposedDragHandles(),
        ExtrudeTool::getDragFaces(tool.proposedDragHandles()),
-       split}},
+       canSplit}},
     inputState,
     initialHandlePosition,
     hit.hitPoint());

--- a/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
@@ -343,6 +343,141 @@ TEST_CASE("ExtrudeTool")
       UnorderedRangeEquals(std::vector<vm::vec3d>{{0, 0, 1}, {0, 0, -1}}));
   }
 
+  SECTION("Pick a horizon edge handle directly")
+  {
+    using namespace mdl::HitFilters;
+
+    auto& document = fixture.create();
+    auto& map = document.map();
+
+    auto tool = ExtrudeTool{document};
+
+    auto builder = mdl::BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
+
+    // Two brushes meeting at the plane y = 16 with identical vertices: frontBrush's +Y
+    // face and backBrush's -Y face are coincident but face in opposite directions. This
+    // shared seam is hidden between the brushes and cannot be picked as a face.
+    auto* frontBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, -16, -16}, {16, 16, 16}}, "material")
+      | kdl::value()};
+    auto* backBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, 16, -16}, {16, 48, 16}}, "material")
+      | kdl::value()};
+
+    addNodes(map, {{map.editorContext().currentLayer(), {frontBrush, backBrush}}});
+    selectNodes(map, {frontBrush, backBrush});
+
+    SECTION("edge handle wins over the adjacent face it shares")
+    {
+      // Look at the seam from the -Y side and slightly above. The ray hits frontBrush's
+      // top face just short of the seam, but passes within the handle radius of the
+      // seam's top edge (a horizon edge: top face visible, +Y seam face hidden). The
+      // adjacent top face is nearer than the edge, yet the edge handle still wins.
+      const auto pickRay = vm::ray3d{{0, -556, 586}, vm::normalize(vm::vec3d{0, 1, -1})};
+
+      const auto pickResult = performPick(map, tool, pickRay);
+
+      // the hidden +Y seam face of frontBrush is chosen for extrusion
+      const auto extrudeHit = pickResult.first(type(ExtrudeTool::ExtrudeHitType));
+      CHECK(
+        extrudeHit.target<ExtrudeHitData>().face
+        == mdl::BrushFaceHandle{
+          frontBrush, *frontBrush->brush().findFace(vm::vec3d{0, 1, 0})});
+
+      // both coincident seam faces become drag handles, one per brush
+      CHECK_THAT(
+        tool.proposedDragHandles()
+          | std::views::transform([](const auto& h) { return h.faceHandle.node(); }),
+        UnorderedRangeEquals(std::vector<mdl::BrushNode*>{frontBrush, backBrush}));
+      CHECK_THAT(
+        tool.proposedDragHandles() | std::views::transform([](const auto& h) {
+          return h.faceAtDragStart().normal();
+        }),
+        UnorderedRangeEquals(std::vector<vm::vec3d>{{0, 1, 0}, {0, -1, 0}}));
+    }
+
+    SECTION("an occluding face in front of the edge wins")
+    {
+      // A third brush sits in front of the seam, closer to the camera, so the ray hits
+      // its face before reaching the seam edge. It is not adjacent to the edge and is
+      // nearer, so it wins over the edge handle.
+      auto* occluderBrush = new mdl::BrushNode{
+        builder.createCuboid(vm::bbox3d{{-16, -100, 114}, {16, -68, 146}}, "material")
+        | kdl::value()};
+      addNodes(map, {{map.editorContext().currentLayer(), {occluderBrush}}});
+      selectNodes(map, {occluderBrush});
+
+      const auto pickRay = vm::ray3d{{0, -556, 586}, vm::normalize(vm::vec3d{0, 1, -1})};
+
+      const auto pickResult = performPick(map, tool, pickRay);
+
+      const auto extrudeHit = pickResult.first(type(ExtrudeTool::ExtrudeHitType));
+      CHECK(
+        extrudeHit.target<ExtrudeHitData>().face
+        == mdl::BrushFaceHandle{
+          occluderBrush, *occluderBrush->brush().findFace(vm::vec3d{0, -1, 0})});
+    }
+
+    SECTION("a face interior away from any edge is picked normally")
+    {
+      // Straight down onto the middle of frontBrush's top face, far from any edge.
+      const auto pickRay = vm::ray3d{{0, 0, 32}, {0, 0, -1}};
+
+      const auto pickResult = performPick(map, tool, pickRay);
+
+      const auto extrudeHit = pickResult.first(type(ExtrudeTool::ExtrudeHitType));
+      CHECK(
+        extrudeHit.target<ExtrudeHitData>().face
+        == mdl::BrushFaceHandle{
+          frontBrush, *frontBrush->brush().findFace(vm::vec3d{0, 0, 1})});
+    }
+  }
+
+  SECTION("Pick a horizon edge handle directly in 2D")
+  {
+    auto& document = fixture.create();
+    auto& map = document.map();
+
+    auto tool = ExtrudeTool{document};
+
+    auto builder = mdl::BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
+
+    // Two brushes meeting at the plane x = 16: leftBrush's +X face and rightBrush's -X
+    // face are coincident but face in opposite directions.
+    auto* leftBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, -16, -16}, {16, 16, 16}}, "material")
+      | kdl::value()};
+    auto* rightBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{16, -16, -16}, {48, 16, 16}}, "material")
+      | kdl::value()};
+
+    addNodes(map, {{map.editorContext().currentLayer(), {leftBrush, rightBrush}}});
+    selectNodes(map, {leftBrush, rightBrush});
+
+    // Top view (looking -Z). The ray hits leftBrush's top face just short of the seam at
+    // x = 16, but passes within the handle radius of the seam's top edge.
+    const auto pickRay = vm::ray3d{{12, 0, 32}, {0, 0, -1}};
+
+    auto pickResult = mdl::PickResult::byDistance();
+    pick(map, pickRay, pickResult);
+
+    const auto hit = tool.pick2D(pickRay, orthographicCameraFor(pickRay), pickResult);
+    REQUIRE(hit.isMatch());
+    pickResult.addHit(hit);
+    tool.updateProposedDragHandles(pickResult);
+
+    // both coincident seam faces become drag handles, one per brush
+    CHECK_THAT(
+      tool.proposedDragHandles()
+        | std::views::transform([](const auto& h) { return h.faceHandle.node(); }),
+      UnorderedRangeEquals(std::vector<mdl::BrushNode*>{leftBrush, rightBrush}));
+    CHECK_THAT(
+      tool.proposedDragHandles() | std::views::transform([](const auto& h) {
+        return h.faceAtDragStart().normal();
+      }),
+      UnorderedRangeEquals(std::vector<vm::vec3d>{{1, 0, 0}, {-1, 0, 0}}));
+  }
+
   SECTION("findDragFaces")
   {
     // https://github.com/TrenchBroom/TrenchBroom/issues/3726

--- a/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
@@ -265,6 +265,48 @@ TEST_CASE("ExtrudeTool")
       RangeEquals(std::vector<vm::vec3d>{{0, 0, 1}, {0, 0, 1}}));
   }
 
+  SECTION("Pick opposing coplanar faces of two brushes")
+  {
+    auto& document = fixture.create();
+    auto& map = document.map();
+
+    auto tool = ExtrudeTool{document};
+
+    auto builder = mdl::BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
+
+    // brushNode2 sits on top of brushNode1: brushNode1's top face (+Z) and brushNode2's
+    // bottom face (-Z) are coincident at z = 16 but face in opposite directions.
+    // brushNode2 is offset along +X so that the western half of brushNode1's top face
+    // remains exposed and can be picked directly.
+    auto* brushNode1 = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, -16, -16}, {16, 16, 16}}, "material")
+      | kdl::value()};
+    auto* brushNode2 = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{0, -16, 16}, {32, 16, 48}}, "material")
+      | kdl::value()};
+
+    addNodes(map, {{map.editorContext().currentLayer(), {brushNode1, brushNode2}}});
+    selectNodes(map, {brushNode1, brushNode2});
+
+    // shoot straight down at the exposed part of the first brush's top face
+    const auto pickRay = vm::ray3d{{-8, 0, 32}, {0, 0, -1}};
+
+    const auto pickResult = performPick(map, tool, pickRay);
+
+    // both coincident faces are chosen as drag handles, one per brush
+    CHECK_THAT(
+      tool.proposedDragHandles()
+        | std::views::transform([](const auto& h) { return h.faceHandle.node(); }),
+      UnorderedRangeEquals(std::vector<mdl::BrushNode*>{brushNode1, brushNode2}));
+
+    // the picked coplanar face faces +Z, the opposing face faces -Z
+    CHECK_THAT(
+      tool.proposedDragHandles() | std::views::transform([](const auto& h) {
+        return h.faceAtDragStart().normal();
+      }),
+      UnorderedRangeEquals(std::vector<vm::vec3d>{{0, 0, 1}, {0, 0, -1}}));
+  }
+
   SECTION("findDragFaces")
   {
     // https://github.com/TrenchBroom/TrenchBroom/issues/3726

--- a/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
@@ -26,7 +26,6 @@
 #include "mdl/BrushNode.h"
 #include "mdl/EditorContext.h"
 #include "mdl/EntityNode.h"
-#include "mdl/GameInfo.h"
 #include "mdl/LayerNode.h"
 #include "mdl/Map.h"
 #include "mdl/Map_Nodes.h"

--- a/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
@@ -227,6 +227,44 @@ TEST_CASE("ExtrudeTool")
     }
   }
 
+  SECTION("Pick coplanar faces of two brushes")
+  {
+    auto& document = fixture.create();
+    auto& map = document.map();
+
+    auto tool = ExtrudeTool{document};
+
+    auto builder = mdl::BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
+
+    // two brushes side by side along the X axis, sharing a coplanar top face at z = 16
+    auto* brushNode1 = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, -16, -16}, {16, 16, 16}}, "material")
+      | kdl::value()};
+    auto* brushNode2 = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{16, -16, -16}, {48, 16, 16}}, "material")
+      | kdl::value()};
+
+    addNodes(map, {{map.editorContext().currentLayer(), {brushNode1, brushNode2}}});
+    selectNodes(map, {brushNode1, brushNode2});
+
+    // shoot straight down at the top face of the first brush
+    const auto pickRay = vm::ray3d{{0, 0, 32}, {0, 0, -1}};
+
+    const auto pickResult = performPick(map, tool, pickRay);
+
+    // both coplanar top faces are chosen as drag handles, one per brush
+    CHECK_THAT(
+      tool.proposedDragHandles()
+        | std::views::transform([](const auto& h) { return h.faceHandle.node(); }),
+      UnorderedRangeEquals(std::vector<mdl::BrushNode*>{brushNode1, brushNode2}));
+
+    CHECK_THAT(
+      tool.proposedDragHandles() | std::views::transform([](const auto& h) {
+        return h.faceAtDragStart().normal();
+      }),
+      RangeEquals(std::vector<vm::vec3d>{{0, 0, 1}, {0, 0, 1}}));
+  }
+
   SECTION("findDragFaces")
   {
     // https://github.com/TrenchBroom/TrenchBroom/issues/3726

--- a/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "Matchers.h"
+#include "gl/Camera.h"
+#include "gl/OrthographicCamera.h"
+#include "gl/PerspectiveCamera.h"
 #include "mdl/Brush.h"
 #include "mdl/BrushBuilder.h"
 #include "mdl/BrushFace.h"
@@ -67,12 +70,43 @@ vm::vec3d n(const vm::vec3d& v)
   return vm::normalize(v);
 }
 
+vm::vec3f upFor(const vm::vec3f& direction)
+{
+  return vm::abs(direction.z()) < 0.9f ? vm::vec3f{0, 0, 1} : vm::vec3f{0, 1, 0};
+}
+
+/**
+ * Build a camera positioned at the pick ray's origin looking along its direction, so
+ * that the handle radius scaling used by the edge picking is realistic.
+ */
+gl::PerspectiveCamera perspectiveCameraFor(const vm::ray3d& pickRay)
+{
+  const auto viewport = gl::Camera::Viewport{0, 0, 1920, 1080};
+  const auto direction = vm::vec3f{vm::normalize(pickRay.direction)};
+  return gl::PerspectiveCamera{
+    90.0f,
+    1.0f,
+    8000.0f,
+    viewport,
+    vm::vec3f{pickRay.origin},
+    direction,
+    upFor(direction)};
+}
+
+gl::OrthographicCamera orthographicCameraFor(const vm::ray3d& pickRay)
+{
+  const auto viewport = gl::Camera::Viewport{0, 0, 1920, 1080};
+  const auto direction = vm::vec3f{vm::normalize(pickRay.direction)};
+  return gl::OrthographicCamera{
+    1.0f, 8000.0f, viewport, vm::vec3f{pickRay.origin}, direction, upFor(direction)};
+}
+
 mdl::PickResult performPick(mdl::Map& map, ExtrudeTool& tool, const vm::ray3d& pickRay)
 {
   auto pickResult = mdl::PickResult::byDistance();
   pick(map, pickRay, pickResult);
 
-  const auto hit = tool.pick3D(pickRay, pickResult);
+  const auto hit = tool.pick3D(pickRay, perspectiveCameraFor(pickRay), pickResult);
   CHECK(hit.type() == ExtrudeTool::ExtrudeHitType);
   CHECK_FALSE(vm::is_nan(hit.hitPoint()));
 
@@ -117,7 +151,7 @@ TEST_CASE("ExtrudeTool")
 
       REQUIRE(pickResult.all().size() == 1);
 
-      const auto hit = tool.pick2D(pickRay, pickResult);
+      const auto hit = tool.pick2D(pickRay, orthographicCameraFor(pickRay), pickResult);
       CHECK_FALSE(hit.isMatch());
     }
 
@@ -138,7 +172,8 @@ TEST_CASE("ExtrudeTool")
 
       CAPTURE(brushBounds, origin, direction);
 
-      const auto hit = tool.pick2D(vm::ray3d{origin, vm::normalize(direction)}, {});
+      const auto pickRay = vm::ray3d{origin, vm::normalize(direction)};
+      const auto hit = tool.pick2D(pickRay, orthographicCameraFor(pickRay), {});
 
       CHECK(hit.isMatch());
       CHECK(hit.type() == ExtrudeTool::ExtrudeHitType);
@@ -179,7 +214,7 @@ TEST_CASE("ExtrudeTool")
 
       REQUIRE(pickResult.all().size() == 1);
 
-      const auto hit = tool.pick3D(pickRay, pickResult);
+      const auto hit = tool.pick3D(pickRay, perspectiveCameraFor(pickRay), pickResult);
 
       CHECK(hit.isMatch());
       CHECK(hit.type() == ExtrudeTool::ExtrudeHitType);
@@ -211,7 +246,8 @@ TEST_CASE("ExtrudeTool")
 
       CAPTURE(brushBounds, origin, direction);
 
-      const auto hit = tool.pick3D(vm::ray3d{origin, vm::normalize(direction)}, {});
+      const auto pickRay = vm::ray3d{origin, vm::normalize(direction)};
+      const auto hit = tool.pick3D(pickRay, perspectiveCameraFor(pickRay), {});
 
       CHECK(hit.isMatch());
       CHECK(hit.type() == ExtrudeTool::ExtrudeHitType);


### PR DESCRIPTION
This PR extends the extrude tool so that it can extrude coplanar faces even when their normals are opposing. In that case, splitting is disabled because it would create overlapping brushes.

Closes #5157.