### PR TITLE
Add support for adding patches to brush entities

### DIFF
--- a/lib/TbMdlLib/include/mdl/Map_Nodes.h
+++ b/lib/TbMdlLib/include/mdl/Map_Nodes.h
@@ -37,7 +37,7 @@ class Node;
  *
  * Otherwise, returns the current group if one is open, otherwise the current layer.
  */
-Node* parentForNodes(const Map& map, const std::vector<Node*>& nodes = {});
+Node& parentForNodes(const Map& map, const std::vector<Node*>& nodes = {});
 
 std::vector<Node*> addNodes(Map& map, const std::map<Node*, std::vector<Node*>>& nodes);
 

--- a/lib/TbMdlLib/include/mdl/Map_Nodes.h
+++ b/lib/TbMdlLib/include/mdl/Map_Nodes.h
@@ -28,6 +28,7 @@ namespace tb::mdl
 class GroupNode;
 class Map;
 class Node;
+class TagMatcherCallback;
 
 /**
  * Suggests a parent to use for new nodes.
@@ -44,6 +45,37 @@ std::vector<Node*> addNodes(Map& map, const std::map<Node*, std::vector<Node*>>&
 void duplicateSelectedNodes(Map& map);
 
 bool reparentNodes(Map& map, const std::map<Node*, std::vector<Node*>>& nodesToAdd);
+
+/**
+ * Returns whether nodes is non-empty, consists solely of geometry nodes (brush or
+ * patch nodes), and at least one of them is not structural (see makeStructural).
+ */
+bool canMakeStructural(const Map& map, const std::vector<Node*>& nodes);
+
+/**
+ * Makes every geometry node (brush or patch node) in nodes structural: moves it out of
+ * any owning entity node (to the group/layer that would otherwise contain it, via
+ * parentForNodes), and disables every smart tag currently matching it (and, for
+ * brushes, matching any of its faces).
+ *
+ * Non-geometry nodes in nodes are ignored, not rejected.
+ *
+ * Returns false without committing a transaction if nodes contains no geometry nodes,
+ * or if none of them needed any change.
+ */
+bool makeStructural(
+  Map& map, const std::vector<Node*>& nodes, TagMatcherCallback& callback);
+
+/**
+ * Moves every geometry node (brush or patch node) in nodes to become a child of
+ * newParent. Nodes already parented under newParent are skipped. Non-geometry nodes in
+ * nodes are ignored.
+ *
+ * Deselects all nodes beforehand and selects the moved nodes on success.
+ *
+ * Returns false without committing a transaction if no node ended up being moved.
+ */
+bool moveToEntity(Map& map, const std::vector<Node*>& nodes, Node& newParent);
 
 void removeNodes(Map& map, const std::vector<Node*>& nodes);
 void removeSelectedNodes(Map& map);

--- a/lib/TbMdlLib/include/mdl/Map_Patches.h
+++ b/lib/TbMdlLib/include/mdl/Map_Patches.h
@@ -23,6 +23,7 @@
 #include "vm/vec.h"
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace tb::mdl
@@ -37,5 +38,7 @@ bool transformControlPoints(
   Map& map,
   const std::vector<vm::vec3d>& controlPointPositions,
   const vm::mat4x4d& transform);
+
+bool setPatchMaterial(Map& map, const std::string& materialName);
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/ModelUtils.h
+++ b/lib/TbMdlLib/include/mdl/ModelUtils.h
@@ -36,6 +36,7 @@ class Node;
 class GroupNode;
 class BrushNode;
 class EntityNode;
+class EntityNodeBase;
 class LayerNode;
 class EditorContext;
 
@@ -51,6 +52,14 @@ std::vector<LayerNode*> collectContainingLayersUserSorted(
 
 GroupNode* findContainingGroup(Node* node);
 const GroupNode* findContainingGroup(const Node* node);
+
+/**
+ * Returns the entity that owns the given node, i.e. the closest ancestor entity or
+ * world node, treating layers and groups as pass-through. Only brush and patch nodes
+ * can be owned by an entity; returns nullptr for every other node type.
+ */
+EntityNodeBase* findContainingEntity(Node* node);
+const EntityNodeBase* findContainingEntity(const Node* node);
 
 /**
  * Searches the ancestor chain of `node` for the outermost closed group and returns

--- a/lib/TbMdlLib/include/mdl/Selection.h
+++ b/lib/TbMdlLib/include/mdl/Selection.h
@@ -75,6 +75,7 @@ public:
   bool hasOnlyBrushes() const;
   bool hasPatches() const;
   bool hasOnlyPatches() const;
+  bool hasOnlyGeometryNodes() const;
   bool hasBrushFaces() const;
   bool hasAnyBrushFaces() const;
 

--- a/lib/TbMdlLib/src/Map_Brushes.cpp
+++ b/lib/TbMdlLib/src/Map_Brushes.cpp
@@ -184,7 +184,7 @@ bool createBrush(Map& map, const std::vector<vm::vec3d>& points)
 
              auto transaction = Transaction{map, "Create Brush"};
              deselectAll(map);
-             if (addNodes(map, {{parentForNodes(map), {brushNode}}}).empty())
+             if (addNodes(map, {{&parentForNodes(map), {brushNode}}}).empty())
              {
                transaction.cancel();
                return Error{"Could not add brush to document"};

--- a/lib/TbMdlLib/src/Map_CopyPaste.cpp
+++ b/lib/TbMdlLib/src/Map_CopyPaste.cpp
@@ -55,7 +55,7 @@ namespace tb::mdl
 namespace
 {
 
-auto extractNodesToPaste(const std::vector<Node*>& nodes, Node* parent)
+auto extractNodesToPaste(const std::vector<Node*>& nodes, Node& parent)
 {
   auto nodesToDetach = std::vector<Node*>{};
   auto nodesToDelete = std::vector<Node*>{};
@@ -75,7 +75,7 @@ auto extractNodesToPaste(const std::vector<Node*>& nodes, Node* parent)
       },
       [&](GroupNode& groupNode) {
         nodesToDetach.push_back(&groupNode);
-        nodesToAdd[parent].push_back(&groupNode);
+        nodesToAdd[&parent].push_back(&groupNode);
       },
       [&](auto&& thisLambda, EntityNode& entityNode) {
         if (isWorldspawn(entityNode.entity().classname()))
@@ -87,16 +87,16 @@ auto extractNodesToPaste(const std::vector<Node*>& nodes, Node* parent)
         else
         {
           nodesToDetach.push_back(&entityNode);
-          nodesToAdd[parent].push_back(&entityNode);
+          nodesToAdd[&parent].push_back(&entityNode);
         }
       },
       [&](BrushNode& brushNode) {
         nodesToDetach.push_back(&brushNode);
-        nodesToAdd[parent].push_back(&brushNode);
+        nodesToAdd[&parent].push_back(&brushNode);
       },
       [&](PatchNode& patchNode) {
         nodesToDetach.push_back(&patchNode);
-        nodesToAdd[parent].push_back(&patchNode);
+        nodesToAdd[&parent].push_back(&patchNode);
       }));
   }
 

--- a/lib/TbMdlLib/src/Map_Entities.cpp
+++ b/lib/TbMdlLib/src/Map_Entities.cpp
@@ -109,7 +109,7 @@ EntityNode* createPointEntity(
 
   auto transaction = Transaction{map, "Create " + definition.name};
   deselectAll(map);
-  if (addNodes(map, {{parentForNodes(map), {entityNode}}}).empty())
+  if (addNodes(map, {{&parentForNodes(map), {entityNode}}}).empty())
   {
     transaction.cancel();
     return nullptr;
@@ -160,7 +160,7 @@ EntityNode* createBrushEntity(Map& map, const EntityDefinition& definition)
 
   auto transaction = Transaction{map, "Create " + definition.name};
   deselectAll(map);
-  if (addNodes(map, {{parentForNodes(map), {entityNode}}}).empty())
+  if (addNodes(map, {{&parentForNodes(map), {entityNode}}}).empty())
   {
     transaction.cancel();
     return nullptr;

--- a/lib/TbMdlLib/src/Map_Entities.cpp
+++ b/lib/TbMdlLib/src/Map_Entities.cpp
@@ -36,6 +36,7 @@
 #include "mdl/WorldNode.h"
 
 #include "kd/contracts.h"
+#include "kd/overload.h"
 #include "kd/string_utils.h"
 
 namespace tb::mdl
@@ -132,19 +133,21 @@ EntityNode* createPointEntity(
 EntityNode* createBrushEntity(Map& map, const EntityDefinition& definition)
 {
   contract_pre(getType(definition) == EntityDefinitionType::Brush);
+  contract_pre(map.selection().hasOnlyGeometryNodes());
 
-  const auto brushes = map.selection().brushes;
-  contract_assert(!brushes.empty());
+  const auto nodes = map.selection().nodes;
+  contract_assert(!nodes.empty());
 
-  // if all brushes belong to the same entity, and that entity is not worldspawn, copy
+  // if all nodes belong to the same entity, and that entity is not worldspawn, copy
   // its properties
+  const auto* containingEntity = findContainingEntity(nodes.front());
   auto entity =
-    (brushes.front()->entity() != &map.worldNode()
+    (containingEntity && containingEntity != &map.worldNode()
      && std::all_of(
-       std::next(brushes.begin()),
-       brushes.end(),
-       [&](const auto* brush) { return brush->entity() == brushes.front()->entity(); }))
-      ? brushes.front()->entity()->entity()
+       std::next(nodes.begin()),
+       nodes.end(),
+       [&](const auto* node) { return findContainingEntity(node) == containingEntity; }))
+      ? containingEntity->entity()
       : Entity{};
 
   entity.addOrUpdateProperty(EntityPropertyKeys::Classname, definition.name);
@@ -155,8 +158,6 @@ EntityNode* createBrushEntity(Map& map, const EntityDefinition& definition)
   }
 
   auto* entityNode = new EntityNode{std::move(entity)};
-
-  const auto nodes = kdl::vec_static_cast<Node*>(brushes);
 
   auto transaction = Transaction{map, "Create " + definition.name};
   deselectAll(map);

--- a/lib/TbMdlLib/src/Map_Geometry.cpp
+++ b/lib/TbMdlLib/src/Map_Geometry.cpp
@@ -658,25 +658,17 @@ bool csgConvexMerge(Map& map)
 
              // We could be merging brushes that have different parents; use the parent
              // of the first brush.
-             auto* parentNode = static_cast<Node*>(nullptr);
-             if (!map.selection().brushes.empty())
-             {
-               parentNode = map.selection().brushes.front()->parent();
-             }
-             else if (!map.selection().brushFaces.empty())
-             {
-               parentNode = map.selection().brushFaces.front().node()->parent();
-             }
-             else
-             {
-               parentNode = parentForNodes(map);
-             }
+             auto& parentNode = !map.selection().brushes.empty()
+                                  ? *map.selection().brushes.front()->parent()
+                                : !map.selection().brushFaces.empty()
+                                  ? *map.selection().brushFaces.front().node()->parent()
+                                  : parentForNodes(map);
 
              auto* brushNode = new BrushNode{std::move(b)};
 
              auto transaction = Transaction{map, "CSG Convex Merge"};
              deselectAll(map);
-             if (addNodes(map, {{parentNode, {brushNode}}}).empty())
+             if (addNodes(map, {{&parentNode, {brushNode}}}).empty())
              {
                transaction.cancel();
                return;
@@ -786,7 +778,7 @@ bool csgIntersect(Map& map)
   if (valid)
   {
     auto* intersectionNode = new BrushNode{std::move(intersection)};
-    if (addNodes(map, {{parentForNodes(map, toRemove), {intersectionNode}}}).empty())
+    if (addNodes(map, {{&parentForNodes(map, toRemove), {intersectionNode}}}).empty())
     {
       transaction.cancel();
       return false;

--- a/lib/TbMdlLib/src/Map_Groups.cpp
+++ b/lib/TbMdlLib/src/Map_Groups.cpp
@@ -289,7 +289,7 @@ GroupNode* groupSelectedNodes(Map& map, const std::string& name)
   auto transaction = Transaction{map, "Group Selected Objects"};
   deselectAll(map);
   if (
-    addNodes(map, {{parentForNodes(map, nodes), {group}}}).empty()
+    addNodes(map, {{&parentForNodes(map, nodes), {group}}}).empty()
     || !reparentNodes(map, {{group, nodes}}))
   {
     transaction.cancel();
@@ -413,10 +413,10 @@ GroupNode* createLinkedDuplicate(Map& map)
   auto* groupNode = map.selection().groups.front();
   auto* groupNodeClone =
     static_cast<GroupNode*>(groupNode->cloneRecursively(map.worldBounds()));
-  auto* suggestedParent = parentForNodes(map, {groupNode});
+  auto& suggestedParent = parentForNodes(map, {groupNode});
 
   auto transaction = Transaction{map, "Create Linked Duplicate"};
-  if (addNodes(map, {{suggestedParent, {groupNodeClone}}}).empty())
+  if (addNodes(map, {{&suggestedParent, {groupNodeClone}}}).empty())
   {
     transaction.cancel();
     return nullptr;

--- a/lib/TbMdlLib/src/Map_Nodes.cpp
+++ b/lib/TbMdlLib/src/Map_Nodes.cpp
@@ -254,7 +254,7 @@ bool isGeometryNode(const Node& node)
     [](const GroupNode&) { return false; },
     [](const EntityNode&) { return false; },
     [](const BrushNode&) { return true; },
-    [](const PatchNode&) { return false; })); // TODO: extend to patches
+    [](const PatchNode&) { return true; }));
 }
 
 bool isStructural(const Map& map, const Node& node)
@@ -268,7 +268,9 @@ bool isStructural(const Map& map, const Node& node)
       return brushNode.entity() == &map.worldNode() && !brushNode.hasAnyTag()
              && !brushNode.anyFaceHasAnyTag();
     },
-    [](const PatchNode&) { return false; })); // TODO: extend to patches
+    [&](const PatchNode& patchNode) {
+      return patchNode.entity() == &map.worldNode() && !patchNode.hasAnyTag();
+    }));
 }
 
 } // namespace

--- a/lib/TbMdlLib/src/Map_Nodes.cpp
+++ b/lib/TbMdlLib/src/Map_Nodes.cpp
@@ -243,28 +243,31 @@ auto collectRemovableParents(const std::map<Node*, std::vector<Node*>>& nodes)
 
 } // namespace
 
-Node* parentForNodes(const Map& map, const std::vector<Node*>& nodes)
+Node& parentForNodes(const Map& map, const std::vector<Node*>& nodes)
 {
   if (nodes.empty())
   {
     // No reference nodes, so return either the current group (if open) or current layer
-    auto* result = static_cast<Node*>(map.editorContext().currentGroup());
-    if (!result)
+    if (auto* currentGroup = map.editorContext().currentGroup())
     {
-      result = map.editorContext().currentLayer();
+      return *currentGroup;
     }
-    return result;
+
+    auto* currentLayer = map.editorContext().currentLayer();
+    contract_post(currentLayer != nullptr);
+
+    return *currentLayer;
   }
 
   if (auto* parentGroup = findContainingGroup(nodes.at(0)))
   {
-    return parentGroup;
+    return *parentGroup;
   }
 
   auto* parentLayer = findContainingLayer(nodes.at(0));
   contract_post(parentLayer != nullptr);
 
-  return parentLayer;
+  return *parentLayer;
 }
 
 std::vector<Node*> addNodes(Map& map, const std::map<Node*, std::vector<Node*>>& nodes)
@@ -305,7 +308,7 @@ void duplicateSelectedNodes(Map& map)
 
   for (auto* original : map.selection().nodes)
   {
-    auto* suggestedParent = parentForNodes(map, {original});
+    auto& suggestedParent = parentForNodes(map, {original});
     auto* clone = original->cloneRecursively(map.worldBounds());
 
     if (shouldCloneParentWhenCloningNode(original))
@@ -324,7 +327,7 @@ void duplicateSelectedNodes(Map& map)
         // parent was not cloned yet
         newParent = originalParent->clone(map.worldBounds());
         newParentMap.emplace(originalParent, newParent);
-        nodesToAdd[suggestedParent].push_back(newParent);
+        nodesToAdd[&suggestedParent].push_back(newParent);
       }
 
       // hierarchy will look like (parent -> child): suggestedParent -> newParent -> clone
@@ -332,7 +335,7 @@ void duplicateSelectedNodes(Map& map)
     }
     else
     {
-      nodesToAdd[suggestedParent].push_back(clone);
+      nodesToAdd[&suggestedParent].push_back(clone);
     }
 
     nodesToSelect.push_back(clone);

--- a/lib/TbMdlLib/src/Map_Nodes.cpp
+++ b/lib/TbMdlLib/src/Map_Nodes.cpp
@@ -41,6 +41,7 @@
 #include "mdl/ReparentNodesCommand.h"
 #include "mdl/SetLinkIdsCommand.h"
 #include "mdl/SwapNodeContentsCommand.h"
+#include "mdl/Tag.h"
 #include "mdl/Transaction.h"
 #include "mdl/VisualEffect.h"
 #include "mdl/WorldNode.h"
@@ -49,6 +50,10 @@
 #include "kd/overload.h"
 #include "kd/ranges/concat_view.h"
 #include "kd/ranges/to.h"
+#include "kd/string_format.h"
+
+#include <algorithm>
+#include <ranges>
 
 namespace tb::mdl
 {
@@ -241,6 +246,31 @@ auto collectRemovableParents(const std::map<Node*, std::vector<Node*>>& nodes)
   return result;
 }
 
+bool isGeometryNode(const Node& node)
+{
+  return node.accept(kdl::overload(
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [](const GroupNode&) { return false; },
+    [](const EntityNode&) { return false; },
+    [](const BrushNode&) { return true; },
+    [](const PatchNode&) { return false; })); // TODO: extend to patches
+}
+
+bool isStructural(const Map& map, const Node& node)
+{
+  return node.accept(kdl::overload(
+    [](const WorldNode&) { return false; },
+    [](const LayerNode&) { return false; },
+    [](const GroupNode&) { return false; },
+    [](const EntityNode&) { return false; },
+    [&](const BrushNode& brushNode) {
+      return brushNode.entity() == &map.worldNode() && !brushNode.hasAnyTag()
+             && !brushNode.anyFaceHasAnyTag();
+    },
+    [](const PatchNode&) { return false; })); // TODO: extend to patches
+}
+
 } // namespace
 
 Node& parentForNodes(const Map& map, const std::vector<Node*>& nodes)
@@ -431,6 +461,113 @@ bool reparentNodes(Map& map, const std::map<Node*, std::vector<Node*>>& nodesToA
     removableNodes = collectRemovableParents(removableNodes);
   }
 
+  return transaction.commit();
+}
+
+bool canMakeStructural(const Map& map, const std::vector<Node*>& nodes)
+{
+  return !nodes.empty() && std::ranges::all_of(nodes, [](const Node* node) {
+    return isGeometryNode(*node);
+  }) && std::ranges::any_of(nodes, [&](const Node* node) {
+    return !isStructural(map, *node);
+  });
+}
+
+bool makeStructural(
+  Map& map, const std::vector<Node*>& nodes, TagMatcherCallback& callback)
+{
+  const auto geometryNodes =
+    nodes | std::views::filter([](const Node* node) { return isGeometryNode(*node); })
+    | kdl::ranges::to<std::vector>();
+
+  if (geometryNodes.empty())
+  {
+    return false;
+  }
+
+  const auto toReparent = geometryNodes | std::views::filter([&](const Node* node) {
+                            return findContainingEntity(node) != &map.worldNode();
+                          })
+                          | kdl::ranges::to<std::vector>();
+
+  auto transaction = Transaction{map, "Make Structural"};
+
+  // Deselect before reparenting: reparenting toReparent's nodes out of their owning
+  // entities can delete those entities if they become empty, and deleting a node that
+  // is still selected desyncs the parent chain's child/descendant selection counts.
+  // (Reselecting geometryNodes below also ensures SmartTag::disable, which operates on
+  // the map's current selection rather than on a node passed explicitly, sees the right
+  // set for the tag checks that follow.)
+  deselectAll(map);
+
+  if (!toReparent.empty())
+  {
+    if (!reparentNodes(map, {{&parentForNodes(map, toReparent), toReparent}}))
+    {
+      transaction.cancel();
+      return false;
+    }
+  }
+
+  selectNodes(map, geometryNodes);
+
+  const auto hasTag = [&](const Node* node, const SmartTag& tag) {
+    return node->accept(kdl::overload(
+      [](const WorldNode&) { return false; },
+      [](const LayerNode&) { return false; },
+      [](const GroupNode&) { return false; },
+      [](const EntityNode&) { return false; },
+      [&](const BrushNode& brushNode) {
+        return brushNode.hasTag(tag) || brushNode.anyFacesHaveAnyTagInMask(tag.type());
+      },
+      [&](const PatchNode& patchNode) { return patchNode.hasTag(tag); }));
+  };
+
+  auto anyTagDisabled = false;
+  for (const auto& tag : map.smartTags())
+  {
+    if (std::ranges::any_of(
+          geometryNodes, [&](const Node* node) { return hasTag(node, tag); }))
+    {
+      anyTagDisabled = true;
+      tag.disable(callback, map);
+    }
+  }
+
+  if (!anyTagDisabled && toReparent.empty())
+  {
+    transaction.cancel();
+    return false;
+  }
+
+  return transaction.commit();
+}
+
+bool moveToEntity(Map& map, const std::vector<Node*>& nodes, Node& newParent)
+{
+  const auto nodesToMove =
+    nodes | std::views::filter([](const Node* node) { return isGeometryNode(*node); })
+    | std::views::filter([&](const Node* node) {
+        return &newParent != node && &newParent != node->parent();
+      })
+    | kdl::ranges::to<std::vector>();
+
+  if (nodesToMove.empty())
+  {
+    return false;
+  }
+
+  auto transaction =
+    Transaction{map, "Move " + kdl::str_plural(nodesToMove.size(), "Object", "Objects")};
+
+  deselectAll(map);
+  if (!reparentNodes(map, {{&newParent, nodesToMove}}))
+  {
+    transaction.cancel();
+    return false;
+  }
+
+  selectNodes(map, nodesToMove);
   return transaction.commit();
 }
 

--- a/lib/TbMdlLib/src/Map_Patches.cpp
+++ b/lib/TbMdlLib/src/Map_Patches.cpp
@@ -20,11 +20,13 @@
 #include "mdl/Map_Patches.h"
 
 #include "mdl/ApplyAndSwap.h"
+#include "mdl/BezierPatch.h"
 #include "mdl/ControlPointCommand.h"
 #include "mdl/Map.h"
 #include "mdl/Map_Groups.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
+#include "mdl/ModelUtils.h"
 #include "mdl/PatchNode.h"
 #include "mdl/PatchUtils.h"
 #include "mdl/Selection.h"
@@ -169,6 +171,25 @@ bool transformControlPoints(
   setHasPendingChanges(changedLinkedGroups, true);
 
   return transaction.commit();
+}
+
+bool setPatchMaterial(Map& map, const std::string& materialName)
+{
+  const auto patchNodes = map.selection().patches;
+  return applyAndSwap(
+    map,
+    "Set Material",
+    patchNodes,
+    collectContainingGroups(kdl::vec_static_cast<Node*>(patchNodes)),
+    kdl::overload(
+      [](Layer&) { return true; },
+      [](Group&) { return true; },
+      [](Entity&) { return true; },
+      [](Brush&) { return true; },
+      [&](BezierPatch& patch) {
+        patch.setMaterialName(materialName);
+        return true;
+      }));
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/src/Map_Patches.cpp
+++ b/lib/TbMdlLib/src/Map_Patches.cpp
@@ -65,7 +65,7 @@ void convertSelectionToPatches(
 
   auto transaction = Transaction{map, "Convert Selection to Patches"};
 
-  auto addedNodes = addNodes(map, {{parentForNodes(map), patchNodes}});
+  auto addedNodes = addNodes(map, {{&parentForNodes(map), patchNodes}});
   deselectAll(map);
   removeNodes(map, nodesToRemove);
   selectNodes(map, addedNodes);

--- a/lib/TbMdlLib/src/ModelUtils.cpp
+++ b/lib/TbMdlLib/src/ModelUtils.cpp
@@ -105,6 +105,22 @@ const GroupNode* findContainingGroup(const Node* node)
   return findContainingGroup(const_cast<Node*>(node));
 }
 
+EntityNodeBase* findContainingEntity(Node* node)
+{
+  return node->accept(kdl::overload(
+    [](WorldNode&) -> EntityNodeBase* { return nullptr; },
+    [](LayerNode&) -> EntityNodeBase* { return nullptr; },
+    [](GroupNode&) -> EntityNodeBase* { return nullptr; },
+    [](EntityNode&) -> EntityNodeBase* { return nullptr; },
+    [](BrushNode& brushNode) { return brushNode.entity(); },
+    [](PatchNode& patchNode) { return patchNode.entity(); }));
+}
+
+const EntityNodeBase* findContainingEntity(const Node* node)
+{
+  return findContainingEntity(const_cast<Node*>(node));
+}
+
 GroupNode* findOutermostClosedGroup(Node* node)
 {
   return node

--- a/lib/TbMdlLib/src/Selection.cpp
+++ b/lib/TbMdlLib/src/Selection.cpp
@@ -236,6 +236,11 @@ bool Selection::hasOnlyPatches() const
   return hasNodes() && nodes.size() == patches.size();
 }
 
+bool Selection::hasOnlyGeometryNodes() const
+{
+  return hasNodes() && nodes.size() == brushes.size() + patches.size();
+}
+
 bool Selection::hasBrushFaces() const
 {
   return !brushFaces.empty();

--- a/lib/TbMdlLib/src/TagMatcher.cpp
+++ b/lib/TbMdlLib/src/TagMatcher.cpp
@@ -33,6 +33,7 @@
 #include "mdl/Map_Entities.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
+#include "mdl/PatchNode.h"
 #include "mdl/Selection.h"
 #include "mdl/UpdateBrushFaceAttributes.h"
 #include "mdl/WorldNode.h" // IWYU pragma: keep
@@ -84,20 +85,32 @@ public:
   }
 };
 
-class BrushMatchVisitor : public MatchVisitor
+/**
+ * Matches brush and patch nodes based on the entity that owns them (or the world node,
+ * if they aren't owned by an entity).
+ */
+class EntityOwnerMatchVisitor : public MatchVisitor
 {
 private:
-  std::function<bool(const BrushNode&)> m_matcher;
+  std::function<bool(const EntityNodeBase*)> m_matcher;
 
 public:
-  explicit BrushMatchVisitor(std::function<bool(const BrushNode&)> matcher)
+  explicit EntityOwnerMatchVisitor(std::function<bool(const EntityNodeBase*)> matcher)
     : m_matcher(std::move(matcher))
   {
   }
 
   void visit(const BrushNode& brush) override
   {
-    if (m_matcher(brush))
+    if (m_matcher(brush.entity()))
+    {
+      setMatches();
+    }
+  }
+
+  void visit(const PatchNode& patch) override
+  {
+    if (m_matcher(patch.entity()))
     {
       setMatches();
     }
@@ -414,16 +427,9 @@ std::unique_ptr<TagMatcher> EntityClassNameTagMatcher::clone() const
 
 bool EntityClassNameTagMatcher::matches(const Taggable& taggable) const
 {
-  BrushMatchVisitor visitor([this](const BrushNode& brush) {
-    if (const auto* entityNode = brush.entity())
-    {
-      return matchesClassname(entityNode->entity().classname());
-    }
-    else
-    {
-      return false;
-    }
-  });
+  auto visitor = EntityOwnerMatchVisitor{[this](const EntityNodeBase* entityNode) {
+    return entityNode && matchesClassname(entityNode->entity().classname());
+  }};
 
   taggable.accept(visitor);
   return visitor.matches();

--- a/lib/TbMdlLib/src/TagMatcher.cpp
+++ b/lib/TbMdlLib/src/TagMatcher.cpp
@@ -498,7 +498,7 @@ void EntityClassNameTagMatcher::disable(TagMatcherCallback&, Map& map) const
     return;
   }
   deselectAll(map);
-  reparentNodes(map, {{parentForNodes(map, selectedBrushes), detailBrushes}});
+  reparentNodes(map, {{&parentForNodes(map, selectedBrushes), detailBrushes}});
   selectNodes(
     map, std::vector<Node*>(std::begin(detailBrushes), std::end(detailBrushes)));
 }

--- a/lib/TbMdlLib/src/TagMatcher.cpp
+++ b/lib/TbMdlLib/src/TagMatcher.cpp
@@ -32,6 +32,7 @@
 #include "mdl/Map_Brushes.h"
 #include "mdl/Map_Entities.h"
 #include "mdl/Map_Nodes.h"
+#include "mdl/Map_Patches.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/PatchNode.h"
 #include "mdl/Selection.h"
@@ -437,7 +438,7 @@ bool EntityClassNameTagMatcher::matches(const Taggable& taggable) const
 
 void EntityClassNameTagMatcher::enable(TagMatcherCallback& callback, Map& map) const
 {
-  if (!map.selection().hasOnlyBrushes())
+  if (!map.selection().hasOnlyGeometryNodes())
   {
     return;
   }
@@ -482,6 +483,7 @@ void EntityClassNameTagMatcher::enable(TagMatcherCallback& callback, Map& map) c
   if (!m_material.empty())
   {
     setBrushFaceAttributes(map, {.materialName = m_material});
+    setPatchMaterial(map, m_material);
   }
 }
 

--- a/lib/TbMdlLib/test/src/tst_Map.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map.cpp
@@ -137,7 +137,7 @@ TEST_CASE("Map")
     CHECK(!map.modified());
 
     auto* entityNode = new EntityNode{Entity{{{"key", "value"}}}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
     CHECK(map.modified());
 
@@ -160,7 +160,7 @@ TEST_CASE("Map")
       auto* brushNode = createBrushNode(map);
       CHECK(brushNode->logicalBounds().center() == vm::vec3d{0, 0, 0});
 
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto topFaceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
       REQUIRE(topFaceIndex);
@@ -224,7 +224,7 @@ TEST_CASE("Map")
 
         addNodes(
           map,
-          {{parentForNodes(map),
+          {{&parentForNodes(map),
             {topLevelEntityNode,
              topLevelBrushEntityNode,
              topLevelBrushNode,
@@ -503,7 +503,7 @@ TEST_CASE("Map")
       auto* brushNode = createBrushNode(map);
       entityNode->addChild(brushNode);
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -551,7 +551,7 @@ TEST_CASE("Map")
     SECTION("Linked group")
     {
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -569,7 +569,7 @@ TEST_CASE("Map")
     SECTION("Nodes in a linked group")
     {
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -590,7 +590,7 @@ TEST_CASE("Map")
     SECTION("Groups in a linked group")
     {
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* innerGroupNode = groupSelectedNodes(map, "inner");
@@ -617,14 +617,14 @@ TEST_CASE("Map")
     SECTION("Nested groups")
     {
       auto* innerBrushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {innerBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {innerBrushNode}}});
       selectNodes(map, {innerBrushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
       REQUIRE(groupNode != nullptr);
 
       auto* outerBrushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {outerBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerBrushNode}}});
 
       deselectAll(map);
       selectNodes(map, {groupNode, outerBrushNode});
@@ -655,7 +655,7 @@ TEST_CASE("Map")
       */
 
       auto* innerBrushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {innerBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {innerBrushNode}}});
       selectNodes(map, {innerBrushNode});
 
       auto* innerGroupNode = groupSelectedNodes(map, "inner");
@@ -670,7 +670,7 @@ TEST_CASE("Map")
       const auto linkedInnerBrushNode = getChildAs<BrushNode>(*linkedInnerGroupNode);
 
       auto* outerBrushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {outerBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerBrushNode}}});
 
       deselectAll(map);
       selectNodes(map, {innerGroupNode, linkedInnerGroupNode, outerBrushNode});

--- a/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Map_Brushes")
       auto& map = fixture.create();
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const size_t firstFaceIndex = 0u;
       const size_t secondFaceIndex = 1u;
@@ -235,7 +235,7 @@ TEST_CASE("Map_Brushes")
       auto& map = fixture.create();
 
       auto* brushNode = createBrushNode(map, "original");
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       for (const auto& face : brushNode->brush().faces())
       {
@@ -325,7 +325,7 @@ TEST_CASE("Map_Brushes")
       auto& map = fixture.create(QuakeFixtureConfig);
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       selectNodes(map, {brushNode});
       CHECK(getFace(*brushNode, 0).surfaceAttributes().empty());
@@ -347,7 +347,7 @@ TEST_CASE("Map_Brushes")
       auto& map = fixture.create(fixtureConfig);
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const size_t faceIndex = 0u;
       const auto initialX = getFace(*brushNode, faceIndex).uAxis();
@@ -386,7 +386,7 @@ TEST_CASE("Map_Brushes")
       auto& map = fixture.create();
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -420,7 +420,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto sourceFaceIndex = brushNode->brush().findFace(vm::vec3d{0, -1, 0});
     REQUIRE(sourceFaceIndex);
@@ -506,7 +506,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
     REQUIRE(faceIndex);
@@ -581,7 +581,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
     REQUIRE(faceIndex);
@@ -646,7 +646,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
     REQUIRE(faceIndex);
@@ -711,7 +711,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
     REQUIRE(faceIndex);
@@ -786,7 +786,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, -1, 0});
     REQUIRE(faceIndex);
@@ -854,7 +854,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, -1, 0});
     REQUIRE(faceIndex);
@@ -927,7 +927,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, -1, 0});
     REQUIRE(faceIndex);
