### PR TITLE
Make grid lines adapt to the color of the fragment

### DIFF
--- a/app/TrenchBroom/resources/shader/Face.fragsh
+++ b/app/TrenchBroom/resources/shader/Face.fragsh
@@ -121,13 +121,28 @@ void main()
     // render for this fragment
     float minGridSize = 2.0 * maxWorldSpaceChange;
 
-    // Scale the line width by the world size of a screen pixel so the lines keep a
-    // constant apparent width regardless of distance, instead of getting thicker up
-    // close. This mirrors the 2D grid, which scales by 1/CameraZoom (see Grid2D.fragsh).
-    float lineWidthFactor = 2.0 * maxWorldSpaceChange;
+    // The line width is the smaller of two factors:
+    //  - a screen-relative width (4.0 * maxWorldSpaceChange, the world size of a screen
+    //    pixel) that keeps a constant apparent width up close, so lines don't get thicker
+    //    as the camera approaches (mirrors the 2D grid's 1/CameraZoom, see
+    //    Grid2D.fragsh);
+    //  - a fixed world-space width (1.0) that shrinks in screen space with distance, so
+    //    far-away lines thin out to sub-pixel instead of cluttering the view.
+    // Taking the min caps the width at the constant-apparent value while restoring the
+    // distance-based thinning: lines never get thicker than the close-up width.
+    float lineWidthFactor = min(4.0 * maxWorldSpaceChange, 1.0);
 
     float gridValue =
       grid(coords, modelNormal.xyz, GridSize, minGridSize, lineWidthFactor);
+
+    // Fade the grid out with distance so distant lines don't pile up into visual noise.
+    // Ramp the opacity down over the fragment's distance from the camera, in world units.
+    // Lowering fadeEnd (or fadeStart) makes the lines fade out quicker with distance.
+    float cameraDistance = length(viewVector);
+    float fadeStart = 512.0; // full opacity closer than this
+    float fadeEnd = 1024.0;  // fully faded beyond this
+    float distanceFade = 1.0 - smoothstep(fadeStart, fadeEnd, cameraDistance);
+    gridValue *= distanceFade;
 
     // Base the light/dark choice on a coarse mip of the texture rather than the
     // per-fragment color, so the line commits to one shade across noisy detail instead of

--- a/app/TrenchBroom/resources/shader/Face.fragsh
+++ b/app/TrenchBroom/resources/shader/Face.fragsh
@@ -121,7 +121,13 @@ void main()
     // render for this fragment
     float minGridSize = 2.0 * maxWorldSpaceChange;
 
-    float gridValue = grid(coords, modelNormal.xyz, GridSize, minGridSize, 1.0);
+    // Scale the line width by the world size of a screen pixel so the lines keep a
+    // constant apparent width regardless of distance, instead of getting thicker up
+    // close. This mirrors the 2D grid, which scales by 1/CameraZoom (see Grid2D.fragsh).
+    float lineWidthFactor = 2.0 * maxWorldSpaceChange;
+
+    float gridValue =
+      grid(coords, modelNormal.xyz, GridSize, minGridSize, lineWidthFactor);
 
     // Base the light/dark choice on a coarse mip of the texture rather than the
     // per-fragment color, so the line commits to one shade across noisy detail instead of

--- a/app/TrenchBroom/resources/shader/Face.fragsh
+++ b/app/TrenchBroom/resources/shader/Face.fragsh
@@ -30,7 +30,6 @@ uniform bool GrayScale;
 uniform bool RenderGrid;
 uniform float GridSize;
 uniform float GridAlpha;
-uniform vec3 GridColor;
 uniform bool ShadeFaces;
 uniform bool ShowFog;
 
@@ -42,6 +41,7 @@ varying vec3 viewVector;
 float grid(
   vec3 coords, vec3 normal, float gridSize, float minGridSize, float lineWidthFactor);
 vec3 applySoftMapBoundsTint(vec3 inputFragColor, vec3 worldCoords);
