### PR TITLE
Allow controlling the sweep Handle with the keyboard

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -785,6 +785,7 @@ When the sweep tool is active, a ghost outline shows where the destination cap w
 - Dragging the center of the handle moves the destination cap.
 - Dragging one of the rings rotates it about the corresponding axis.
 - Dragging the green handle scales it uniformly, flaring or tapering the sweep.
+- Pressing #action(Controls/Map view/Move objects up; Move objects forward) and the other movement shortcuts moves the destination cap by one grid step.
 
 The generated brushes are shown as a preview in the viewports while you place the destination cap. Shortcuts that act on the selection, including UV editing, are unavailable until the tool is deactivated. The controls above the editing views determine how the gap is filled:
 

--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -786,7 +786,7 @@ When the sweep tool is active, a ghost outline shows where the destination cap w
 - Dragging one of the rings rotates it about the corresponding axis.
 - Dragging the green handle scales it uniformly, flaring or tapering the sweep.
 
-The generated brushes are shown as a preview in the viewports while you place the destination cap. The controls above the editing views determine how the gap is filled:
+The generated brushes are shown as a preview in the viewports while you place the destination cap. Shortcuts that act on the selection, including UV editing, are unavailable until the tool is deactivated. The controls above the editing views determine how the gap is filled:
 
 - **Segments** is the number of brushes created between the selected faces and the destination cap.
 - **Path** selects how the brushes are laid out: Arc revolves the faces around an axis derived from the rotation, Straight lofts them along a line, and S-bend routes them through an S-curve. The destination cap ends up in the same place in each mode.

--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -787,6 +787,7 @@ When the sweep tool is active, a ghost outline shows where the destination cap w
 - Dragging the green handle scales it uniformly, flaring or tapering the sweep.
 - Pressing #action(Controls/Map view/Move objects up; Move objects forward) and the other movement shortcuts moves the destination cap by one grid step.
 - Pressing #action(Controls/Map view/Roll objects clockwise) and the other rotation shortcuts rotates the destination cap by one angle snap step.
+- Pressing #action(Controls/Map view/Increase sweep scale) or #action(Controls/Map view/Decrease sweep scale) moves the scale handle out or in by one grid step, growing or shrinking the destination cap.
 
 The generated brushes are shown as a preview in the viewports while you place the destination cap. Shortcuts that act on the selection, including UV editing, are unavailable until the tool is deactivated. The controls above the editing views determine how the gap is filled:
 

--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -786,6 +786,7 @@ When the sweep tool is active, a ghost outline shows where the destination cap w
 - Dragging one of the rings rotates it about the corresponding axis.
 - Dragging the green handle scales it uniformly, flaring or tapering the sweep.
 - Pressing #action(Controls/Map view/Move objects up; Move objects forward) and the other movement shortcuts moves the destination cap by one grid step.
+- Pressing #action(Controls/Map view/Roll objects clockwise) and the other rotation shortcuts rotates the destination cap by one angle snap step.
 
 The generated brushes are shown as a preview in the viewports while you place the destination cap. Shortcuts that act on the selection, including UV editing, are unavailable until the tool is deactivated. The controls above the editing views determine how the gap is filled:
 

--- a/lib/TbUiLib/include/ui/ActionContext.h
+++ b/lib/TbUiLib/include/ui/ActionContext.h
@@ -38,12 +38,11 @@ constexpr Type ScaleTool = 1u << 6u;
 constexpr Type ShearTool = 1u << 7u;
 constexpr Type AnyVertexTool = 1u << 8u;
 constexpr Type ControlPointTool = 1u << 9u;
+constexpr Type SweepTool = 1u << 10u;
 constexpr Type AnyNodeHandleTool = AnyVertexTool | ControlPointTool;
-constexpr Type NoSelection = 1u << 10u;
-constexpr Type NodeSelection = 1u << 11u;
-constexpr Type FaceSelection = 1u << 12u;
-// placed after the selection block so the existing bits keep their values
-constexpr Type SweepTool = 1u << 13u;
+constexpr Type NoSelection = 1u << 11u;
+constexpr Type NodeSelection = 1u << 12u;
+constexpr Type FaceSelection = 1u << 13u;
 constexpr Type AnyTool = AnyNodeHandleTool | AssembleBrushTool | ClipTool | RotateTool
                          | ScaleTool | ShearTool | SweepTool;
 constexpr Type AnyOrNoTool = AnyTool | NoTool;

--- a/lib/TbUiLib/include/ui/ActionContext.h
+++ b/lib/TbUiLib/include/ui/ActionContext.h
@@ -43,11 +43,12 @@ constexpr Type AnyNodeHandleTool = AnyVertexTool | ControlPointTool;
 constexpr Type NoSelection = 1u << 11u;
 constexpr Type NodeSelection = 1u << 12u;
 constexpr Type FaceSelection = 1u << 13u;
