### PR TITLE
Fix non-ASCII path handling for TbMdlLibTest by embedding a UTF-8 code page manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,13 @@ else()
   message(FATAL_ERROR "Unsupported compiler detected.")
 endif()
 
+# Templates for embedding a Windows manifest that sets the process active code page to
+# UTF-8 (see cmake/Utils.cmake's CONFIGURE_UTF8_MANIFEST/EMBED_UTF8_MANIFEST functions).
+if(WIN32)
+  set(TB_UTF8_MANIFEST_TEMPLATE "${CMAKE_SOURCE_DIR}/cmake/Utf8CodePage.manifest.in")
+  set(TB_UTF8_RC_TEMPLATE "${CMAKE_SOURCE_DIR}/cmake/Utf8CodePage.rc.in")
+endif()
+
 include(cmake/Utils.cmake)
 include(cmake/CompilerConfig.cmake)
 include(cmake/PrecompileHeaders.cmake)

--- a/app/CmdTool/CMakeLists.txt
+++ b/app/CmdTool/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(CmdTool)
+EMBED_UTF8_MANIFEST(CmdTool)
 
 target_sources(CmdTool PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Main.cpp

--- a/app/DumpShortcuts/CMakeLists.txt
+++ b/app/DumpShortcuts/CMakeLists.txt
@@ -7,8 +7,9 @@ add_executable(DumpShortcuts
   ${DOC_MANUAL_SHORTCUTS_JS_TARGET_ABSOLUTE}
   ${DOC_MANUAL_TARGET_IMAGE_FILES_ABSOLUTE}
 )
+EMBED_UTF8_MANIFEST(DumpShortcuts)
 
-target_link_libraries(DumpShortcuts 
+target_link_libraries(DumpShortcuts
   PRIVATE 
     CompilerConfig
     KdLib

--- a/app/TrenchBroom/CMakeLists.txt
+++ b/app/TrenchBroom/CMakeLists.txt
@@ -89,12 +89,11 @@ endif()
 
 # Set up resource compilation for Windows
 if(WIN32)
+    # Generate the UTF-8 code page manifest referenced by TrenchBroom.rc.in below.
+    CONFIGURE_UTF8_MANIFEST(TrenchBroom TB_UTF8_MANIFEST_PATH)
+
     # Create the windows resource file
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/TrenchBroom.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/TrenchBroom.rc" @ONLY)
-
-    # Copy the application manifest next to the generated .rc so the resource compiler
-    # (rc.exe / windres) can resolve the RT_MANIFEST reference by bare filename.
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/TrenchBroom.manifest" "${CMAKE_CURRENT_BINARY_DIR}/TrenchBroom.manifest" COPYONLY)
 
     if(COMPILER_IS_MSVC)
         set(APP_SOURCE ${APP_SOURCE} "${CMAKE_CURRENT_BINARY_DIR}/TrenchBroom.rc")

--- a/app/TrenchBroom/cmake/TrenchBroom.rc.in
+++ b/app/TrenchBroom/cmake/TrenchBroom.rc.in
@@ -4,8 +4,8 @@ AAAAAAAA                ICON                    "@TB_RESOURCE_DIR@/win32/icons/A
 APPICON                 ICON                    "@TB_RESOURCE_DIR@/win32/icons/DocIcon.ico"
 
 // Embed the application manifest (sets the process active code page to UTF-8; see
-// TrenchBroom.manifest). 1 = CREATEPROCESS_MANIFEST_RESOURCE_ID, 24 = RT_MANIFEST.
-1                       24                      "TrenchBroom.manifest"
+// cmake/Utf8CodePage.manifest.in). 1 = CREATEPROCESS_MANIFEST_RESOURCE_ID, 24 = RT_MANIFEST.
+1                       24                      "@TB_UTF8_MANIFEST_PATH@"
 
 1 VERSIONINFO
  FILEVERSION VERSION_WIN_RC

--- a/cmake/Utf8CodePage.manifest.in
+++ b/cmake/Utf8CodePage.manifest.in
@@ -2,7 +2,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
     type="win32"
-    name="TrenchBroom.TrenchBroom"
+    name="TrenchBroom.@TB_UTF8_MANIFEST_TARGET@"
     version="1.0.0.0"
     processorArchitecture="*"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/cmake/Utf8CodePage.rc.in
+++ b/cmake/Utf8CodePage.rc.in
@@ -1,0 +1,4 @@
+// Embed the UTF-8 code page manifest (see Utf8CodePage.manifest.in / the
+// CONFIGURE_UTF8_MANIFEST cmake function). 1 = CREATEPROCESS_MANIFEST_RESOURCE_ID,
+// 24 = RT_MANIFEST.
+1                       24                      "@TB_UTF8_MANIFEST_PATH@"

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -87,3 +87,40 @@ macro(GET_BUILD_PLATFORM PLATFORM_NAME)
         set(${PLATFORM_NAME} "Unknown")
     endif()
 endmacro(GET_BUILD_PLATFORM)
+
+# Generates a Windows manifest (from cmake/Utf8CodePage.manifest.in) that sets the
+# process active code page to UTF-8, with its assemblyIdentity named after TARGET.
+# Sets OUT_MANIFEST_PATH to the generated file's path. No-op (OUT_MANIFEST_PATH unset)
+# if not building for Windows.
+function(CONFIGURE_UTF8_MANIFEST TARGET OUT_MANIFEST_PATH)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    set(TB_UTF8_MANIFEST_TARGET ${TARGET})
+    set(manifest_out "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_Utf8CodePage.manifest")
+    configure_file("${TB_UTF8_MANIFEST_TEMPLATE}" "${manifest_out}" @ONLY)
+    set(${OUT_MANIFEST_PATH} "${manifest_out}" PARENT_SCOPE)
+endfunction(CONFIGURE_UTF8_MANIFEST)
+
+# Embeds a Windows manifest into TARGET that sets the process active code page to
+# UTF-8, so std::filesystem::path narrow conversions and other "A"-suffixed Win32/CRT
+# file APIs handle non-ASCII paths losslessly instead of throwing or mangling them.
+# No-op on non-Windows platforms. TARGET must not already embed its own manifest.
+function(EMBED_UTF8_MANIFEST TARGET)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    CONFIGURE_UTF8_MANIFEST(${TARGET} TB_UTF8_MANIFEST_PATH)
+
+    set(rc_out "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_Utf8CodePage.rc")
+    configure_file("${TB_UTF8_RC_TEMPLATE}" "${rc_out}" @ONLY)
+    target_sources(${TARGET} PRIVATE "${rc_out}")
+
+    if(COMPILER_IS_MSVC)
+        # Prevent the linker from also generating its own default manifest, which
+        # would conflict with the RT_MANIFEST resource embedded above.
+        target_link_options(${TARGET} PRIVATE "/MANIFEST:NO")
+    endif()
+endfunction(EMBED_UTF8_MANIFEST)

--- a/lib/KdLib/test/CMakeLists.txt
+++ b/lib/KdLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(KdLibTest)
+EMBED_UTF8_MANIFEST(KdLibTest)
 target_sources(KdLibTest PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ranges/range_test_utils.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ranges/tst_adjacent_transform_view.cpp"

--- a/lib/TbBaseLib/test-utils/test/CMakeLists.txt
+++ b/lib/TbBaseLib/test-utils/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbBaseTestUtilsLibTest)
+EMBED_UTF8_MANIFEST(TbBaseTestUtilsLibTest)
 
 target_sources(TbBaseTestUtilsLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Matchers.cpp

--- a/lib/TbBaseLib/test/CMakeLists.txt
+++ b/lib/TbBaseLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbBaseLibTest)
+EMBED_UTF8_MANIFEST(TbBaseLibTest)
 
 target_sources(TbBaseLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Color.cpp

--- a/lib/TbElLib/test/CMakeLists.txt
+++ b/lib/TbElLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbElLibTest)
+EMBED_UTF8_MANIFEST(TbElLibTest)
 
 target_sources(TbElLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_EL.cpp

--- a/lib/TbFsLib/test-utils/test/CMakeLists.txt
+++ b/lib/TbFsLib/test-utils/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbFsTestUtilsLibTest)
+EMBED_UTF8_MANIFEST(TbFsTestUtilsLibTest)
 
 target_sources(TbFsTestUtilsLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_TestFileSystem.cpp

--- a/lib/TbFsLib/test/CMakeLists.txt
+++ b/lib/TbFsLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbFsLibTest)
+EMBED_UTF8_MANIFEST(TbFsLibTest)
 
 target_sources(TbFsLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_CachedFileTree.cpp

--- a/lib/TbGlLib/test/CMakeLists.txt
+++ b/lib/TbGlLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbGlLibTest)
+EMBED_UTF8_MANIFEST(TbGlLibTest)
 
 target_sources(TbGlLibTest PRIVATE
 ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_PerspectiveCamera.cpp

--- a/lib/TbMdlLib/test-utils/test/CMakeLists.txt
+++ b/lib/TbMdlLib/test-utils/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbMdlTestUtilsLibTest)
+EMBED_UTF8_MANIFEST(TbMdlTestUtilsLibTest)
 
 target_sources(TbMdlTestUtilsLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Matchers.cpp

--- a/lib/TbMdlLib/test/CMakeLists.txt
+++ b/lib/TbMdlLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbMdlLibTest)
+EMBED_UTF8_MANIFEST(TbMdlLibTest)
 
 target_sources(TbMdlLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_AssetUtils.cpp

--- a/lib/TbRenderLib/test/CMakeLists.txt
+++ b/lib/TbRenderLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbRenderLibTest)
+EMBED_UTF8_MANIFEST(TbRenderLibTest)
 
 target_sources(TbRenderLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_AllocationTracker.cpp

--- a/lib/TbUiLib/test/CMakeLists.txt
+++ b/lib/TbUiLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(TbUiLibTest)
+EMBED_UTF8_MANIFEST(TbUiLibTest)
 
 target_sources(TbUiLibTest
   PRIVATE

--- a/lib/UpdateLib/test/CMakeLists.txt
+++ b/lib/UpdateLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(UpdateLibTest)
+EMBED_UTF8_MANIFEST(UpdateLibTest)
 target_sources(UpdateLibTest PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/src/TestHttpClient.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/TestHttpClient.h"

--- a/lib/VmLib/test/CMakeLists.txt
+++ b/lib/VmLib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(VmLibTest)
+EMBED_UTF8_MANIFEST(VmLibTest)
 target_sources(VmLibTest PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_bbox.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_bezier_surface.cpp"


### PR DESCRIPTION
https://github.com/TrenchBroom/TrenchBroom/pull/5353 Did this for the TrenchBroom app, but we need to consistently use UTF-8 as the code page for all apps.