+vec3 adaptiveGridColor(vec3 background);
 
 void main()
 {
@@ -121,7 +121,17 @@ void main()
     float minGridSize = 2.0 * maxWorldSpaceChange;
 
     float gridValue = grid(coords, modelNormal.xyz, GridSize, minGridSize, 1.0);
-    gl_FragColor.rgb = mix(gl_FragColor.rgb, GridColor, gridValue * GridAlpha);
+
+    // Base the light/dark choice on a coarse mip of the texture rather than the
+    // per-fragment color, so the line commits to one shade across noisy detail instead of
+    // speckling. The line is still composited onto the actual shaded fragment color.
+    vec3 decisionColor =
+      ApplyMaterial
+        ? clamp(Brightness * texture2D(Material, gl_TexCoord[0].st, 4.0).rgb, 0.0, 1.0)
+        : gl_FragColor.rgb;
+
+    vec3 lineColor = adaptiveGridColor(decisionColor);
+    gl_FragColor.rgb = mix(gl_FragColor.rgb, lineColor, gridValue * GridAlpha);
   }
 
   gl_FragColor.rgb = applySoftMapBoundsTint(gl_FragColor.rgb, modelCoordinates.xyz);

--- a/app/TrenchBroom/resources/shader/Face.fragsh
+++ b/app/TrenchBroom/resources/shader/Face.fragsh
@@ -42,6 +42,7 @@ float grid(
   vec3 coords, vec3 normal, float gridSize, float minGridSize, float lineWidthFactor);
 vec3 applySoftMapBoundsTint(vec3 inputFragColor, vec3 worldCoords);
 vec3 adaptiveGridColor(vec3 background);
+float texturedGridAlpha(float alpha);
 
 void main()
 {
@@ -131,7 +132,8 @@ void main()
         : gl_FragColor.rgb;
 
     vec3 lineColor = adaptiveGridColor(decisionColor);
-    gl_FragColor.rgb = mix(gl_FragColor.rgb, lineColor, gridValue * GridAlpha);
+    gl_FragColor.rgb =
+      mix(gl_FragColor.rgb, lineColor, gridValue * texturedGridAlpha(GridAlpha));
   }
 
   gl_FragColor.rgb = applySoftMapBoundsTint(gl_FragColor.rgb, modelCoordinates.xyz);

