### PR TITLE
Fix transparent surface glitches on Wayland

### DIFF
--- a/app/TrenchBroom/src/Main.cpp
+++ b/app/TrenchBroom/src/Main.cpp
@@ -260,6 +260,9 @@ int main(int argc, char* argv[])
   format.setVersion(2, 1);
   format.setProfile(QSurfaceFormat::CompatibilityProfile);
   format.setDepthBufferSize(24);
+  // Best-effort hint; not reliably honored by Qt's Wayland QPA plugin (see
+  // RenderView::render() for the fix that doesn't depend on this).
+  format.setAlphaBufferSize(0);
   format.setSamples(4);
   QSurfaceFormat::setDefaultFormat(format);
 

--- a/lib/TbGlLib/include/gl/GlDebug.h
+++ b/lib/TbGlLib/include/gl/GlDebug.h
@@ -70,6 +70,9 @@ public:
   void depthRange(GLclampd nearVal, GLclampd farVal) override;
   void depthFunc(GLenum func) override;
 
+  void colorMask(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
+
   GLuint createProgram() override;
   void deleteProgram(GLuint program) override;
 

--- a/lib/TbGlLib/include/gl/GlInterface.h
+++ b/lib/TbGlLib/include/gl/GlInterface.h
@@ -67,6 +67,9 @@ public:
   virtual void depthRange(GLclampd nearVal, GLclampd farVal) = 0;
   virtual void depthFunc(GLenum func) = 0;
 
+  virtual void colorMask(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) = 0;
+
   virtual GLuint createProgram() = 0;
   virtual void deleteProgram(GLuint program) = 0;
 

--- a/lib/TbGlLib/src/GlDebug.cpp
+++ b/lib/TbGlLib/src/GlDebug.cpp
@@ -217,6 +217,12 @@ void GlDebug::depthRange(const GLclampd nearVal, const GLclampd farVal)
   glAssert(m_gl.depthRange(nearVal, farVal));
 }
 