+constexpr Type SelectionOwnedByTool = 1u << 14u;
 constexpr Type AnyTool = AnyNodeHandleTool | AssembleBrushTool | ClipTool | RotateTool
                          | ScaleTool | ShearTool | SweepTool;
 constexpr Type AnyOrNoTool = AnyTool | NoTool;
 constexpr Type AnySelection = NodeSelection | FaceSelection;
-constexpr Type AnyOrNoSelection = AnySelection | NoSelection;
+constexpr Type AnyOrNoSelection = AnySelection | NoSelection | SelectionOwnedByTool;
 constexpr Type Any = AnyView | AnyOrNoSelection | AnyOrNoTool;
 constexpr Type FlyMode = View3D | AnyOrNoTool | AnyOrNoSelection;
 } // namespace ActionContext

--- a/lib/TbUiLib/include/ui/MapViewBase.h
+++ b/lib/TbUiLib/include/ui/MapViewBase.h
@@ -173,6 +173,7 @@ public: // move, rotate, flip actions
   void move(vm::direction direction);
   void moveNodeHandles(vm::direction direction);
   void moveRotationCenter(vm::direction direction);
+  void moveSweepCenter(vm::direction direction);
   void moveObjects(vm::direction direction);
   virtual vm::vec3d moveDirection(vm::direction direction) const = 0;
 

--- a/lib/TbUiLib/include/ui/MapViewBase.h
+++ b/lib/TbUiLib/include/ui/MapViewBase.h
@@ -183,6 +183,9 @@ public: // move, rotate, flip actions
   void rotate(vm::rotation_axis axis, bool clockwise);
   vm::vec3d rotationAxis(vm::rotation_axis axis, bool clockwise) const;
 
+  void increaseSweepScale();
+  void decreaseSweepScale();
+
   void flip(vm::direction direction);
   bool canFlip() const;
   virtual size_t flipAxis(vm::direction direction) const = 0;

--- a/lib/TbUiLib/include/ui/MapViewToolBox.h
+++ b/lib/TbUiLib/include/ui/MapViewToolBox.h
@@ -144,6 +144,7 @@ public: // tools
   bool canToggleSweepTool() const;
   void toggleSweepTool();
   bool sweepToolActive() const;
+  void moveSweepCenter(const vm::vec3d& delta);
   void performSweep();
 
   bool canToggleScaleTool() const;

--- a/lib/TbUiLib/include/ui/MapViewToolBox.h
+++ b/lib/TbUiLib/include/ui/MapViewToolBox.h
@@ -145,6 +145,7 @@ public: // tools
   void toggleSweepTool();
   bool sweepToolActive() const;
   void moveSweepCenter(const vm::vec3d& delta);
+  void rotateSweepCap(const vm::vec3d& axis, double angle);
   void performSweep();
 
   bool canToggleScaleTool() const;

--- a/lib/TbUiLib/include/ui/MapViewToolBox.h
+++ b/lib/TbUiLib/include/ui/MapViewToolBox.h
@@ -146,6 +146,7 @@ public: // tools
   bool sweepToolActive() const;
   void moveSweepCenter(const vm::vec3d& delta);
   void rotateSweepCap(const vm::vec3d& axis, double angle);
+  void scaleSweepCap(double distance);
   void performSweep();
 
   bool canToggleScaleTool() const;

--- a/lib/TbUiLib/include/ui/RotateHandleController.h
+++ b/lib/TbUiLib/include/ui/RotateHandleController.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include "mdl/HitFilter.h"
+#include "ui/HandleDragTracker.h"
+#include "ui/MoveHandleDragTracker.h"
 #include "ui/RotateHandle.h"
 
 #include "vm/vec.h"
@@ -106,6 +108,8 @@ public:
 
   virtual vm::vec3d handlePosition() const = 0;
   virtual void setHandlePosition(const vm::vec3d& position) = 0;
+
+  virtual DragHandleSnapper makeDragHandleSnapper(SnapMode snapMode) const;
 
   virtual void renderHighlight(
     render::RenderContext& renderContext, render::RenderBatch& renderBatch) const = 0;

--- a/lib/TbUiLib/include/ui/SweepTool.h
+++ b/lib/TbUiLib/include/ui/SweepTool.h
@@ -123,6 +123,7 @@ public:
   bool hasScaleHandle() const;
   vm::vec3d scaleHandlePosition() const;
   void dragScaleHandleTo(const vm::vec3d& position);
+  void moveScaleHandle(double distance);
   mdl::Hit pickScaleHandle(const vm::ray3d& pickRay, const gl::Camera& camera) const;
   void renderScaleHandle(
     render::RenderContext& renderContext, render::RenderBatch& renderBatch) const;

--- a/lib/TbUiLib/include/ui/SweepTool.h
+++ b/lib/TbUiLib/include/ui/SweepTool.h
@@ -89,6 +89,8 @@ public:
   explicit SweepTool(MapDocument& document);
   ~SweepTool() override;
 
+  bool ownsSelection() const override;
+
   bool doActivate() override;
   bool doDeactivate() override;
 