--- a/app/TrenchBroom/resources/shader/Grid.fragsh
+++ b/app/TrenchBroom/resources/shader/Grid.fragsh
@@ -19,25 +19,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Soft (antialiased) coverage of a grid line, weighted by whether it is a major or minor
-// line. Returns the line's opacity before the overall grid alpha is applied.
-//
-//   coord      the coordinate in grid-cell units (integer values fall on grid lines)
-//   stripeSize 1 minus the relative line width; larger values mean thinner lines
-//   isMajor    1.0 for a major grid line, 0.0 for a minor one
-float gridLine(float coord, float stripeSize, float isMajor)
-{
-  // antialiasing half-width, in grid-cell units
-  float edge = 2.0 * fwidth(coord);
-  // triangle wave: 1.0 on a grid line, 0.0 exactly between two adjacent lines
-  float triangle = abs(2.0 * fract(coord) - 1.0);
-  float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
-
-  // Relative opacity of minor and major lines, so all grids match in strength.
-  float minorOpacity = 0.425;
-  float majorOpacity = 0.775;
-  return stripe * mix(minorOpacity, majorOpacity, isMajor);
-}
+// Soft line coverage shared with the other grid shaders (see GridCommon.fragsh).
+float gridLine(float coord, float stripeSize, float isMajor);
 
 float getSoftStripes(float value, float gridRatio, float stripeSize)
 {

--- a/app/TrenchBroom/resources/shader/Grid.fragsh
+++ b/app/TrenchBroom/resources/shader/Grid.fragsh
@@ -19,22 +19,36 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-float getSoftStripes(float value, float gridSize, float stripeSize)
+// Soft (antialiased) coverage of a grid line, weighted by whether it is a major or minor
+// line. Returns the line's opacity before the overall grid alpha is applied.
+//
+//   coord      the coordinate in grid-cell units (integer values fall on grid lines)
+//   stripeSize 1 minus the relative line width; larger values mean thinner lines
+//   isMajor    1.0 for a major grid line, 0.0 for a minor one
+float gridLine(float coord, float stripeSize, float isMajor)
 {
-  float mainVal = value * gridSize;
-  float filterWidth = fwidth(value);
-  float edge = filterWidth * gridSize * 2.0;
+  // antialiasing half-width, in grid-cell units
+  float edge = 2.0 * fwidth(coord);
+  // triangle wave: 1.0 on a grid line, 0.0 exactly between two adjacent lines
+  float triangle = abs(2.0 * fract(coord) - 1.0);
+  float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
+
+  // Relative opacity of minor and major lines, so all grids match in strength.
+  float minorOpacity = 0.425;
+  float majorOpacity = 0.775;
+  return stripe * mix(minorOpacity, majorOpacity, isMajor);
+}
+
+float getSoftStripes(float value, float gridRatio, float stripeSize)
+{
+  float coord = value * gridRatio; // coordinate in grid-cell units
 
   // major line shading, currently set to place a major line every 64 units
-  float mValue = 1.0 / (64.0 * gridSize);
-  float triMajor = abs(2.0 * fract(mainVal * mValue) - 1.0);
+  float mValue = 1.0 / (64.0 * gridRatio);
+  float triMajor = abs(2.0 * fract(coord * mValue) - 1.0);
   float isMajor = step(1.0 - mValue, triMajor);
 
-  float outIntensity = isMajor * 0.7 + 0.85; // tweak intensities here
-  float sSize = stripeSize;
-
-  float triangle = abs(2.0 * fract(mainVal) - 1.0);
-  return smoothstep(sSize - edge, sSize + edge, triangle) * outIntensity;
+  return gridLine(coord, stripeSize, isMajor);
 }
 
 /**
@@ -65,7 +79,7 @@ float gridLinesSoft(
 
   theGrid = mix(theGrid, nextGrid, gridBlend);
 
-  return theGrid * 0.5;
+  return theGrid;
 }
 
 /**

--- a/app/TrenchBroom/resources/shader/GridCommon.fragsh
+++ b/app/TrenchBroom/resources/shader/GridCommon.fragsh
@@ -41,8 +41,8 @@ float gridLine(float coord, float stripeSize, float isMajor)
   float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
 
   // Relative opacity of minor and major lines, so all grids match in strength.
-  float minorOpacity = 0.425;
-  float majorOpacity = 0.775;
+  float minorOpacity = 0.6;
+  float majorOpacity = 0.9;
   return stripe * mix(minorOpacity, majorOpacity, isMajor);
 }
 

--- a/app/TrenchBroom/resources/shader/GridCommon.fragsh
+++ b/app/TrenchBroom/resources/shader/GridCommon.fragsh
@@ -45,3 +45,22 @@ float gridLine(float coord, float stripeSize, float isMajor)
   float majorOpacity = 0.775;
   return stripe * mix(minorOpacity, majorOpacity, isMajor);
 }
+
+/**
+ * Computes an adaptive grid line color that maximizes contrast against the surface the
+ * line is drawn onto: a light line on dark surfaces, a dark line on bright ones.
+ *
+ * @param background the already-shaded color of the fragment under the grid line
+ */
+vec3 adaptiveGridColor(vec3 background)
+{
+  // perceived brightness of the surface under the line
+  float luma = dot(background, vec3(0.299, 0.587, 0.114));
+
+  // Pick the luminance extreme farther from the surface, guaranteeing strong contrast on
+  // any surface. Unlike a smooth blend between the two, the line never converges to
+  // mid-gray, where it would vanish on mid-tone textures at any alpha.
+  float darkLine = 0.1;
+  float lightLine = 0.9;
+  return vec3(luma < 0.5 ? lightLine : darkLine);
+}

--- a/app/TrenchBroom/resources/shader/GridCommon.fragsh
+++ b/app/TrenchBroom/resources/shader/GridCommon.fragsh
@@ -1,0 +1,47 @@
+#version 120
+
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Helpers shared by all grid shaders (3D faces, patches, 2D grid and UV view), so the
+ * grids stay consistent.
+ */
+
+/**
+ * Soft (antialiased) coverage of a grid line, weighted by whether it is a major or minor
+ * line. Returns the line's opacity before the overall grid alpha is applied.
+ *
+ * @param coord      the coordinate in grid-cell units (integer values fall on grid lines)
+ * @param stripeSize 1 minus the relative line width; larger values mean thinner lines
+ * @param isMajor    1.0 for a major grid line, 0.0 for a minor one
+ */
+float gridLine(float coord, float stripeSize, float isMajor)
+{
+  // antialiasing half-width, in grid-cell units
+  float edge = 2.0 * fwidth(coord);
+  // triangle wave: 1.0 on a grid line, 0.0 exactly between two adjacent lines
+  float triangle = abs(2.0 * fract(coord) - 1.0);
+  float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
+
+  // Relative opacity of minor and major lines, so all grids match in strength.
+  float minorOpacity = 0.425;
+  float majorOpacity = 0.775;
+  return stripe * mix(minorOpacity, majorOpacity, isMajor);
+}

--- a/app/TrenchBroom/resources/shader/GridCommon.fragsh
+++ b/app/TrenchBroom/resources/shader/GridCommon.fragsh
@@ -38,11 +38,19 @@ float gridLine(float coord, float stripeSize, float isMajor)
   float edge = 2.0 * fwidth(coord);
   // triangle wave: 1.0 on a grid line, 0.0 exactly between two adjacent lines
   float triangle = abs(2.0 * fract(coord) - 1.0);
-  float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
+
+  // Draw major lines thicker than minor ones. stripeSize is 1 minus the relative line
+  // width, so scaling up the width (1 - stripeSize) and converting back makes the major
+  // line proportionally wider at every distance.
+  float majorWidthScale = 1.5;
+  float majorStripeSize = 1.0 - majorWidthScale * (1.0 - stripeSize);
+  float effectiveStripeSize = mix(stripeSize, majorStripeSize, isMajor);
+  float stripe =
+    smoothstep(effectiveStripeSize - edge, effectiveStripeSize + edge, triangle);
 
   // Relative opacity of minor and major lines, so all grids match in strength.
-  float minorOpacity = 0.6;
-  float majorOpacity = 0.9;
+  float minorOpacity = 0.65;
+  float majorOpacity = 1.0;
   return stripe * mix(minorOpacity, majorOpacity, isMajor);
 }
 

