### PR TITLE
Add windows manifest

### DIFF
--- a/app/TrenchBroom/CMakeLists.txt
+++ b/app/TrenchBroom/CMakeLists.txt
@@ -92,6 +92,10 @@ if(WIN32)
     # Create the windows resource file
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/TrenchBroom.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/TrenchBroom.rc" @ONLY)
 
+    # Copy the application manifest next to the generated .rc so the resource compiler
+    # (rc.exe / windres) can resolve the RT_MANIFEST reference by bare filename.
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/TrenchBroom.manifest" "${CMAKE_CURRENT_BINARY_DIR}/TrenchBroom.manifest" COPYONLY)
+
     if(COMPILER_IS_MSVC)
         set(APP_SOURCE ${APP_SOURCE} "${CMAKE_CURRENT_BINARY_DIR}/TrenchBroom.rc")
     elseif(MINGW)
@@ -110,6 +114,12 @@ get_build_platform(APP_PLATFORM_NAME)
 # Create the executable target and link with libraries
 add_executable(TrenchBroom WIN32 MACOSX_BUNDLE)
 target_sources(TrenchBroom PRIVATE ${APP_SOURCE} ${INDEX_OUTPUT_PATH} ${DOC_MANUAL_TARGET_FILES_ABSOLUTE} ${DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE} ${DOC_MANUAL_TARGET_IMAGE_FILES_ABSOLUTE})
+
+if(WIN32 AND COMPILER_IS_MSVC)
+    # We embed our own application manifest via TrenchBroom.rc; tell the linker not to
+    # generate and embed a second one (which would conflict with the RT_MANIFEST resource).
+    target_link_options(TrenchBroom PRIVATE "/MANIFEST:NO")
+endif()
 
 if(APPLE)
     target_sources(TrenchBroom PRIVATE "$<$<CONFIG:Debug>:${MACOSX_GAME_TESTING_SOURCE_FILES}>")

--- a/app/TrenchBroom/cmake/TrenchBroom.manifest
+++ b/app/TrenchBroom/cmake/TrenchBroom.manifest
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="TrenchBroom.TrenchBroom"
+    version="1.0.0.0"
+    processorArchitecture="*"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!--
+        Treat narrow (char) strings as UTF-8 process-wide. This makes the process
+        ANSI code page (CP_ACP) UTF-8, so std::filesystem::path::string() and other
+        narrow conversions round-trip losslessly and never throw std::system_error
+        on paths containing characters outside the legacy code page. Requires
+        Windows 10 version 1903+, which is already implied by our Qt 6 requirement.
+      -->
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/app/TrenchBroom/cmake/TrenchBroom.rc.in
+++ b/app/TrenchBroom/cmake/TrenchBroom.rc.in
@@ -3,6 +3,10 @@
 AAAAAAAA                ICON                    "@TB_RESOURCE_DIR@/win32/icons/AppIcon.ico"
 APPICON                 ICON                    "@TB_RESOURCE_DIR@/win32/icons/DocIcon.ico"
 
+// Embed the application manifest (sets the process active code page to UTF-8; see
+// TrenchBroom.manifest). 1 = CREATEPROCESS_MANIFEST_RESOURCE_ID, 24 = RT_MANIFEST.
+1                       24                      "TrenchBroom.manifest"
+
 1 VERSIONINFO
  FILEVERSION VERSION_WIN_RC
  PRODUCTVERSION VERSION_WIN_RC


### PR DESCRIPTION
On Windows, std::filesystem::path's narrow-string conversions (.string(), .generic_string(), etc.) go through the process's ANSI code page (GetACP()), not UTF-8. On any system whose default code page isn't already UTF-8 (most non-English Windows installs, and most English ones too unless the user manually enabled the "Beta: Use Unicode UTF-8" setting), a path containing a character outside that code page throws std::system_error, crashing the app. This hits document paths, texture/material discovery, and any other narrow path conversion.

Add a Windows application manifest (TrenchBroom.manifest) that sets activeCodePage to UTF-8 via the windowsSettings element (requires Windows 10 1903+, already implied by our Qt 6 requirement). This makes the process's ANSI code page UTF-8 for the whole app, so narrow std::filesystem::path conversions round-trip losslessly instead of throwing. The manifest is embedded via the .rc file as RT_MANIFEST resource 1, and the linker is told /MANIFEST:NO so it doesn't generate a second, conflicting manifest.

Closes #5352 and #5318.