### PR TITLE
Select entities by classname

### DIFF
--- a/app/TrenchBroom/resources/documentation/manual/index.md
+++ b/app/TrenchBroom/resources/documentation/manual/index.md
@@ -428,6 +428,9 @@ Select All in Layers
 Make Structural
 :   Moves brushes back into the world and clears any content flags. See [Brush Entities](#brush_entities).
 
+Select All CLASSNAME
+:   Select every entity in the map which has the same classname as the entity being hovered.
+
 Reveal MATERIALNAME in Material Browser
 :   Switches to the face inspector and scroll to the clicked material in the [Material Browser](#material_browser).
 

--- a/lib/TbMdlLib/include/mdl/Map_Selection.h
+++ b/lib/TbMdlLib/include/mdl/Map_Selection.h
@@ -41,6 +41,8 @@ void selectTouchingNodes(Map& map, vm::axis::type cameraAxis, bool del);
 void selectContainedNodes(Map& map, bool del);
 void selectNodesWithFilePosition(Map& map, const std::vector<size_t>& positions);
 void selectBrushesWithMaterial(Map& map, std::string_view materialName);
+void selectEntitiesWithClassname(Map& map, std::string_view classname);
+bool canSelectEntitiesWithClassname(const Map& map, std::string_view classname);
 void invertNodeSelection(Map& map);
 
 void selectAllInLayers(Map& map, const std::vector<LayerNode*>& layers);

--- a/lib/TbMdlLib/include/mdl/ModelUtils.h
+++ b/lib/TbMdlLib/include/mdl/ModelUtils.h
@@ -36,6 +36,7 @@ class Node;
 class GroupNode;
 class BrushNode;
 class EntityNode;
+class EntityNodeBase;
 class LayerNode;
 class EditorContext;
 
@@ -51,6 +52,14 @@ std::vector<LayerNode*> collectContainingLayersUserSorted(
 
 GroupNode* findContainingGroup(Node* node);
 const GroupNode* findContainingGroup(const Node* node);
+
+/**
+ * Returns the entity that owns the given node, i.e. the closest ancestor entity or
+ * world node, treating layers and groups as pass-through. Only brush and patch nodes
+ * can be owned by an entity; returns nullptr for every other node type.
+ */
+EntityNodeBase* findContainingEntity(Node* node);
+const EntityNodeBase* findContainingEntity(const Node* node);
 
 /**
  * Searches the ancestor chain of `node` for the outermost closed group and returns

--- a/lib/TbMdlLib/src/Map_Selection.cpp
+++ b/lib/TbMdlLib/src/Map_Selection.cpp
@@ -32,6 +32,7 @@
 #include "mdl/Map_Nodes.h"
 #include "mdl/ModelUtils.h"
 #include "mdl/Node.h"
+#include "mdl/NodeQueries.h"
 #include "mdl/PatchNode.h"
 #include "mdl/SelectionCommand.h"
 #include "mdl/Transaction.h"
@@ -271,6 +272,31 @@ void selectBrushesWithMaterial(Map& map, const std::string_view materialName)
   deselectAll(map);
   selectNodes(map, brushes);
   transaction.commit();
+}
+
+void selectEntitiesWithClassname(Map& map, const std::string_view classname)
+{
+  const auto& editorContext = map.editorContext();
+  const auto* currentGroup = editorContext.currentGroup();
+
+  // Entities in closed groups are selected individually because selecting the containing
+  // group would act on every entity in it, not just the matching ones.
+  const auto nodes =
+    collectNodesAndDescendants({&map.worldNode()}, [&](const EntityNode& entityNode) {
+      return kdl::ci::str_is_equal(entityNode.entity().classname(), classname)
+             && (!currentGroup || entityNode.isDescendantOf(*currentGroup))
+             && editorContext.visible(entityNode) && editorContext.editable(entityNode);
+    });
+
+  auto transaction = Transaction{map, "Select Entities with Classname"};
+  deselectAll(map);
+  selectNodes(map, nodes);
+  transaction.commit();
+}
+
+bool canSelectEntitiesWithClassname(const Map& map, const std::string_view)
+{
+  return map.editorContext().canChangeSelection();
 }
 
 void invertNodeSelection(Map& map)

--- a/lib/TbMdlLib/src/ModelUtils.cpp
+++ b/lib/TbMdlLib/src/ModelUtils.cpp
@@ -105,6 +105,22 @@ const GroupNode* findContainingGroup(const Node* node)
   return findContainingGroup(const_cast<Node*>(node));
 }
 
+EntityNodeBase* findContainingEntity(Node* node)
+{
+  return node->accept(kdl::overload(
+    [](WorldNode&) -> EntityNodeBase* { return nullptr; },
+    [](LayerNode&) -> EntityNodeBase* { return nullptr; },
+    [](GroupNode&) -> EntityNodeBase* { return nullptr; },
+    [](EntityNode&) -> EntityNodeBase* { return nullptr; },
+    [](BrushNode& brushNode) { return brushNode.entity(); },
+    [](PatchNode& patchNode) { return patchNode.entity(); }));
+}
+
+const EntityNodeBase* findContainingEntity(const Node* node)
+{
+  return findContainingEntity(const_cast<Node*>(node));
+}
+
 GroupNode* findOutermostClosedGroup(Node* node)
 {
   return node

--- a/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
@@ -32,6 +32,8 @@
 #include "mdl/Map_Entities.h"
 #include "mdl/Map_Geometry.h"
 #include "mdl/Map_Groups.h"
+#include "mdl/Map_NodeLocking.h"
+#include "mdl/Map_NodeVisibility.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/PatchNode.h"
@@ -614,6 +616,112 @@ TEST_CASE("Map_Selection")
       selectBrushesWithMaterial(map, "material1");
 
       CHECK(map.selection().nodes == std::vector<Node*>{groupedBrushNodeM1});
+    }
+  }
+
+  SECTION("selectEntitiesWithClassname")
+  {
+    auto* pointEntityNode = new EntityNode{Entity{{{"classname", "trigger_secret"}}}};
+    auto* otherPointEntityNode =
+      new EntityNode{Entity{{{"classname", "info_player_start"}}}};
+    auto* brushNode = createBrushNode(map);
+    auto* groupNode = new GroupNode{Group{"group"}};
+    auto* groupedEntityNode = new EntityNode{Entity{{{"classname", "trigger_secret"}}}};
+    auto* otherGroupedEntityNode =
+      new EntityNode{Entity{{{"classname", "info_player_start"}}}};
+    auto* brushEntityNode = new EntityNode{Entity{{{"classname", "trigger_secret"}}}};
+    auto* entityBrushNode = createBrushNode(map);
+
+    addNodes(
+      map,
+      {{parentForNodes(map),
+        {pointEntityNode, otherPointEntityNode, brushNode, groupNode, brushEntityNode}}});
+    addNodes(map, {{groupNode, {groupedEntityNode, otherGroupedEntityNode}}});
+    addNodes(map, {{brushEntityNode, {entityBrushNode}}});
+
+    SECTION("Case insensitivity")
+    {
+      const auto classname = GENERATE("trigger_secret", "TRIGGER_SECRET");
+      CAPTURE(classname);
+
+      selectEntitiesWithClassname(map, classname);
+
+      CHECK_THAT(
+        map.selection().nodes,
+        UnorderedEquals(
+          std::vector<Node*>{pointEntityNode, entityBrushNode, groupedEntityNode}));
+    }
+
+    SECTION("Entities in a closed group are selected individually")
+    {
+      selectEntitiesWithClassname(map, "trigger_secret");
+
+      CHECK_THAT(
+        map.selection().nodes,
+        UnorderedEquals(
+          std::vector<Node*>{pointEntityNode, entityBrushNode, groupedEntityNode}));
+
+      // Selecting the group instead would act on otherGroupedEntityNode too.
+      CHECK_THAT(
+        map.selection().allEntities(),
+        UnorderedEquals(std::vector<EntityNodeBase*>{
+          pointEntityNode, brushEntityNode, groupedEntityNode}));
+    }
+
+    SECTION("With open group")
+    {
+      openGroup(map, *groupNode);
+
+      selectEntitiesWithClassname(map, "trigger_secret");
+
+      CHECK(map.selection().nodes == std::vector<Node*>{groupedEntityNode});
+    }
+
+    SECTION("Worldspawn is not selected")
+    {
+      selectEntitiesWithClassname(map, "worldspawn");
+
+      CHECK(map.selection().nodes == std::vector<Node*>{});
+    }
+
+    SECTION("Hidden entities are not selected")
+    {
+      hideNodes(map, {pointEntityNode, brushEntityNode});
+
+      selectEntitiesWithClassname(map, "trigger_secret");
+
+      CHECK(map.selection().nodes == std::vector<Node*>{groupedEntityNode});
+    }
+
+    SECTION("Entities in a hidden group are not selected")
+    {
+      hideNodes(map, {groupNode});
+
+      selectEntitiesWithClassname(map, "trigger_secret");
+
+      CHECK_THAT(
+        map.selection().nodes,
+        UnorderedEquals(std::vector<Node*>{pointEntityNode, entityBrushNode}));
+    }
+
+    SECTION("Locked entities are not selected")
+    {
+      lockNodes(map, {pointEntityNode, brushEntityNode});
+
+      selectEntitiesWithClassname(map, "trigger_secret");
+
+      CHECK(map.selection().nodes == std::vector<Node*>{groupedEntityNode});
+    }
+
+    SECTION("Entities in a locked group are not selected")
+    {
+      lockNodes(map, {groupNode});
+
+      selectEntitiesWithClassname(map, "trigger_secret");
+
+      CHECK_THAT(
+        map.selection().nodes,
+        UnorderedEquals(std::vector<Node*>{pointEntityNode, entityBrushNode}));
     }
   }
 

--- a/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
@@ -116,6 +116,47 @@ TEST_CASE("ModelUtils.findContainingGroup")
   CHECK(findContainingGroup(patchNode) == outerGroupNode);
 }
 
+TEST_CASE("ModelUtils.findContainingEntity")
+{
+  constexpr auto worldBounds = vm::bbox3d{8192.0};
+  constexpr auto mapFormat = MapFormat::Quake3;
+
+  auto worldNode = WorldNode{{}, {}, mapFormat};
+
+  auto* layerNode = new LayerNode{Layer{"layer"}};
+  auto* groupNode = new GroupNode{Group{"group"}};
+  auto* entityNode = new EntityNode{Entity{}};
+  auto* structuralBrushNode = new BrushNode{
+    BrushBuilder{mapFormat, worldBounds}.createCube(64.0, "material") | kdl::value()};
+  auto* entityBrushNode = new BrushNode{
+    BrushBuilder{mapFormat, worldBounds}.createCube(64.0, "material") | kdl::value()};
+
+  // clang-format off
+  auto* structuralPatchNode = new PatchNode{BezierPatch{3, 3, {
+    {0, 0, 0}, {1, 0, 1}, {2, 0, 0},
+    {0, 1, 1}, {1, 1, 2}, {2, 1, 1},
+    {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
+  auto* entityPatchNode = new PatchNode{BezierPatch{3, 3, {
+    {0, 0, 0}, {1, 0, 1}, {2, 0, 0},
+    {0, 1, 1}, {1, 1, 2}, {2, 1, 1},
+    {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
+  // clang-format on
+
+  entityNode->addChildren({entityBrushNode, entityPatchNode});
+  groupNode->addChildren({entityNode, structuralBrushNode, structuralPatchNode});
+  layerNode->addChild(groupNode);
+  worldNode.addChild(layerNode);
+
+  CHECK(findContainingEntity(&worldNode) == nullptr);
+  CHECK(findContainingEntity(layerNode) == nullptr);
+  CHECK(findContainingEntity(groupNode) == nullptr);
+  CHECK(findContainingEntity(entityNode) == nullptr);
+  CHECK(findContainingEntity(structuralBrushNode) == &worldNode);
+  CHECK(findContainingEntity(structuralPatchNode) == &worldNode);
+  CHECK(findContainingEntity(entityBrushNode) == entityNode);
+  CHECK(findContainingEntity(entityPatchNode) == entityNode);
+}
+
 TEST_CASE("ModelUtils.findOutermostClosedGroup")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -1328,6 +1328,31 @@ void MapViewBase::showPopupMenuLater()
   menu.addSeparator();
 
   using namespace mdl::HitFilters;
+
+  if (const auto* hitNode = mdl::hitToNode(pickResult().first(type(mdl::nodeHitType()))))
+  {
+    // brushes and patches report their containing entity, while a point entity is hit
+    // directly
+    const auto* entityNode = dynamic_cast<const mdl::EntityNodeBase*>(hitNode);
+    if (!entityNode)
+    {
+      entityNode = mdl::findContainingEntity(hitNode);
+    }
+
+    if (entityNode && entityNode != &map.worldNode())
+    {
+      const auto& classname = entityNode->entity().classname();
+      auto* selectEntitiesWithClassnameAction = menu.addAction(
+        tr("Select All %1").arg(QString::fromStdString(classname)),
+        this,
+        [&map, classname] { selectEntitiesWithClassname(map, classname); });
+      selectEntitiesWithClassnameAction->setEnabled(
+        canSelectEntitiesWithClassname(map, classname));
+
+      menu.addSeparator();
+    }
+  }
+
   const auto& hit = pickResult().first(type(mdl::BrushNode::BrushHitType));
   const auto faceHandle = mdl::hitToFaceHandle(hit);
   if (faceHandle)


### PR DESCRIPTION
Resolves #5257 by adding a "Select All CLASSNAME" item to the map view context menu. Right clicking an entity then clicking this selects every entity in the map sharing the classname of the entity being hovered by the cursor. Differently to other selection commands, I implemented this so that matching entities inside closed groups are selected individually rather than collapsing to the containing group, so a batch edit across the selection acts only on the matching entities. This felt the most faithful to the feature request use cases + seems to add the most utility.