--- a/app/TrenchBroom/resources/shader/GridCommon.fragsh
+++ b/app/TrenchBroom/resources/shader/GridCommon.fragsh
@@ -64,3 +64,15 @@ vec3 adaptiveGridColor(vec3 background)
   float lightLine = 0.9;
   return vec3(luma < 0.5 ? lightLine : darkLine);
 }
+
+/**
+ * Remaps the grid alpha for grids drawn on textured surfaces (3D faces, patches, UV
+ * view). These need more presence than the 2D grid, which sits on the plain viewport
+ * background, so the same GridAlpha slider ramps them up faster. The concave curve stays
+ * in [0..1], so it never pushes the line past full opacity. The 2D grid uses the raw
+ * alpha instead.
+ */
+float texturedGridAlpha(float alpha)
+{
+  return pow(alpha, 0.7);
+}

--- a/app/TrenchBroom/resources/shader/UVView.fragsh
+++ b/app/TrenchBroom/resources/shader/UVView.fragsh
@@ -35,29 +35,37 @@ varying vec4 modelCoordinates;
 varying vec3 modelNormal;
 varying vec4 faceColor;
 
-// Returns a measure for the closeness of the given coord from the next grid line, where 1
-// means the coord is on a grid line and 0 means the coord is exactly between two adjacent
-// grid lines.
-float closeness(float coord, float gridSize)
+// Soft (antialiased) coverage of a grid line, weighted by whether it is a major or minor
+// line. Returns the line's opacity before the overall grid alpha is applied.
+//
+//   coord      the coordinate in grid-cell units (integer values fall on grid lines)
+//   stripeSize 1 minus the relative line width; larger values mean thinner lines
+//   isMajor    1.0 for a major grid line, 0.0 for a minor one
+float gridLine(float coord, float stripeSize, float isMajor)
 {
-  return abs(2.0 * fract(coord / gridSize) - 1.0);
+  // antialiasing half-width, in grid-cell units
+  float edge = 2.0 * fwidth(coord);
+  // triangle wave: 1.0 on a grid line, 0.0 exactly between two adjacent lines
+  float triangle = abs(2.0 * fract(coord) - 1.0);
+  float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
+
+  // Relative opacity of minor and major lines, so all grids match in strength.
+  float minorOpacity = 0.425;
+  float majorOpacity = 0.775;
+  return stripe * mix(minorOpacity, majorOpacity, isMajor);
 }
 
 float getSoftStripes(float coord, float gridDivider, float gridSize, float stripeSize)
 {
-  // size of the minor and major grids
+  // minor grid line spacing; the coordinate expressed in minor-grid-cell units
   float minorGridSize = gridSize / gridDivider;
-  float majorGridSize = gridSize;
+  float minorCoord = coord / minorGridSize;
 
-  // How close is the coord to the next major and minor grid lines?
-  float minorCloseness = closeness(coord, minorGridSize);
-  float majorCloseness = closeness(coord, majorGridSize);
+  // a major line falls on every `gridDivider`-th minor line
+  float majorCloseness = abs(2.0 * fract(coord / gridSize) - 1.0);
   float isMajor = step(1.0 - 1.0 / gridDivider, majorCloseness);
 
-  float outIntensity = isMajor * 0.9 + 0.65; // tweak intensities here
-
-  float edge = 2.0 * fwidth(coord) / minorGridSize;
-  return smoothstep(stripeSize - edge, stripeSize + edge, minorCloseness) * outIntensity;
+  return gridLine(minorCoord, stripeSize, isMajor);
 }
 
 void gridLinesSoft(vec2 inCoords)

