### PR TITLE
Fix flaky preference save-delay test on Windows

### DIFF
--- a/lib/TbUiLib/src/QPreferenceStoreDelegate.cpp
+++ b/lib/TbUiLib/src/QPreferenceStoreDelegate.cpp
@@ -96,6 +96,10 @@ QPreferenceStoreDelegate::QPreferenceStoreDelegate(
 {
   m_saveTimer->setSingleShot(true);
   m_saveTimer->setInterval(saveDelay);
+  // Qt::CoarseTimer (the default) may fire up to 5% early to align with other pending
+  // timers, which made the "preferences are saved after a delay" tests flaky on Windows,
+  // where the effective inaccuracy is even larger
+  m_saveTimer->setTimerType(Qt::PreciseTimer);
 
   connect(m_saveTimer, &QTimer::timeout, this, [&]() {
     qDebug() << "Saving preferences after timeout";

--- a/lib/TbUiLib/test/src/tst_QPreferenceStore.cpp
+++ b/lib/TbUiLib/test/src/tst_QPreferenceStore.cpp
@@ -172,8 +172,8 @@ TEST_CASE("QPreferenceStore")
     CHECK(!env.fileExists(preferenceFilename));
   }
 
-  // Qt's coarse timers may fire up to 5% early, so lower bounds on the save delay must
-  // be checked with some tolerance
+  // even with Qt::PreciseTimer, a loaded machine may cause the timer to fire slightly
+  // early, so lower bounds on the save delay must be checked with some tolerance
   const auto notBefore = [](const auto saveTime, const auto saveDelay) {
     return std::chrono::steady_clock::now() >= saveTime + (saveDelay * 9) / 10;
   };


### PR DESCRIPTION
QPreferenceStoreDelegate's save timer used Qt::CoarseTimer, which may fire up to 5% early to batch with other pending timers. The effective inaccuracy on Windows CI exceeded the test's 10% tolerance, causing "preferences are saved after a delay" to fail intermittently. Switch the timer to Qt::PreciseTimer to fix the underlying imprecision rather than further loosening the test's tolerance.