@@ -1021,7 +1021,7 @@ TEST_CASE("Map_Brushes")
     auto& map = fixture.create(QuakeFixtureConfig);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto iFront = *brushNode->brush().findFace(vm::vec3d{0, -1, 0});
     REQUIRE(iFront);

--- a/lib/TbMdlLib/test/src/tst_Map_Commands.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Commands.cpp
@@ -60,7 +60,7 @@ TEST_CASE("Map_Commands")
       setEntityProperty(map, EntityPropertyKeys::Wad, "test/mdl/Map/cr8_czg.wad");
 
       auto* brushNode = createBrushNode(map, "coffin1");
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto* material = map.materialManager().material("coffin1");
       REQUIRE(material != nullptr);
@@ -124,7 +124,7 @@ TEST_CASE("Map_Commands")
     CHECK_FALSE(map.canRepeatCommands());
 
     auto* entityNode = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     CHECK_FALSE(map.canRepeatCommands());
 
     selectNodes(map, {entityNode});
@@ -145,7 +145,7 @@ TEST_CASE("Map_Commands")
     SECTION("Repeat translation")
     {
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       REQUIRE_FALSE(map.canRepeatCommands());
@@ -164,7 +164,7 @@ TEST_CASE("Map_Commands")
 
       auto* entityNode = new EntityNode(std::move(entity));
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       REQUIRE_FALSE(map.canRepeatCommands());
@@ -188,7 +188,7 @@ TEST_CASE("Map_Commands")
     {
       auto* brushNode1 = createBrushNode(map);
 
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
       selectNodes(map, {brushNode1});
 
       REQUIRE_FALSE(map.canRepeatCommands());
@@ -198,7 +198,7 @@ TEST_CASE("Map_Commands")
       CHECK(map.canRepeatCommands());
 
       auto* brushNode2 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
       selectNodes(map, {brushNode2});
 
       map.repeatCommands();
@@ -209,7 +209,7 @@ TEST_CASE("Map_Commands")
     {
       auto* brushNode1 = createBrushNode(map);
 
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
       selectNodes(map, {brushNode1});
 
       REQUIRE_FALSE(map.canRepeatCommands());
@@ -217,7 +217,7 @@ TEST_CASE("Map_Commands")
       CHECK(map.canRepeatCommands());
 
       auto* brushNode2 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
       deselectAll(map);
       selectNodes(map, {brushNode2});
 
@@ -230,7 +230,7 @@ TEST_CASE("Map_Commands")
       auto* brushNode1 = createBrushNode(map);
       const auto originalBounds = brushNode1->logicalBounds();
 
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
       selectNodes(map, {brushNode1});
 
       REQUIRE_FALSE(map.canRepeatCommands());
@@ -239,7 +239,7 @@ TEST_CASE("Map_Commands")
       CHECK(map.canRepeatCommands());
 
       auto* brushNode2 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
       deselectAll(map);
       selectNodes(map, {brushNode2});
 
@@ -252,7 +252,7 @@ TEST_CASE("Map_Commands")
       auto* brushNode1 = createBrushNode(map);
       const auto originalBounds = brushNode1->logicalBounds();
 
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
       selectNodes(map, {brushNode1});
 
       REQUIRE_FALSE(map.canRepeatCommands());
@@ -261,7 +261,7 @@ TEST_CASE("Map_Commands")
       CHECK(map.canRepeatCommands());
 
       auto* brushNode2 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
       deselectAll(map);
       selectNodes(map, {brushNode2});
 
@@ -272,7 +272,7 @@ TEST_CASE("Map_Commands")
     SECTION("Duplicate and translate")
     {
       auto* entityNode1 = new EntityNode({});
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       selectNodes(map, {entityNode1});
       CHECK(entityNode1->entity().origin() == vm::vec3d(0, 0, 0));
@@ -334,7 +334,7 @@ TEST_CASE("Map_Commands")
     SECTION("Repeat applies to transactions")
     {
       auto* entityNode1 = new EntityNode({});
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       selectNodes(map, {entityNode1});
       CHECK(entityNode1->entity().origin() == vm::vec3d(0, 0, 0));
@@ -351,7 +351,7 @@ TEST_CASE("Map_Commands")
       // now repeat the transaction on a second entity
 
       auto* entityNode2 = new EntityNode({});
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
 
       deselectAll(map);
       selectNodes(map, {entityNode2});
@@ -372,7 +372,7 @@ TEST_CASE("Map_Commands")
     SECTION("Undo")
     {
       auto* entityNode1 = new EntityNode({});
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       selectNodes(map, {entityNode1});
       CHECK(entityNode1->entity().origin() == vm::vec3d(0, 0, 0));

--- a/lib/TbMdlLib/test/src/tst_Map_CopyPaste.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_CopyPaste.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Map_CopyPaste")
     auto* brushNode = new BrushNode{builder.createCube(64.0, "some_material").value()};
     auto* entityNode = new EntityNode{Entity{{{"some_key", "some_value"}}}};
 
-    addNodes(map, {{parentForNodes(map), {brushNode, entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode, entityNode}}});
 
     SECTION("nothing is selected")
     {
@@ -114,7 +114,7 @@ TEST_CASE("Map_CopyPaste")
 
     auto* brushNode = new BrushNode{builder.createCube(64.0, "some_material").value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     SECTION("nothing is selected")
     {
@@ -357,7 +357,7 @@ common/caulk
 
       auto* brushNode1 =
         new BrushNode{builder.createCuboid(box, "material") | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
       selectNodes(map, {brushNode1});
 
       const auto groupName = std::string{"testGroup"};
@@ -389,7 +389,7 @@ common/caulk
       auto& map = fixture.create();
       auto* brushNode = createBrushNode(map);
 
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -445,7 +445,7 @@ common/caulk
       auto& map = fixture.create();
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       selectNodes(map, {entityNode});
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -491,7 +491,7 @@ common/caulk
       auto& map = fixture.create();
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");

--- a/lib/TbMdlLib/test/src/tst_Map_Entities.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Entities.cpp
@@ -33,6 +33,7 @@
 #include "mdl/Map_Groups.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
+#include "mdl/PatchNode.h"
 #include "mdl/TestFactory.h"
 #include "mdl/TestUtils.h"
 #include "mdl/Transaction.h"
@@ -244,6 +245,35 @@ TEST_CASE("Map_Entities")
       }
     }
 
+    SECTION("Patch entity is created and selected")
+    {
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+
+      selectNodes(map, {patchNode});
+      auto* entityNode = createBrushEntity(map, *brushEntityDefinition);
+      CHECK(entityNode != nullptr);
+      CHECK(map.worldNode().defaultLayer()->children() == std::vector<Node*>{entityNode});
+      CHECK(entityNode->children() == std::vector<Node*>{patchNode});
+      CHECK(entityNode->entity().definition() == brushEntityDefinition);
+      CHECK(map.selection().nodes == std::vector<Node*>{patchNode});
+
+      SECTION("Undo and redo")
+      {
+        map.undoCommand();
+        CHECK(
+          map.worldNode().defaultLayer()->children() == std::vector<Node*>{patchNode});
+        CHECK(map.selection().nodes == std::vector<Node*>{patchNode});
+
+        map.redoCommand();
+        CHECK(
+          map.worldNode().defaultLayer()->children() == std::vector<Node*>{entityNode});
+        CHECK(entityNode->children() == std::vector<Node*>{patchNode});
+        CHECK(entityNode->entity().definition() == brushEntityDefinition);
+        CHECK(map.selection().nodes == std::vector<Node*>{patchNode});
+      }
+    }
+
     SECTION("Copies properties from existing brush entity")
     {
       auto* brushNode1 = createBrushNode(map, "some_material");
@@ -259,6 +289,26 @@ TEST_CASE("Map_Entities")
 
       deselectAll(map);
       selectNodes(map, {brushNode1, brushNode2});
+
+      auto* newEntityNode = createBrushEntity(map, *brushEntityDefinition);
+      CHECK(newEntityNode != nullptr);
+      CHECK(newEntityNode->entity().hasProperty("prop", "value"));
+    }
+
+    SECTION("Copies properties from mixed brush and patch entity")
+    {
+      auto* brushNode = createBrushNode(map, "some_material");
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{&parentForNodes(map), {brushNode, patchNode}}});
+
+      selectNodes(map, {brushNode, patchNode});
+      auto* previousEntityNode = createBrushEntity(map, *brushEntityDefinition);
+
+      setEntityProperty(map, "prop", "value");
+      REQUIRE(previousEntityNode->entity().hasProperty("prop", "value"));
+
+      deselectAll(map);
+      selectNodes(map, {patchNode});
 
       auto* newEntityNode = createBrushEntity(map, *brushEntityDefinition);
       CHECK(newEntityNode != nullptr);

--- a/lib/TbMdlLib/test/src/tst_Map_Entities.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Entities.cpp
@@ -180,7 +180,7 @@ TEST_CASE("Map_Entities")
     SECTION("Linked group update failure")
     {
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       // move the entity down
@@ -218,7 +218,7 @@ TEST_CASE("Map_Entities")
     SECTION("Brush entity is created and selected")
     {
       auto* brushNode = createBrushNode(map, "some_material");
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       selectNodes(map, {brushNode});
       auto* entityNode = createBrushEntity(map, *brushEntityDefinition);
@@ -249,7 +249,7 @@ TEST_CASE("Map_Entities")
       auto* brushNode1 = createBrushNode(map, "some_material");
       auto* brushNode2 = createBrushNode(map, "some_material");
       auto* brushNode3 = createBrushNode(map, "some_material");
-      addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
 
       selectNodes(map, {brushNode1, brushNode2, brushNode3});
       auto* previousEntityNode = createBrushEntity(map, *brushEntityDefinition);
@@ -288,7 +288,7 @@ TEST_CASE("Map_Entities")
       auto* brushNode = createBrushNode(mapWithDefaultProperties, "some_material");
       addNodes(
         mapWithDefaultProperties,
-        {{parentForNodes(mapWithDefaultProperties), {brushNode}}});
+        {{&parentForNodes(mapWithDefaultProperties), {brushNode}}});
 
       selectNodes(mapWithDefaultProperties, {brushNode});
       auto* entityNode =
@@ -305,7 +305,7 @@ TEST_CASE("Map_Entities")
     SECTION("Linked group update failure")
     {
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       // move the entity down
@@ -334,7 +334,7 @@ TEST_CASE("Map_Entities")
         *brushNode, vm::translation_matrix(vm::vec3d{0, 0, -32}), map.worldBounds());
       REQUIRE(brushNode->physicalBounds() == vm::bbox3d{{-16, -16, -48}, {16, 16, -16}});
 
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       deselectAll(map);
       selectNodes(map, {brushNode});
 
@@ -373,7 +373,7 @@ TEST_CASE("Map_Entities")
       const auto entityNode1 = new EntityNode{originalEntity1};
       const auto entityNode2 = new EntityNode{originalEntity2};
 
-      addNodes(map, {{parentForNodes(map), {entityNode1, entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1, entityNode2}}});
 
       selectNodes(map, {entityNode1, entityNode2});
       CHECK(setEntityProperty(map, "some_key", "some_value", defaultToProtected));
@@ -407,7 +407,7 @@ TEST_CASE("Map_Entities")
       }};
 
       const auto entityNode = new EntityNode{originalEntity};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       selectNodes(map, {entityNode});
       CHECK(setEntityProperty(map, "some_key", "some_value", defaultToProtected));
@@ -429,7 +429,7 @@ TEST_CASE("Map_Entities")
     {
       auto* entityNode = new EntityNode(Entity{{{"classname", "large_entity"}}});
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       REQUIRE(entityNode->entity().definition() == largeEntityDefinition);
 
       deselectAll(map);
@@ -479,7 +479,7 @@ TEST_CASE("Map_Entities")
       // https://github.com/TrenchBroom/TrenchBroom/issues/3768
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -540,7 +540,7 @@ TEST_CASE("Map_Entities")
       const auto entityNode1 = new EntityNode{originalEntity1};
       const auto entityNode2 = new EntityNode{originalEntity2};
 
-      addNodes(map, {{parentForNodes(map), {entityNode1, entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1, entityNode2}}});
 
       selectNodes(map, {entityNode1, entityNode2});
       CHECK(renameEntityProperty(map, "some_key", "some_other_key"));
@@ -565,7 +565,7 @@ TEST_CASE("Map_Entities")
     {
       auto* entityNode = new EntityNode(Entity{{{"classname", "large_entity"}}});
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       REQUIRE(entityNode->entity().definition() == largeEntityDefinition);
 
       deselectAll(map);
@@ -634,7 +634,7 @@ TEST_CASE("Map_Entities")
       const auto entityNode1 = new EntityNode{originalEntity1};
       const auto entityNode2 = new EntityNode{originalEntity2};
 
-      addNodes(map, {{parentForNodes(map), {entityNode1, entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1, entityNode2}}});
 
       selectNodes(map, {entityNode1, entityNode2});
       CHECK(removeEntityProperty(map, "some_key"));
@@ -659,7 +659,7 @@ TEST_CASE("Map_Entities")
     {
       auto* entityNode = new EntityNode{Entity{{{"classname", "large_entity"}}}};
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       REQUIRE(entityNode->entity().definition() == largeEntityDefinition);
 
       deselectAll(map);
@@ -700,7 +700,7 @@ TEST_CASE("Map_Entities")
     }};
 
     auto* entityNode = new EntityNode{originalEntity1};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     selectNodes(map, {entityNode});
 
     SECTION("single entity selected")
@@ -760,7 +760,7 @@ TEST_CASE("Map_Entities")
       }};
 
       auto* entityNode2 = new EntityNode{originalEntity2};
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
       selectNodes(map, {entityNode2});
 
       REQUIRE(setEntityColorProperty(map, "color", RgbF{0.0f, 0.5f, 1.0f}));
@@ -801,7 +801,7 @@ TEST_CASE("Map_Entities")
     CAPTURE(key, range);
 
     auto* entityNode = new EntityNode{originalEntity};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     selectNodes(map, {entityNode});
 
     REQUIRE(convertEntityColorRange(map, key, range));
@@ -816,7 +816,7 @@ TEST_CASE("Map_Entities")
       auto* brushNode = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       selectAllNodes(map);
 
@@ -848,7 +848,7 @@ TEST_CASE("Map_Entities")
     SECTION("Toggle protected state")
     {
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       selectNodes(map, {entityNode});
 
@@ -907,7 +907,7 @@ TEST_CASE("Map_Entities")
     SECTION("Setting protected entity properties restores their values")
     {
       auto* entityNode = new EntityNode{Entity{{{"some_key", "some_value"}}}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       selectNodes(map, {entityNode});
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -1043,7 +1043,7 @@ TEST_CASE("Map_Entities")
       {"some_key", "some_value"},
       {"another_key", "another_value"},
     }}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
     CHECK_FALSE(canClearProtectedEntityProperties(map));
 
@@ -1220,7 +1220,7 @@ TEST_CASE("Map_Entities")
     auto* entityNodeWithoutDefinition = new EntityNode{Entity{{
       {"classname", "some_class"},
     }}};
-    addNodes(map, {{parentForNodes(map), {entityNodeWithoutDefinition}}});
+    addNodes(map, {{&parentForNodes(map), {entityNodeWithoutDefinition}}});
     selectNodes(map, {entityNodeWithoutDefinition});
     setEntityProperty(map, "some_prop", "some_value");
     deselectAll(map);

--- a/lib/TbMdlLib/test/src/tst_Map_EntityLinks.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_EntityLinks.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Map_EntityLinks")
       {Targetname, "some_value"},
     }}};
 
-    addNodes(map, {{parentForNodes(map), {sourceNode, targetNode}}});
+    addNodes(map, {{&parentForNodes(map), {sourceNode, targetNode}}});
     CHECK(map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
   }
 
@@ -98,7 +98,7 @@ TEST_CASE("Map_EntityLinks")
       {Targetname, "some_value"},
     }}};
 
