### PR TITLE
Improve shared edge extrude

### DIFF
--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -50,6 +50,7 @@
 #include "kd/result_fold.h"
 
 #include "vm/distance.h"
+#include "vm/intersection.h"
 #include "vm/line_io.h"  // IWYU pragma: keep
 #include "vm/plane_io.h" // IWYU pragma: keep
 #include "vm/polygon.h"
@@ -223,12 +224,11 @@ std::vector<EdgeInfo> findHorizonEdges(
 }
 
 /**
- * Returns true if the horizon edge's cylindrical handle (with the same radius as the
- * vertex handles) is grabbed and should take priority over the given direct brush face
+ * Returns true if the given edge should take priority over the given direct brush face
  * hit. The edge's own adjacent face never steals the handle; a different, occluding face
  * only wins if it is nearer along the ray than the edge.
  */
-bool preferEdgeHandle(
+bool edgeHandleWinsOverFace(
   const gl::Camera& camera,
   const vm::ray3d& pickRay,
   const EdgeInfo& edgeInfo,
@@ -236,10 +236,7 @@ bool preferEdgeHandle(
 {
   const auto edgeDistance = camera.pickLineSegmentHandle(
     pickRay, edgeInfo.segment, pref(Preferences::HandleRadius));
-  if (!edgeDistance)
-  {
-    return false;
-  }
+  contract_assert(edgeDistance);
 
   const auto faceHandle = hitToFaceHandle(faceHit);
   const auto hitIsAdjacentFace =
@@ -249,21 +246,71 @@ bool preferEdgeHandle(
 }
 
 /**
+ * Returns true if some edge of a brush other than excludeBrush is collinear with, and
+ * genuinely overlaps (shares more than a single point with), the given segment. Unlike a
+ * horizon edge, the partner edge does not itself need to pass the front/back-facing test:
+ * at a seam between two flush brushes, only the brush whose own face pair straddles the
+ * silhouette (one face visible, one hidden) produces a horizon edge there; the other
+ * brush's coincident edge typically has both of its adjacent faces on the same side of
+ * that test (their shared visibility ignores that the near brush occludes it), so it is
+ * never classified as a horizon edge itself. Its mere existence as a plain, overlapping
+ * edge belonging to a different brush is what proves the seam is real.
+ */
+bool hasOverlappingEdgeInOtherBrush(
+  const std::vector<mdl::Node*>& nodes,
+  const mdl::BrushNode* excludeBrush,
+  const vm::segment3d& segment)
+{
+  auto eligibleNodes =
+    nodes | std::views::filter([&](const auto* node) { return node != excludeBrush; });
+
+  return std::ranges::any_of(eligibleNodes, [&](const auto* node) {
+    return node->accept(kdl::overload(
+      [](const mdl::WorldNode&) { return false; },
+      [](const mdl::LayerNode&) { return false; },
+      [](const mdl::GroupNode&) { return false; },
+      [](const mdl::EntityNode&) { return false; },
+      [&](const mdl::BrushNode& brushNode) {
+        return std::ranges::any_of(brushNode.brush().edges(), [&](const auto* edge) {
+          return vm::segments_overlap(segment, edge->segment(), vm::Cd::almost_zero());
+        });
+      },
+      [](const mdl::PatchNode&) { return false; }));
+  });
+}
+
+/**
  * Returns the horizon edge, if any, that should override the given direct brush face hit.
- * Of the given candidates, picks the closest one and defers to preferEdgeHandle to decide
- * whether it should win.
+ * A single nearby horizon edge is never enough on its own -- it is only eligible if it is
+ * within the full handle radius *and* some other brush has a plain edge that is collinear
+ * with, and genuinely overlaps, it. This is the geometric signature of two separate
+ * brushes meeting flush at a seam, which is what makes the touching-face feature possible
+ * in the first place; a face's own distinct edges merely clustering near the cursor does
+ * not qualify, since they all belong to the same brush. Of the eligible edges, the
+ * closest one still has to win out over a closer, non-adjacent occluding face.
  */
 std::optional<EdgeInfo> selectOverridingEdge(
+  const std::vector<mdl::Node*>& nodes,
   const gl::Camera& camera,
   const vm::ray3d& pickRay,
   const std::vector<EdgeInfo>& edgeInfos,
   const mdl::Hit& faceHit)
 {
-  const auto closest = std::ranges::min_element(edgeInfos);
-  return closest != edgeInfos.end()
-             && preferEdgeHandle(camera, pickRay, *closest, faceHit)
-           ? std::optional{*closest}
-           : std::nullopt;
+  auto eligible = edgeInfos | std::views::filter([&](const auto& edgeInfo) {
+                    return camera.pickLineSegmentHandle(
+                             pickRay, edgeInfo.segment, pref(Preferences::HandleRadius))
+                           && hasOverlappingEdgeInOtherBrush(
+                             nodes, edgeInfo.leftFaceHandle.node(), edgeInfo.segment);
+                  });
+
+  if (eligible.empty())
+  {
+    return std::nullopt;
+  }
+
+  const auto& winner = *std::ranges::min_element(eligible);
+  return edgeHandleWinsOverFace(camera, pickRay, winner, faceHit) ? std::optional{winner}
+                                                                  : std::nullopt;
 }
 
 std::vector<ExtrudeDragHandle> getDragHandles(
@@ -560,8 +607,10 @@ mdl::Hit ExtrudeTool::pick2D(
   if (hit.isMatch())
   {
     // The cursor is over a brush face. Only engage if a horizon edge handle is grabbed.
-    const auto edgeInfos = findHorizonEdges(m_document.map().selection().nodes, pickRay);
-    if (const auto edgeInfo = selectOverridingEdge(camera, pickRay, edgeInfos, hit))
+    const auto& nodes = m_document.map().selection().nodes;
+    const auto edgeInfos = findHorizonEdges(nodes, pickRay);
+    if (
+      const auto edgeInfo = selectOverridingEdge(nodes, camera, pickRay, edgeInfos, hit))
     {
       return makeEdgeHit(*edgeInfo);
     }
@@ -611,8 +660,10 @@ mdl::Hit ExtrudeTool::pick3D(
   if (faceHandle)
   {
     // The cursor is over a brush face. Prefer it unless a horizon edge handle is grabbed.
-    const auto edgeInfos = findHorizonEdges(m_document.map().selection().nodes, pickRay);
-    if (const auto edgeInfo = selectOverridingEdge(camera, pickRay, edgeInfos, hit))
+    const auto& nodes = m_document.map().selection().nodes;
+    const auto edgeInfos = findHorizonEdges(nodes, pickRay);
+    if (
+      const auto edgeInfo = selectOverridingEdge(nodes, camera, pickRay, edgeInfos, hit))
     {
       return makeEdgeHit(*edgeInfo);
     }

--- a/lib/TbUiLib/src/ExtrudeTool.cpp
+++ b/lib/TbUiLib/src/ExtrudeTool.cpp
@@ -55,6 +55,7 @@
 #include "vm/polygon.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
+#include <algorithm>
 #include <map>
 #include <ranges>
 #include <vector>
@@ -192,6 +193,36 @@ std::optional<EdgeInfo> findClosestHorizonEdge(
 }
 
 /**
+ * Returns every horizon edge of the given nodes (i.e. all candidates that could possibly
+ * compete for the edge handle at the current pick ray), unlike findClosestHorizonEdge,
+ * which only returns the single closest one.
+ */
+std::vector<EdgeInfo> findHorizonEdges(
+  const std::vector<mdl::Node*>& nodes, const vm::ray3d& pickRay)
+{
+  auto result = std::vector<EdgeInfo>{};
+  for (auto* node : nodes)
+  {
+    node->accept(kdl::overload(
+      [](mdl::WorldNode&) {},
+      [](mdl::LayerNode&) {},
+      [](mdl::GroupNode&) {},
+      [](mdl::EntityNode&) {},
+      [&](mdl::BrushNode& brushNode) {
+        for (const auto* edge : brushNode.brush().edges())
+        {
+          if (auto edgeInfo = getEdgeInfo(edge, brushNode, pickRay))
+          {
+            result.push_back(std::move(*edgeInfo));
+          }
+        }
+      },
+      [](mdl::PatchNode&) {}));
+  }
+  return result;
+}
+
+/**
  * Returns true if the horizon edge's cylindrical handle (with the same radius as the
  * vertex handles) is grabbed and should take priority over the given direct brush face
  * hit. The edge's own adjacent face never steals the handle; a different, occluding face
@@ -215,6 +246,24 @@ bool preferEdgeHandle(
     faceHandle
     && (*faceHandle == edgeInfo.leftFaceHandle || *faceHandle == edgeInfo.rightFaceHandle);
   return hitIsAdjacentFace || *edgeDistance <= faceHit.distance();
+}
+
+/**
+ * Returns the horizon edge, if any, that should override the given direct brush face hit.
+ * Of the given candidates, picks the closest one and defers to preferEdgeHandle to decide
+ * whether it should win.
+ */
+std::optional<EdgeInfo> selectOverridingEdge(
+  const gl::Camera& camera,
+  const vm::ray3d& pickRay,
+  const std::vector<EdgeInfo>& edgeInfos,
+  const mdl::Hit& faceHit)
+{
+  const auto closest = std::ranges::min_element(edgeInfos);
+  return closest != edgeInfos.end()
+             && preferEdgeHandle(camera, pickRay, *closest, faceHit)
+           ? std::optional{*closest}
+           : std::nullopt;
 }
 
 std::vector<ExtrudeDragHandle> getDragHandles(
@@ -507,19 +556,20 @@ mdl::Hit ExtrudeTool::pick2D(
   };
 
   const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
-  const auto edgeInfo =
-    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
 
   if (hit.isMatch())
   {
     // The cursor is over a brush face. Only engage if a horizon edge handle is grabbed.
-    if (edgeInfo && preferEdgeHandle(camera, pickRay, *edgeInfo, hit))
+    const auto edgeInfos = findHorizonEdges(m_document.map().selection().nodes, pickRay);
+    if (const auto edgeInfo = selectOverridingEdge(camera, pickRay, edgeInfos, hit))
     {
       return makeEdgeHit(*edgeInfo);
     }
     return mdl::Hit::NoHit;
   }
 
+  const auto edgeInfo =
+    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
   if (!edgeInfo)
   {
     return mdl::Hit::NoHit;
@@ -557,13 +607,12 @@ mdl::Hit ExtrudeTool::pick3D(
 
   const auto& hit = pickResult.first(type(mdl::BrushNode::BrushHitType) && selected());
   const auto faceHandle = hitToFaceHandle(hit);
-  const auto edgeInfo =
-    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
 
   if (faceHandle)
   {
     // The cursor is over a brush face. Prefer it unless a horizon edge handle is grabbed.
-    if (edgeInfo && preferEdgeHandle(camera, pickRay, *edgeInfo, hit))
+    const auto edgeInfos = findHorizonEdges(m_document.map().selection().nodes, pickRay);
+    if (const auto edgeInfo = selectOverridingEdge(camera, pickRay, edgeInfos, hit))
     {
       return makeEdgeHit(*edgeInfo);
     }
@@ -577,6 +626,8 @@ mdl::Hit ExtrudeTool::pick3D(
         hit.hitPoint()}};
   }
 
+  const auto edgeInfo =
+    findClosestHorizonEdge(m_document.map().selection().nodes, pickRay);
   if (!edgeInfo)
   {
     return mdl::Hit::NoHit;

--- a/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ExtrudeTool.cpp
@@ -478,6 +478,76 @@ TEST_CASE("ExtrudeTool")
       UnorderedRangeEquals(std::vector<vm::vec3d>{{1, 0, 0}, {-1, 0, 0}}));
   }
 
+  SECTION("A single brush's own edge does not override its adjacent face")
+  {
+    using namespace mdl::HitFilters;
+
+    auto& document = fixture.create();
+    auto& map = document.map();
+
+    auto tool = ExtrudeTool{document};
+
+    auto builder = mdl::BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
+
+    // A single brush with no touching neighbor. Its own top/+Y edge is still a horizon
+    // edge for this ray (top face visible, +Y face back facing) and is within the handle
+    // radius of the seam's top edge -- the same ray used in "edge handle wins over the
+    // adjacent face it shares" above, which does have a touching backBrush. With no other
+    // brush to prove this is a genuine touching seam, the face must win instead of the
+    // edge.
+    auto* frontBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, -16, -16}, {16, 16, 16}}, "material")
+      | kdl::value()};
+
+    addNodes(map, {{map.editorContext().currentLayer(), {frontBrush}}});
+    selectNodes(map, {frontBrush});
+
+    const auto pickRay = vm::ray3d{{0, -556, 586}, vm::normalize(vm::vec3d{0, 1, -1})};
+
+    const auto pickResult = performPick(map, tool, pickRay);
+
+    const auto extrudeHit = pickResult.first(type(ExtrudeTool::ExtrudeHitType));
+    CHECK(
+      extrudeHit.target<ExtrudeHitData>().face
+      == mdl::BrushFaceHandle{
+        frontBrush, *frontBrush->brush().findFace(vm::vec3d{0, 0, 1})});
+  }
+
+  SECTION("A non-collinear edge of a different touching brush does not override the face")
+  {
+    using namespace mdl::HitFilters;
+
+    auto& document = fixture.create();
+    auto& map = document.map();
+
+    auto tool = ExtrudeTool{document};
+
+    auto builder = mdl::BrushBuilder{map.worldNode().mapFormat(), map.worldBounds()};
+
+    auto* frontBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{-16, -16, -16}, {16, 16, 16}}, "material")
+      | kdl::value()};
+
+    // Touches frontBrush's +X face, at a right angle to the +Y seam edge under test, so
+    // its edges are not collinear with it and cannot prove that edge is a genuine seam.
+    auto* sideBrush = new mdl::BrushNode{
+      builder.createCuboid(vm::bbox3d{{16, -16, -16}, {48, 16, 16}}, "material")
+      | kdl::value()};
+
+    addNodes(map, {{map.editorContext().currentLayer(), {frontBrush, sideBrush}}});
+    selectNodes(map, {frontBrush, sideBrush});
+
+    const auto pickRay = vm::ray3d{{0, -556, 586}, vm::normalize(vm::vec3d{0, 1, -1})};
+
+    const auto pickResult = performPick(map, tool, pickRay);
+
+    const auto extrudeHit = pickResult.first(type(ExtrudeTool::ExtrudeHitType));
+    CHECK(
+      extrudeHit.target<ExtrudeHitData>().face
+      == mdl::BrushFaceHandle{
+        frontBrush, *frontBrush->brush().findFace(vm::vec3d{0, 0, 1})});
+  }
+
   SECTION("findDragFaces")
   {
     // https://github.com/TrenchBroom/TrenchBroom/issues/3726


### PR DESCRIPTION
https://github.com/TrenchBroom/TrenchBroom/pull/5348 introduced the ability to extrude brushes with touching faces. To make it more useful, we also introduced the ability to select a shared face by hovering the edge, however, this makes extruding single brushes a bit less useful because when near an edge, the edge gets selected over the face that is under the mouse.

This PR limits this new behavior to situations where edges of selected brushes genuinely overlap.

Closes #5395.