### PR TITLE
Fix flaky tests

### DIFF
--- a/lib/TbFsLib/test-utils/include/fs/TestEnvironment.h
+++ b/lib/TbFsLib/test-utils/include/fs/TestEnvironment.h
@@ -48,6 +48,7 @@ public:
   void createTestEnvironment(const SetupFunction& setup);
   void createDirectory(const std::filesystem::path& path);
   void createFile(const std::filesystem::path& path, std::string_view contents);
+  void createFileAtomically(const std::filesystem::path& path, std::string_view contents);
   void createSymLink(
     const std::filesystem::path& target, const std::filesystem::path& link);
 

--- a/lib/TbFsLib/test-utils/src/TestEnvironment.cpp
+++ b/lib/TbFsLib/test-utils/src/TestEnvironment.cpp
@@ -24,6 +24,7 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <chrono>
 #include <fstream>
 #include <string>
 
@@ -89,6 +90,36 @@ void TestEnvironment::createFile(
 {
   auto stream = std::ofstream{m_dir / path, std::ios::out};
   stream << contents;
+}
+
+void TestEnvironment::createFileAtomically(
+  const std::filesystem::path& path, const std::string_view contents)
+{
+  const auto filePath = m_dir / path;
+  const auto replacesExistingFile = std::filesystem::exists(filePath);
+  const auto previousModificationTime = replacesExistingFile
+                                          ? std::filesystem::last_write_time(filePath)
+                                          : std::filesystem::file_time_type{};
+
+  auto tempFilename = path;
+  tempFilename += ".tmp";
+  const auto tempPath = m_dir / tempFilename;
+
+  createFile(tempFilename, contents);
+
+  if (replacesExistingFile)
+  {
+    // Give the new file a modification time that differs from that of the file it
+    // replaces. File systems stamp writes with a coarse clock (~15ms on Windows), so two
+    // writes in quick succession can be indistinguishable to a file system watcher
+    // otherwise. This must happen before the file is moved into place so that the
+    // watcher observes the new contents and the new modification time as one change.
+    std::filesystem::last_write_time(
+      tempPath, previousModificationTime + std::chrono::seconds{1});
+  }
+
+  // the temporary file is in the same directory, so this replaces the file atomically
+  std::filesystem::rename(tempPath, filePath);
 }
 
 void TestEnvironment::createSymLink(

--- a/lib/TbUiLib/test/src/tst_QPreferenceStore.cpp
+++ b/lib/TbUiLib/test/src/tst_QPreferenceStore.cpp
@@ -178,19 +178,27 @@ TEST_CASE("QPreferenceStore")
     CHECK(!env.fileExists(preferenceFilename));
   }
 
-  // The following tests are unreliable on Windows
-#if !defined(Q_OS_WIN)
+  // Qt's coarse timers may fire up to 5% early, so lower bounds on the save delay must
+  // be checked with some tolerance
+  const auto notBefore = [](const auto saveTime, const auto saveDelay) {
+    return std::chrono::steady_clock::now() >= saveTime + (saveDelay * 9) / 10;
+  };
+
   SECTION("preferences are saved after a delay")
   {
-    auto preferenceStore = QPreferenceStore{pathAsQString(preferenceFilePath), 100ms};
+    constexpr auto saveDelay = 100ms;
+    auto preferenceStore = QPreferenceStore{pathAsQString(preferenceFilePath), saveDelay};
 
     preferenceStore.save("some/path", "asdf"s);
-    const auto startTime = std::chrono::steady_clock::now();
+    const auto saveTime = std::chrono::steady_clock::now();
 
     REQUIRE(!env.fileExists(preferenceFilename));
 
+    // the timeout is generous because a loaded machine can delay the timer arbitrarily
     REQUIRE(checkAndWaitUntil(
-      startTime + 500ms, [&]() { return env.fileExists(preferenceFilename); }));
+      saveTime + 10s, [&]() { return env.fileExists(preferenceFilename); }));
+    CHECK(notBefore(saveTime, saveDelay));
+
     CHECK(env.loadFile(preferenceFilename) == R"({
     "some/path": "asdf"
 }
@@ -199,21 +207,26 @@ TEST_CASE("QPreferenceStore")
 
   SECTION("preferences save delay extends when new values are set")
   {
-    auto preferenceStore = QPreferenceStore{pathAsQString(preferenceFilePath), 500ms};
+    constexpr auto saveDelay = 1000ms;
+    auto preferenceStore = QPreferenceStore{pathAsQString(preferenceFilePath), saveDelay};
 
     preferenceStore.save("some/path", "asdf"s);
-    const auto startTime = std::chrono::steady_clock::now();
+    const auto firstSaveTime = std::chrono::steady_clock::now();
 
-    REQUIRE(!checkAndWaitUntil(
-      startTime + 300ms, [&]() { return env.fileExists(preferenceFilename); }));
+    REQUIRE(!checkAndWaitUntil(firstSaveTime + saveDelay / 4, [&]() {
+      return env.fileExists(preferenceFilename);
+    }));
 
     preferenceStore.save("some/path", "fdsa"s);
+    const auto secondSaveTime = std::chrono::steady_clock::now();
 
-    REQUIRE(!checkAndWaitUntil(
-      startTime + 600ms, [&]() { return env.fileExists(preferenceFilename); }));
+    // the test is only meaningful if the second save extended a pending save delay
+    REQUIRE(secondSaveTime < firstSaveTime + saveDelay);
 
+    // the file is written eventually, but not before the extended delay has elapsed
     REQUIRE(checkAndWaitUntil(
-      startTime + 1000ms, [&]() { return env.fileExists(preferenceFilename); }));
+      secondSaveTime + 10s, [&]() { return env.fileExists(preferenceFilename); }));
+    CHECK(notBefore(secondSaveTime, saveDelay));
 
     CHECK(env.loadFile(preferenceFilename) == R"({
     "some/path": "fdsa"
@@ -236,12 +249,15 @@ TEST_CASE("QPreferenceStore")
     REQUIRE(preferenceStore.load("some/path", value));
     REQUIRE(value == "asdf");
 
-    env.createFile(preferenceFilename, R"({
+    // the file must be replaced atomically and with a distinct modification time,
+    // otherwise the file system watcher may not report the change (see
+    // TestEnvironment::createFileAtomically)
+    env.createFileAtomically(preferenceFilename, R"({
   "some/path": "fdsa"
 }
 )");
 
-    CHECK(checkAndWaitUntil(std::chrono::steady_clock::now() + 1000ms, [&]() {
+    CHECK(checkAndWaitUntil(std::chrono::steady_clock::now() + 10s, [&]() {
       return !preferencesWereReloaded.notifications.empty();
     }));
 
@@ -252,7 +268,6 @@ TEST_CASE("QPreferenceStore")
     CHECK(preferenceStore.load("some/path", value));
     CHECK(value == "fdsa");
   }
-#endif
 }
 
 TEST_CASE("Preference lock file")


### PR DESCRIPTION
The tests for QPreference store are timing sensitive and therefore can be flaky. This commit makes these tests less sensitive to such issues.