-    addNodes(map, {{parentForNodes(map), {sourceNode, targetNode}}});
+    addNodes(map, {{&parentForNodes(map), {sourceNode, targetNode}}});
     REQUIRE(map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
 
     SECTION("Remove source node")
@@ -128,7 +128,7 @@ TEST_CASE("Map_EntityLinks")
         {Targetname, "some_value"},
       }}};
 
-      addNodes(map, {{parentForNodes(map), {sourceNode, targetNode}}});
+      addNodes(map, {{&parentForNodes(map), {sourceNode, targetNode}}});
       REQUIRE(map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
 
       SECTION("Change source classname")
@@ -172,7 +172,7 @@ TEST_CASE("Map_EntityLinks")
         {Targetname, "some_value"},
       }}};
 
-      addNodes(map, {{parentForNodes(map), {sourceNode, targetNode}}});
+      addNodes(map, {{&parentForNodes(map), {sourceNode, targetNode}}});
       REQUIRE(!map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
 
       SECTION("Change source classname, then target classname")
@@ -210,7 +210,7 @@ TEST_CASE("Map_EntityLinks")
       {Classname, targetClassname},
     }}};
 
-    addNodes(map, {{parentForNodes(map), {sourceNode, targetNode}}});
+    addNodes(map, {{&parentForNodes(map), {sourceNode, targetNode}}});
     REQUIRE(!map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
 
     SECTION("First set target, then targetname")
@@ -250,7 +250,7 @@ TEST_CASE("Map_EntityLinks")
       {Targetname, "some_value"},
     }}};
 
-    addNodes(map, {{parentForNodes(map), {sourceNode, targetNode}}});
+    addNodes(map, {{&parentForNodes(map), {sourceNode, targetNode}}});
     REQUIRE(map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
 
     SECTION("Unset target property")
@@ -283,7 +283,7 @@ TEST_CASE("Map_EntityLinks")
     auto* sourceGroupNode = new GroupNode{mdl::Group{"source"}};
     sourceGroupNode->addChild(sourceNode);
 
-    addNodes(map, {{parentForNodes(map), {sourceGroupNode, targetNode}}});
+    addNodes(map, {{&parentForNodes(map), {sourceGroupNode, targetNode}}});
 
     SECTION("Adding a grouped node adds links")
     {

--- a/lib/TbMdlLib/test/src/tst_Map_Geometry.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Geometry.cpp
@@ -141,7 +141,7 @@ TEST_CASE("Map_Geometry")
       auto* node = createNode(map);
       CAPTURE(node->name());
 
-      addNodes(map, {{parentForNodes(map), {node}}});
+      addNodes(map, {{&parentForNodes(map), {node}}});
 
       const auto originalNode =
         std::unique_ptr<Node>{node->cloneRecursively(map.worldBounds())};
@@ -184,10 +184,10 @@ TEST_CASE("Map_Geometry")
       // https://github.com/TrenchBroom/TrenchBroom/issues/1715
 
       auto* brushNode1 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       reparentNodes(map, {{entityNode, {brushNode1}}});
 
       selectNodes(map, {brushNode1});
@@ -227,7 +227,7 @@ TEST_CASE("Map_Geometry")
 
       auto* brushNode1 =
         new BrushNode{builder.createCuboid(box, "material") | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
       selectNodes(map, {brushNode1});
 
       auto* group = groupSelectedNodes(map, "testGroup");
@@ -276,7 +276,7 @@ TEST_CASE("Map_Geometry")
     GIVEN("An entity")
     {
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       selectNodes(map, {entityNode});
 
       WHEN("The entity is translated")
@@ -313,7 +313,7 @@ TEST_CASE("Map_Geometry")
 
       SECTION("two brushes")
       {
-        addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2}}});
+        addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2}}});
         selectNodes(map, {brushNode1, brushNode2});
 
         const auto boundsCenter = map.selectionBounds()->center();
@@ -340,7 +340,7 @@ TEST_CASE("Map_Geometry")
           {"angle", "45"},
         }}};
 
-        addNodes(map, {{parentForNodes(map), {entityNode}}});
+        addNodes(map, {{&parentForNodes(map), {entityNode}}});
         addNodes(map, {{entityNode, {brushNode1, brushNode2}}});
 
         REQUIRE(*entityNode->entity().property("angle") == "45");
@@ -395,7 +395,7 @@ TEST_CASE("Map_Geometry")
         builder.createCuboid(vm::bbox3d{{-32, -32, -32}, {32, 32, 32}}, "material")
         | kdl::value()};
 
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto& vertexHandles = map.nodeHandles();
@@ -428,10 +428,10 @@ TEST_CASE("Map_Geometry")
       // https://github.com/TrenchBroom/TrenchBroom/issues/1754
 
       auto* brushNode1 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       reparentNodes(map, {{entityNode, {brushNode1}}});
 
       selectNodes(map, {brushNode1});
@@ -454,7 +454,7 @@ TEST_CASE("Map_Geometry")
         {EntityPropertyKeys::Classname, "test"},
       }}};
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       CHECK(!entityNode->entity().hasProperty("angle"));
 
       selectNodes(map, {entityNode});
@@ -479,7 +479,7 @@ TEST_CASE("Map_Geometry")
     auto* brushNode =
       new BrushNode{builder.createCuboid(initialBBox, "material") | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     REQUIRE(brushNode->logicalBounds().size() == vm::vec3d{200, 200, 200});
@@ -540,7 +540,7 @@ TEST_CASE("Map_Geometry")
       auto* brushNode =
         new BrushNode{builder.createCuboid(initialBBox, "material") | kdl::value()};
 
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       CHECK_THAT(
@@ -585,7 +585,7 @@ TEST_CASE("Map_Geometry")
       auto* brushNode =
         new BrushNode{builder.createCuboid(initialBBox, "material") | kdl::value()};
 
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       CHECK_THAT(
@@ -639,8 +639,8 @@ TEST_CASE("Map_Geometry")
     CHECK(checkBrushIntegral(brushNode1));
     CHECK(checkBrushIntegral(brushNode2));
 
-    addNodes(map, {{parentForNodes(map), {brushNode1}}});
-    addNodes(map, {{parentForNodes(map), {brushNode2}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode1}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode2}}});
 
     selectNodes(map, {brushNode1, brushNode2});
 
@@ -665,7 +665,7 @@ TEST_CASE("Map_Geometry")
       builder.createCuboid(vm::bbox3d{{-32, -32, -32}, {32, 32, 32}}, "material")
       | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     SECTION("no vertex gets deleted")
@@ -745,7 +745,7 @@ TEST_CASE("Map_Geometry")
       builder.createCuboid(vm::bbox3d{{-32, -32, -32}, {32, 32, 32}}, "material")
       | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     SECTION("Edge transform is valid")
@@ -832,7 +832,7 @@ TEST_CASE("Map_Geometry")
       builder.createCuboid(vm::bbox3d{{-32, -32, -32}, {32, 32, 32}}, "material")
       | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     SECTION("Face transform is valid")
@@ -931,7 +931,7 @@ TEST_CASE("Map_Geometry")
       builder.createCuboid(vm::bbox3d{{-32, -32, -32}, {32, 32, 32}}, "material")
       | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     SECTION("Vertex can be added")
@@ -972,7 +972,7 @@ TEST_CASE("Map_Geometry")
       builder.createCuboid(vm::bbox3d{{-32, -32, -32}, {32, 32, 32}}, "material")
       | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     SECTION("Remove single vertex")
@@ -1068,7 +1068,7 @@ TEST_CASE("Map_Geometry")
       // https://github.com/TrenchBroom/TrenchBroom/issues/3768
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -1101,7 +1101,7 @@ TEST_CASE("Map_Geometry")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       auto* brushNode1 = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {32, 64, 64}}, "material")
@@ -1110,7 +1110,7 @@ TEST_CASE("Map_Geometry")
         builder.createCuboid(vm::bbox3d{{32, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
       addNodes(map, {{entityNode, {brushNode1}}});
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
       CHECK(entityNode->children().size() == 1u);
 
       selectNodes(map, {brushNode1, brushNode2});
@@ -1127,7 +1127,7 @@ TEST_CASE("Map_Geometry")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       auto* brushNode1 = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {32, 64, 64}}, "material")
@@ -1136,7 +1136,7 @@ TEST_CASE("Map_Geometry")
         builder.createCuboid(vm::bbox3d{{32, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
       addNodes(map, {{entityNode, {brushNode1}}});
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
       REQUIRE(entityNode->children().size() == 1u);
 
       const auto oFace1Index = brushNode1->brush().findFace(vm::vec3d{-1, 0, 0});
@@ -1173,7 +1173,7 @@ TEST_CASE("Map_Geometry")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       const auto texAlignmentSnapshot =
         UvCoordSystemSnapshot{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}};
@@ -1216,7 +1216,7 @@ TEST_CASE("Map_Geometry")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       auto* minuendNode = new BrushNode{
         builder.createCuboid(
@@ -1262,7 +1262,7 @@ TEST_CASE("Map_Geometry")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       auto* subtrahend1 = new BrushNode{
         builder.createCuboid(
@@ -1289,7 +1289,7 @@ TEST_CASE("Map_Geometry")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       const auto texAlignmentSnapshot =
         UvCoordSystemSnapshot{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}};
@@ -1407,7 +1407,7 @@ TEST_CASE("Map_Geometry")
       builder.createCuboid(vm::bbox3d{{0, -32, -32}, {64, 32, 32}}, "material")
       | kdl::value()};
 
-    addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2}}});
     selectNodes(map, {brushNode1, brushNode2});
 
     SECTION("Extrude one brush")

--- a/lib/TbMdlLib/test/src/tst_Map_Groups.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Groups.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Map_Groups")
       auto* innerGroupNode = new GroupNode{Group{"inner"}};
       auto* outerGroupNode = new GroupNode{Group{"outer"}};
 
-      addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
       addNodes(map, {{outerGroupNode, {innerGroupNode}}});
       addNodes(map, {{innerGroupNode, {entityNode}}});
 
@@ -111,7 +111,7 @@ TEST_CASE("Map_Groups")
     auto* innerGroupNode = new GroupNode{Group{"inner"}};
     auto* outerGroupNode = new GroupNode{Group{"outer"}};
 
-    addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+    addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
     addNodes(map, {{outerGroupNode, {innerGroupNode}}});
     addNodes(map, {{innerGroupNode, {entityNode1}}});
 
@@ -153,7 +153,7 @@ TEST_CASE("Map_Groups")
     auto* innerGroupNode = new GroupNode{Group{"inner"}};
     auto* outerGroupNode = new GroupNode{Group{"outer"}};
 
-    addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+    addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
     addNodes(map, {{outerGroupNode, {innerGroupNode}}});
     addNodes(map, {{innerGroupNode, {entityNode1}}});
 
@@ -208,7 +208,7 @@ TEST_CASE("Map_Groups")
         CreateNode{[](const auto&) { return createPatchNode(); }});
 
       auto* node = createNode(map);
-      addNodes(map, {{parentForNodes(map), {node}}});
+      addNodes(map, {{&parentForNodes(map), {node}}});
       selectNodes(map, {node});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -220,20 +220,20 @@ TEST_CASE("Map_Groups")
 
       map.undoCommand();
       CHECK(groupNode->parent() == nullptr);
-      CHECK(node->parent() == parentForNodes(map));
+      CHECK(node->parent() == &parentForNodes(map));
       CHECK(node->selected());
     }
 
     SECTION("Create group with partial brush entity")
     {
       auto* childNode1 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {childNode1}}});
+      addNodes(map, {{&parentForNodes(map), {childNode1}}});
 
       auto* childNode2 = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {childNode2}}});
+      addNodes(map, {{&parentForNodes(map), {childNode2}}});
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       reparentNodes(map, {{entityNode, {childNode1, childNode2}}});
 
       selectNodes(map, {childNode1});
@@ -251,7 +251,7 @@ TEST_CASE("Map_Groups")
       CHECK(groupNode->parent() == nullptr);
       CHECK(childNode1->parent() == entityNode);
       CHECK(childNode2->parent() == entityNode);
-      CHECK(entityNode->parent() == parentForNodes(map));
+      CHECK(entityNode->parent() == &parentForNodes(map));
       CHECK_FALSE(groupNode->selected());
       CHECK(childNode1->selected());
     }
@@ -259,13 +259,13 @@ TEST_CASE("Map_Groups")
     SECTION("Create group with full brush entity")
     {
       auto* childNode1 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {childNode1}}});
+      addNodes(map, {{&parentForNodes(map), {childNode1}}});
 
       auto* childNode2 = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {childNode2}}});
+      addNodes(map, {{&parentForNodes(map), {childNode2}}});
 
       auto* entityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       reparentNodes(map, {{entityNode, {childNode1, childNode2}}});
 
       selectNodes(map, {childNode1, childNode2});
@@ -284,7 +284,7 @@ TEST_CASE("Map_Groups")
       CHECK(groupNode->parent() == nullptr);
       CHECK(childNode1->parent() == entityNode);
       CHECK(childNode2->parent() == entityNode);
-      CHECK(entityNode->parent() == parentForNodes(map));
+      CHECK(entityNode->parent() == &parentForNodes(map));
       CHECK_FALSE(groupNode->selected());
       CHECK(childNode1->selected());
       CHECK(childNode2->selected());
@@ -317,7 +317,7 @@ TEST_CASE("Map_Groups")
       auto* nestedBrushNode = createBrushNode(map);
       auto* nestedEntityNode = new EntityNode{Entity{}};
 
-      addNodes(map, {{parentForNodes(map), {nestedBrushNode, nestedEntityNode}}});
+      addNodes(map, {{&parentForNodes(map), {nestedBrushNode, nestedEntityNode}}});
       selectNodes(map, {nestedBrushNode, nestedEntityNode});
 
       auto* nestedGroupNode = groupSelectedNodes(map, "nested");
@@ -332,7 +332,7 @@ TEST_CASE("Map_Groups")
       auto* entityBrushNode = createBrushNode(map);
       entityNode->addChild(entityBrushNode);
 
-      addNodes(map, {{parentForNodes(map), {brushNode, entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode, entityNode}}});
 
       selectNodes(map, {brushNode, entityNode, nestedGroupNode});
       auto* groupNode = groupSelectedNodes(map, "group");
@@ -376,15 +376,15 @@ TEST_CASE("Map_Groups")
       auto* innerEntityNode1 = new EntityNode{Entity{}};
       auto* innerEntityNode2 = new EntityNode{Entity{}};
 
-      addNodes(map, {{parentForNodes(map), {innerEntityNode1}}});
-      addNodes(map, {{parentForNodes(map), {innerEntityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {innerEntityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {innerEntityNode2}}});
       selectNodes(map, {innerEntityNode1, innerEntityNode2});
 
       auto* innerGroupNode = groupSelectedNodes(map, "Inner");
 
       deselectAll(map);
-      addNodes(map, {{parentForNodes(map), {outerEntityNode1}}});
-      addNodes(map, {{parentForNodes(map), {outerEntityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {outerEntityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {outerEntityNode2}}});
       selectNodes(map, {innerGroupNode, outerEntityNode1, outerEntityNode2});
 
       auto* outerGroupNode = groupSelectedNodes(map, "Outer");
@@ -427,7 +427,7 @@ TEST_CASE("Map_Groups")
     {
       auto* entityNode1 = new EntityNode{Entity{}};
 
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
       selectNodes(map, {entityNode1});
 
       auto* groupNode = groupSelectedNodes(map, "Group");
@@ -442,7 +442,7 @@ TEST_CASE("Map_Groups")
       const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
 
       auto* entityNode1 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       auto* brushNode1 = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
@@ -472,8 +472,8 @@ TEST_CASE("Map_Groups")
       auto* entityNode1 = new EntityNode{Entity{}};
       auto* entityNode2 = new EntityNode{Entity{}};
 
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
       selectNodes(map, {entityNode1});
 
       auto* groupNode = groupSelectedNodes(map, "Group");
@@ -491,7 +491,7 @@ TEST_CASE("Map_Groups")
     SECTION("Ungrouping linked groups")
     {
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       selectNodes(map, {brushNode});
 
@@ -600,13 +600,13 @@ TEST_CASE("Map_Groups")
   SECTION("mergeSelectedGroupsWithGroup")
   {
     auto* entityNode1 = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode1}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode1}}});
     deselectAll(map);
     selectNodes(map, {entityNode1});
     auto* groupNode1 = groupSelectedNodes(map, "group1");
 
     auto* entityNode2 = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode2}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode2}}});
     deselectAll(map);
     selectNodes(map, {entityNode2});
     auto* groupNode2 = groupSelectedNodes(map, "group2");
@@ -632,7 +632,7 @@ TEST_CASE("Map_Groups")
   SECTION("renameSelectedGroups")
   {
     auto* brushNode1 = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode1}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode1}}});
     selectNodes(map, {brushNode1});
 
     auto* groupNode = groupSelectedNodes(map, "test");
@@ -650,7 +650,7 @@ TEST_CASE("Map_Groups")
   SECTION("createLinkedDuplicate")
   {
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     auto* groupNode = groupSelectedNodes(map, "test");
@@ -671,7 +671,7 @@ TEST_CASE("Map_Groups")
   SECTION("separateSelectedLinkedGroups")
   {
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     auto* groupNode = groupSelectedNodes(map, "test");
@@ -854,7 +854,7 @@ TEST_CASE("Map_Groups")
 
     addNodes(
       map,
-      {{parentForNodes(map),
+      {{&parentForNodes(map),
         {groupedBrushNode, groupedEntityNode, groupedBrushEntityNode, ungroupedNode}}});
     addNodes(
       map,
@@ -1115,7 +1115,7 @@ TEST_CASE("Map_Groups")
     auto* outerGroupNode = new mdl::GroupNode{mdl::Group{"outer"}};
     outerGroupNode->addChildren({innerGroupNode, linkedInnerGroupNode});
 
-    addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+    addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
     selectNodes(map, {outerGroupNode});
 
     const auto entityNodes = map.selection().allEntities();

--- a/lib/TbMdlLib/test/src/tst_Map_Initialization.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Initialization.cpp
@@ -457,7 +457,7 @@ TEST_CASE("Map_Initialization")
           REQUIRE(map->persistent());
 
           auto* transientEntityNode = new EntityNode{{}};
-          addNodes(*map, {{parentForNodes(*map), {transientEntityNode}}});
+          addNodes(*map, {{&parentForNodes(*map), {transientEntityNode}}});
           REQUIRE(
             map->worldNode().defaultLayer()->children()
             == std::vector<Node*>{transientEntityNode});

--- a/lib/TbMdlLib/test/src/tst_Map_Layers.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Layers.cpp
@@ -127,7 +127,7 @@ TEST_CASE("Map_Layers")
 
       // Create an entity in layer1
       auto* entityNode1 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       // Hide layer1. The entity now inherits its visibility state and is hidden
       hideLayers(map, {layerNode1});
@@ -138,7 +138,7 @@ TEST_CASE("Map_Layers")
       // Create another entity in layer1. It will be visible, while entity1 will still be
       // hidden.
       auto* entityNode2 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
 
       REQUIRE(entityNode2->parent() == layerNode1);
 
@@ -177,7 +177,7 @@ TEST_CASE("Map_Layers")
 
       // Create an entity in layer1
       auto* entityNode1 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       lockNodes(map, {layerNode1});
 
@@ -187,7 +187,7 @@ TEST_CASE("Map_Layers")
       // Create another entity in layer1. It will be unlocked, while entity1 will still be
       // locked.
       auto* entityNode2 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
 
       REQUIRE(entityNode2->parent() == layerNode1);
 
@@ -306,7 +306,7 @@ TEST_CASE("Map_Layers")
         CreateNode{[](const auto&) { return createPatchNode(); }});
 
       auto* node = createNode(map);
-      addNodes(map, {{parentForNodes(map), {node}}});
+      addNodes(map, {{&parentForNodes(map), {node}}});
 
       REQUIRE(findContainingLayer(node) == defaultLayer);
 
@@ -349,7 +349,7 @@ TEST_CASE("Map_Layers")
       auto* childNode2 = createPatchNode();
 
       entityNode->addChildren({childNode1, childNode2});
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       REQUIRE(findContainingLayer(entityNode) == defaultLayer);
 

--- a/lib/TbMdlLib/test/src/tst_Map_NodeIndex.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_NodeIndex.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Map_NodeIndex")
 
     groupNode->addChild(entityNode);
 
-    addNodes(map, {{parentForNodes(map), {groupNode}}});
+    addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
     REQUIRE(map.findNodes("classname") == std::vector<Node*>{&map.worldNode()});
 
@@ -83,7 +83,7 @@ TEST_CASE("Map_NodeIndex")
       {"name1234", "wildcard_value"},
     }}};
 
-    addNodes(map, {{parentForNodes(map), {literalEntityNode, wildcardEntityNode}}});
+    addNodes(map, {{&parentForNodes(map), {literalEntityNode, wildcardEntityNode}}});
 
     CHECK_THAT(
       map.findNodes("name*"),
@@ -102,7 +102,7 @@ TEST_CASE("Map_NodeIndex")
 
     groupNode->addChild(entityNode);
 
-    addNodes(map, {{parentForNodes(map), {groupNode}}});
+    addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
     REQUIRE(map.findNodes("classname") == std::vector<Node*>{&map.worldNode()});
     REQUIRE(map.findNodes("some_key") == std::vector<Node*>{entityNode});
@@ -142,7 +142,7 @@ TEST_CASE("Map_NodeIndex")
 
     groupNode->addChild(entityNode);
 
-    addNodes(map, {{parentForNodes(map), {groupNode}}});
+    addNodes(map, {{&parentForNodes(map), {groupNode}}});
     selectNodes(map, {entityNode});
 
     REQUIRE(map.findNodes("classname") == std::vector<Node*>{&map.worldNode()});
@@ -167,7 +167,7 @@ TEST_CASE("Map_NodeIndex")
 
     groupNode->addChild(entityNode);
 
-    addNodes(map, {{parentForNodes(map), {groupNode}}});
+    addNodes(map, {{&parentForNodes(map), {groupNode}}});
     selectNodes(map, {groupNode});
 
     auto* linkedGroupNode = createLinkedDuplicate(map);

--- a/lib/TbMdlLib/test/src/tst_Map_NodeLocking.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_NodeLocking.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Map_NodeLocking")
 
       addNodes(
         map,
-        {{parentForNodes(map), {brushNode, entityNode, patchNode, entityNodeInGroup}}});
+        {{&parentForNodes(map), {brushNode, entityNode, patchNode, entityNodeInGroup}}});
       deselectAll(map);
       selectNodes(map, {entityNodeInGroup});
 
@@ -117,7 +117,7 @@ TEST_CASE("Map_NodeLocking")
 
       addNodes(
         map,
-        {{parentForNodes(map), {brushNode, entityNode, patchNode, entityNodeInGroup}}});
+        {{&parentForNodes(map), {brushNode, entityNode, patchNode, entityNodeInGroup}}});
       deselectAll(map);
       selectNodes(map, {entityNodeInGroup});
 