--- a/lib/TbUiLib/include/ui/SweepTool.h
+++ b/lib/TbUiLib/include/ui/SweepTool.h
@@ -140,6 +140,7 @@ public:
   // PointHandleDelegate (scale handle)
   vm::vec3d handlePosition() const override;
   void setHandlePosition(const vm::vec3d& position) override;
+  DragHandleSnapper makeDragHandleSnapper(SnapMode snapMode) const override;
   void renderHighlight(
     render::RenderContext& renderContext,
     render::RenderBatch& renderBatch) const override;

--- a/lib/TbUiLib/include/ui/SweepTool.h
+++ b/lib/TbUiLib/include/ui/SweepTool.h
@@ -105,6 +105,8 @@ public:
   vm::vec3d destinationCenter() const;
   void setDestinationCenter(const vm::vec3d& position);
 
+  void rotateDestinationCap(const vm::vec3d& axis, double angle);
+
   void reset();
   bool cancel();
 

--- a/lib/TbUiLib/include/ui/Tool.h
+++ b/lib/TbUiLib/include/ui/Tool.h
@@ -56,6 +56,8 @@ public:
   void createPage(QStackedLayout* book);
   void showPage();
 
+  virtual bool ownsSelection() const;
+
 private:
   virtual bool doActivate();
   virtual bool doDeactivate();

--- a/lib/TbUiLib/include/ui/ToolBox.h
+++ b/lib/TbUiLib/include/ui/ToolBox.h
@@ -148,6 +148,9 @@ public: // tool management
   void enable();
   void disable();
 
+public: // selection
+  bool selectionOwnedByTool() const;
+
 public: // rendering
   void setRenderOptions(
     ToolChain& chain, const InputState& inputState, render::RenderContext& renderContext);

--- a/lib/TbUiLib/src/ActionContext.cpp
+++ b/lib/TbUiLib/src/ActionContext.cpp
@@ -87,6 +87,10 @@ std::string actionContextName(const ActionContext::Type actionContext)
     {
       actionContexts.emplace_back("faces selected");
     }
+    if (actionContext & ActionContext::SelectionOwnedByTool)
+    {
+      actionContexts.emplace_back("selection owned by tool");
+    }
   }
 
   if ((actionContext & ActionContext::AnyOrNoTool) == ActionContext::AnyOrNoTool)

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -192,6 +192,24 @@ void ActionManager::createViewActions()
       return context.hasDocument() && context.mapWindow().toolBox().sweepToolActive();
     },
   });
+  addAction(Action{
+    std::filesystem::path{"Controls/Map view/Decrease sweep scale"},
+    QObject::tr("Decrease Sweep Scale"),
+    ActionContext::AnyView | ActionContext::SelectionOwnedByTool
+      | ActionContext::SweepTool,
+    QKeySequence{Qt::Key_BracketLeft},
+    [](auto& context) { context.mapView().decreaseSweepScale(); },
+    [](const auto& context) { return context.hasDocument(); },
+  });
+  addAction(Action{
+    std::filesystem::path{"Controls/Map view/Increase sweep scale"},
+    QObject::tr("Increase Sweep Scale"),
+    ActionContext::AnyView | ActionContext::SelectionOwnedByTool
+      | ActionContext::SweepTool,
+    QKeySequence{Qt::Key_BracketRight},
+    [](auto& context) { context.mapView().increaseSweepScale(); },
+    [](const auto& context) { return context.hasDocument(); },
+  });
 
   /* ========== Translation ========== */
   // applies to objects, vertices, handles (e.g. rotation center, sweep handle)

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -194,14 +194,14 @@ void ActionManager::createViewActions()
   });
 
   /* ========== Translation ========== */
-  // applies to objects, vertices, handles (e.g. rotation center)
+  // applies to objects, vertices, handles (e.g. rotation center, sweep handle)
   // these preference paths are structured like "action in 2D view; action in 3D view"
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Move objects up; Move objects forward"},
     QObject::tr("Move Forward"),
     ActionContext::AnyView | ActionContext::NodeSelection
-      | ActionContext::AnyNodeHandleTool | ActionContext::RotateTool
-      | ActionContext::NoTool,
+      | ActionContext::SelectionOwnedByTool | ActionContext::AnyNodeHandleTool
+      | ActionContext::RotateTool | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::Key_Up},
     [](auto& context) { context.mapView().move(vm::direction::forward); },
     [](const auto& context) { return context.hasDocument(); },
@@ -210,8 +210,8 @@ void ActionManager::createViewActions()
     std::filesystem::path{"Controls/Map view/Move objects down; Move objects backward"},
     QObject::tr("Move Backward"),
     ActionContext::AnyView | ActionContext::NodeSelection
-      | ActionContext::AnyNodeHandleTool | ActionContext::RotateTool
-      | ActionContext::NoTool,
+      | ActionContext::SelectionOwnedByTool | ActionContext::AnyNodeHandleTool
+      | ActionContext::RotateTool | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::Key_Down},
     [](auto& context) { context.mapView().move(vm::direction::backward); },
     [](const auto& context) { return context.hasDocument(); },