--- a/app/TrenchBroom/resources/shader/UVView.fragsh
+++ b/app/TrenchBroom/resources/shader/UVView.fragsh
@@ -35,25 +35,8 @@ varying vec4 modelCoordinates;
 varying vec3 modelNormal;
 varying vec4 faceColor;
 
-// Soft (antialiased) coverage of a grid line, weighted by whether it is a major or minor
-// line. Returns the line's opacity before the overall grid alpha is applied.
-//
-//   coord      the coordinate in grid-cell units (integer values fall on grid lines)
-//   stripeSize 1 minus the relative line width; larger values mean thinner lines
-//   isMajor    1.0 for a major grid line, 0.0 for a minor one
-float gridLine(float coord, float stripeSize, float isMajor)
-{
-  // antialiasing half-width, in grid-cell units
-  float edge = 2.0 * fwidth(coord);
-  // triangle wave: 1.0 on a grid line, 0.0 exactly between two adjacent lines
-  float triangle = abs(2.0 * fract(coord) - 1.0);
-  float stripe = smoothstep(stripeSize - edge, stripeSize + edge, triangle);
-
-  // Relative opacity of minor and major lines, so all grids match in strength.
-  float minorOpacity = 0.425;
-  float majorOpacity = 0.775;
-  return stripe * mix(minorOpacity, majorOpacity, isMajor);
-}
+// Soft line coverage shared with the other grid shaders (see GridCommon.fragsh).
+float gridLine(float coord, float stripeSize, float isMajor);
 
 float getSoftStripes(float coord, float gridDivider, float gridSize, float stripeSize)
 {

--- a/app/TrenchBroom/resources/shader/UVView.fragsh
+++ b/app/TrenchBroom/resources/shader/UVView.fragsh
@@ -38,6 +38,7 @@ varying vec4 faceColor;
 // Shared with the other grid shaders (see GridCommon.fragsh).
 float gridLine(float coord, float stripeSize, float isMajor);
 vec3 adaptiveGridColor(vec3 background);
+float texturedGridAlpha(float alpha);
 
 float getSoftStripes(float coord, float gridDivider, float gridSize, float stripeSize)
 {
@@ -76,7 +77,8 @@ void gridLinesSoft(vec2 inCoords)
       : gl_FragColor.rgb;
 
   vec3 lineColor = adaptiveGridColor(decisionColor);
-  gl_FragColor.rgb = mix(gl_FragColor.rgb, lineColor, lineAlpha * GridAlpha);
+  gl_FragColor.rgb =
+    mix(gl_FragColor.rgb, lineColor, lineAlpha * texturedGridAlpha(GridAlpha));
 }
 
 void main()

--- a/app/TrenchBroom/resources/shader/UVView.fragsh
+++ b/app/TrenchBroom/resources/shader/UVView.fragsh
@@ -24,7 +24,7 @@ uniform bool ApplyMaterial;
 uniform sampler2D Material;
 uniform bool RenderGrid;
 uniform vec2 GridSizes;
-uniform vec4 GridColor;
+uniform float GridAlpha;
 uniform vec2 GridScales;
 uniform mat4 GridMatrix;
 uniform vec2 GridDivider;
@@ -35,8 +35,9 @@ varying vec4 modelCoordinates;
 varying vec3 modelNormal;
 varying vec4 faceColor;
 
-// Soft line coverage shared with the other grid shaders (see GridCommon.fragsh).
+// Shared with the other grid shaders (see GridCommon.fragsh).
 float gridLine(float coord, float stripeSize, float isMajor);
+vec3 adaptiveGridColor(vec3 background);
 
 float getSoftStripes(float coord, float gridDivider, float gridSize, float stripeSize)
 {
@@ -65,22 +66,17 @@ void gridLinesSoft(vec2 inCoords)
   float lineAlpha = max(
     getSoftStripes(inCoords.x, GridDivider.x, GridSizes.x, stripeSizes.x),
     getSoftStripes(inCoords.y, GridDivider.y, GridSizes.y, stripeSizes.y));
-  lineAlpha = clamp(lineAlpha, 0.0, 1.0);
 
-  // Pick the grid shade using local fragment brightness.
-  // This keeps lines readable on dark details inside otherwise bright textures.
-  float localLum = dot(gl_FragColor.rgb, vec3(0.2126, 0.7152, 0.0722));
-  float darkGridLum = 0.15;
-  float lightGridLum = 0.85;
+  // Base the light/dark choice on a coarse mip of the texture rather than the
+  // per-fragment color, so the line commits to one shade across noisy detail instead of
+  // speckling.
+  vec3 decisionColor =
+    ApplyMaterial
+      ? clamp(Brightness * texture2D(Material, gl_TexCoord[0].st, 4.0).rgb, 0.0, 1.0)
+      : gl_FragColor.rgb;
 
-  float darkContrast = abs(localLum - darkGridLum);
-  float lightContrast = abs(localLum - lightGridLum);
-  float chooseLightGrid = step(darkContrast, lightContrast);
-  float gridLum = mix(darkGridLum, lightGridLum, chooseLightGrid);
-  vec3 adaptiveGridColor = vec3(gridLum);
-
-  gl_FragColor.rgb =
-    mix(gl_FragColor.rgb, adaptiveGridColor, lineAlpha * GridColor.a * 0.85);
+  vec3 lineColor = adaptiveGridColor(decisionColor);
+  gl_FragColor.rgb = mix(gl_FragColor.rgb, lineColor, lineAlpha * GridAlpha);
 }
 
 void main()

--- a/lib/TbGlLib/include/gl/Material.h
+++ b/lib/TbGlLib/include/gl/Material.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "Color.h"
 #include "gl/GlUtils.h"
 #include "gl/TextureResource.h"
 
@@ -171,7 +170,5 @@ public:
 
 const Texture* getTexture(const Material* material);
 Texture* getTexture(Material* material);
-
-RgbF gridColorForMaterial(const gl::Material* material);
 
 } // namespace tb::gl