@@ -245,7 +245,7 @@ TEST_CASE("Map_NodeLocking")
   {
     auto* brushNode = createBrushNode(map);
     auto* entityNode = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {brushNode, entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode, entityNode}}});
 
     lockNodes(map, {brushNode});
     REQUIRE(brushNode->locked());
@@ -272,7 +272,7 @@ TEST_CASE("Map_NodeLocking")
     auto* lockedNode = new EntityNode{Entity{}};
     auto* unlockedNode = new EntityNode{Entity{}};
     auto* inheritedNode = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {lockedNode, unlockedNode, inheritedNode}}});
+    addNodes(map, {{&parentForNodes(map), {lockedNode, unlockedNode, inheritedNode}}});
 
     lockNodes(map, {lockedNode});
     unlockNodes(map, {unlockedNode});
@@ -304,7 +304,7 @@ TEST_CASE("Map_NodeLocking")
     auto* lockedNode = new EntityNode{Entity{}};
     auto* unlockedNode = new EntityNode{Entity{}};
     auto* inheritedNode = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {lockedNode, unlockedNode, inheritedNode}}});
+    addNodes(map, {{&parentForNodes(map), {lockedNode, unlockedNode, inheritedNode}}});
 
     lockNodes(map, {lockedNode});
     unlockNodes(map, {unlockedNode});

--- a/lib/TbMdlLib/test/src/tst_Map_NodeVisibility.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_NodeVisibility.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Map_NodeVisibility")
     GIVEN("An unrelated top level node")
     {
       auto* nodeToHide = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {nodeToHide}}});
+      addNodes(map, {{&parentForNodes(map), {nodeToHide}}});
 
       REQUIRE(!nodeToHide->hidden());
 
@@ -69,7 +69,7 @@ TEST_CASE("Map_NodeVisibility")
           CreateNode{[](const auto&) { return createPatchNode(); }});
 
         auto* nodeToIsolate = createNode(map);
-        addNodes(map, {{parentForNodes(map), {nodeToIsolate}}});
+        addNodes(map, {{&parentForNodes(map), {nodeToIsolate}}});
 
         REQUIRE(!nodeToIsolate->hidden());
 
@@ -110,7 +110,7 @@ TEST_CASE("Map_NodeVisibility")
         auto* entityNode = new EntityNode{Entity{}};
         entityNode->addChildren({childNode1, childNode2});
 
-        addNodes(map, {{parentForNodes(map), {entityNode}}});
+        addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
         // Check initial state
         REQUIRE_FALSE(nodeToHide->hidden());
@@ -180,7 +180,7 @@ TEST_CASE("Map_NodeVisibility")
     auto* groupNode = new GroupNode{Group{"group"}};
     auto* groupedEntityNode = new EntityNode{Entity{}};
 
-    addNodes(map, {{parentForNodes(map), {entityNode, groupNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode, groupNode}}});
     addNodes(map, {{groupNode, {groupedEntityNode}}});
 
     showNodes(map, {groupedEntityNode});
@@ -204,7 +204,7 @@ TEST_CASE("Map_NodeVisibility")
 
     addNodes(
       map,
-      {{parentForNodes(map), {pointEntityNode, selectedEntityNode, brushEntityNode}}});
+      {{&parentForNodes(map), {pointEntityNode, selectedEntityNode, brushEntityNode}}});
     addNodes(map, {{brushEntityNode, {brushNode, selectedBrushNode}}});
 
     showNodes(map, {selectedBrushNode});
@@ -247,7 +247,8 @@ TEST_CASE("Map_NodeVisibility")
     auto* hiddenBrushNode = createBrushNode(map);
 
     addNodes(
-      map, {{parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
+      map,
+      {{&parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
     addNodes(map, {{brushEntityNode, {brushNode, hiddenBrushNode}}});
 
     shownEntityNode->setVisibilityState(VisibilityState::Shown);
@@ -295,7 +296,8 @@ TEST_CASE("Map_NodeVisibility")
     auto* hiddenBrushNode = createBrushNode(map);
 
     addNodes(
-      map, {{parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
+      map,
+      {{&parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
     addNodes(map, {{brushEntityNode, {brushNode, hiddenBrushNode}}});
 
     shownEntityNode->setVisibilityState(VisibilityState::Shown);
@@ -342,7 +344,8 @@ TEST_CASE("Map_NodeVisibility")
     auto* hiddenBrushNode = createBrushNode(map);
 
     addNodes(
-      map, {{parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
+      map,
+      {{&parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
     addNodes(map, {{brushEntityNode, {brushNode, hiddenBrushNode}}});
 
     shownEntityNode->setVisibilityState(VisibilityState::Shown);
@@ -389,7 +392,8 @@ TEST_CASE("Map_NodeVisibility")
     auto* hiddenBrushNode = createBrushNode(map);
 
     addNodes(
-      map, {{parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
+      map,
+      {{&parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
     addNodes(map, {{brushEntityNode, {brushNode, hiddenBrushNode}}});
 
     shownEntityNode->setVisibilityState(VisibilityState::Shown);
@@ -436,7 +440,8 @@ TEST_CASE("Map_NodeVisibility")
     auto* hiddenBrushNode = createBrushNode(map);
 
     addNodes(
-      map, {{parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
+      map,
+      {{&parentForNodes(map), {shownEntityNode, hiddenEntityNode, brushEntityNode}}});
     addNodes(map, {{brushEntityNode, {brushNode, hiddenBrushNode}}});
 
     shownEntityNode->setVisibilityState(VisibilityState::Shown);

--- a/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
@@ -850,7 +850,26 @@ TEST_CASE("Map_Nodes")
       CHECK(canMakeStructural(map, {brushNode}));
     }
 
-    SECTION("Selection containing a patch is rejected")
+    SECTION("Structural patch")
+    {
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+
+      CHECK(!canMakeStructural(map, {patchNode}));
+    }
+
+    SECTION("Non-structural patch owned by an entity")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{entityNode, {patchNode}}});
+
+      CHECK(canMakeStructural(map, {patchNode}));
+    }
+
+    SECTION("Selection containing a non-entity node is rejected")
     {
       auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
       addNodes(map, {{&parentForNodes(map), {entityNode}}});
@@ -858,10 +877,21 @@ TEST_CASE("Map_Nodes")
       auto* brushNode = createBrushNode(map);
       addNodes(map, {{entityNode, {brushNode}}});
 
-      auto* patchNode = createPatchNode();
-      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+      CHECK(!canMakeStructural(map, {brushNode, entityNode}));
+    }
 
-      CHECK(!canMakeStructural(map, {brushNode, patchNode}));
+    SECTION("Mixed brush and patch selection with a non-structural member")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{entityNode, {patchNode}}});
+
+      CHECK(canMakeStructural(map, {brushNode, patchNode}));
     }
   }
 
@@ -924,8 +954,11 @@ TEST_CASE("Map_Nodes")
       CHECK(!brushNode->anyFaceHasAnyTag());
     }
 
-    SECTION("A patch in the input is ignored")
+    SECTION("Patch owned by an entity is reparented to the world")
     {
+      // Unlike brushes, patches can't carry the "entity" smart tag today -- its
+      // EntityClassNameTagMatcher only visits BrushNode -- so this only exercises the
+      // reparenting side of makeStructural, not tag clearing.
       auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
       addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
@@ -933,7 +966,31 @@ TEST_CASE("Map_Nodes")
       addNodes(map, {{entityNode, {patchNode}}});
 
       auto callback = TestCallback{0};
-      CHECK(!makeStructural(map, {patchNode}, callback));
+      CHECK(makeStructural(map, {patchNode}, callback));
+      CHECK(patchNode->entity() == &map.worldNode());
+
+      map.undoCommand();
+      CHECK(patchNode->entity() == entityNode);
+    }
+
+    SECTION("Mixed brush and patch selection both become structural in one transaction")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{entityNode, {brushNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{entityNode, {patchNode}}});
+
+      auto callback = TestCallback{0};
+      CHECK(makeStructural(map, {brushNode, patchNode}, callback));
+      CHECK(brushNode->entity() == &map.worldNode());
+      CHECK(patchNode->entity() == &map.worldNode());
+
+      map.undoCommand();
+      CHECK(brushNode->entity() == entityNode);
       CHECK(patchNode->entity() == entityNode);
     }
 
@@ -954,6 +1011,25 @@ TEST_CASE("Map_Nodes")
       CHECK(brushNode->entity() == &map.worldNode());
       CHECK(entityNode->parent() == nullptr);
       CHECK(map.selection().nodes == std::vector<Node*>{brushNode});
+    }
+
+    SECTION(
+      "Selected patch that is the sole child of its entity is reparented without "
+      "corrupting selection state")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{entityNode, {patchNode}}});
+
+      selectNodes(map, {patchNode});
+
+      auto callback = TestCallback{0};
+      CHECK(makeStructural(map, {patchNode}, callback));
+      CHECK(patchNode->entity() == &map.worldNode());
+      CHECK(entityNode->parent() == nullptr);
+      CHECK(map.selection().nodes == std::vector<Node*>{patchNode});
     }
   }
 
@@ -994,7 +1070,7 @@ TEST_CASE("Map_Nodes")
       CHECK(!moveToEntity(map, {brushNode}, *entityNode));
     }
 
-    SECTION("A patch in the input is ignored")
+    SECTION("Moves a structural patch into an entity and selects it")
     {
       auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
       addNodes(map, {{&parentForNodes(map), {entityNode}}});
@@ -1002,8 +1078,47 @@ TEST_CASE("Map_Nodes")
       auto* patchNode = createPatchNode();
       addNodes(map, {{&parentForNodes(map), {patchNode}}});
 
-      CHECK(!moveToEntity(map, {patchNode}, *entityNode));
+      CHECK(moveToEntity(map, {patchNode}, *entityNode));
+      CHECK(patchNode->entity() == entityNode);
+      CHECK(map.selection().patches == std::vector<PatchNode*>{patchNode});
+
+      map.undoCommand();
       CHECK(patchNode->entity() == &map.worldNode());
+    }
+
+    SECTION("Moves a brush and a patch together; only the brush picks up the entity's tag")
+    {
+      // Unlike brushes, patches can't carry the "entity" smart tag today -- its
+      // EntityClassNameTagMatcher only visits BrushNode.
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+
+      const auto& entityTag = map.smartTag("entity");
+      REQUIRE(!brushNode->hasTag(entityTag));
+
+      CHECK(moveToEntity(map, {brushNode, patchNode}, *entityNode));
+      CHECK(brushNode->hasTag(entityTag));
+      CHECK(!patchNode->hasTag(entityTag));
+    }
+
+    SECTION("Non-geometry node in the input is ignored")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* otherEntityNode = new EntityNode{Entity{}};
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {otherEntityNode, brushNode}}});
+
+      CHECK(moveToEntity(map, {otherEntityNode, brushNode}, *entityNode));
+      CHECK(brushNode->entity() == entityNode);
+      CHECK(otherEntityNode->parent() != entityNode);
     }
   }
 

--- a/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
@@ -954,23 +954,25 @@ TEST_CASE("Map_Nodes")
       CHECK(!brushNode->anyFaceHasAnyTag());
     }
 
-    SECTION("Patch owned by an entity is reparented to the world")
+    SECTION("Patch owned by an entity is reparented and its entity tag is cleared")
     {
-      // Unlike brushes, patches can't carry the "entity" smart tag today -- its
-      // EntityClassNameTagMatcher only visits BrushNode -- so this only exercises the
-      // reparenting side of makeStructural, not tag clearing.
       auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
       addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       auto* patchNode = createPatchNode();
       addNodes(map, {{entityNode, {patchNode}}});
 
+      const auto& entityTag = map.smartTag("entity");
+      REQUIRE(patchNode->hasTag(entityTag));
+
       auto callback = TestCallback{0};
       CHECK(makeStructural(map, {patchNode}, callback));
       CHECK(patchNode->entity() == &map.worldNode());
+      CHECK(!patchNode->hasTag(entityTag));
 
       map.undoCommand();
       CHECK(patchNode->entity() == entityNode);
+      CHECK(patchNode->hasTag(entityTag));
     }
 
     SECTION("Mixed brush and patch selection both become structural in one transaction")
@@ -1086,10 +1088,8 @@ TEST_CASE("Map_Nodes")
       CHECK(patchNode->entity() == &map.worldNode());
     }
 
-    SECTION("Moves a brush and a patch together; only the brush picks up the entity's tag")
+    SECTION("Moves a brush and a patch together and both pick up the entity's tag")
     {
-      // Unlike brushes, patches can't carry the "entity" smart tag today -- its
-      // EntityClassNameTagMatcher only visits BrushNode.
       auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
       addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
@@ -1101,10 +1101,11 @@ TEST_CASE("Map_Nodes")
 
       const auto& entityTag = map.smartTag("entity");
       REQUIRE(!brushNode->hasTag(entityTag));
+      REQUIRE(!patchNode->hasTag(entityTag));
 
       CHECK(moveToEntity(map, {brushNode, patchNode}, *entityNode));
       CHECK(brushNode->hasTag(entityTag));
-      CHECK(!patchNode->hasTag(entityTag));
+      CHECK(patchNode->hasTag(entityTag));
     }
 
     SECTION("Non-geometry node in the input is ignored")

--- a/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
@@ -80,19 +80,19 @@ TEST_CASE("Map_Nodes")
 
     SECTION("Returns default layer if no group is open")
     {
-      CHECK(parentForNodes(map) == map.worldNode().defaultLayer());
+      CHECK(&parentForNodes(map) == map.worldNode().defaultLayer());
     }
 
     SECTION("Returns currently opened group, if any")
     {
       openGroup(map, *groupNode);
-      CHECK(parentForNodes(map) == groupNode);
+      CHECK(&parentForNodes(map) == groupNode);
     }
 
     SECTION("Returns parent of first node in given vector")
     {
-      CHECK(parentForNodes(map, {groupedEntityNode}) == groupNode);
-      CHECK(parentForNodes(map, {groupNode}) == customLayerNode);
+      CHECK(&parentForNodes(map, {groupedEntityNode}) == groupNode);
+      CHECK(&parentForNodes(map, {groupNode}) == customLayerNode);
     }
   }
 
@@ -109,7 +109,7 @@ TEST_CASE("Map_Nodes")
 
       // Create an entity in layer1
       auto* entityNode1 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       REQUIRE(entityNode1->parent() == layerNode1);
 
@@ -126,7 +126,7 @@ TEST_CASE("Map_Nodes")
       // Create another entity in layer1. It will be visible, while entity1 will still be
       // hidden.
       auto* entityNode2 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
 
       REQUIRE(entityNode2->parent() == layerNode1);
 
@@ -147,7 +147,7 @@ TEST_CASE("Map_Nodes")
 
       // Create an entity in layer1
       auto* entityNode1 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       REQUIRE(entityNode1->parent() == layerNode1);
 
@@ -160,7 +160,7 @@ TEST_CASE("Map_Nodes")
       REQUIRE(entityNode1->locked());
 
       auto* entityNode2 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode2}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode2}}});
 
       REQUIRE(entityNode2->parent() == layerNode1);
 
@@ -177,7 +177,7 @@ TEST_CASE("Map_Nodes")
         auto* groupNode = new GroupNode{Group{"test"}};
         auto* brushNode = createBrushNode(map);
         groupNode->addChild(brushNode);
-        addNodes(map, {{parentForNodes(map), {groupNode}}});
+        addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
         selectNodes(map, {groupNode});
         auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -228,7 +228,7 @@ TEST_CASE("Map_Nodes")
       SECTION("Linked nodes inherit the group's transformation when they are added")
       {
         auto* groupNode = new GroupNode{Group{"group"}};
-        addNodes(map, {{parentForNodes(map), {groupNode}}});
+        addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
         selectNodes(map, {groupNode});
         auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -269,7 +269,7 @@ TEST_CASE("Map_Nodes")
       SECTION("Child cannot be added because adding it to a linked group fails")
       {
         auto* groupNode = new GroupNode{Group{"group"}};
-        addNodes(map, {{parentForNodes(map), {groupNode}}});
+        addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
         selectNodes(map, {groupNode});
         auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -339,7 +339,7 @@ TEST_CASE("Map_Nodes")
       // Create entity1 and brush1 in the hidden layer1
       auto* entityNode1 = new EntityNode{Entity{}};
       auto* brushNode1 = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {entityNode1, brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1, brushNode1}}});
 
       REQUIRE(entityNode1->parent() == layerNode1);
       REQUIRE(brushNode1->parent() == layerNode1);
@@ -405,7 +405,7 @@ TEST_CASE("Map_Nodes")
     SECTION("Cannot reparent a group to itself")
     {
       auto* group = new GroupNode{Group{"Group"}};
-      addNodes(map, {{parentForNodes(map), {group}}});
+      addNodes(map, {{&parentForNodes(map), {group}}});
 
       CHECK_FALSE(reparentNodes(map, {{group, {group}}}));
     }
@@ -413,7 +413,7 @@ TEST_CASE("Map_Nodes")
     SECTION("Cannot reparent a group to its descendants")
     {
       auto* outer = new GroupNode{Group{"Outer"}};
-      addNodes(map, {{parentForNodes(map), {outer}}});
+      addNodes(map, {{&parentForNodes(map), {outer}}});
 
       auto* inner = new GroupNode{Group{"Inner"}};
       addNodes(map, {{outer, {inner}}});
@@ -424,24 +424,24 @@ TEST_CASE("Map_Nodes")
     SECTION("Empty groups are removed after reparenting")
     {
       auto* group = new GroupNode{Group{"Group"}};
-      addNodes(map, {{parentForNodes(map), {group}}});
+      addNodes(map, {{&parentForNodes(map), {group}}});
 
       auto* entity = new EntityNode{Entity{}};
       addNodes(map, {{group, {entity}}});
 
-      CHECK(reparentNodes(map, {{parentForNodes(map), {entity}}}));
-      CHECK(entity->parent() == parentForNodes(map));
+      CHECK(reparentNodes(map, {{&parentForNodes(map), {entity}}}));
+      CHECK(entity->parent() == &parentForNodes(map));
       CHECK(group->parent() == nullptr);
 
       map.undoCommand();
-      CHECK(group->parent() == parentForNodes(map));
+      CHECK(group->parent() == &parentForNodes(map));
       CHECK(entity->parent() == group);
     }
 
     SECTION("Empty groups are removed recursively after reparenting")
     {
       auto* outer = new GroupNode{Group{"Outer"}};
-      addNodes(map, {{parentForNodes(map), {outer}}});
+      addNodes(map, {{&parentForNodes(map), {outer}}});
 
       auto* inner = new GroupNode{Group{"Inner"}};
       addNodes(map, {{outer, {inner}}});
@@ -449,13 +449,13 @@ TEST_CASE("Map_Nodes")
       auto* entity = new EntityNode{Entity{}};
       addNodes(map, {{inner, {entity}}});
 
-      CHECK(reparentNodes(map, {{parentForNodes(map), {entity}}}));
-      CHECK(entity->parent() == parentForNodes(map));
+      CHECK(reparentNodes(map, {{&parentForNodes(map), {entity}}}));
+      CHECK(entity->parent() == &parentForNodes(map));
       CHECK(inner->parent() == nullptr);
       CHECK(outer->parent() == nullptr);
 
       map.undoCommand();
-      CHECK(outer->parent() == parentForNodes(map));
+      CHECK(outer->parent() == &parentForNodes(map));
       CHECK(inner->parent() == outer);
       CHECK(entity->parent() == inner);
     }
@@ -463,24 +463,24 @@ TEST_CASE("Map_Nodes")
     SECTION("Empty entities are removed after reparenting")
     {
       auto* entity = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entity}}});
+      addNodes(map, {{&parentForNodes(map), {entity}}});
 
       auto* brush = createBrushNode(map);
       addNodes(map, {{entity, {brush}}});
 
-      CHECK(reparentNodes(map, {{parentForNodes(map), {brush}}}));
-      CHECK(brush->parent() == parentForNodes(map));
+      CHECK(reparentNodes(map, {{&parentForNodes(map), {brush}}}));
+      CHECK(brush->parent() == &parentForNodes(map));
       CHECK(entity->parent() == nullptr);
 
       map.undoCommand();
-      CHECK(entity->parent() == parentForNodes(map));
+      CHECK(entity->parent() == &parentForNodes(map));
       CHECK(brush->parent() == entity);
     }
 
     SECTION("Empty groups and entities are removed after reparenting")
     {
       auto* group = new GroupNode{Group{"Group"}};
-      addNodes(map, {{parentForNodes(map), {group}}});
+      addNodes(map, {{&parentForNodes(map), {group}}});
 
       auto* entity = new EntityNode{Entity{}};
       addNodes(map, {{group, {entity}}});
@@ -488,13 +488,13 @@ TEST_CASE("Map_Nodes")
       auto* brush = createBrushNode(map);
       addNodes(map, {{entity, {brush}}});
 
-      CHECK(reparentNodes(map, {{parentForNodes(map), {brush}}}));
-      CHECK(brush->parent() == parentForNodes(map));
+      CHECK(reparentNodes(map, {{&parentForNodes(map), {brush}}}));
+      CHECK(brush->parent() == &parentForNodes(map));
       CHECK(group->parent() == nullptr);
       CHECK(entity->parent() == nullptr);
 
       map.undoCommand();
-      CHECK(group->parent() == parentForNodes(map));
+      CHECK(group->parent() == &parentForNodes(map));
       CHECK(entity->parent() == group);
       CHECK(brush->parent() == entity);
     }
@@ -504,7 +504,7 @@ TEST_CASE("Map_Nodes")
       auto* nestedBrushNode = createBrushNode(map);
       auto* nestedEntityNode = new EntityNode{Entity{}};
 
-      addNodes(map, {{parentForNodes(map), {nestedBrushNode, nestedEntityNode}}});
+      addNodes(map, {{&parentForNodes(map), {nestedBrushNode, nestedEntityNode}}});
       selectNodes(map, {nestedBrushNode, nestedEntityNode});
 
       auto* nestedGroupNode = groupSelectedNodes(map, "nested");
@@ -519,7 +519,7 @@ TEST_CASE("Map_Nodes")
       auto* entityBrushNode = createBrushNode(map);
       entityNode->addChild(entityBrushNode);
 
-      addNodes(map, {{parentForNodes(map), {brushNode, entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode, entityNode}}});
 
       selectNodes(map, {brushNode, entityNode, nestedGroupNode});
       auto* groupNode = groupSelectedNodes(map, "group");
