### PR TITLE
Fix build errors in tests

### DIFF
--- a/lib/TbMdlLib/test/src/tst_Map_CopyPaste.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_CopyPaste.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Map_CopyPaste")
       // https://github.com/TrenchBroom/TrenchBroom/issues/5367
 
       auto* patchNode = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
       selectNodes(map, {patchNode});
 
       CHECK(serializeSelectedNodes(map) != R"()");
@@ -364,7 +364,7 @@ common/caulk
       auto& map = fixture.create({.mapFormat = MapFormat::Quake3});
 
       auto* patchNode = createPatchNode();
-      addNodes(map, {{parentForNodes(map), {patchNode}}});
+      addNodes(map, {{&parentForNodes(map), {patchNode}}});
       selectNodes(map, {patchNode});
 
       const auto copied = serializeSelectedNodes(map);

--- a/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Selection.cpp
@@ -634,7 +634,7 @@ TEST_CASE("Map_Selection")
 
     addNodes(
       map,
-      {{parentForNodes(map),
+      {{&parentForNodes(map),
         {pointEntityNode, otherPointEntityNode, brushNode, groupNode, brushEntityNode}}});
     addNodes(map, {{groupNode, {groupedEntityNode, otherGroupedEntityNode}}});
     addNodes(map, {{brushEntityNode, {entityBrushNode}}});

--- a/lib/TbUiLib/test/src/tst_ControlPointTool.cpp
+++ b/lib/TbUiLib/test/src/tst_ControlPointTool.cpp
@@ -72,7 +72,7 @@ TEST_CASE("ControlPointTool")
   SECTION("pick")
   {
     auto* patchNode = mdl::createPatchNode();
-    mdl::addNodes(map, {{mdl::parentForNodes(map), {patchNode}}});
+    mdl::addNodes(map, {{&mdl::parentForNodes(map), {patchNode}}});
     mdl::selectNodes(map, {patchNode});
 
     auto tool = ControlPointTool{document};
@@ -126,7 +126,7 @@ TEST_CASE("ControlPointTool")
   SECTION("handlePositionAndHitPoint")
   {
     auto* patchNode = mdl::createPatchNode();
-    mdl::addNodes(map, {{mdl::parentForNodes(map), {patchNode}}});
+    mdl::addNodes(map, {{&mdl::parentForNodes(map), {patchNode}}});
     mdl::selectNodes(map, {patchNode});
 
     auto tool = ControlPointTool{document};
@@ -151,7 +151,7 @@ TEST_CASE("ControlPointTool")
   {
     auto* patchNode1 = mdl::createPatchNode();
     auto* patchNode2 = createOffsetPatchNode();
-    mdl::addNodes(map, {{mdl::parentForNodes(map), {patchNode1, patchNode2}}});
+    mdl::addNodes(map, {{&mdl::parentForNodes(map), {patchNode1, patchNode2}}});
     mdl::selectNodes(map, {patchNode1});
 
     auto tool = ControlPointTool{document};
@@ -173,7 +173,7 @@ TEST_CASE("ControlPointTool")
   {
     auto* patchNode1 = mdl::createPatchNode();
     auto* patchNode2 = createOffsetPatchNode();
-    mdl::addNodes(map, {{mdl::parentForNodes(map), {patchNode1, patchNode2}}});
+    mdl::addNodes(map, {{&mdl::parentForNodes(map), {patchNode1, patchNode2}}});
     mdl::selectNodes(map, {patchNode1, patchNode2});
 
     auto tool = ControlPointTool{document};
@@ -194,7 +194,7 @@ TEST_CASE("ControlPointTool")
   SECTION("move")
   {
     auto* patchNode = mdl::createPatchNode();
-    mdl::addNodes(map, {{mdl::parentForNodes(map), {patchNode}}});
+    mdl::addNodes(map, {{&mdl::parentForNodes(map), {patchNode}}});
     mdl::selectNodes(map, {patchNode});
 
     auto tool = ControlPointTool{document};


### PR DESCRIPTION
parentForNodes now returns by reference, but some new tests didn't have this change yet, and when I merged them all without rebasing, the new tests broke.