@@ -220,8 +220,8 @@ void ActionManager::createViewActions()
     std::filesystem::path{"Controls/Map view/Move objects left"},
     QObject::tr("Move Left"),
     ActionContext::AnyView | ActionContext::NodeSelection
-      | ActionContext::AnyNodeHandleTool | ActionContext::RotateTool
-      | ActionContext::NoTool,
+      | ActionContext::SelectionOwnedByTool | ActionContext::AnyNodeHandleTool
+      | ActionContext::RotateTool | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::Key_Left},
     [](auto& context) { context.mapView().move(vm::direction::left); },
     [](const auto& context) { return context.hasDocument(); },
@@ -230,8 +230,8 @@ void ActionManager::createViewActions()
     std::filesystem::path{"Controls/Map view/Move objects right"},
     QObject::tr("Move Right"),
     ActionContext::AnyView | ActionContext::NodeSelection
-      | ActionContext::AnyNodeHandleTool | ActionContext::RotateTool
-      | ActionContext::NoTool,
+      | ActionContext::SelectionOwnedByTool | ActionContext::AnyNodeHandleTool
+      | ActionContext::RotateTool | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::Key_Right},
     [](auto& context) { context.mapView().move(vm::direction::right); },
     [](const auto& context) { return context.hasDocument(); },
@@ -240,8 +240,8 @@ void ActionManager::createViewActions()
     std::filesystem::path{"Controls/Map view/Move objects backward; Move objects up"},
     QObject::tr("Move Up"),
     ActionContext::AnyView | ActionContext::NodeSelection
-      | ActionContext::AnyNodeHandleTool | ActionContext::RotateTool
-      | ActionContext::NoTool,
+      | ActionContext::SelectionOwnedByTool | ActionContext::AnyNodeHandleTool
+      | ActionContext::RotateTool | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::Key_PageUp},
     [](auto& context) { context.mapView().move(vm::direction::up); },
     [](const auto& context) { return context.hasDocument(); },
@@ -250,8 +250,8 @@ void ActionManager::createViewActions()
     std::filesystem::path{"Controls/Map view/Move objects forward; Move objects down"},
     QObject::tr("Move Down"),
     ActionContext::AnyView | ActionContext::NodeSelection
-      | ActionContext::AnyNodeHandleTool | ActionContext::RotateTool
-      | ActionContext::NoTool,
+      | ActionContext::SelectionOwnedByTool | ActionContext::AnyNodeHandleTool
+      | ActionContext::RotateTool | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::Key_PageDown},
     [](auto& context) { context.mapView().move(vm::direction::down); },
     [](const auto& context) { return context.hasDocument(); },

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -323,12 +323,13 @@ void ActionManager::createViewActions()
   });
 
   /* ========== Rotation ========== */
-  // applies to objects, vertices, handles (e.g. rotation center)
+  // applies to objects, vertices, handles (e.g. rotation center), the sweep cap
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Roll objects clockwise"},
     QObject::tr("Roll Clockwise"),
-    ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::RotateTool
-      | ActionContext::NoTool,
+    ActionContext::AnyView | ActionContext::NodeSelection
+      | ActionContext::SelectionOwnedByTool | ActionContext::RotateTool
+      | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::ALT | Qt::Key_Up},
     [](auto& context) { context.mapView().rotate(vm::rotation_axis::roll, true); },
     [](const auto& context) { return context.hasDocument(); },
@@ -336,8 +337,9 @@ void ActionManager::createViewActions()
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Roll objects counter-clockwise"},
     QObject::tr("Roll Counter-clockwise"),
-    ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::RotateTool
-      | ActionContext::NoTool,
+    ActionContext::AnyView | ActionContext::NodeSelection
+      | ActionContext::SelectionOwnedByTool | ActionContext::RotateTool
+      | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::ALT | Qt::Key_Down},
     [](auto& context) { context.mapView().rotate(vm::rotation_axis::roll, false); },
     [](const auto& context) { return context.hasDocument(); },
@@ -345,8 +347,9 @@ void ActionManager::createViewActions()
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Yaw objects clockwise"},
     QObject::tr("Yaw Clockwise"),
-    ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::RotateTool
-      | ActionContext::NoTool,
+    ActionContext::AnyView | ActionContext::NodeSelection
+      | ActionContext::SelectionOwnedByTool | ActionContext::RotateTool
+      | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::ALT | Qt::Key_Left},
     [](auto& context) { context.mapView().rotate(vm::rotation_axis::yaw, true); },
     [](const auto& context) { return context.hasDocument(); },
@@ -354,8 +357,9 @@ void ActionManager::createViewActions()
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Yaw objects counter-clockwise"},
     QObject::tr("Yaw Counter-clockwise"),