@@ -543,7 +543,7 @@ TEST_CASE("Map_Nodes")
 
       SECTION("Moving a brush entity to the world resets its link IDs")
       {
-        REQUIRE(reparentNodes(map, {{parentForNodes(map), {entityNode}}}));
+        REQUIRE(reparentNodes(map, {{&parentForNodes(map), {entityNode}}}));
 
         CHECK(entityNode->linkId() != originalEntityLinkId);
         CHECK(entityBrushNode->linkId() != originalEntityBrushLinkId);
@@ -592,7 +592,7 @@ TEST_CASE("Map_Nodes")
       auto* groupNode = new GroupNode{Group{"group"}};
       auto* brushNode = createBrushNode(map);
       groupNode->addChild(brushNode);
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
       selectNodes(map, {groupNode});
       auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -605,7 +605,7 @@ TEST_CASE("Map_Nodes")
       SECTION("Move node into group node")
       {
         auto* entityNode = new EntityNode{Entity{}};
-        addNodes(map, {{parentForNodes(map), {entityNode}}});
+        addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
         REQUIRE(groupNode->childCount() == 1u);
         REQUIRE(linkedGroupNode->childCount() == 1u);
@@ -626,7 +626,7 @@ TEST_CASE("Map_Nodes")
 
         map.undoCommand();
 
-        CHECK(entityNode->parent() == parentForNodes(map));
+        CHECK(entityNode->parent() == &parentForNodes(map));
         CHECK(groupNode->childCount() == 1u);
         CHECK(linkedGroupNode->childCount() == 1u);
       }
@@ -639,9 +639,9 @@ TEST_CASE("Map_Nodes")
         REQUIRE(groupNode->childCount() == 2u);
         REQUIRE(linkedGroupNode->childCount() == 2u);
 
-        reparentNodes(map, {{parentForNodes(map), {entityNode}}});
+        reparentNodes(map, {{&parentForNodes(map), {entityNode}}});
 
-        CHECK(entityNode->parent() == parentForNodes(map));
+        CHECK(entityNode->parent() == &parentForNodes(map));
         CHECK(groupNode->childCount() == 1u);
         CHECK(linkedGroupNode->childCount() == 1u);
 
@@ -656,7 +656,7 @@ TEST_CASE("Map_Nodes")
     SECTION("Nested linked groups")
     {
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -691,18 +691,18 @@ TEST_CASE("Map_Nodes")
     SECTION("Update linked groups after recursive deletion")
     {
       auto* outerGroupNode = new GroupNode{Group{"outer"}};
-      addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
 
       openGroup(map, *outerGroupNode);
 
       auto* outerEntityNode = new EntityNode{Entity{}};
       auto* innerGroupNode = new GroupNode{Group{"inner"}};
-      addNodes(map, {{parentForNodes(map), {outerEntityNode, innerGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerEntityNode, innerGroupNode}}});
 
       openGroup(map, *innerGroupNode);
 
       auto* innerEntityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {innerEntityNode}}});
+      addNodes(map, {{&parentForNodes(map), {innerEntityNode}}});
 
       closeGroup(map);
       closeGroup(map);
@@ -717,7 +717,7 @@ TEST_CASE("Map_Nodes")
 
       deselectAll(map);
 
-      reparentNodes(map, {{parentForNodes(map), {innerEntityNode}}});
+      reparentNodes(map, {{&parentForNodes(map), {innerEntityNode}}});
       CHECK(outerGroupNode->children() == std::vector<Node*>{outerEntityNode});
       CHECK_THAT(*linkedOuterGroupNode, MatchesNode(*outerGroupNode));
 
@@ -735,7 +735,7 @@ TEST_CASE("Map_Nodes")
     SECTION("Linked group update fails")
     {
       auto* groupNode = new GroupNode{Group{"group"}};
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
       selectNodes(map, {groupNode});
       auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -748,7 +748,7 @@ TEST_CASE("Map_Nodes")
       deselectAll(map);
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       CHECK_FALSE(reparentNodes(map, {{groupNode, {brushNode}}}));
 
@@ -762,7 +762,7 @@ TEST_CASE("Map_Nodes")
       auto* brushNode = createBrushNode(map);
       groupNode->addChild(brushNode);
 
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
       selectNodes(map, {groupNode});
       auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -792,12 +792,12 @@ TEST_CASE("Map_Nodes")
     SECTION("Remove empty group")
     {
       auto* group = new GroupNode{Group{"group"}};
-      addNodes(map, {{parentForNodes(map), {group}}});
+      addNodes(map, {{&parentForNodes(map), {group}}});
 
       openGroup(map, *group);
 
       auto* brush = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brush}}});
+      addNodes(map, {{&parentForNodes(map), {brush}}});
 
       removeNodes(map, {brush});
       CHECK(map.editorContext().currentGroup() == nullptr);
@@ -813,17 +813,17 @@ TEST_CASE("Map_Nodes")
     SECTION("Recursively remove empty groups")
     {
       auto* outer = new GroupNode{Group{"outer"}};
-      addNodes(map, {{parentForNodes(map), {outer}}});
+      addNodes(map, {{&parentForNodes(map), {outer}}});
 
       openGroup(map, *outer);
 
       auto* inner = new GroupNode{Group{"inner"}};
-      addNodes(map, {{parentForNodes(map), {inner}}});
+      addNodes(map, {{&parentForNodes(map), {inner}}});
 
       openGroup(map, *inner);
 
       auto* brush = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brush}}});
+      addNodes(map, {{&parentForNodes(map), {brush}}});
 
       removeNodes(map, {brush});
       CHECK(map.editorContext().currentGroup() == nullptr);
@@ -871,7 +871,7 @@ TEST_CASE("Map_Nodes")
 
       auto* nodeToRemove = createNode(map);
       groupNode->addChildren({brushNode, nodeToRemove});
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
       selectNodes(map, {groupNode});
       auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -890,18 +890,18 @@ TEST_CASE("Map_Nodes")
     SECTION("Update linked groups with recursion")
     {
       auto* outerGroupNode = new GroupNode{Group{"outer"}};
-      addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
 
       openGroup(map, *outerGroupNode);
 
       auto* outerEntityNode = new EntityNode{Entity{}};
       auto* innerGroupNode = new GroupNode{Group{"inner"}};
-      addNodes(map, {{parentForNodes(map), {outerEntityNode, innerGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerEntityNode, innerGroupNode}}});
 
       openGroup(map, *innerGroupNode);
 
       auto* innerEntityNode = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {innerEntityNode}}});
+      addNodes(map, {{&parentForNodes(map), {innerEntityNode}}});
 
       closeGroup(map);
       closeGroup(map);
@@ -935,7 +935,7 @@ TEST_CASE("Map_Nodes")
   SECTION("removeSelectedNodes")
   {
     auto* entityNode = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     selectNodes(map, {entityNode});
 
     removeSelectedNodes(map);
@@ -948,7 +948,7 @@ TEST_CASE("Map_Nodes")
     SECTION("Update brushes")
     {
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto originalBrush = brushNode->brush();
       auto modifiedBrush = originalBrush;
@@ -968,7 +968,7 @@ TEST_CASE("Map_Nodes")
     SECTION("Update patches")
     {
       auto* patchNode = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
 
       const auto originalPatch = patchNode->patch();
       auto modifiedPatch = originalPatch;
@@ -994,7 +994,7 @@ TEST_CASE("Map_Nodes")
       REQUIRE(material != nullptr);
 
       auto* brushNode = createBrushNode(map, MaterialName);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto& originalBrush = brushNode->brush();
       auto modifiedBrush = originalBrush;
@@ -1021,7 +1021,7 @@ TEST_CASE("Map_Nodes")
         {EntityPropertyKeys::Classname, Classname},
       }}};
 
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       const auto& originalEntity = entityNode->entity();
       auto modifiedEntity = originalEntity;
@@ -1044,7 +1044,7 @@ TEST_CASE("Map_Nodes")
       auto* groupNode = new GroupNode{Group{"group"}};
       auto* brushNode = createBrushNode(map);
       groupNode->addChild(brushNode);
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
       selectNodes(map, {groupNode});
       auto* linkedGroupNode = createLinkedDuplicate(map);
@@ -1089,7 +1089,7 @@ TEST_CASE("Map_Nodes")
       auto* groupNode = new GroupNode{Group{"group"}};
       auto* brushNode = createBrushNode(map);
       groupNode->addChild(brushNode);
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
 
       selectNodes(map, {groupNode});
       auto* linkedGroupNode = createLinkedDuplicate(map);

--- a/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
@@ -19,6 +19,8 @@
 
 #include "Observer.h"
 #include "gl/MaterialManager.h"
+#include "mdl/Brush.h"
+#include "mdl/BrushFace.h"
 #include "mdl/BrushNode.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/EditorContext.h"
@@ -39,6 +41,8 @@
 #include "mdl/Map_Selection.h"
 #include "mdl/Matchers.h"
 #include "mdl/PatchNode.h"
+#include "mdl/SurfaceAttributes.h"
+#include "mdl/TagMatcher.h"
 #include "mdl/TestFactory.h"
 #include "mdl/TestUtils.h"
 #include "mdl/VisualEffect.h"
@@ -52,16 +56,53 @@
 namespace tb::mdl
 {
 
+namespace
+{
+class TestCallback : public TagMatcherCallback
+{
+private:
+  size_t m_option;
+
+public:
+  explicit TestCallback(const size_t option)
+    : m_option{option}
+  {
+  }
+
+  size_t selectOption(const std::vector<std::string>&) override { return m_option; }
+};
+} // namespace
+
 TEST_CASE("Map_Nodes")
 {
+  auto fixtureConfig = MapFixtureConfig{};
+  fixtureConfig.gameInfo.gameConfig.smartTags = {
+    SmartTag{
+      "entity",
+      {},
+      std::make_unique<EntityClassNameTagMatcher>("brush_entity", ""),
+    },
+    SmartTag{
+      "material",
+      {},
+      std::make_unique<MaterialNameTagMatcher>("tagged_material"),
+    },
+    SmartTag{
+      "content",
+      {},
+      std::make_unique<ContentFlagsTagMatcher>(1),
+    },
+  };
+
   auto fixture = MapFixture{};
-  auto& map = fixture.create();
+  auto& map = fixture.create(fixtureConfig);
   map.entityDefinitionManager().setDefinitions({
     {"point_entity",
      Color{},
      "this is a point entity",
      {},
      PointEntityDefinition{vm::bbox3d{16.0}, {}, {}}},
+    {"brush_entity", Color{}, "this is a brush entity", {}},
   });
 
   const auto& pointEntityDefinition = map.entityDefinitionManager().definitions().front();
@@ -772,6 +813,197 @@ TEST_CASE("Map_Nodes")
 
       CHECK(groupNode->childCount() == 1u);
       CHECK(linkedGroupNode->childCount() == 1u);
+    }
+  }
+
+  SECTION("canMakeStructural")
+  {
+    SECTION("Empty selection")
+    {
+      CHECK(!canMakeStructural(map, {}));
+    }
+
+    SECTION("Structural brush")
+    {
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      CHECK(!canMakeStructural(map, {brushNode}));
+    }
+
+    SECTION("Non-structural brush owned by an entity")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{entityNode, {brushNode}}});
+
+      CHECK(canMakeStructural(map, {brushNode}));
+    }
+
+    SECTION("Non-structural brush with a tagged face")
+    {
+      auto* brushNode = createBrushNode(map, "tagged_material");
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      CHECK(canMakeStructural(map, {brushNode}));
+    }
+
+    SECTION("Selection containing a patch is rejected")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{entityNode, {brushNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+
+      CHECK(!canMakeStructural(map, {brushNode, patchNode}));
+    }
+  }
+
+  SECTION("makeStructural")
+  {
+    SECTION("Empty node list does nothing")
+    {
+      auto callback = TestCallback{0};
+      CHECK(!makeStructural(map, {}, callback));
+    }
+
+    SECTION("Already-structural untagged brush does nothing")
+    {
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      auto callback = TestCallback{0};
+      CHECK(!makeStructural(map, {brushNode}, callback));
+      CHECK(brushNode->entity() == &map.worldNode());
+    }
+
+    SECTION("Brush owned by an entity is reparented and its entity tag is cleared")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{entityNode, {brushNode}}});
+
+      const auto& entityTag = map.smartTag("entity");
+      REQUIRE(brushNode->hasTag(entityTag));
+
+      auto callback = TestCallback{0};
+      CHECK(makeStructural(map, {brushNode}, callback));
+      CHECK(brushNode->entity() == &map.worldNode());
+      CHECK(!brushNode->hasTag(entityTag));
+
+      map.undoCommand();
+      CHECK(brushNode->entity() == entityNode);
+      CHECK(brushNode->hasTag(entityTag));
+    }
+
+    SECTION("Structural brush with a tagged face has the content flags tag disabled")
+    {
+      // Material name tags (like "material" above) have no disable logic -- there is
+      // no sensible default material to fall back to -- so use a flags-based tag,
+      // which does support being disabled, to test that face tags are cleared.
+      auto* brushNode = createBrushNode(map, "material", [](auto& brush) {
+        for (auto& face : brush.faces())
+        {
+          face.setSurfaceAttributes({.contents = 1});
+        }
+      });
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      REQUIRE(brushNode->anyFaceHasAnyTag());
+
+      auto callback = TestCallback{0};
+      CHECK(makeStructural(map, {brushNode}, callback));
+      CHECK(!brushNode->anyFaceHasAnyTag());
+    }
+
+    SECTION("A patch in the input is ignored")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{entityNode, {patchNode}}});
+
+      auto callback = TestCallback{0};
+      CHECK(!makeStructural(map, {patchNode}, callback));
+      CHECK(patchNode->entity() == entityNode);
+    }
+
+    SECTION(
+      "Selected brush that is the sole child of its entity is reparented without "
+      "corrupting selection state")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{entityNode, {brushNode}}});
+
+      selectNodes(map, {brushNode});
+
+      auto callback = TestCallback{0};
+      CHECK(makeStructural(map, {brushNode}, callback));
+      CHECK(brushNode->entity() == &map.worldNode());
+      CHECK(entityNode->parent() == nullptr);
+      CHECK(map.selection().nodes == std::vector<Node*>{brushNode});
+    }
+  }
+
+  SECTION("moveToEntity")
+  {
+    SECTION("Empty node list does nothing")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      CHECK(!moveToEntity(map, {}, *entityNode));
+    }
+
+    SECTION("Moves a structural brush into an entity and selects it")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      CHECK(moveToEntity(map, {brushNode}, *entityNode));
+      CHECK(brushNode->entity() == entityNode);
+      CHECK(map.selection().brushes == std::vector<BrushNode*>{brushNode});
+
+      map.undoCommand();
+      CHECK(brushNode->entity() == &map.worldNode());
+    }
+
+    SECTION("Brush already parented under the target entity is skipped")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{entityNode, {brushNode}}});
+
+      CHECK(!moveToEntity(map, {brushNode}, *entityNode));
+    }
+
+    SECTION("A patch in the input is ignored")
+    {
+      auto* entityNode = new EntityNode{Entity{{{"classname", "brush_entity"}}}};
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
+
+      auto* patchNode = createPatchNode();
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+
+      CHECK(!moveToEntity(map, {patchNode}, *entityNode));
+      CHECK(patchNode->entity() == &map.worldNode());
     }
   }
 

--- a/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Nodes.cpp
@@ -380,7 +380,7 @@ TEST_CASE("Map_Nodes")
       auto* layer2 = new LayerNode{Layer{"Layer 2"}};
       addNodes(map, {{&map.worldNode(), {layer2}}});
 
-      CHECK_FALSE(reparentNodes(map, {{layer2, {layer1}}}));
+      CHECK(!reparentNodes(map, {{layer2, {layer1}}}));
     }
 
     SECTION("Reparent between layers")
@@ -407,7 +407,7 @@ TEST_CASE("Map_Nodes")
       auto* group = new GroupNode{Group{"Group"}};
       addNodes(map, {{&parentForNodes(map), {group}}});
 
-      CHECK_FALSE(reparentNodes(map, {{group, {group}}}));
+      CHECK(!reparentNodes(map, {{group, {group}}}));
     }
 
     SECTION("Cannot reparent a group to its descendants")
@@ -418,7 +418,7 @@ TEST_CASE("Map_Nodes")
       auto* inner = new GroupNode{Group{"Inner"}};
       addNodes(map, {{outer, {inner}}});
 
-      CHECK_FALSE(reparentNodes(map, {{inner, {outer}}}));
+      CHECK(!reparentNodes(map, {{inner, {outer}}}));
     }
 
     SECTION("Empty groups are removed after reparenting")
@@ -671,7 +671,7 @@ TEST_CASE("Map_Nodes")
 
       SECTION("Adding a linked group to its linked sibling does nothing")
       {
-        CHECK_FALSE(reparentNodes(map, {{groupNode, {linkedGroupNode}}}));
+        CHECK(!reparentNodes(map, {{groupNode, {linkedGroupNode}}}));
       }
 
       SECTION(
@@ -684,7 +684,7 @@ TEST_CASE("Map_Nodes")
         REQUIRE(outerGroupNode != nullptr);
 
         deselectAll(map);
-        CHECK_FALSE(reparentNodes(map, {{groupNode, {outerGroupNode}}}));
+        CHECK(!reparentNodes(map, {{groupNode, {outerGroupNode}}}));
       }
     }
 
@@ -750,7 +750,7 @@ TEST_CASE("Map_Nodes")
       auto* brushNode = createBrushNode(map);
       addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
-      CHECK_FALSE(reparentNodes(map, {{groupNode, {brushNode}}}));
+      CHECK(!reparentNodes(map, {{groupNode, {brushNode}}}));
 
       CHECK(groupNode->childCount() == 0u);
       CHECK(linkedGroupNode->childCount() == 0u);
@@ -768,7 +768,7 @@ TEST_CASE("Map_Nodes")
       auto* linkedGroupNode = createLinkedDuplicate(map);
       deselectAll(map);
 
-      CHECK_FALSE(reparentNodes(map, {{linkedGroupNode, {brushNode}}}));
+      CHECK(!reparentNodes(map, {{linkedGroupNode, {brushNode}}}));
 
       CHECK(groupNode->childCount() == 1u);
       CHECK(linkedGroupNode->childCount() == 1u);
@@ -1105,7 +1105,7 @@ TEST_CASE("Map_Nodes")
       const auto originalBrushBounds = brushNode->physicalBounds();
 
       selectNodes(map, {brushNode});
-      CHECK_FALSE(translateSelection(map, vm::vec3d{0, 16, 0}));
+      CHECK(!translateSelection(map, vm::vec3d{0, 16, 0}));
 
       REQUIRE(brushNode->physicalBounds() == originalBrushBounds);
 

--- a/lib/TbMdlLib/test/src/tst_Map_Patches.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Patches.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "mdl/BezierPatch.h"
 #include "mdl/BrushBuilder.h"
 #include "mdl/BrushFaceHandle.h"
 #include "mdl/BrushNode.h"
@@ -290,6 +291,39 @@ TEST_CASE("Map_Patches")
           }
         }
       }
+    }
+  }
+
+  SECTION("setPatchMaterial")
+  {
+    auto& map = fixture.create();
+
+    SECTION("Sets the material of a selected patch")
+    {
+      auto* patchNode = createPatchNode("some_material");
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+      selectNodes(map, {patchNode});
+
+      CHECK(setPatchMaterial(map, "new_material"));
+      CHECK(patchNode->patch().materialName() == "new_material");
+
+      SECTION("Undo and redo")
+      {
+        map.undoCommand();
+        CHECK(patchNode->patch().materialName() == "some_material");
+
+        map.redoCommand();
+        CHECK(patchNode->patch().materialName() == "new_material");
+      }
+    }
+
+    SECTION("Does nothing when nothing is selected")
+    {
+      auto* patchNode = createPatchNode("some_material");
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+
+      CHECK(setPatchMaterial(map, "new_material"));
+      CHECK(patchNode->patch().materialName() == "some_material");
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_Map_Patches.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Patches.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Map_Patches")
 
     const auto builder = BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
     auto* brushNode = new BrushNode{builder.createCube(64.0, "material") | kdl::value()};
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto firstFaceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
     const auto secondFaceIndex = brushNode->brush().findFace(vm::vec3d{1, 0, 0});
@@ -93,7 +93,7 @@ TEST_CASE("Map_Patches")
     GIVEN("No patches are selected")
     {
       auto* patchNode = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
 
       const auto originalControlPoints = patchNode->patch().controlPoints();
 
@@ -112,7 +112,7 @@ TEST_CASE("Map_Patches")
     {
       auto* patchNode1 = createPatchNode();
       auto* patchNode2 = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode1, patchNode2}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode1, patchNode2}}});
       selectNodes(map, {patchNode1});
 
       const auto patch2OriginalControlPoints = patchNode2->patch().controlPoints();
@@ -135,7 +135,7 @@ TEST_CASE("Map_Patches")
     {
       auto* patchNode1 = createPatchNode();
       auto* patchNode2 = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode1, patchNode2}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode1, patchNode2}}});
       selectNodes(map, {patchNode1, patchNode2});
 
       WHEN("The patches are resampled")
@@ -187,7 +187,7 @@ TEST_CASE("Map_Patches")
     {
       auto* patchNode1 = createPatchNode();
       auto* patchNode2 = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode1, patchNode2}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode1, patchNode2}}});
       selectNodes(map, {patchNode1, patchNode2});
 
       const auto patch1OriginalControlPoints = patchNode1->patch().controlPoints();
@@ -222,7 +222,7 @@ TEST_CASE("Map_Patches")
       }, "material"}};
       // clang-format on
 
-      addNodes(map, {{parentForNodes(map), {patchNode1, patchNode2}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode1, patchNode2}}});
       selectNodes(map, {patchNode1, patchNode2});
 
       const auto patch2OriginalControlPoints = patchNode2->patch().controlPoints();
@@ -248,7 +248,7 @@ TEST_CASE("Map_Patches")
     {
       auto* patchNode1 = createPatchNode();
       auto* patchNode2 = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode1, patchNode2}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode1, patchNode2}}});
       selectNodes(map, {patchNode1, patchNode2});
 
       WHEN("Control points are transformed")

