### PR TITLE
Improve keyboard shortcut table in preferences

### DIFF
--- a/lib/TbUiLib/src/KeyboardPreferencePane.cpp
+++ b/lib/TbUiLib/src/KeyboardPreferencePane.cpp
@@ -52,18 +52,18 @@ KeyboardPreferencePane::KeyboardPreferencePane(
 {
   m_proxy->setSourceModel(m_model);
   m_proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
-  m_proxy->setFilterKeyColumn(3); // Filter based on the text in the Description column
+  m_proxy->setFilterKeyColumn(0); // Filter based on the text in the Description column
 
   m_table->setModel(m_proxy);
 
   m_table->setHorizontalHeader(new QHeaderView(Qt::Horizontal));
-  m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::Fixed);
-  m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Fixed);
-  m_table->horizontalHeader()->resizeSection(0, 100);
-  m_table->horizontalHeader()->resizeSection(1, 100);
+  m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeMode::Fixed);
+  m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeMode::Fixed);
+  m_table->horizontalHeader()->resizeSection(2, 100);
+  m_table->horizontalHeader()->resizeSection(3, 100);
   m_table->horizontalHeader()->setSectionResizeMode(
-    2, QHeaderView::ResizeMode::ResizeToContents);
-  m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeMode::Stretch);
+    0, QHeaderView::ResizeMode::ResizeToContents);
+  m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Stretch);
 
   // Tighter than default vertical row height, without the overhead of autoresizing
   m_table->verticalHeader()->setDefaultSectionSize(

--- a/lib/TbUiLib/src/KeyboardShortcutModel.cpp
+++ b/lib/TbUiLib/src/KeyboardShortcutModel.cpp
@@ -35,6 +35,8 @@
 
 #include "kd/contracts.h"
 #include "kd/path_utils.h"
+#include "kd/ranges/join_with_view.h"
+#include "kd/ranges/to.h"
 #include "kd/set_adapter.h"
 #include "kd/vector_utils.h"
 
@@ -83,13 +85,13 @@ QVariant KeyboardShortcutModel::headerData(
     switch (section)
     {
     case 0:
-      return QString{"Shortcut"};
-    case 1:
-      return QString{"Alternative"};
-    case 2:
-      return QString{"Context"};
-    case 3:
       return QString{"Description"};
+    case 1:
+      return QString{"Context"};
+    case 2:
+      return QString{"Shortcut"};
+    case 3:
+      return QString{"Alternative"};
     }
   }
   return QVariant{};
@@ -110,20 +112,28 @@ QVariant KeyboardShortcutModel::data(const QModelIndex& index, const int role) c
     const auto& keyboardShortcuts =
       prefs.getPendingValue(actionInfo.keyboardShortcutPreference());
 
+    const auto s = std::filesystem::path{"a/b"};
+    const std::string blah =
+      s | std::views::transform([](const auto& e) { return e.string(); })
+      | kdl::views::join_with(std::string{" > "}) | kdl::ranges::to<std::string>();
+
     switch (index.column())
     {
     case 0:
+      return QString::fromStdString(
+        actionInfo.displayPath()
+        | std::views::transform([](const auto& e) { return e.string(); })
+        | kdl::views::join_with(std::string{" » "}) | kdl::ranges::to<std::string>());
+    case 1:
+      return QString::fromStdString(actionContextName(actionInfo.actionContext()));
+    case 2:
       return QVariant::fromValue(
         !keyboardShortcuts.empty() ? toQKeySequence(keyboardShortcuts[0])
                                    : QKeySequence{});
-    case 1:
+    case 3:
       return QVariant::fromValue(
         keyboardShortcuts.size() > 1 ? toQKeySequence(keyboardShortcuts[1])
                                      : QKeySequence{});
-    case 2:
-      return QString::fromStdString(actionContextName(actionInfo.actionContext()));
-    case 3:
-      return QString::fromStdString(actionInfo.displayPath().generic_string());
     }
   }
 
@@ -156,14 +166,14 @@ bool KeyboardShortcutModel::setData(
 
   switch (index.column())
   {
-  case 0:
+  case 2:
     if (keyboardShortcuts.empty())
     {
       keyboardShortcuts.emplace_back();
     }
     keyboardShortcuts[0] = fromQKeySequence(keySequence);
     break;
-  case 1:
+  case 3:
     if (keyboardShortcuts.empty())
     {
       keyboardShortcuts.emplace_back();
@@ -195,8 +205,8 @@ Qt::ItemFlags KeyboardShortcutModel::flags(const QModelIndex& index) const
 
   switch (index.column())
   {
-  case 0:
-  case 1:
+  case 2:
+  case 3:
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
   default:
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable;


### PR DESCRIPTION
We reorder the columns to show the description first, context second, and the two shortcuts at the end. We change how the paths are shown to make them easier to read.