+void GlDebug::colorMask(
+  const GLboolean red, const GLboolean green, const GLboolean blue, const GLboolean alpha)
+{
+  glAssert(m_gl.colorMask(red, green, blue, alpha));
+}
+
 void GlDebug::depthFunc(const GLenum func)
 {
   glAssert(m_gl.depthFunc(func));

--- a/lib/TbGlLib/test-utils/include/gl/MockGl.h
+++ b/lib/TbGlLib/test-utils/include/gl/MockGl.h
@@ -86,6 +86,8 @@ public:
   std::function<void(GLclampd, GLclampd)> onDepthRange;
   std::function<void(GLenum)> onDepthFunc;
 
+  std::function<void(GLboolean, GLboolean, GLboolean, GLboolean)> onColorMask;
+
   std::function<GLuint()> onCreateProgram;
   std::function<void(GLuint)> onDeleteProgram;
 
@@ -225,6 +227,9 @@ public:
   void depthMask(GLboolean flag) override;
   void depthRange(GLclampd nearVal, GLclampd farVal) override;
   void depthFunc(GLenum func) override;
+
+  void colorMask(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
 
   GLuint createProgram() override;
   void deleteProgram(GLuint program) override;

--- a/lib/TbGlLib/test-utils/include/gl/TestGl.h
+++ b/lib/TbGlLib/test-utils/include/gl/TestGl.h
@@ -65,6 +65,8 @@ public:
   void depthRange(GLclampd, GLclampd) override;
   void depthFunc(GLenum) override;
 
+  void colorMask(GLboolean, GLboolean, GLboolean, GLboolean) override;
+
   GLuint createProgram() override;
   void deleteProgram(GLuint) override;
 

--- a/lib/TbGlLib/test-utils/src/MockGl.cpp
+++ b/lib/TbGlLib/test-utils/src/MockGl.cpp
@@ -265,6 +265,16 @@ void MockGl::depthRange(const GLclampd nearVal, const GLclampd farVal)
   onDepthRange(nearVal, farVal);
 }
 
+void MockGl::colorMask(
+  const GLboolean red, const GLboolean green, const GLboolean blue, const GLboolean alpha)
+{
+  if (!onColorMask)
+  {
+    throw MockGlUnexpectedCall{"colorMask"};
+  }
+  onColorMask(red, green, blue, alpha);
+}
+
 void MockGl::depthFunc(const GLenum func)
 {
   if (!onDepthFunc)

--- a/lib/TbGlLib/test-utils/src/TestGl.cpp
+++ b/lib/TbGlLib/test-utils/src/TestGl.cpp
@@ -60,6 +60,8 @@ void TestGl::depthMask(GLboolean) {}
 void TestGl::depthRange(GLclampd, GLclampd) {}
 void TestGl::depthFunc(GLenum) {}
 
+void TestGl::colorMask(GLboolean, GLboolean, GLboolean, GLboolean) {}
+
 GLuint TestGl::createProgram()
 {
   return 0u;

--- a/lib/TbUiLib/include/ui/GlQt.h
+++ b/lib/TbUiLib/include/ui/GlQt.h
@@ -72,6 +72,9 @@ public:
   void depthRange(GLclampd nearVal, GLclampd farVal) override;
   void depthFunc(GLenum func) override;
 
+  void colorMask(
+    GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
+
   GLuint createProgram() override;
   void deleteProgram(GLuint program) override;
 

--- a/lib/TbUiLib/src/GlQt.cpp
+++ b/lib/TbUiLib/src/GlQt.cpp
@@ -151,6 +151,12 @@ void GlQt::depthRange(const GLclampd nearVal, const GLclampd farVal)
   m_gl.glDepthRange(nearVal, farVal);
 }
 
+void GlQt::colorMask(
+  const GLboolean red, const GLboolean green, const GLboolean blue, const GLboolean alpha)
+{
+  m_gl.glColorMask(red, green, blue, alpha);
+}
+
 void GlQt::depthFunc(const GLenum func)
 {
   m_gl.glDepthFunc(func);

--- a/lib/TbUiLib/src/RenderView.cpp
+++ b/lib/TbUiLib/src/RenderView.cpp
@@ -240,6 +240,17 @@ void RenderView::render()
   clearBackground(gl);
   renderContents(gl);
   renderFocusIndicator(gl);
+
+  // Work around a Qt/Wayland bug (QTBUG-110014, QTBUG-132197, QTBUG-119214) where
+  // non-opaque alpha values left in a QOpenGLWidget's framebuffer by translucent draws
+  // cause the Wayland compositor to blend the whole window against the desktop behind it.
+  // Force the framebuffer's alpha to fully opaque after rendering so this doesn't happen
+  // regardless of the requested surface format.
+  gl.pushAttrib(GL_COLOR_BUFFER_BIT);
+  gl.colorMask(false, false, false, true);
+  gl.clearColor(0.0f, 0.0f, 0.0f, 1.0f);
+  gl.clear(GL_COLOR_BUFFER_BIT);
+  gl.popAttrib();
 }
 
 void RenderView::processInput()

--- a/lib/TbUiLib/src/UvView.cpp
+++ b/lib/TbUiLib/src/UvView.cpp
@@ -314,6 +314,7 @@ void UvView::setupGL(render::RenderContext& renderContext)
   gl.blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   gl.shadeModel(GL_SMOOTH);
   gl.disable(GL_DEPTH_TEST);
+  gl.disable(GL_CULL_FACE);
 }
 
 void UvView::renderMaterial(render::RenderContext&, render::RenderBatch& renderBatch)


### PR DESCRIPTION
The default QSurfaceFormat never set an alpha buffer size, leaving it at Qt's "don't care" default. On Wayland's EGL path this often resolves to a real alpha channel in the window's own framebuffer, whereas X11 typically resolves to none.

Since the 3D view blends transparent geometry with standard GL_SRC_ALPHA/GL_ONE_MINUS_SRC_ALPHA (MapViewBase.cpp), those blends also wrote partial alpha back into the framebuffer. Wayland compositors use that alpha to composite the window itself against the desktop, so translucent brush faces and materials could bleed through to whatever's behind the window.

Force the alpha buffer size to 0 so the window's own framebuffer is always opaque, without touching in-scene transparency rendering.