--- a/lib/TbMdlLib/test/src/tst_Map_Persistence.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Persistence.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Map_Persistence")
     REQUIRE(map.path() == path);
 
     auto* entityNode = new EntityNode{Entity{{{"name", "entity2"}}}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
     auto mapWasSaved = Observer<>{map.mapWasSavedNotifier};
     auto modificationStateDidChange = Observer<>{map.modificationStateDidChangeNotifier};
@@ -102,7 +102,7 @@ TEST_CASE("Map_Persistence")
     auto& map = fixture.create();
 
     auto* entityNode = new EntityNode{Entity{{{"key", "value"}}}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     REQUIRE(map.worldNode().defaultLayer()->children() == std::vector<Node*>{entityNode});
 
     auto mapWasSaved = Observer<>{map.mapWasSavedNotifier};
@@ -146,7 +146,7 @@ TEST_CASE("Map_Persistence")
       auto* brushNode = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto objFilename = "test.obj";
       const auto mtlFilename = "test.mtl";
@@ -167,7 +167,7 @@ TEST_CASE("Map_Persistence")
       auto& map = fixture.create();
 
       auto* entityNode = new EntityNode{Entity{{{"key", "value"}}}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       const auto filename = "test.map";
       REQUIRE(map.exportAs(MapExportOptions{
@@ -249,7 +249,7 @@ TEST_CASE("Map_Persistence")
       auto& map = fixture.create(QuakeFixtureConfig);
 
       auto* entityNode = new mdl::EntityNode{mdl::Entity{{{"classname", "light"}}}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       REQUIRE(map.exportAs(MapExportOptions{
         env.dir() / newDocumentPath,
@@ -272,7 +272,7 @@ TEST_CASE("Map_Persistence")
       auto& map = fixture.create(QuakeFixtureConfig);
 
       auto* entityNode = new mdl::EntityNode{mdl::Entity{{{"classname", "light"}}}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
       REQUIRE(map.exportAs(MapExportOptions{
         env.dir() / newDocumentPath,

--- a/lib/TbMdlLib/test/src/tst_Map_Picking.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Picking.cpp
@@ -60,7 +60,7 @@ TEST_CASE("Map_Picking")
       auto* brushNode1 = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto pickResult = PickResult{};
       pick(map, vm::ray3d{{-32, 0, 0}, {1, 0, 0}}, pickResult);
@@ -82,7 +82,7 @@ TEST_CASE("Map_Picking")
     SECTION("Single entity")
     {
       auto* entityNode1 = new EntityNode{Entity{}};
-      addNodes(map, {{parentForNodes(map), {entityNode1}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
       const auto origin = entityNode1->entity().origin();
       const auto bounds = entityNode1->logicalBounds();
@@ -111,13 +111,13 @@ TEST_CASE("Map_Picking")
       auto* brushNode1 = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto* brushNode2 = new BrushNode{
         builder.createCuboid(
           vm::bbox3d{{0, 0, 0}, {64, 64, 64}}.translate({0, 0, 128}), "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
 
       selectAllNodes(map);
       auto* group = groupSelectedNodes(map, "test");
@@ -181,13 +181,13 @@ TEST_CASE("Map_Picking")
       auto* brushNode1 = new BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto* brushNode2 = new BrushNode{
         builder.createCuboid(
           vm::bbox3d{{0, 0, 0}, {64, 64, 64}}.translate({0, 0, 128}), "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
 
       selectAllNodes(map);
       auto* innerGroup = groupSelectedNodes(map, "inner");
@@ -197,7 +197,7 @@ TEST_CASE("Map_Picking")
         builder.createCuboid(
           vm::bbox3d{{0, 0, 0}, {64, 64, 64}}.translate({0, 0, 256}), "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode3}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode3}}});
 
       selectAllNodes(map);
       auto* outerGroup = groupSelectedNodes(map, "outer");
@@ -344,13 +344,13 @@ TEST_CASE("Map_Picking")
       auto* brushNode1 = new mdl::BrushNode{
         builder.createCuboid(vm::bbox3d{{0, 0, 0}, {64, 64, 64}}, "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto* brushNode2 = new mdl::BrushNode{
         builder.createCuboid(
           vm::bbox3d{{0, 0, 0}, {64, 64, 64}}.translate({0, 0, 128}), "material")
         | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
 
       selectAllNodes(map);
 
@@ -386,7 +386,7 @@ TEST_CASE("Map_Picking")
       builder.createCuboid(
         vm::bbox3d{{0, 0, 0}, {64, 64, 64}}.translate({0, 0, 32}), "material")
       | kdl::value()};
-    addNodes(map, {{parentForNodes(map), {brushNode, entityNode, groupedBrushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode, entityNode, groupedBrushNode}}});
 
     selectNodes(map, {groupedBrushNode});
     groupSelectedNodes(map, "test");

--- a/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Map_Selection")
 
     addNodes(
       map,
-      {{parentForNodes(map),
+      {{&parentForNodes(map),
         {entityNode, brushNode, groupNode, patchNode, brushEntityNode}}});
     addNodes(map, {{groupNode, {groupedEntityNode}}});
     addNodes(map, {{brushEntityNode, {entityBrushNode}}});
@@ -124,7 +124,7 @@ TEST_CASE("Map_Selection")
     {
       auto* entityNode = new EntityNode{Entity{}};
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode, entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode, entityNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -188,7 +188,7 @@ TEST_CASE("Map_Selection")
     auto* patchNode = createPatchNode();
 
     addNodes(
-      map, {{parentForNodes(map), {brushNode1, brushNode2, brushNode3, patchNode}}});
+      map, {{&parentForNodes(map), {brushNode1, brushNode2, brushNode3, patchNode}}});
 
     selectNodes(map, {brushNode1, brushNode2});
     createBrushEntity(map, brushEntityDefinition);
@@ -250,7 +250,7 @@ TEST_CASE("Map_Selection")
         vm::translation_matrix(vm::vec3d{100.0, 0.0, 0.0}),
         map.worldBounds());
 
-      addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
 
       REQUIRE(brushNode1->intersects(*brushNode2));
       REQUIRE(brushNode2->intersects(*brushNode1));
@@ -298,11 +298,11 @@ TEST_CASE("Map_Selection")
 
       auto* brushNode1 =
         new BrushNode{builder.createCuboid(box, "material") | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode1}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
       auto* brushNode2 = new BrushNode{
         builder.createCuboid(box.translate({1, 1, 1}), "material") | kdl::value()};
-      addNodes(map, {{parentForNodes(map), {brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode2}}});
 
       selectAllNodes(map);
 
@@ -335,7 +335,7 @@ TEST_CASE("Map_Selection")
       auto* outerGroup = new GroupNode{Group{"outerGroup"}};
       auto* innerGroup = new GroupNode{Group{"innerGroup"}};
 
-      addNodes(map, {{parentForNodes(map), {outerGroup}}});
+      addNodes(map, {{&parentForNodes(map), {outerGroup}}});
       addNodes(map, {{outerGroup, {innerGroup}}});
       addNodes(map, {{innerGroup, {brushNode1, brushNode2}}});
 
@@ -373,7 +373,7 @@ TEST_CASE("Map_Selection")
       REQUIRE(!brushNode1->intersects(*brushNode2));
       REQUIRE(!brushNode1->intersects(*brushNode3));
 
-      addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2, brushNode3}}});
       selectNodes(map, {brushNode1});
 
       SECTION("z camera")
@@ -581,7 +581,7 @@ TEST_CASE("Map_Selection")
 
     addNodes(
       map,
-      {{parentForNodes(map),
+      {{&parentForNodes(map),
         {entityNode, brushNodeM1, brushNodeM2, groupNode, patchNode, brushEntityNode}}});
     addNodes(map, {{groupNode, {groupedBrushNodeM1}}});
     addNodes(map, {{brushEntityNode, {entityBrushNodeM1}}});
@@ -623,18 +623,18 @@ TEST_CASE("Map_Selection")
 
     auto* brushNode1 =
       new BrushNode{builder.createCuboid(box, "material") | kdl::value()};
-    addNodes(map, {{parentForNodes(map), {brushNode1}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode1}}});
 
     auto* brushNode2 = new BrushNode{
       builder.createCuboid(box.translate({1, 1, 1}), "material") | kdl::value()};
-    addNodes(map, {{parentForNodes(map), {brushNode2}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode2}}});
 
     auto* brushNode3 = new BrushNode{
       builder.createCuboid(box.translate({2, 2, 2}), "material") | kdl::value()};
-    addNodes(map, {{parentForNodes(map), {brushNode3}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode3}}});
 
     auto* patchNode = createPatchNode();
-    addNodes(map, {{parentForNodes(map), {patchNode}}});
+    addNodes(map, {{&parentForNodes(map), {patchNode}}});
 
     selectNodes(map, {brushNode1, brushNode2});
     auto* brushEnt = createBrushEntity(map, brushEntityDefinition);
@@ -703,7 +703,7 @@ TEST_CASE("Map_Selection")
     auto* linkedEntityNode1 = new EntityNode{{}};
     auto* linkedGroupNode1 = new GroupNode{Group{"linked group"}};
 
-    addNodes(map, {{parentForNodes(map), {entityNode, groupNode, linkedGroupNode1}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode, groupNode, linkedGroupNode1}}});
     addNodes(
       map,
       {
@@ -769,7 +769,7 @@ TEST_CASE("Map_Selection")
       auto* brushNode1 = createBrushNode(map);
       auto* brushNode2 = createBrushNode(map);
 
-      addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2}}});
 
       selectBrushFaces(map, {{brushNode1, 0}, {brushNode1, 2}, {brushNode2, 5}});
 
@@ -798,7 +798,7 @@ TEST_CASE("Map_Selection")
       // https://github.com/TrenchBroom/TrenchBroom/issues/3768
 
       auto* brushNode = createBrushNode(map);
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
       selectNodes(map, {brushNode});
 
       auto* groupNode = groupSelectedNodes(map, "test");
@@ -845,7 +845,7 @@ TEST_CASE("Map_Selection")
 
     addNodes(
       map,
-      {{parentForNodes(map),
+      {{&parentForNodes(map),
         {brushNodeM1, brushNodeM2, brushNodeM13, groupNode, brushEntityNode}}});
     addNodes(
       map,
@@ -910,7 +910,7 @@ TEST_CASE("Map_Selection")
     auto* brushEntityNode = new EntityNode{Entity{}};
     auto* entityBrushNode = createBrushNode(map);
 
-    addNodes(map, {{parentForNodes(map), {entityNode, groupNode, brushEntityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode, groupNode, brushEntityNode}}});
     addNodes(map, {{groupNode, {groupedEntityNode}}});
     addNodes(map, {{brushEntityNode, {entityBrushNode}}});
 
@@ -948,7 +948,7 @@ TEST_CASE("Map_Selection")
 
     addNodes(
       map,
-      {{parentForNodes(map),
+      {{&parentForNodes(map),
         {entityNode, unselectedEntityNode, groupNode, brushEntityNode}}});
     addNodes(map, {{groupNode, {groupedEntityNode}}});
     addNodes(map, {{brushEntityNode, {entityBrushNode}}});
@@ -1016,7 +1016,7 @@ TEST_CASE("Map_Selection")
     auto* brushNode1 = createBrushNode(map);
     auto* brushNode2 = createBrushNode(map);
 
-    addNodes(map, {{parentForNodes(map), {brushNode1, brushNode2}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode1, brushNode2}}});
 
     selectBrushFaces(map, {{brushNode1, 0}, {brushNode1, 2}, {brushNode2, 5}});
 
@@ -1083,10 +1083,10 @@ TEST_CASE("Map_Selection")
   SECTION("Selection clears repeat stack")
   {
     auto* entityNode1 = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode1}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode1}}});
 
     auto* entityNode2 = new EntityNode{Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode2}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode2}}});
 
     selectNodes(map, {entityNode1});
 
@@ -1120,7 +1120,7 @@ TEST_CASE("Map_Selection")
   SECTION("lastSelectionBounds")
   {
     auto* entityNode = new EntityNode{Entity{{{"classname", "point_entity"}}}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     REQUIRE(!entityNode->logicalBounds().is_empty());
 
     selectAllNodes(map);
@@ -1133,7 +1133,7 @@ TEST_CASE("Map_Selection")
     CHECK(map.lastSelectionBounds() == bounds);
 
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     selectNodes(map, {brushNode});
     CHECK(map.lastSelectionBounds() == bounds);

--- a/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
@@ -177,8 +177,8 @@ TEST_CASE("Map_TagManagement")
     CHECK(map.smartTag("entity").index() == 6u);
     CHECK(map.smartTag("entity").type() == 64u);
 
-    CHECK_FALSE(map.isRegisteredSmartTag(""));
-    CHECK_FALSE(map.isRegisteredSmartTag("asdf"));
+    CHECK(!map.isRegisteredSmartTag(""));
+    CHECK(!map.isRegisteredSmartTag("asdf"));
   }
 
   SECTION("registerSmartTags checks duplicate tags")
@@ -232,7 +232,7 @@ TEST_CASE("Map_TagManagement")
       removeNodes(map, {brush});
 
       const auto& tag = map.smartTag("entity");
-      CHECK_FALSE(brush->hasTag(tag));
+      CHECK(!brush->hasTag(tag));
     }
 
     SECTION("Brush face tags")
@@ -244,7 +244,7 @@ TEST_CASE("Map_TagManagement")
       const auto& tag = map.smartTag("material");
       for (const auto& face : brushNodeWithTags->brush().faces())
       {
-        CHECK_FALSE(face.hasTag(tag));
+        CHECK(!face.hasTag(tag));
       }
     }
   }
@@ -263,7 +263,7 @@ TEST_CASE("Map_TagManagement")
       REQUIRE(entityNode->entity().definition() == brushEntityDefinition);
 
       const auto& tag = map.smartTag("entity");
-      CHECK_FALSE(brushNode->hasTag(tag));
+      CHECK(!brushNode->hasTag(tag));
 
       reparentNodes(map, {{entityNode, {brushNode}}});
       CHECK(brushNode->hasTag(tag));
@@ -284,7 +284,7 @@ TEST_CASE("Map_TagManagement")
       addNodes(map, {{otherEntityNode, {brushNode}}});
 
       const auto& tag = map.smartTag("entity");
-      CHECK_FALSE(brushNode->hasTag(tag));
+      CHECK(!brushNode->hasTag(tag));
 
       reparentNodes(map, {{lightEntityNode, {brushNode}}});
       CHECK(brushNode->hasTag(tag));
@@ -302,7 +302,7 @@ TEST_CASE("Map_TagManagement")
     addNodes(map, {{lightEntityNode, {brushNode}}});
 
     const auto& tag = map.smartTag("entity");
-    CHECK_FALSE(brushNode->hasTag(tag));
+    CHECK(!brushNode->hasTag(tag));
 
     selectNodes(map, {lightEntityNode});
     setEntityProperty(map, "classname", "brush_entity");
@@ -319,7 +319,7 @@ TEST_CASE("Map_TagManagement")
     const auto& tag = map.smartTag("contentflags");
 
     const auto faceHandle = BrushFaceHandle{brushNode, 0u};
-    CHECK_FALSE(faceHandle.face().hasTag(tag));
+    CHECK(!faceHandle.face().hasTag(tag));
 
     selectBrushFaces(map, {faceHandle});
     setBrushFaceAttributes(map, {.surfaceContents = SetFlagBits{1}});
@@ -347,16 +347,16 @@ TEST_CASE("Map_TagManagement")
       for (const auto& face : nodeA->brush().faces())
       {
         CHECK(tag.matches(face));
-        CHECK_FALSE(patternTag.matches(face));
+        CHECK(!patternTag.matches(face));
       }
       for (const auto& face : nodeB->brush().faces())
       {
-        CHECK_FALSE(tag.matches(face));
+        CHECK(!tag.matches(face));
         CHECK(patternTag.matches(face));
       }
       for (const auto& face : nodeC->brush().faces())
       {
-        CHECK_FALSE(tag.matches(face));
+        CHECK(!tag.matches(face));
         CHECK(patternTag.matches(face));
       }
     }
@@ -370,7 +370,7 @@ TEST_CASE("Map_TagManagement")
       CHECK(tag.canEnable());
 
       const auto faceHandle = BrushFaceHandle{nonMatchingBrushNode, 0u};
-      CHECK_FALSE(tag.matches(faceHandle.face()));
+      CHECK(!tag.matches(faceHandle.face()));
 
       selectBrushFaces(map, {faceHandle});
 
@@ -383,7 +383,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("disable")
     {
       const auto& tag = map.smartTag("material");
-      CHECK_FALSE(tag.canDisable());
+      CHECK(!tag.canDisable());
     }
   }
 
@@ -416,7 +416,7 @@ TEST_CASE("Map_TagManagement")
       const auto& multiTag = map.smartTag("surfaceparm_multi");
       for (const auto& face : nodeA->brush().faces())
       {
-        CHECK_FALSE(singleTag.matches(face));
+        CHECK(!singleTag.matches(face));
         CHECK(multiTag.matches(face));
       }
       for (const auto& face : nodeB->brush().faces())
@@ -426,8 +426,8 @@ TEST_CASE("Map_TagManagement")
       }
       for (const auto& face : nodeC->brush().faces())
       {
-        CHECK_FALSE(singleTag.matches(face));
-        CHECK_FALSE(multiTag.matches(face));
+        CHECK(!singleTag.matches(face));
+        CHECK(!multiTag.matches(face));
       }
     }
 
@@ -440,7 +440,7 @@ TEST_CASE("Map_TagManagement")
       CHECK(tag.canEnable());
 
       const auto faceHandle = BrushFaceHandle{nonMatchingBrushNode, 0u};
-      CHECK_FALSE(tag.matches(faceHandle.face()));
+      CHECK(!tag.matches(faceHandle.face()));
 
       selectBrushFaces(map, {faceHandle});
 
@@ -453,7 +453,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("disable")
     {
       const auto& tag = map.smartTag("surfaceparm_single");
-      CHECK_FALSE(tag.canDisable());
+      CHECK(!tag.canDisable());
     }
   }
 
@@ -483,7 +483,7 @@ TEST_CASE("Map_TagManagement")
       }
       for (const auto& face : nonMatchingBrushNode->brush().faces())
       {
-        CHECK_FALSE(tag.matches(face));
+        CHECK(!tag.matches(face));
       }
     }
 
@@ -496,7 +496,7 @@ TEST_CASE("Map_TagManagement")
       CHECK(tag.canEnable());
 
       const auto faceHandle = BrushFaceHandle{nonMatchingBrushNode, 0u};
-      CHECK_FALSE(tag.matches(faceHandle.face()));
+      CHECK(!tag.matches(faceHandle.face()));
 
       selectBrushFaces(map, {faceHandle});
 
@@ -528,7 +528,7 @@ TEST_CASE("Map_TagManagement")
       auto callback = TestCallback{0};
       tag.disable(callback, map);
 
-      CHECK_FALSE(tag.matches(faceHandle.face()));
+      CHECK(!tag.matches(faceHandle.face()));
     }
   }
 
@@ -558,7 +558,7 @@ TEST_CASE("Map_TagManagement")
       }
       for (const auto& face : nonMatchingBrushNode->brush().faces())
       {
-        CHECK_FALSE(tag.matches(face));
+        CHECK(!tag.matches(face));
       }
     }
 
@@ -571,7 +571,7 @@ TEST_CASE("Map_TagManagement")
       CHECK(tag.canEnable());
 
       const auto faceHandle = BrushFaceHandle{nonMatchingBrushNode, 0u};
-      CHECK_FALSE(tag.matches(faceHandle.face()));
+      CHECK(!tag.matches(faceHandle.face()));
 
       selectBrushFaces(map, {faceHandle});
 
@@ -603,7 +603,7 @@ TEST_CASE("Map_TagManagement")
       auto callback = TestCallback{0};
       tag.disable(callback, map);
 
-      CHECK_FALSE(tag.matches(faceHandle.face()));
+      CHECK(!tag.matches(faceHandle.face()));
     }
   }
 
@@ -624,7 +624,7 @@ TEST_CASE("Map_TagManagement")
 
       const auto& tag = map.smartTag("entity");
       CHECK(tag.matches(*matchingBrushNode));
-      CHECK_FALSE(tag.matches(*nonMatchingBrushNode));
+      CHECK(!tag.matches(*nonMatchingBrushNode));
     }
 
     SECTION("enable")
@@ -633,7 +633,7 @@ TEST_CASE("Map_TagManagement")
       addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto& tag = map.smartTag("entity");
-      CHECK_FALSE(tag.matches(*brushNode));
+      CHECK(!tag.matches(*brushNode));
 
       CHECK(tag.canEnable());
 
@@ -692,7 +692,7 @@ TEST_CASE("Map_TagManagement")
 
       auto callback = TestCallback{0};
       tag.disable(callback, map);
