### PR TITLE
Don't strip necessary dependencies from AppImage

### DIFF
--- a/app/TrenchBroom/cmake/AppImageGenerator.cmake.in
+++ b/app/TrenchBroom/cmake/AppImageGenerator.cmake.in
@@ -1,3 +1,18 @@
+# Because our install() rules use COMPONENT TrenchBroom, CPack's staging
+# install for the External generator places everything under
+# ${CPACK_TEMPORARY_DIRECTORY}/TrenchBroom/usr/... instead of merging it
+# directly into ${CPACK_TEMPORARY_DIRECTORY}/usr/..., which is where
+# linuxdeploy (and the rest of this script) expect to find it. Flatten it
+# before anything else inspects the AppDir.
+if(EXISTS "${CPACK_TEMPORARY_DIRECTORY}/TrenchBroom/usr")
+  file(COPY "${CPACK_TEMPORARY_DIRECTORY}/TrenchBroom/usr" DESTINATION "${CPACK_TEMPORARY_DIRECTORY}")
+endif()
+
+set(TB_APP_EXECUTABLE "${CPACK_TEMPORARY_DIRECTORY}/usr/bin/@APP_TARGET_NAME_LOWER@")
+if(NOT EXISTS "${TB_APP_EXECUTABLE}")
+  message(FATAL_ERROR "Could not find staged executable ${TB_APP_EXECUTABLE}")
+endif()
+
 execute_process(
   COMMAND @TB_QMAKE_PATH@ -query QT_INSTALL_LIBS
   OUTPUT_VARIABLE QT_LIBS_DIR
@@ -51,7 +66,38 @@ foreach(GTK3_DEPENDENCY IN LISTS GTK3_DEPENDENCIES)
 endforeach()
 list(REMOVE_DUPLICATES GTK3_LIBRARY_NAMES)
 list(FILTER GTK3_LIBRARY_NAMES EXCLUDE REGEX "^(libatomic|libgcc_s|libstdc\\+\\+)\\.so")
+
+# GTK 3 pulls in general purpose libraries that TrenchBroom links as well, and
+# those must be bundled: the host is not guaranteed to provide them. FreeImage
+# links libjpeg.so.8, for example, which only Ubuntu still ships, so leaving it
+# to the host breaks the AppImage on Debian and others (see issue 5363).
+# Sharing a bundled library with the host's GTK is harmless because their ABIs
+# are stable across the versions in question. The GLib libraries are the
+# exception: the host's GTK needs the host's GLib, and since both would resolve
+# to the same soname, GLib must come from the host.
+file(
+  GET_RUNTIME_DEPENDENCIES
+  EXECUTABLES "${TB_APP_EXECUTABLE}"
+  DIRECTORIES "${QT_LIBS_DIR}"
+  RESOLVED_DEPENDENCIES_VAR APP_DEPENDENCIES
+  UNRESOLVED_DEPENDENCIES_VAR APP_UNRESOLVED_DEPENDENCIES
+)
+if(APP_UNRESOLVED_DEPENDENCIES)
+  message(FATAL_ERROR "Could not resolve TrenchBroom dependencies: ${APP_UNRESOLVED_DEPENDENCIES}")
+endif()
+
+set(APP_LIBRARY_NAMES "")
+foreach(APP_DEPENDENCY IN LISTS APP_DEPENDENCIES)
+  get_filename_component(APP_DEPENDENCY_NAME "${APP_DEPENDENCY}" NAME)
+  list(APPEND APP_LIBRARY_NAMES "${APP_DEPENDENCY_NAME}")
+endforeach()
+list(FILTER APP_LIBRARY_NAMES EXCLUDE REGEX "^lib(glib|gio|gmodule|gobject|gthread)-2\\.0\\.so")
+if(APP_LIBRARY_NAMES)
+  list(REMOVE_ITEM GTK3_LIBRARY_NAMES ${APP_LIBRARY_NAMES})
+endif()
+
 list(JOIN GTK3_LIBRARY_NAMES ";" TB_LINUXDEPLOY_EXCLUDED_LIBRARIES)
+message(STATUS "Excluding libraries from AppImage: ${TB_LINUXDEPLOY_EXCLUDED_LIBRARIES}")
 
 # Build the AppImage: deploy the executable, Qt plugins, and shared libraries,
 # then package everything into an AppImage in one step.
@@ -65,16 +111,6 @@ list(JOIN GTK3_LIBRARY_NAMES ";" TB_LINUXDEPLOY_EXCLUDED_LIBRARIES)
 # DEPLOY_PLATFORM_THEMES bundles the GTK 3 and xdg-desktop-portal themes. The
 # AppRun hook selects GTK 3 on GTK-based desktops and xdg-desktop-portal
 # elsewhere, while allowing users to override QT_QPA_PLATFORMTHEME.
-
-# Because our install() rules use COMPONENT TrenchBroom, CPack's staging
-# install for the External generator places everything under
-# ${CPACK_TEMPORARY_DIRECTORY}/TrenchBroom/usr/... instead of merging it
-# directly into ${CPACK_TEMPORARY_DIRECTORY}/usr/..., which is where
-# linuxdeploy (and the rest of this script) expect to find it. Flatten it.
-if(EXISTS "${CPACK_TEMPORARY_DIRECTORY}/TrenchBroom/usr")
-  file(COPY "${CPACK_TEMPORARY_DIRECTORY}/TrenchBroom/usr" DESTINATION "${CPACK_TEMPORARY_DIRECTORY}")
-endif()
-
 file(
   COPY "@TB_RESOURCE_DIR@/linux/trenchbroom-platform-theme.sh"
   DESTINATION "${CPACK_TEMPORARY_DIRECTORY}/apprun-hooks"


### PR DESCRIPTION
GTK 3 pulls in general purpose libraries that TrenchBroom links as well, and those must be bundled: the host is not guaranteed to provide them. FreeImage links libjpeg.so.8, for example, which only Ubuntu still ships, so leaving it to the host breaks the AppImage on Debian and others (see issue 5363). Sharing a bundled library with the host's GTK is harmless because their ABIs are stable across the versions in question. The GLib libraries are the exception: the host's GTK needs the host's GLib, and since both would resolve to the same soname, GLib must come from the host.

Closes #5363 