-    ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::RotateTool
-      | ActionContext::NoTool,
+    ActionContext::AnyView | ActionContext::NodeSelection
+      | ActionContext::SelectionOwnedByTool | ActionContext::RotateTool
+      | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::ALT | Qt::Key_Right},
     [](auto& context) { context.mapView().rotate(vm::rotation_axis::yaw, false); },
     [](const auto& context) { return context.hasDocument(); },
@@ -363,8 +367,9 @@ void ActionManager::createViewActions()
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Pitch objects clockwise"},
     QObject::tr("Pitch Clockwise"),
-    ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::RotateTool
-      | ActionContext::NoTool,
+    ActionContext::AnyView | ActionContext::NodeSelection
+      | ActionContext::SelectionOwnedByTool | ActionContext::RotateTool
+      | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::ALT | Qt::Key_PageUp},
     [](auto& context) { context.mapView().rotate(vm::rotation_axis::pitch, true); },
     [](const auto& context) { return context.hasDocument(); },
@@ -372,8 +377,9 @@ void ActionManager::createViewActions()
   addAction(Action{
     std::filesystem::path{"Controls/Map view/Pitch objects counter-clockwise"},
     QObject::tr("Pitch Counter-clockwise"),
-    ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::RotateTool
-      | ActionContext::NoTool,
+    ActionContext::AnyView | ActionContext::NodeSelection
+      | ActionContext::SelectionOwnedByTool | ActionContext::RotateTool
+      | ActionContext::SweepTool | ActionContext::NoTool,
     QKeySequence{Qt::ALT | Qt::Key_PageDown},
     [](auto& context) { context.mapView().rotate(vm::rotation_axis::pitch, false); },
     [](const auto& context) { return context.hasDocument(); },

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -365,6 +365,10 @@ void MapViewBase::move(const vm::direction direction)
   {
     moveNodeHandles(direction);
   }
+  else if ((actionContext() & ActionContext::SweepTool) != 0)
+  {
+    moveSweepCenter(direction);
+  }
   else if ((actionContext() & ActionContext::NodeSelection) != 0)
   {
     moveObjects(direction);
@@ -377,6 +381,15 @@ void MapViewBase::moveRotationCenter(const vm::direction direction)
   const auto& grid = map.grid();
   const auto delta = moveDirection(direction) * double(grid.actualSize());
   m_toolBox.moveRotationCenter(delta);
+  update();
+}
+
+void MapViewBase::moveSweepCenter(const vm::direction direction)
+{
+  const auto& map = m_document.map();
+  const auto& grid = map.grid();
+  const auto delta = moveDirection(direction) * double(grid.actualSize());
+  m_toolBox.moveSweepCenter(delta);
   update();
 }
 

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -918,10 +918,11 @@ ActionContext::Type MapViewBase::actionContext() const
     : m_toolBox.scaleToolActive()        ? ActionContext::ScaleTool
     : m_toolBox.shearToolActive()        ? ActionContext::ShearTool
                                          : ActionContext::NoTool;
-  const auto selectionContext = map.selection().hasNodes() ? ActionContext::NodeSelection
-                                : map.selection().hasBrushFaces()
-                                  ? ActionContext::FaceSelection
-                                  : ActionContext::NoSelection;
+  const auto selectionContext =
+    m_toolBox.selectionOwnedByTool()  ? ActionContext::SelectionOwnedByTool
+    : map.selection().hasNodes()      ? ActionContext::NodeSelection
+    : map.selection().hasBrushFaces() ? ActionContext::FaceSelection
+                                      : ActionContext::NoSelection;
   return viewContext | toolContext | selectionContext;
 }
 

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -471,6 +471,22 @@ vm::vec3d MapViewBase::rotationAxis(
   return clockwise ? -axis : axis;
 }
 
+void MapViewBase::increaseSweepScale()
+{
+  const auto& map = m_document.map();
+  const auto& grid = map.grid();
+  m_toolBox.scaleSweepCap(double(grid.actualSize()));
+  update();
+}
+
+void MapViewBase::decreaseSweepScale()
+{
+  const auto& map = m_document.map();
+  const auto& grid = map.grid();
+  m_toolBox.scaleSweepCap(-double(grid.actualSize()));
+  update();
+}
+
 void MapViewBase::flip(const vm::direction direction)
 {
   if (canFlip())

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -430,7 +430,13 @@ void MapViewBase::duplicateAndMoveObjects(const vm::direction direction)
 void MapViewBase::rotate(const vm::rotation_axis axisSpec, const bool clockwise)
 {
   auto& map = m_document.map();
-  if (const auto& bounds = map.selectionBounds())
+  if (m_toolBox.sweepToolActive())
+  {
+    const auto axis = rotationAxis(axisSpec, clockwise);
+    m_toolBox.rotateSweepCap(axis, map.grid().angle());
+    update();
+  }
+  else if (const auto& bounds = map.selectionBounds())
   {
     const auto axis = rotationAxis(axisSpec, clockwise);
     const auto angle = m_toolBox.rotateToolActive() ? vm::abs(m_toolBox.rotateToolAngle())

--- a/lib/TbUiLib/src/MapViewToolBox.cpp
+++ b/lib/TbUiLib/src/MapViewToolBox.cpp
@@ -312,6 +312,14 @@ bool MapViewToolBox::sweepToolActive() const
   return m_sweepTool->active();
 }
 
+void MapViewToolBox::moveSweepCenter(const vm::vec3d& delta)
+{
+  contract_pre(sweepToolActive());
+
+  const auto center = m_sweepTool->destinationCenter();
+  m_sweepTool->setDestinationCenter(center + delta);
+}
+
 void MapViewToolBox::performSweep()
 {
   contract_pre(sweepToolActive());

--- a/lib/TbUiLib/src/MapViewToolBox.cpp
+++ b/lib/TbUiLib/src/MapViewToolBox.cpp
@@ -320,6 +320,13 @@ void MapViewToolBox::moveSweepCenter(const vm::vec3d& delta)
   m_sweepTool->setDestinationCenter(center + delta);
 }
 
+void MapViewToolBox::rotateSweepCap(const vm::vec3d& axis, const double angle)
+{
+  contract_pre(sweepToolActive());
+
+  m_sweepTool->rotateDestinationCap(axis, angle);
+}
+
 void MapViewToolBox::performSweep()
 {
   contract_pre(sweepToolActive());

--- a/lib/TbUiLib/src/MapViewToolBox.cpp
+++ b/lib/TbUiLib/src/MapViewToolBox.cpp
@@ -327,6 +327,13 @@ void MapViewToolBox::rotateSweepCap(const vm::vec3d& axis, const double angle)
   m_sweepTool->rotateDestinationCap(axis, angle);
 }
 
+void MapViewToolBox::scaleSweepCap(const double distance)
+{
+  contract_pre(sweepToolActive());
+
+  m_sweepTool->moveScaleHandle(distance);
+}
+
 void MapViewToolBox::performSweep()
 {
   contract_pre(sweepToolActive());

--- a/lib/TbUiLib/src/RotateHandleController.cpp
+++ b/lib/TbUiLib/src/RotateHandleController.cpp
@@ -47,6 +47,12 @@ void RotateHandleDelegate::handleClicked(RotateHandle::HitArea) {}
 
 PointHandleDelegate::~PointHandleDelegate() = default;
 
+DragHandleSnapper PointHandleDelegate::makeDragHandleSnapper(
+  const SnapMode snapMode) const
+{
+  return makeDragHandleSnapperFromSnapMode(grid(), snapMode);
+}
+
 namespace
 {
 
@@ -345,7 +351,7 @@ public:
   DragHandleSnapper makeDragHandleSnapper(
     const InputState&, const SnapMode snapMode) const override
   {
-    return makeDragHandleSnapperFromSnapMode(m_delegate.grid(), snapMode);
+    return m_delegate.makeDragHandleSnapper(snapMode);
   }
 };
 

--- a/lib/TbUiLib/src/SweepTool.cpp
+++ b/lib/TbUiLib/src/SweepTool.cpp
@@ -193,6 +193,11 @@ SweepTool::SweepTool(MapDocument& document)
 
 SweepTool::~SweepTool() = default;
 
+bool SweepTool::ownsSelection() const
+{
+  return true;
+}
+
 bool SweepTool::doActivate()
 {
   auto& map = m_document.map();

--- a/lib/TbUiLib/src/SweepTool.cpp
+++ b/lib/TbUiLib/src/SweepTool.cpp
@@ -270,6 +270,13 @@ void SweepTool::setDestinationCenter(const vm::vec3d& position)
   setTransform(transform);
 }
 
+void SweepTool::rotateDestinationCap(const vm::vec3d& axis, const double angle)
+{
+  auto transform = m_transform;
+  transform.rotation = vm::quatd{vm::normalize(axis), angle} * transform.rotation;
+  setTransform(transform);
+}
+
 void SweepTool::reset()
 {
   setTransform(SweepTransform{});

--- a/lib/TbUiLib/src/SweepTool.cpp
+++ b/lib/TbUiLib/src/SweepTool.cpp
@@ -439,6 +439,23 @@ void SweepTool::dragScaleHandleTo(const vm::vec3d& position)
   updateBrushes();
 }
 
+void SweepTool::moveScaleHandle(const double distance)
+{
+  const auto center = destinationCenter();
+  const auto arm = scaleHandlePosition() - center;
+  const auto armLength = vm::length(arm);
+  if (armLength < vm::Cd::almost_zero())
+  {
+    return;
+  }
+
+  // move the arm's largest component by the given distance, like a snapped drag
+  const auto direction = arm / armLength;
+  const auto step = distance / vm::abs(vm::get_abs_max_component(direction));
+  const auto target = center + direction * (armLength + step);
+  dragScaleHandleTo(grid().snap(target, vm::line3d{center, direction}));
+}
+
 mdl::Hit SweepTool::pickScaleHandle(
   const vm::ray3d& pickRay, const gl::Camera& camera) const
 {

--- a/lib/TbUiLib/src/SweepTool.cpp
+++ b/lib/TbUiLib/src/SweepTool.cpp
@@ -36,6 +36,7 @@
 #include "render/RenderBatch.h"
 #include "render/RenderContext.h"
 #include "render/RenderService.h"
+#include "ui/HandleDragTracker.h"
 #include "ui/MapDocument.h"
 #include "ui/SweepToolPage.h"
 
@@ -44,6 +45,7 @@
 #include "kd/vector_utils.h"
 
 #include "vm/bbox.h"
+#include "vm/line.h"
 #include "vm/mat.h"
 #include "vm/polygon_io.h" // IWYU pragma: keep
 #include "vm/quat.h"
@@ -521,6 +523,20 @@ vm::vec3d SweepTool::handlePosition() const
 void SweepTool::setHandlePosition(const vm::vec3d& position)
 {
   dragScaleHandleTo(position);
+}
+
+DragHandleSnapper SweepTool::makeDragHandleSnapper(const SnapMode snapMode) const
+{
+  const auto center = destinationCenter();
+  const auto arm = scaleHandlePosition() - center;
+  const auto armLength = vm::length(arm);
+  if (armLength < vm::Cd::almost_zero())
+  {
+    return PointHandleDelegate::makeDragHandleSnapper(snapMode);
+  }
+
+  // snap along the arm, otherwise off-arm drags land the cap between grid lines
+  return makeAbsoluteLineHandleSnapper(grid(), vm::line3d{center, arm / armLength});
 }
 
 void SweepTool::renderHighlight(

--- a/lib/TbUiLib/src/Tool.cpp
+++ b/lib/TbUiLib/src/Tool.cpp
@@ -87,6 +87,11 @@ void Tool::showPage()
   m_book->setCurrentIndex(m_pageIndex);
 }
 
+bool Tool::ownsSelection() const
+{
+  return false;
+}
+
 bool Tool::doActivate()
 {
   return true;

--- a/lib/TbUiLib/src/ToolBox.cpp
+++ b/lib/TbUiLib/src/ToolBox.cpp
@@ -326,6 +326,11 @@ void ToolBox::disable()
   m_enabled = false;
 }
 
+bool ToolBox::selectionOwnedByTool() const
+{
+  return !m_modalToolStack.empty() && m_modalToolStack.back()->ownsSelection();
+}
+
 void ToolBox::setRenderOptions(
   ToolChain& chain, const InputState& inputState, render::RenderContext& renderContext)
 {

--- a/lib/TbUiLib/test/src/tst_SweepTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SweepTool.cpp
@@ -121,6 +121,22 @@ TEST_CASE("SweepTool")
         tool.transform().rotation * vm::vec3d{1, 0, 0} == vm::approx{vm::vec3d{0, 1, 0}});
     }
 
+    SECTION("rotateDestinationCap composes onto the rotation like a ring drag")
+    {
+      tool.setTransform(SweepTransform{
+        vm::vec3d{64, 0, 0},
+        vm::quatd{vm::vec3d{0, 0, 1}, vm::Cd::half_pi()},
+        vm::vec3d{2, 2, 2}});
+
+      tool.rotateDestinationCap(vm::vec3d{1, 0, 0}, vm::Cd::half_pi());
+
+      // a quarter turn about z followed by a quarter turn about x maps {1,0,0} to {0,0,1}
+      CHECK(
+        tool.transform().rotation * vm::vec3d{1, 0, 0} == vm::approx{vm::vec3d{0, 0, 1}});
+      CHECK(tool.transform().translation == vm::vec3d{64, 0, 0});
+      CHECK(tool.transform().scale == vm::vec3d{2, 2, 2});
+    }
+
     SECTION("dragScaleHandleTo reads a uniform scale off the handle arm")
     {
       tool.setDestinationCenter(vm::vec3d{80, 0, 0});

--- a/lib/TbUiLib/test/src/tst_SweepTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SweepTool.cpp
@@ -139,6 +139,27 @@ TEST_CASE("SweepTool")
       CHECK(tool.destinationCenter() == vm::vec3d{80, 0, 0});
     }
 
+    SECTION("setDestinationCenter round-trips exactly and leaves rotation and scale")
+    {
+      tool.setTransform(SweepTransform{
+        vm::vec3d{64, 0, 0},
+        vm::quatd{vm::vec3d{0, 0, 1}, vm::Cd::half_pi()},
+        vm::vec3d{2, 2, 2}});
+
+      const auto center = tool.destinationCenter();
+      const auto delta = vm::vec3d{16, -32, 8};
+
+      tool.setDestinationCenter(center + delta);
+      CHECK(tool.destinationCenter() == center + delta);
+      CHECK(
+        tool.transform().rotation == vm::quatd{vm::vec3d{0, 0, 1}, vm::Cd::half_pi()});
+      CHECK(tool.transform().scale == vm::vec3d{2, 2, 2});
+
+      // nudging repeatedly must not accumulate error
+      tool.setDestinationCenter(tool.destinationCenter() + delta);
+      CHECK(tool.destinationCenter() == center + 2.0 * delta);
+    }
+
     SECTION("cancel resets the transform")
     {
       tool.setDestinationCenter(vm::vec3d{80, 0, 0});

--- a/lib/TbUiLib/test/src/tst_SweepTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SweepTool.cpp
@@ -137,6 +137,28 @@ TEST_CASE("SweepTool")
       CHECK(tool.transform().scale == vm::vec3d{2, 2, 2});
     }
 
+    SECTION("moveScaleHandle steps the cap by whole grid steps like a snapped drag")
+    {
+      tool.setTransform(SweepTransform{
+        vm::vec3d{64, 0, 0},
+        vm::quatd{vm::vec3d{0, 0, 1}, vm::Cd::half_pi()},
+        vm::vec3d{2, 2, 2}});
+
+      // the arm's largest component is 16 at scale 1, so 16 units are one whole factor
+      tool.moveScaleHandle(16.0);
+      CHECK(tool.transform().scale == vm::approx{vm::vec3d{3, 3, 3}});
+
+      tool.moveScaleHandle(-16.0);
+      CHECK(tool.transform().scale == vm::approx{vm::vec3d{2, 2, 2}});
+      CHECK(tool.transform().translation == vm::vec3d{64, 0, 0});
+      CHECK(
+        tool.transform().rotation == vm::quatd{vm::vec3d{0, 0, 1}, vm::Cd::half_pi()});
+
+      // stepping far past the center clamps instead of inverting the profile
+      tool.moveScaleHandle(-4096.0);
+      CHECK(tool.transform().scale == vm::vec3d::fill(SweepTool::MinScaleFactor));
+    }
+
     SECTION("dragScaleHandleTo reads a uniform scale off the handle arm")
     {
       tool.setDestinationCenter(vm::vec3d{80, 0, 0});

--- a/lib/TbUiLib/test/src/tst_SweepTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SweepTool.cpp
@@ -21,14 +21,18 @@
 #include "mdl/BrushNode.h"
 #include "mdl/Entity.h"
 #include "mdl/EntityNode.h"
+#include "mdl/Grid.h"
 #include "mdl/GroupNode.h"
 #include "mdl/Map.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/TestFactory.h"
 #include "ui/CatchConfig.h"
+#include "ui/HandleDragTracker.h"
+#include "ui/InputState.h"
 #include "ui/MapDocument.h"
 #include "ui/MapDocumentFixture.h"
+#include "ui/MoveHandleDragTracker.h"
 #include "ui/SweepTool.h"
 
 #include "vm/approx.h"
@@ -129,6 +133,23 @@ TEST_CASE("SweepTool")
       tool.dragScaleHandleTo(tool.destinationCenter() - arm);
       CHECK(
         tool.transform().scale == vm::approx{vm::vec3d::fill(SweepTool::MinScaleFactor)});
+    }
+
+    SECTION("scale handle drags snap the destination cap onto the grid")
+    {
+      map.grid().setSize(2); // 2^2, so this sets it to grid 4
+
+      const auto center = tool.destinationCenter();
+      const auto arm = tool.scaleHandlePosition() - center;
+
+      const auto snapper = tool.makeDragHandleSnapper(SnapMode::Relative);
+
+      // off-arm positions are projected onto the arm before snapping
+      const auto proposed = center + arm * 1.3 + vm::vec3d{5, 0, 0};
+      const auto snapped = snapper(InputState{}, DragState{}, proposed);
+
+      REQUIRE(snapped.has_value());
+      CHECK(*snapped == vm::approx{center + arm * 1.25});
     }
 
     SECTION("setDestinationCenter translates towards the given position")


### PR DESCRIPTION
Issue #5369 raised (very fairly) that you should be able to use the arrow keys to adjust the handle for the destination cap of the new Sweep Tool. Investigating this actually led me to find another issue: you could still access UV shortcuts during a sweep, and they'd apply to the source face behind the gizmo. So the fix for this issue required two commits:

* First, fixing the UV shortcut piece by adding an ActionContext::ToolSelection bit that lets the tool own the selection. The map view then reports that instead of the real selection context. There's a single opt-in point in MapViewToolBox (selectionOwnedByTool()) which could be leveraged by further snapshot-style tools that are added in the future, too. I've updated the manual just so it's clear that shortcuts like UV editing will not work til the Sweep Tool is deactivated.
* Secondly, actually implementing the arrow key controls following the same pattern as the rotate tool's center. It just nudges the destination cap y one grid step per press. Added testing to ensure setDestinationCenter round-trips properly and updated the manual. 

@kduske This touches a bit more than I had hoped to touch but was necessary given how the face selection handling works. I do think that it's a cleaner UX now that you can't accidentally mess with the UVs while using the Sweep Tool, and we have the arrow keys hooked up now. LMK if there's anything you'd want to change. 