-      CHECK_FALSE(tag.matches(*brushNode));
+      CHECK(!tag.matches(*brushNode));
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
@@ -206,7 +206,7 @@ TEST_CASE("Map_TagManagement")
     auto* entityNode = new EntityNode{Entity{{
       {"classname", "brush_entity"},
     }}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
     REQUIRE(entityNode->entity().definition() == brushEntityDefinition);
 
     auto* brush = createBrushNode(map, "some_material");
@@ -223,7 +223,7 @@ TEST_CASE("Map_TagManagement")
       auto* entityNode = new EntityNode{Entity{{
         {"classname", "brush_entity"},
       }}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       REQUIRE(entityNode->entity().definition() == brushEntityDefinition);
 
       auto* brush = createBrushNode(map, "some_material");
@@ -238,7 +238,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("Brush face tags")
     {
       auto* brushNodeWithTags = createBrushNode(map, "some_material");
-      addNodes(map, {{parentForNodes(map), {brushNodeWithTags}}});
+      addNodes(map, {{&parentForNodes(map), {brushNodeWithTags}}});
       removeNodes(map, {brushNodeWithTags});
 
       const auto& tag = map.smartTag("material");
@@ -254,12 +254,12 @@ TEST_CASE("Map_TagManagement")
     SECTION("Reparent from world to entity")
     {
       auto* brushNode = createBrushNode(map, "some_material");
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       auto* entityNode = new EntityNode{Entity{{
         {"classname", "brush_entity"},
       }}};
-      addNodes(map, {{parentForNodes(map), {entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {entityNode}}});
       REQUIRE(entityNode->entity().definition() == brushEntityDefinition);
 
       const auto& tag = map.smartTag("entity");
@@ -277,7 +277,7 @@ TEST_CASE("Map_TagManagement")
       auto* otherEntityNode = new EntityNode{Entity{{
         {"classname", "other"},
       }}};
-      addNodes(map, {{parentForNodes(map), {lightEntityNode, otherEntityNode}}});
+      addNodes(map, {{&parentForNodes(map), {lightEntityNode, otherEntityNode}}});
       REQUIRE(lightEntityNode->entity().definition() == brushEntityDefinition);
 
       auto* brushNode = createBrushNode(map, "some_material");
@@ -296,7 +296,7 @@ TEST_CASE("Map_TagManagement")
     auto* lightEntityNode = new EntityNode{Entity{{
       {"classname", "asdf"},
     }}};
-    addNodes(map, {{parentForNodes(map), {lightEntityNode}}});
+    addNodes(map, {{&parentForNodes(map), {lightEntityNode}}});
 
     auto* brushNode = createBrushNode(map, "some_material");
     addNodes(map, {{lightEntityNode, {brushNode}}});
@@ -314,7 +314,7 @@ TEST_CASE("Map_TagManagement")
   SECTION("setBrushFaceAttributes updates tags")
   {
     auto* brushNode = createBrushNode(map, "asdf");
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto& tag = map.smartTag("contentflags");
 
@@ -364,7 +364,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("enable")
     {
       auto* nonMatchingBrushNode = createBrushNode(map, "asdf");
-      addNodes(map, {{parentForNodes(map), {nonMatchingBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {nonMatchingBrushNode}}});
 
       const auto& tag = map.smartTag("material");
       CHECK(tag.canEnable());
@@ -434,7 +434,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("enable")
     {
       auto* nonMatchingBrushNode = createBrushNode(map, "asdf");
-      addNodes(map, {{parentForNodes(map), {nonMatchingBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {nonMatchingBrushNode}}});
 
       const auto& tag = map.smartTag("surfaceparm_single");
       CHECK(tag.canEnable());
@@ -490,7 +490,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("enable")
     {
       auto* nonMatchingBrushNode = createBrushNode(map, "asdf");
-      addNodes(map, {{parentForNodes(map), {nonMatchingBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {nonMatchingBrushNode}}});
 
       const auto& tag = map.smartTag("contentflags");
       CHECK(tag.canEnable());
@@ -515,7 +515,7 @@ TEST_CASE("Map_TagManagement")
         }
       });
 
-      addNodes(map, {{parentForNodes(map), {matchingBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {matchingBrushNode}}});
 
       const auto& tag = map.smartTag("contentflags");
       CHECK(tag.canDisable());
@@ -565,7 +565,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("enable")
     {
       auto* nonMatchingBrushNode = createBrushNode(map, "asdf");
-      addNodes(map, {{parentForNodes(map), {nonMatchingBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {nonMatchingBrushNode}}});
 
       const auto& tag = map.smartTag("surfaceflags");
       CHECK(tag.canEnable());
@@ -590,7 +590,7 @@ TEST_CASE("Map_TagManagement")
         }
       });
 
-      addNodes(map, {{parentForNodes(map), {matchingBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {matchingBrushNode}}});
 
       const auto& tag = map.smartTag("surfaceflags");
       CHECK(tag.canDisable());
@@ -630,7 +630,7 @@ TEST_CASE("Map_TagManagement")
     SECTION("enable")
     {
       auto* brushNode = createBrushNode(map, "asdf");
-      addNodes(map, {{parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
       const auto& tag = map.smartTag("entity");
       CHECK_FALSE(tag.matches(*brushNode));
@@ -653,7 +653,7 @@ TEST_CASE("Map_TagManagement")
         {"some_attr", "some_value"},
       }}};
 
-      addNodes(map, {{parentForNodes(map), {oldEntity}}});
+      addNodes(map, {{&parentForNodes(map), {oldEntity}}});
       addNodes(map, {{oldEntity, {brushNode}}});
 
       const auto& tag = map.smartTag("entity");
@@ -679,7 +679,7 @@ TEST_CASE("Map_TagManagement")
         {"classname", "brush_entity"},
       }}};
 
-      addNodes(map, {{parentForNodes(map), {oldEntityNode}}});
+      addNodes(map, {{&parentForNodes(map), {oldEntityNode}}});
       addNodes(map, {{oldEntityNode, {brushNode}}});
       REQUIRE(oldEntityNode->entity().definition() == brushEntityDefinition);
 

--- a/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
@@ -615,52 +615,56 @@ TEST_CASE("Map_TagManagement")
       auto* matchingBrushNode = createBrushNode(map, "asdf");
       auto* nonMatchingBrushNode = createBrushNode(map, "asdf");
 
-      auto matchingEntity =
-        std::make_unique<EntityNode>(Entity{{{"classname", "brush_entity"}}});
-      matchingEntity->addChild(matchingBrushNode);
-
-      auto nonMatchingEntity =
-        std::make_unique<EntityNode>(Entity{{{"classname", "something"}}});
-      nonMatchingEntity->addChild(nonMatchingBrushNode);
-
-      const auto& tag = map.smartTag("entity");
-      CHECK(tag.matches(*matchingBrushNode));
-      CHECK(!tag.matches(*nonMatchingBrushNode));
-    }
-
-    SECTION("matches (patch)")
-    {
       auto* matchingPatchNode = createPatchNode();
       auto* nonMatchingPatchNode = createPatchNode();
 
       auto matchingEntity =
         std::make_unique<EntityNode>(Entity{{{"classname", "brush_entity"}}});
-      matchingEntity->addChild(matchingPatchNode);
+      matchingEntity->addChildren({matchingBrushNode, matchingPatchNode});
 
       auto nonMatchingEntity =
         std::make_unique<EntityNode>(Entity{{{"classname", "something"}}});
-      nonMatchingEntity->addChild(nonMatchingPatchNode);
+      nonMatchingEntity->addChildren({nonMatchingBrushNode, nonMatchingPatchNode});
 
       const auto& tag = map.smartTag("entity");
+      CHECK(tag.matches(*matchingBrushNode));
       CHECK(tag.matches(*matchingPatchNode));
+      CHECK(!tag.matches(*nonMatchingBrushNode));
       CHECK(!tag.matches(*nonMatchingPatchNode));
     }
 
     SECTION("enable")
     {
+      auto* patchNode = createPatchNode();
       auto* brushNode = createBrushNode(map, "asdf");
-      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode, patchNode}}});
 
       const auto& tag = map.smartTag("entity");
       CHECK(!tag.matches(*brushNode));
+      CHECK(!tag.matches(*patchNode));
 
       CHECK(tag.canEnable());
 
-      selectNodes(map, {brushNode});
+      selectNodes(map, {brushNode, patchNode});
 
       auto callback = TestCallback{0};
       tag.enable(callback, map);
       CHECK(tag.matches(*brushNode));
+      CHECK(tag.matches(*patchNode));
+    }
+
+    SECTION("enable sets patch material")
+    {
+      auto* patchNode = createPatchNode("some_material");
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
+      selectNodes(map, {patchNode});
+
+      const auto matcherWithMaterial =
+        EntityClassNameTagMatcher{"brush_entity", "trigger_material"};
+
+      auto callback = TestCallback{0};
+      matcherWithMaterial.enable(callback, map);
+      CHECK(patchNode->patch().materialName() == "trigger_material");
     }
 
     SECTION("enable retains entity properties")

--- a/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_TagManagement.cpp
@@ -34,6 +34,7 @@
 #include "mdl/Map_Geometry.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
+#include "mdl/PatchNode.h"
 #include "mdl/TagMatcher.h"
 #include "mdl/TestFactory.h"
 #include "mdl/UpdateBrushFaceAttributes.h"
@@ -627,6 +628,24 @@ TEST_CASE("Map_TagManagement")
       CHECK(!tag.matches(*nonMatchingBrushNode));
     }
 
+    SECTION("matches (patch)")
+    {
+      auto* matchingPatchNode = createPatchNode();
+      auto* nonMatchingPatchNode = createPatchNode();
+
+      auto matchingEntity =
+        std::make_unique<EntityNode>(Entity{{{"classname", "brush_entity"}}});
+      matchingEntity->addChild(matchingPatchNode);
+
+      auto nonMatchingEntity =
+        std::make_unique<EntityNode>(Entity{{{"classname", "something"}}});
+      nonMatchingEntity->addChild(nonMatchingPatchNode);
+
+      const auto& tag = map.smartTag("entity");
+      CHECK(tag.matches(*matchingPatchNode));
+      CHECK(!tag.matches(*nonMatchingPatchNode));
+    }
+
     SECTION("enable")
     {
       auto* brushNode = createBrushNode(map, "asdf");
@@ -693,6 +712,30 @@ TEST_CASE("Map_TagManagement")
       auto callback = TestCallback{0};
       tag.disable(callback, map);
       CHECK(!tag.matches(*brushNode));
+    }
+
+    SECTION("disable (patch)")
+    {
+      auto* patchNode = createPatchNode();
+
+      auto* oldEntityNode = new EntityNode{Entity{{
+        {"classname", "brush_entity"},
+      }}};
+
+      addNodes(map, {{&parentForNodes(map), {oldEntityNode}}});
+      addNodes(map, {{oldEntityNode, {patchNode}}});
+      REQUIRE(oldEntityNode->entity().definition() == brushEntityDefinition);
+
+      const auto& tag = map.smartTag("entity");
+      CHECK(tag.matches(*patchNode));
+
+      CHECK(tag.canDisable());
+
+      selectNodes(map, {patchNode});
+
+      auto callback = TestCallback{0};
+      tag.disable(callback, map);
+      CHECK_FALSE(tag.matches(*patchNode));
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_ModelUtils.cpp
@@ -116,6 +116,47 @@ TEST_CASE("ModelUtils.findContainingGroup")
   CHECK(findContainingGroup(patchNode) == outerGroupNode);
 }
 
+TEST_CASE("ModelUtils.findContainingEntity")
+{
+  constexpr auto worldBounds = vm::bbox3d{8192.0};
+  constexpr auto mapFormat = MapFormat::Quake3;
+
+  auto worldNode = WorldNode{{}, {}, mapFormat};
+
+  auto* layerNode = new LayerNode{Layer{"layer"}};
+  auto* groupNode = new GroupNode{Group{"group"}};
+  auto* entityNode = new EntityNode{Entity{}};
+  auto* structuralBrushNode = new BrushNode{
+    BrushBuilder{mapFormat, worldBounds}.createCube(64.0, "material") | kdl::value()};
+  auto* entityBrushNode = new BrushNode{
+    BrushBuilder{mapFormat, worldBounds}.createCube(64.0, "material") | kdl::value()};
+
+  // clang-format off
+  auto* structuralPatchNode = new PatchNode{BezierPatch{3, 3, {
+    {0, 0, 0}, {1, 0, 1}, {2, 0, 0},
+    {0, 1, 1}, {1, 1, 2}, {2, 1, 1},
+    {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
+  auto* entityPatchNode = new PatchNode{BezierPatch{3, 3, {
+    {0, 0, 0}, {1, 0, 1}, {2, 0, 0},
+    {0, 1, 1}, {1, 1, 2}, {2, 1, 1},
+    {0, 2, 0}, {1, 2, 1}, {2, 2, 0} }, "material"}};
+  // clang-format on
+
+  entityNode->addChildren({entityBrushNode, entityPatchNode});
+  groupNode->addChildren({entityNode, structuralBrushNode, structuralPatchNode});
+  layerNode->addChild(groupNode);
+  worldNode.addChild(layerNode);
+
+  CHECK(findContainingEntity(&worldNode) == nullptr);
+  CHECK(findContainingEntity(layerNode) == nullptr);
+  CHECK(findContainingEntity(groupNode) == nullptr);
+  CHECK(findContainingEntity(entityNode) == nullptr);
+  CHECK(findContainingEntity(structuralBrushNode) == &worldNode);
+  CHECK(findContainingEntity(structuralPatchNode) == &worldNode);
+  CHECK(findContainingEntity(entityBrushNode) == entityNode);
+  CHECK(findContainingEntity(entityPatchNode) == entityNode);
+}
+
 TEST_CASE("ModelUtils.findOutermostClosedGroup")
 {
   constexpr auto worldBounds = vm::bbox3d{8192.0};

--- a/lib/TbMdlLib/test/src/tst_Selection.cpp
+++ b/lib/TbMdlLib/test/src/tst_Selection.cpp
@@ -350,6 +350,25 @@ TEST_CASE("Selection")
     CHECK(map.selection().hasOnlyPatches() == expected);
   }
 
+  SECTION("hasOnlyGeometryNodes")
+  {
+    using T = std::tuple<std::vector<SelectionItem>, bool>;
+    const auto [selectionItems, expected] = GENERATE(values<T>({
+      {{SelectionItem::nothing}, false},
+      {{SelectionItem::brushNode}, true},
+      {{SelectionItem::patchNode}, true},
+      {{SelectionItem::brushNode, SelectionItem::patchNode}, true},
+      {{SelectionItem::entityNode, SelectionItem::brushNode}, false},
+      {{SelectionItem::entityNode}, false},
+      {{SelectionItem::brushFace}, false},
+    }));
+
+    CAPTURE(selectionItems);
+
+    selectItems(selectionItems);
+    CHECK(map.selection().hasOnlyGeometryNodes() == expected);
+  }
+
   SECTION("hasBrushFaces")
   {
     using T = std::tuple<std::vector<SelectionItem>, bool>;

--- a/lib/TbMdlLib/test/src/tst_Selection.cpp
+++ b/lib/TbMdlLib/test/src/tst_Selection.cpp
@@ -144,7 +144,7 @@ TEST_CASE("Selection")
 
   addNodes(
     map,
-    {{parentForNodes(map),
+    {{&parentForNodes(map),
       {outerGroupNode, entityNode, brushEntityNode, otherGroupNode}}});
 
   const auto selectItem = [&](const auto selectionItem) {

--- a/lib/TbMdlLib/test/src/tst_Transaction.cpp
+++ b/lib/TbMdlLib/test/src/tst_Transaction.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Transaction")
   auto transaction = Transaction{map};
   CHECK(transaction.state() == Transaction::State::Running);
 
-  addNodes(map, {{parentForNodes(map), {entityNode}}});
+  addNodes(map, {{&parentForNodes(map), {entityNode}}});
   selectNodes(map, {entityNode});
   transformSelection(map, "translate", vm::translation_matrix(vm::vec3d{1, 0, 0}));
 

--- a/lib/TbMdlLib/test/src/tst_UpdateLinkedGroupsCommand.cpp
+++ b/lib/TbMdlLib/test/src/tst_UpdateLinkedGroupsCommand.cpp
@@ -40,7 +40,7 @@ TEST_CASE("UpdateLinkedGroupsCommand")
 
   const auto createLinkedGroup = [&]() {
     auto brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
     selectNodes(map, {brushNode});
 
     auto* groupNode = groupSelectedNodes(map, "group");

--- a/lib/TbMdlLib/test/src/tst_UpdateLinkedGroupsHelper.cpp
+++ b/lib/TbMdlLib/test/src/tst_UpdateLinkedGroupsHelper.cpp
@@ -140,7 +140,7 @@ TEST_CASE("UpdateLinkedGroupsHelper")
     auto* linkedNode =
       static_cast<GroupNode*>(groupNode->cloneRecursively(map.worldBounds()));
 
-    addNodes(map, {{parentForNodes(map), {groupNode, linkedNode}}});
+    addNodes(map, {{&parentForNodes(map), {groupNode, linkedNode}}});
 
     SECTION("Helper takes ownership of replaced child nodes")
     {
@@ -188,7 +188,7 @@ TEST_CASE("UpdateLinkedGroupsHelper")
         linkedBrushNode->physicalBounds()
         == brushNode->physicalBounds().translate(vm::vec3d(32.0, 0.0, 0.0)));
 
-      addNodes(map, {{parentForNodes(map), {groupNode, linkedGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode, linkedGroupNode}}});
 
       /*
       world
@@ -270,7 +270,7 @@ TEST_CASE("UpdateLinkedGroupsHelper")
       innerGroupNode->addChild(brushNode);
       outerGroupNode->addChild(innerGroupNode);
 
-      addNodes(map, {{parentForNodes(map), {outerGroupNode}}});
+      addNodes(map, {{&parentForNodes(map), {outerGroupNode}}});
 
       // create a linked group of the inner group node so that cloning the outer group
       // node will create a linked clone of the inner group node
@@ -290,7 +290,7 @@ TEST_CASE("UpdateLinkedGroupsHelper")
       REQUIRE(nestedLinkedInnerGroupNode->linkId() == innerGroupNode->linkId());
 
       addNodes(
-        map, {{parentForNodes(map), {linkedInnerGroupNode, linkedOuterGroupNode}}});
+        map, {{&parentForNodes(map), {linkedInnerGroupNode, linkedOuterGroupNode}}});
 
       /*
       world

--- a/lib/TbRenderLib/test/src/tst_EntityLinkRenderer.cpp
+++ b/lib/TbRenderLib/test/src/tst_EntityLinkRenderer.cpp
@@ -98,7 +98,7 @@ TEST_CASE("EntityLinkRenderer")
     {Origin, "64 0 0"},
   }}};
 
-  mdl::addNodes(map, {{mdl::parentForNodes(map), {sourceNode, targetNode}}});
+  mdl::addNodes(map, {{&mdl::parentForNodes(map), {sourceNode, targetNode}}});
   REQUIRE(map.entityLinkManager().hasLink(*sourceNode, *targetNode, Target));
 
   const auto defaultColor = Color{RgbaF{0, 1, 0, 1}};

--- a/lib/TbRenderLib/test/src/tst_GroupLinkRenderer.cpp
+++ b/lib/TbRenderLib/test/src/tst_GroupLinkRenderer.cpp
@@ -67,7 +67,7 @@ TEST_CASE("GroupLinkRenderer")
   auto& map = fixture.create();
 
   auto* brushNode = mdl::createBrushNode(map);
-  mdl::addNodes(map, {{mdl::parentForNodes(map), {brushNode}}});
+  mdl::addNodes(map, {{&mdl::parentForNodes(map), {brushNode}}});
   mdl::selectNodes(map, {brushNode});
 
   auto* groupA = mdl::groupSelectedNodes(map, "group A");

--- a/lib/TbUiLib/include/ui/BrushHandleToolBase.h
+++ b/lib/TbUiLib/include/ui/BrushHandleToolBase.h
@@ -74,10 +74,10 @@ public:
             b.cloneFaceAttributesFrom(selectedBrushNode->brush());
           }
 
-          auto* newParent = parentForNodes(map, map.selection().nodes);
+          auto& newParent = parentForNodes(map, map.selection().nodes);
           auto transaction = mdl::Transaction{map, "CSG Convex Merge"};
           this->deselectAll();
-          if (addNodes(map, {{newParent, {new mdl::BrushNode{std::move(b)}}}}).empty())
+          if (addNodes(map, {{&newParent, {new mdl::BrushNode{std::move(b)}}}}).empty())
           {
             transaction.cancel();
             return;

--- a/lib/TbUiLib/include/ui/MapViewBase.h
+++ b/lib/TbUiLib/include/ui/MapViewBase.h
@@ -269,7 +269,7 @@ public: // tags
   void disableTag(const mdl::SmartTag& tag);
 
 public: // make structural
-  void makeStructural();
+  void makeSelectionStructural();
 
 public: // entity definitions
   void toggleEntityDefinitionVisible(const mdl::EntityDefinition& definition);
@@ -372,7 +372,7 @@ private:
   QMenu* makeEntityGroupsMenu(mdl::EntityDefinitionType type);
 
   bool canMergeGroups() const;
-  bool canMakeStructural() const;
+  bool canMakeSelectionStructural() const;
 };
 
 } // namespace ui

--- a/lib/TbUiLib/include/ui/MapViewBase.h
+++ b/lib/TbUiLib/include/ui/MapViewBase.h
@@ -236,7 +236,7 @@ public: // reparenting objects
    */
   bool canReparentNode(const mdl::Node* node, const mdl::Node* newParent) const;
 
-  mdl::Node* findNewParentEntityForNodes(const std::vector<mdl::Node*>& nodes) const;
+  mdl::Node& findNewParentEntityForNodes(const std::vector<mdl::Node*>& nodes) const;
 
   bool canReparentNodes(
     const std::vector<mdl::Node*>& nodes, const mdl::Node* newParent) const;

--- a/lib/TbUiLib/include/ui/MapViewBase.h
+++ b/lib/TbUiLib/include/ui/MapViewBase.h
@@ -236,8 +236,7 @@ public: // reparenting objects
    */
   bool canReparentNode(const mdl::Node* node, const mdl::Node* newParent) const;
 
-  void moveSelectedBrushesToEntity();
-  mdl::Node* findNewParentEntityForBrushes(const std::vector<mdl::Node*>& nodes) const;
+  mdl::Node* findNewParentEntityForNodes(const std::vector<mdl::Node*>& nodes) const;
 
   bool canReparentNodes(
     const std::vector<mdl::Node*>& nodes, const mdl::Node* newParent) const;
@@ -268,8 +267,9 @@ public: // tags
   void enableTag(const mdl::SmartTag& tag);
   void disableTag(const mdl::SmartTag& tag);
 
-public: // make structural
+public: // make structural / move to entity
   void makeSelectionStructural();
+  void moveSelectedNodesToEntity();
 
 public: // entity definitions
   void toggleEntityDefinitionVisible(const mdl::EntityDefinition& definition);

--- a/lib/TbUiLib/src/ActionManager.cpp
+++ b/lib/TbUiLib/src/ActionManager.cpp
@@ -607,7 +607,7 @@ void ActionManager::createViewActions()
     QObject::tr("Make Structural"),
     ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyOrNoTool,
     QKeySequence{Qt::ALT | Qt::Key_S},
-    [](auto& context) { context.mapView().makeStructural(); },
+    [](auto& context) { context.mapView().makeSelectionStructural(); },
     [](const auto& context) { return context.hasDocument(); },
   });
 

--- a/lib/TbUiLib/src/CreateBrushesToolBase.cpp
+++ b/lib/TbUiLib/src/CreateBrushesToolBase.cpp
@@ -66,7 +66,7 @@ void CreateBrushesToolBase::createBrushes()
     auto transaction = mdl::Transaction{m_document.map(), "Create Brush"};
     deselectAll(m_document.map());
     auto addedNodes =
-      addNodes(m_document.map(), {{parentForNodes(m_document.map()), nodesToAdd}});
+      addNodes(m_document.map(), {{&parentForNodes(m_document.map()), nodesToAdd}});
     selectNodes(m_document.map(), addedNodes);
     transaction.commit();
 

--- a/lib/TbUiLib/src/DrawShapeTool.cpp
+++ b/lib/TbUiLib/src/DrawShapeTool.cpp
@@ -101,7 +101,7 @@ QWidget* DrawShapeTool::doCreatePage(QWidget* parent)
             const auto addedNodes = addNodes(
               map,
               {
-                {parentForNodes(map), brushNodes | std::views::transform([](auto& node) {
+                {&parentForNodes(map), brushNodes | std::views::transform([](auto& node) {
                                         return static_cast<mdl::Node*>(node.release());
                                       }) | kdl::ranges::to<std::vector>()},
               });

--- a/lib/TbUiLib/src/DrawShapeTool.cpp
+++ b/lib/TbUiLib/src/DrawShapeTool.cpp
@@ -102,8 +102,8 @@ QWidget* DrawShapeTool::doCreatePage(QWidget* parent)
               map,
               {
                 {&parentForNodes(map), brushNodes | std::views::transform([](auto& node) {
-                                        return static_cast<mdl::Node*>(node.release());
-                                      }) | kdl::ranges::to<std::vector>()},
+                                         return static_cast<mdl::Node*>(node.release());
+                                       }) | kdl::ranges::to<std::vector>()},
               });
             selectNodes(map, addedNodes);
 

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -738,7 +738,7 @@ void MapViewBase::makeStructural()
 
   if (!toReparent.empty())
   {
-    reparentNodes(toReparent, parentForNodes(map, toReparent), false);
+    reparentNodes(toReparent, &parentForNodes(map, toReparent), false);
   }
 
   auto anyTagDisabled = false;

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -722,47 +722,8 @@ void MapViewBase::disableTag(const mdl::SmartTag& tag)
 void MapViewBase::makeSelectionStructural()
 {
   auto& map = m_document.map();
-  if (!map.selection().hasBrushes())
-  {
-    return;
-  }
-
-  auto toReparent = std::vector<mdl::Node*>{};
-  const auto& selectedBrushes = map.selection().brushes;
-  std::ranges::copy_if(
-    selectedBrushes, std::back_inserter(toReparent), [&](const auto* brushNode) {
-      return brushNode->entity() != &map.worldNode();
-    });
-
-  auto transaction = mdl::Transaction{map, "Make Structural"};
-
-  if (!toReparent.empty())
-  {
-    reparentNodes(toReparent, &parentForNodes(map, toReparent), false);
-  }
-
-  auto anyTagDisabled = false;
   auto callback = EnableDisableTagCallback{};
-  for (auto* brush : map.selection().brushes)
-  {
-    for (const auto& tag : map.smartTags())
-    {
-      if (brush->hasTag(tag) || brush->anyFacesHaveAnyTagInMask(tag.type()))
-      {
-        anyTagDisabled = true;
-        tag.disable(callback, map);
-      }
-    }
-  }
-
-  if (!anyTagDisabled && toReparent.empty())
-  {
-    transaction.cancel();
-  }
-  else
-  {
-    transaction.commit();
-  }
+  mdl::makeStructural(map, map.selection().nodes, callback);
 }
 
 void MapViewBase::moveSelectedNodesToEntity()
@@ -772,13 +733,7 @@ void MapViewBase::moveSelectedNodesToEntity()
   auto* newParent = findNewParentEntityForNodes(nodes);
   contract_assert(newParent);
 
-  auto transaction =
-    mdl::Transaction{map, "Move " + kdl::str_plural(nodes.size(), "Brush", "Brushes")};
-  reparentNodes(nodes, newParent, false);
-
-  deselectAll(map);
-  selectNodes(map, nodes);
-  transaction.commit();
+  mdl::moveToEntity(map, nodes, *newParent);
 }
 
 void MapViewBase::toggleEntityDefinitionVisible(const mdl::EntityDefinition& definition)
@@ -1703,15 +1658,7 @@ bool MapViewBase::canMergeGroups() const
 bool MapViewBase::canMakeSelectionStructural() const
 {
   const auto& map = m_document.map();
-  if (map.selection().hasOnlyBrushes())
-  {
-    const auto& brushes = map.selection().brushes;
-    return std::ranges::any_of(brushes, [&](const auto* brush) {
-      return brush->hasAnyTag() || brush->entity() != &map.worldNode()
-             || brush->anyFaceHasAnyTag();
-    });
-  }
-  return false;
+  return mdl::canMakeStructural(map, map.selection().nodes);
 }
 
 } // namespace tb::ui

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -1272,7 +1272,7 @@ void MapViewBase::showPopupMenuLater()
 
   menu.addSeparator();
 
-  if (map.selection().hasOnlyBrushes())
+  if (map.selection().hasOnlyGeometryNodes())
   {
     auto* moveToWorldAction =
       menu.addAction(tr("Make Structural"), this, &MapViewBase::makeSelectionStructural);
@@ -1289,8 +1289,7 @@ void MapViewBase::showPopupMenuLater()
     if (isEntity)
     {
       menu.addAction(
-        tr("Move Brushes to Entity %1")
-          .arg(QString::fromStdString(newNodeParent->name())),
+        tr("Move to Entity %1").arg(QString::fromStdString(newNodeParent->name())),
         this,
         &MapViewBase::moveSelectedNodesToEntity);
     }
@@ -1540,13 +1539,12 @@ mdl::Node* MapViewBase::findNewParentEntityForNodes(
   using namespace mdl::HitFilters;
 
   const auto& map = m_document.map();
-  const auto& hit = pickResult().first(type(mdl::BrushNode::BrushHitType));
-  if (const auto faceHandle = mdl::hitToFaceHandle(hit))
+  const auto& hit =
+    pickResult().first(type(mdl::BrushNode::BrushHitType | mdl::PatchNode::PatchHitType));
+  if (auto* hitNode = mdl::hitToNode(hit))
   {
-    auto* brush = faceHandle->node();
-    auto* newParent = brush->entity();
-
-    if (newParent && newParent != &map.worldNode() && canReparentNodes(nodes, newParent))
+    if (auto* newParent = mdl::findContainingEntity(hitNode);
+        newParent && newParent != &map.worldNode() && canReparentNodes(nodes, newParent))
     {
       return newParent;
     }

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -719,7 +719,7 @@ void MapViewBase::disableTag(const mdl::SmartTag& tag)
   transaction.commit();
 }
 
-void MapViewBase::makeStructural()
+void MapViewBase::makeSelectionStructural()
 {
   auto& map = m_document.map();
   if (!map.selection().hasBrushes())
@@ -1304,8 +1304,8 @@ void MapViewBase::showPopupMenuLater()
   if (map.selection().hasOnlyBrushes())
   {
     auto* moveToWorldAction =
-      menu.addAction(tr("Make Structural"), this, &MapViewBase::makeStructural);
-    moveToWorldAction->setEnabled(canMakeStructural());
+      menu.addAction(tr("Make Structural"), this, &MapViewBase::makeSelectionStructural);
+    moveToWorldAction->setEnabled(canMakeSelectionStructural());
 
     const auto isEntity = newBrushParent->accept(kdl::overload(
       [](const mdl::WorldNode&) { return false; },
@@ -1700,7 +1700,7 @@ bool MapViewBase::canMergeGroups() const
   return mergeGroup;
 }
 
-bool MapViewBase::canMakeStructural() const
+bool MapViewBase::canMakeSelectionStructural() const
 {
   const auto& map = m_document.map();
   if (map.selection().hasOnlyBrushes())

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -683,7 +683,7 @@ void MapViewBase::createBrushEntity(const mdl::EntityDefinition& definition)
 bool MapViewBase::canCreateBrushEntity()
 {
   const auto& map = m_document.map();
-  return map.selection().hasOnlyBrushes();
+  return map.selection().hasOnlyGeometryNodes();
 }
 
 void MapViewBase::toggleTagVisible(const mdl::SmartTag& tag)

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -730,10 +730,9 @@ void MapViewBase::moveSelectedNodesToEntity()
 {
   auto& map = m_document.map();
   const auto nodes = map.selection().nodes;
-  auto* newParent = findNewParentEntityForNodes(nodes);
-  contract_assert(newParent);
+  auto& newParent = findNewParentEntityForNodes(nodes);
 
-  mdl::moveToEntity(map, nodes, *newParent);
+  mdl::moveToEntity(map, nodes, newParent);
 }
 
 void MapViewBase::toggleEntityDefinitionVisible(const mdl::EntityDefinition& definition)
@@ -1156,7 +1155,7 @@ void MapViewBase::showPopupMenuLater()
 
   auto& map = m_document.map();
   const auto& nodes = map.selection().nodes;
-  auto* newNodeParent = findNewParentEntityForNodes(nodes);
+  auto& newNodeParent = findNewParentEntityForNodes(nodes);
   auto* currentGroup = map.editorContext().currentGroup();
   auto* newGroup = findNewGroupForObjects(nodes);
   auto* mergeGroup = findGroupToMergeGroupsInto(map.selection());
@@ -1278,7 +1277,7 @@ void MapViewBase::showPopupMenuLater()
       menu.addAction(tr("Make Structural"), this, &MapViewBase::makeSelectionStructural);
     moveToWorldAction->setEnabled(canMakeSelectionStructural());
 
-    const auto isEntity = newNodeParent->accept(kdl::overload(
+    const auto isEntity = newNodeParent.accept(kdl::overload(
       [](const mdl::WorldNode&) { return false; },
       [](const mdl::LayerNode&) { return false; },
       [](const mdl::GroupNode&) { return false; },
@@ -1289,7 +1288,7 @@ void MapViewBase::showPopupMenuLater()
     if (isEntity)
     {
       menu.addAction(
-        tr("Move to Entity %1").arg(QString::fromStdString(newNodeParent->name())),
+        tr("Move to Entity %1").arg(QString::fromStdString(newNodeParent.name())),
         this,
         &MapViewBase::moveSelectedNodesToEntity);
     }
@@ -1533,7 +1532,7 @@ bool MapViewBase::canReparentNode(const mdl::Node* node, const mdl::Node* newPar
          && newParent->canAddChild(*node);
 }
 
-mdl::Node* MapViewBase::findNewParentEntityForNodes(
+mdl::Node& MapViewBase::findNewParentEntityForNodes(
   const std::vector<mdl::Node*>& nodes) const
 {
   using namespace mdl::HitFilters;
@@ -1546,26 +1545,11 @@ mdl::Node* MapViewBase::findNewParentEntityForNodes(
     if (auto* newParent = mdl::findContainingEntity(hitNode);
         newParent && newParent != &map.worldNode() && canReparentNodes(nodes, newParent))
     {
-      return newParent;
+      return *newParent;
     }
   }
 
-  if (!nodes.empty())
-  {
-    auto* lastNode = nodes.back();
-
-    if (auto* group = mdl::findContainingGroup(lastNode))
-    {
-      return group;
-    }
-
-    if (auto* layer = mdl::findContainingLayer(lastNode))
-    {
-      return layer;
-    }
-  }
-
-  return map.editorContext().currentLayer();
+  return mdl::parentForNodes(map, nodes);
 }
 
 bool MapViewBase::canReparentNodes(

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -765,6 +765,22 @@ void MapViewBase::makeSelectionStructural()
   }
 }
 
+void MapViewBase::moveSelectedNodesToEntity()
+{
+  auto& map = m_document.map();
+  const auto nodes = map.selection().nodes;
+  auto* newParent = findNewParentEntityForNodes(nodes);
+  contract_assert(newParent);
+
+  auto transaction =
+    mdl::Transaction{map, "Move " + kdl::str_plural(nodes.size(), "Brush", "Brushes")};
+  reparentNodes(nodes, newParent, false);
+
+  deselectAll(map);
+  selectNodes(map, nodes);
+  transaction.commit();
+}
+
 void MapViewBase::toggleEntityDefinitionVisible(const mdl::EntityDefinition& definition)
 {
   auto& map = m_document.map();
@@ -1185,7 +1201,7 @@ void MapViewBase::showPopupMenuLater()
 
   auto& map = m_document.map();
   const auto& nodes = map.selection().nodes;
-  auto* newBrushParent = findNewParentEntityForBrushes(nodes);
+  auto* newNodeParent = findNewParentEntityForNodes(nodes);
   auto* currentGroup = map.editorContext().currentGroup();
   auto* newGroup = findNewGroupForObjects(nodes);
   auto* mergeGroup = findGroupToMergeGroupsInto(map.selection());
@@ -1307,7 +1323,7 @@ void MapViewBase::showPopupMenuLater()
       menu.addAction(tr("Make Structural"), this, &MapViewBase::makeSelectionStructural);
     moveToWorldAction->setEnabled(canMakeSelectionStructural());
 
-    const auto isEntity = newBrushParent->accept(kdl::overload(
+    const auto isEntity = newNodeParent->accept(kdl::overload(
       [](const mdl::WorldNode&) { return false; },
       [](const mdl::LayerNode&) { return false; },
       [](const mdl::GroupNode&) { return false; },
@@ -1319,9 +1335,9 @@ void MapViewBase::showPopupMenuLater()
     {
       menu.addAction(
         tr("Move Brushes to Entity %1")
-          .arg(QString::fromStdString(newBrushParent->name())),
+          .arg(QString::fromStdString(newNodeParent->name())),
         this,
-        &MapViewBase::moveSelectedBrushesToEntity);
+        &MapViewBase::moveSelectedNodesToEntity);
     }
   }
 
@@ -1563,23 +1579,7 @@ bool MapViewBase::canReparentNode(const mdl::Node* node, const mdl::Node* newPar
          && newParent->canAddChild(*node);
 }
 
-void MapViewBase::moveSelectedBrushesToEntity()
-{
-  auto& map = m_document.map();
-  const auto nodes = map.selection().nodes;
-  auto* newParent = findNewParentEntityForBrushes(nodes);
-  contract_assert(newParent);
-
-  auto transaction =
-    mdl::Transaction{map, "Move " + kdl::str_plural(nodes.size(), "Brush", "Brushes")};
-  reparentNodes(nodes, newParent, false);
-
-  deselectAll(map);
-  selectNodes(map, nodes);
-  transaction.commit();
-}
-
-mdl::Node* MapViewBase::findNewParentEntityForBrushes(
+mdl::Node* MapViewBase::findNewParentEntityForNodes(
   const std::vector<mdl::Node*>& nodes) const
 {
   using namespace mdl::HitFilters;

--- a/lib/TbUiLib/src/SweepToolUtils.cpp
+++ b/lib/TbUiLib/src/SweepToolUtils.cpp
@@ -358,7 +358,7 @@ std::map<mdl::Node*, std::vector<std::unique_ptr<mdl::BrushNode>>> generateSweep
   for (const auto& sourceFace : source.faces)
   {
     // fall back to the default insertion parent if the captured parent has been deleted
-    auto* parent = sourceFace.parent ? sourceFace.parent : parentForNodes(map);
+    auto& parent = sourceFace.parent ? *sourceFace.parent : parentForNodes(map);
 
     const auto& sourceVertices = sourceFace.polygon.vertices();
     for (size_t r = 0; r < parameters.iterations; ++r)
@@ -372,7 +372,7 @@ std::map<mdl::Node*, std::vector<std::unique_ptr<mdl::BrushNode>>> generateSweep
 
         builder.createBrush(points, materialName) | kdl::transform([&](auto brush) {
           setMaterial(brush, material);
-          result[parent].push_back(std::make_unique<mdl::BrushNode>(std::move(brush)));
+          result[&parent].push_back(std::make_unique<mdl::BrushNode>(std::move(brush)));
         }) | kdl::transform_error([&](auto e) {
           // a degenerate segment cannot form a brush; skip it
           map.logger().debug() << "Sweep: could not create segment brush: " << e.msg;

--- a/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
+++ b/lib/TbUiLib/test/src/tst_CompilationRunner.cpp
@@ -448,7 +448,7 @@ TEST_CASE("CompilationExportMapTaskRunner")
     CAPTURE(exportSpec);
 
     auto node = new mdl::EntityNode{mdl::Entity{}};
-    addNodes(map, {{parentForNodes(map), {node}}});
+    addNodes(map, {{&parentForNodes(map), {node}}});
 
     auto task = mdl::CompilationExportMap{
       K(enabled),
@@ -495,7 +495,7 @@ TEST_CASE("CompilationExportMapTaskRunner")
   SECTION("variable interpolation error")
   {
     auto node = new mdl::EntityNode{mdl::Entity{}};
-    addNodes(map, {{parentForNodes(map), {node}}});
+    addNodes(map, {{&parentForNodes(map), {node}}});
 
     auto task = mdl::CompilationExportMap{
       K(enabled),

--- a/lib/TbUiLib/test/src/tst_EntityPropertyModel.cpp
+++ b/lib/TbUiLib/test/src/tst_EntityPropertyModel.cpp
@@ -111,7 +111,7 @@ TEST_CASE("EntityPropertyModel")
   mdl::addNodes(
     map,
     {
-      {mdl::parentForNodes(map),
+      {&mdl::parentForNodes(map),
        {
          entityNode1,
          entityNode2,
@@ -434,7 +434,7 @@ TEST_CASE("EntityPropertyModel")
       mdl::addNodes(
         map,
         {{
-          mdl::parentForNodes(map),
+          &mdl::parentForNodes(map),
           {literalKeyEntityNode, wildcardMatchedEntityNode},
         }});
 

--- a/lib/TbUiLib/test/src/tst_MapDocument.cpp
+++ b/lib/TbUiLib/test/src/tst_MapDocument.cpp
@@ -184,7 +184,7 @@ TEST_CASE("MapDocument")
 
     auto* transientEntityNode = new mdl::EntityNode{{}};
     addNodes(
-      document->map(), {{mdl::parentForNodes(document->map()), {transientEntityNode}}});
+      document->map(), {{&mdl::parentForNodes(document->map()), {transientEntityNode}}});
     REQUIRE(
       document->map().worldNode().defaultLayer()->children()
       == std::vector<mdl::Node*>{transientEntityNode});

--- a/lib/TbUiLib/test/src/tst_RotateTool.cpp
+++ b/lib/TbUiLib/test/src/tst_RotateTool.cpp
@@ -56,7 +56,7 @@ TEST_CASE("RotateTool")
     auto* entityNode2 = new mdl::EntityNode{std::move(entity2)};
     auto* brushNode = createBrushNode(map);
 
-    addNodes(map, {{parentForNodes(map), {entityNode1, entityNode2, brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode1, entityNode2, brushNode}}});
 
     SECTION("If nothing is selected")
     {

--- a/lib/TbUiLib/test/src/tst_ScaleTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ScaleTool.cpp
@@ -46,7 +46,7 @@ TEST_CASE("ScaleTool")
   auto* entityNode = new mdl::EntityNode{mdl::Entity{}};
   auto* brushNode = mdl::createBrushNode(map);
   auto* patchNode = mdl::createPatchNode("some_material");
-  mdl::addNodes(map, {{mdl::parentForNodes(map), {brushNode, entityNode, patchNode}}});
+  mdl::addNodes(map, {{&mdl::parentForNodes(map), {brushNode, entityNode, patchNode}}});
 
   auto nodes = std::vector<mdl::Node*>{entityNode, brushNode, patchNode};
   constexpr size_t iEntityNode = 0;

--- a/lib/TbUiLib/test/src/tst_SelectionTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SelectionTool.cpp
@@ -75,7 +75,7 @@ TEST_CASE("SelectionTool")
       auto* entityNode = new mdl::EntityNode{mdl::Entity{{{"origin", "64 0 0"}}}};
       auto* groupNode = new mdl::GroupNode(mdl::Group{"some_group"});
 
-      addNodes(map, {{parentForNodes(map), {groupNode}}});
+      addNodes(map, {{&parentForNodes(map), {groupNode}}});
       addNodes(map, {{groupNode, {brushNode, entityNode}}});
 
       auto camera = gl::OrthographicCamera{};
@@ -144,7 +144,7 @@ TEST_CASE("SelectionTool")
 
       auto* entityNode = new mdl::EntityNode{mdl::Entity{{{"origin", "64 0 0"}}}};
 
-      addNodes(map, {{parentForNodes(map), {brushNode, entityNode}}});
+      addNodes(map, {{&parentForNodes(map), {brushNode, entityNode}}});
 
       auto camera = gl::OrthographicCamera{};
 
@@ -336,7 +336,7 @@ TEST_CASE("SelectionTool")
               | kdl::value();
 
             auto* coplanarBrushNode = new mdl::BrushNode{std::move(coplanarBrush)};
-            addNodes(map, {{parentForNodes(map), {coplanarBrushNode}}});
+            addNodes(map, {{&parentForNodes(map), {coplanarBrushNode}}});
 
             const auto coplanarTopFaceIndex =
               *coplanarBrushNode->brush().findFace("top_face");
@@ -557,7 +557,7 @@ TEST_CASE("SelectionTool")
       auto* hiddenBrushNode = new mdl::BrushNode{std::move(hiddenBrush)};
       const auto hiddenTopFaceIndex = *hiddenBrushNode->brush().findFace("top_face");
 
-      addNodes(map, {{parentForNodes(map), {visibleBrushNode, hiddenBrushNode}}});
+      addNodes(map, {{&parentForNodes(map), {visibleBrushNode, hiddenBrushNode}}});
 
       const auto hiddenTag = mdl::Tag{"hidden", {}};
       auto taggedBrush = hiddenBrushNode->brush();

--- a/lib/TbUiLib/test/src/tst_ShearTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ShearTool.cpp
@@ -50,7 +50,7 @@ TEST_CASE("ShearTool")
   auto* entityNode = new mdl::EntityNode{mdl::Entity{}};
   auto* brushNode = mdl::createBrushNode(map);
   auto* patchNode = mdl::createPatchNode("some_material");
-  mdl::addNodes(map, {{mdl::parentForNodes(map), {brushNode, entityNode, patchNode}}});
+  mdl::addNodes(map, {{&mdl::parentForNodes(map), {brushNode, entityNode, patchNode}}});
 
   auto nodes = std::vector<mdl::Node*>{entityNode, brushNode, patchNode};
   constexpr size_t iEntityNode = 0;

--- a/lib/TbUiLib/test/src/tst_SweepTool.cpp
+++ b/lib/TbUiLib/test/src/tst_SweepTool.cpp
@@ -55,7 +55,7 @@ TEST_CASE("SweepTool")
   SECTION("applies")
   {
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     CHECK(!tool.applies());
 
@@ -76,7 +76,7 @@ TEST_CASE("SweepTool")
   SECTION("with a selected face")
   {
     auto* brushNode = createBrushNode(map);
-    addNodes(map, {{parentForNodes(map), {brushNode}}});
+    addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
     const auto faceIndex = *brushNode->brush().findFace(vm::vec3d{1, 0, 0});
     selectBrushFaces(map, {{brushNode, faceIndex}});
@@ -202,7 +202,7 @@ TEST_CASE("SweepTool")
   SECTION("removing the source face's parent while the tool is active")
   {
     auto* entityNode = new mdl::EntityNode{mdl::Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
     auto* brushNode = createBrushNode(map);
     addNodes(map, {{entityNode, {brushNode}}});
@@ -217,7 +217,7 @@ TEST_CASE("SweepTool")
     removeNodes(map, {entityNode});
 
     // the generated brushes fall back to the map's default insertion parent
-    auto* defaultParent = parentForNodes(map);
+    auto* defaultParent = &parentForNodes(map);
     const auto childCountBefore = defaultParent->childCount();
 
     tool.commitSweep();
@@ -228,13 +228,13 @@ TEST_CASE("SweepTool")
     "sweeping faces with cancelling normals falls back to a straight path in S-Bend mode")
   {
     auto* entityNode = new mdl::EntityNode{mdl::Entity{}};
-    addNodes(map, {{parentForNodes(map), {entityNode}}});
+    addNodes(map, {{&parentForNodes(map), {entityNode}}});
 
     auto* brushNodeA = createBrushNode(map);
     addNodes(map, {{entityNode, {brushNodeA}}});
     const auto entityChildCountBefore = entityNode->childCount();
 
-    auto* defaultParent = parentForNodes(map);
+    auto* defaultParent = &parentForNodes(map);
     auto* brushNodeB = createBrushNode(map);
     addNodes(map, {{defaultParent, {brushNodeB}}});
     const auto defaultChildCountBefore = defaultParent->childCount();

--- a/lib/TbUiLib/test/src/tst_SweepToolUtils.cpp
+++ b/lib/TbUiLib/test/src/tst_SweepToolUtils.cpp
@@ -223,7 +223,7 @@ TEST_CASE("generateSweepBrushes")
   auto& document = fixture.create();
   auto& map = document.map();
 
-  auto* defaultParent = parentForNodes(map);
+  auto& defaultParent = parentForNodes(map);
 
   const auto squareAt = [](const double x) {
     return vm::polygon3d{
@@ -235,7 +235,7 @@ TEST_CASE("generateSweepBrushes")
   };
 
   auto source = SweepSource{
-    {SweepFace{squareAt(0.0), defaultParent}},
+    {SweepFace{squareAt(0.0), &defaultParent}},
     vm::vec3d{0, 0, 0},
     vm::vec3d{1, 0, 0},
     vm::vec3d{0, 16, 16},
@@ -251,7 +251,7 @@ TEST_CASE("generateSweepBrushes")
     const auto result = generateSweepBrushes(map, source, transform, parameters);
     REQUIRE(result.size() == 1);
 
-    const auto& brushes = result.at(defaultParent);
+    const auto& brushes = result.at(&defaultParent);
     REQUIRE(brushes.size() == 4);
     CHECK(brushes[0]->logicalBounds() == vm::bbox3d{{0, -16, -16}, {16, 16, 16}});
     CHECK(brushes[3]->logicalBounds() == vm::bbox3d{{48, -16, -16}, {64, 16, 16}});
@@ -265,7 +265,7 @@ TEST_CASE("generateSweepBrushes")
 
     const auto result = generateSweepBrushes(map, source, transform, parameters);
 
-    const auto& brushes = result.at(defaultParent);
+    const auto& brushes = result.at(&defaultParent);
     REQUIRE(brushes.size() == 4);
     CHECK(brushes[3]->logicalBounds() == vm::bbox3d{{96, -16, -16}, {128, 16, 16}});
   }
@@ -273,7 +273,7 @@ TEST_CASE("generateSweepBrushes")
   SECTION("groups the brushes by the parent of their source face")
   {
     auto* entityNode = new mdl::EntityNode{mdl::Entity{}};
-    addNodes(map, {{defaultParent, {entityNode}}});
+    addNodes(map, {{&defaultParent, {entityNode}}});
 
     source.faces = {
       SweepFace{squareAt(0.0), entityNode},
@@ -286,12 +286,12 @@ TEST_CASE("generateSweepBrushes")
     REQUIRE(result.size() == 2);
     CHECK(result.at(entityNode).size() == 2);
     // a face without a parent falls back to the map's default insertion parent
-    CHECK(result.at(defaultParent).size() == 2);
+    CHECK(result.at(&defaultParent).size() == 2);
   }
 
   SECTION("integer alignment keeps the source station exact and rounds the rest")
   {
-    source.faces = {SweepFace{squareAt(0.25), defaultParent}};
+    source.faces = {SweepFace{squareAt(0.25), &defaultParent}};
     source.center = vm::vec3d{0.25, 0, 0};
     transform.translation = vm::vec3d{16, 0, 0};
     parameters.segments = 2;
@@ -300,7 +300,7 @@ TEST_CASE("generateSweepBrushes")
     // the stations sit at x = 0.25 (exact), round(8.25) = 8 and round(16.25) = 16
     const auto result = generateSweepBrushes(map, source, transform, parameters);
 
-    const auto& brushes = result.at(defaultParent);
+    const auto& brushes = result.at(&defaultParent);
     REQUIRE(brushes.size() == 2);
     CHECK(brushes[0]->logicalBounds() == vm::bbox3d{{0.25, -16, -16}, {8, 16, 16}});
     CHECK(brushes[1]->logicalBounds() == vm::bbox3d{{8, -16, -16}, {16, 16, 16}});
@@ -317,7 +317,7 @@ TEST_CASE("generateSweepBrushes")
 
     const auto result = generateSweepBrushes(map, source, transform, parameters);
 
-    const auto& brushes = result.at(defaultParent);
+    const auto& brushes = result.at(&defaultParent);
     REQUIRE(brushes.size() == 2);
     CHECK(brushes[0]->logicalBounds() == vm::bbox3d{{0, -16, -16}, {16, 16, 16}});
     CHECK(brushes[1]->logicalBounds() == vm::bbox3d{{16, -16, -16}, {31, 16, 16}});
@@ -332,7 +332,7 @@ TEST_CASE("generateSweepBrushes")
     // rounding collapses the second segment: the stations sit at x = 0, 1 and 1
     const auto result = generateSweepBrushes(map, source, transform, parameters);
 
-    const auto& brushes = result.at(defaultParent);
+    const auto& brushes = result.at(&defaultParent);
     REQUIRE(brushes.size() == 1);
     CHECK(brushes[0]->logicalBounds() == vm::bbox3d{{0, -16, -16}, {1, 16, 16}});
   }


### PR DESCRIPTION
Closes #5383. Patches can be part of brush entities. This PR

- adds support for creating a brush entity from a selection that contains patches,
- adds support for moving a structural patch to an existing brush entity,
- adds support for making a patch that is part of a brush entity structural again.