--- a/lib/TbGlLib/include/gl/Shaders.h
+++ b/lib/TbGlLib/include/gl/Shaders.h
@@ -27,7 +27,7 @@ namespace tb::gl::Shaders
 inline const ShaderConfig Grid2DShader = ShaderConfig{
   "2D Grid",
   {"Grid2D.vertsh"},
-  {"Grid.fragsh", "Grid2D.fragsh"},
+  {"GridCommon.fragsh", "Grid.fragsh", "Grid2D.fragsh"},
 };
 
 inline const ShaderConfig VaryingPCShader = ShaderConfig{
@@ -57,13 +57,13 @@ inline const ShaderConfig EntityModelShader = ShaderConfig{
 inline const ShaderConfig FaceShader = ShaderConfig{
   "Face",
   {"Face.vertsh"},
-  {"Grid.fragsh", "MapBounds.fragsh", "Face.fragsh"},
+  {"GridCommon.fragsh", "Grid.fragsh", "MapBounds.fragsh", "Face.fragsh"},
 };
 
 inline const ShaderConfig PatchShader = ShaderConfig{
   "Patch",
   {"Face.vertsh"},
-  {"Grid.fragsh", "MapBounds.fragsh", "Face.fragsh"},
+  {"GridCommon.fragsh", "Grid.fragsh", "MapBounds.fragsh", "Face.fragsh"},
 };
 
 inline const ShaderConfig EdgeShader = ShaderConfig{
@@ -153,7 +153,7 @@ inline const ShaderConfig TriangleShader = ShaderConfig{
 inline const ShaderConfig UVViewShader = ShaderConfig{
   "UV View",
   {"UVView.vertsh"},
-  {"UVView.fragsh"},
+  {"GridCommon.fragsh", "UVView.fragsh"},
 };
 
 } // namespace tb::gl::Shaders

--- a/lib/TbGlLib/src/Material.cpp
+++ b/lib/TbGlLib/src/Material.cpp
@@ -301,25 +301,4 @@ Texture* getTexture(Material* material)
   return material ? material->texture() : nullptr;
 }
 
-RgbF gridColorForMaterial(const gl::Material* material)
-{
-  if (const auto* texture = getTexture(material))
-  {
-    const auto averageColor = texture->averageColor().to<RgbF>();
-    const auto brightness =
-      (averageColor.get<ColorChannel::r>() + averageColor.get<ColorChannel::g>()
-       + averageColor.get<ColorChannel::b>())
-      / 3.0f;
-
-    if (brightness > 0.50f)
-    {
-      // bright material grid color
-      return RgbF{0, 0, 0};
-    }
-  }
-
-  // dark material grid color
-  return RgbF{1, 1, 1};
-}
-
 } // namespace tb::gl

--- a/lib/TbRenderLib/src/FaceRenderer.cpp
+++ b/lib/TbRenderLib/src/FaceRenderer.cpp
@@ -196,7 +196,6 @@ void FaceRenderer::render(RenderContext& context)
         const auto enableMasked = texture && texture->mask() == gl::TextureMask::On;
 
         // set any per-material uniforms
-        shader.set("GridColor", gridColorForMaterial(material));
         shader.set("EnableMasked", enableMasked);
 
         func.before(gl, material);

--- a/lib/TbRenderLib/src/PatchRenderer.cpp
+++ b/lib/TbRenderLib/src/PatchRenderer.cpp
@@ -345,7 +345,6 @@ struct RenderFunc : public gl::MaterialRenderFunc
 
   void before(gl::Gl& gl, const gl::Material* material) override
   {
-    shader.set("GridColor", gridColorForMaterial(material));
     if (const auto* texture = getTexture(material))
     {
       material->activate(gl, minFilter, magFilter);

--- a/lib/TbUiLib/src/UVView.cpp
+++ b/lib/TbUiLib/src/UVView.cpp
@@ -129,7 +129,7 @@ private:
     shader.set("Brightness", pref(Preferences::Brightness));
     shader.set("RenderGrid", true);
     shader.set("GridSizes", texture->sizef());
-    shader.set("GridColor", RgbaF{gl::gridColorForMaterial(material), 0.6f});
+    shader.set("GridAlpha", pref(Preferences::GridAlpha));
     shader.set("DpiScale", renderContext.dpiScale());
     shader.set("GridScales", scale);
     shader.set("GridMatrix", vm::mat4x4f{toTex});

--- a/lib/TbUiLib/src/UVView.cpp
+++ b/lib/TbUiLib/src/UVView.cpp
@@ -150,6 +150,23 @@ private:
   }
 };
 
+// Chooses a light overlay color on dark textures and a dark one on bright textures, so UV
+// view overlays stay visible on any texture (mirrors the adaptive grid). The UV view
+// shows a single face, so a per-texture decision from its average color is stable.
+RgbaF adaptiveOverlayColor(const gl::Texture* texture, const float alpha)
+{
+  auto luma = 0.0f;
+  if (texture)
+  {
+    const auto avg = texture->averageColor().to<RgbF>();
+    luma = pref(Preferences::Brightness)
+           * (0.299f * avg.get<ColorChannel::r>() + 0.587f * avg.get<ColorChannel::g>()
+              + 0.114f * avg.get<ColorChannel::b>());
+  }
+  const auto shade = luma < 0.5f ? 0.9f : 0.1f;
+  return RgbaF{shade, shade, shade, alpha};
+}
+
 } // namespace
 
 const mdl::HitType::Type UVView::FaceHitType = mdl::HitType::freeType();
@@ -322,7 +339,8 @@ void UVView::renderFace(render::RenderContext&, render::RenderBatch& renderBatch
   auto edgeRenderer = render::DirectEdgeRenderer{
     gl::VertexArray::move(std::move(edgeVertices)), gl::PrimType::LineLoop};
 
-  const auto edgeColor = RgbaF{1.0f, 1.0f, 1.0f, 1.0f};
+  const auto edgeColor =
+    adaptiveOverlayColor(getTexture(m_helper.face()->material()), 1.0f);
   edgeRenderer.renderOnTop(renderBatch, edgeColor, 2.5f);
 }
 


### PR DESCRIPTION
To improve grid visibility, we make the grid color adapt to the fragment under the grid. The effect is subtle, but it helps with grid lines on very bright fragments without being too distracting.

<img width="343" height="249" alt="Screenshot 2026-07-23 at 09 32 31" src="https://github.com/user-attachments/assets/20f2f72d-d6fd-4144-90b9-caaad811fcb1" />

<img width="529" height="333" alt="Screenshot 2026-07-23 at 09 33 21" src="https://github.com/user-attachments/assets/38956d19-3105-49d2-b314-973d8b1879b7" />

Closes #2061, #3075