### PR TITLE
Fix layer list visibility icons not updating on isolate

### DIFF
--- a/lib/TbUiLib/src/LayerListBox.cpp
+++ b/lib/TbUiLib/src/LayerListBox.cpp
@@ -61,6 +61,8 @@ LayerListBoxWidget::LayerListBoxWidget(
   m_nameText->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   setInfoStyle(m_infoText);
 
+  m_hiddenButton->setObjectName("LayerListBoxWidget_HiddenButton");
+
   connect(m_omitFromExportButton, &QAbstractButton::clicked, this, [&]() {
     emit layerOmitFromExportToggled(m_layer);
   });
@@ -217,6 +219,10 @@ void LayerListBox::connectObservers()
     m_document.documentWasLoadedNotifier.connect([&] { reloadItems(); });
   m_notifierConnection +=
     m_document.documentDidChangeNotifier.connect([&] { reloadItems(); });
+  m_notifierConnection += m_document.nodeVisibilityDidChangeNotifier.connect(
+    [&](const std::vector<mdl::Node*>&) { updateItems(); });
+  m_notifierConnection += m_document.nodeLockingDidChangeNotifier.connect(
+    [&](const std::vector<mdl::Node*>&) { updateItems(); });
   m_notifierConnection +=
     map.currentLayerDidChangeNotifier.connect([&] { updateItems(); });
 }

--- a/lib/TbUiLib/test/CMakeLists.txt
+++ b/lib/TbUiLib/test/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(TbUiLibTest
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_QVecUtils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_RecentDocuments.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_KeyboardShortcutUtils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_LayerListBox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_SystemPaths.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_TextOutputAdapter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UpdateVersion.cpp

--- a/lib/TbUiLib/test/src/tst_LayerListBox.cpp
+++ b/lib/TbUiLib/test/src/tst_LayerListBox.cpp
@@ -1,0 +1,72 @@
+/*
+ Copyright (C) 2026 Atirna
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QToolButton>
+
+#include "mdl/Layer.h"
+#include "mdl/LayerNode.h"
+#include "mdl/Map.h"
+#include "mdl/Map_Layers.h"
+#include "mdl/Map_Nodes.h"
+#include "mdl/WorldNode.h"
+#include "ui/AppControllerFixture.h"
+#include "ui/CatchConfig.h"
+#include "ui/LayerListBox.h"
+#include "ui/MapDocument.h"
+#include "ui/MapDocumentFixture.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb::ui
+{
+
+TEST_CASE("LayerListBox")
+{
+  auto appControllerFixture = AppControllerFixture{};
+
+  auto documentFixture = MapDocumentFixture{};
+  auto& document = documentFixture.create();
+  auto& map = document.map();
+
+  auto listBox = LayerListBox{document};
+
+  auto* customLayerNode = new mdl::LayerNode{mdl::Layer{"custom layer"}};
+  mdl::addNodes(map, {{&map.worldNode(), {customLayerNode}}});
+
+  SECTION("updates the visibility icon when a layer is isolated")
+  {
+    const auto widgets = listBox.findChildren<LayerListBoxWidget*>();
+    REQUIRE(widgets.size() == 2);
+
+    mdl::isolateLayers(map, {customLayerNode});
+
+    CHECK(map.worldNode().defaultLayer()->hidden());
+    CHECK(!customLayerNode->hidden());
+
+    for (const auto* widget : widgets)
+    {
+      const auto* hiddenButton =
+        widget->findChild<QToolButton*>("LayerListBoxWidget_HiddenButton");
+      REQUIRE(hiddenButton != nullptr);
+      CHECK(hiddenButton->isChecked() == widget->layer()->hidden());
+    }
+  }
+}
+
+} // namespace tb::ui


### PR DESCRIPTION
Isolating a layer hides the other layers, but the layer list only observed
document and current layer changes, so the visibility icons kept showing the
old state until something else forced a refresh.

Fixes #5388

I changed the layer list to also observe the node visibility and locking
notifiers and refresh the item icons when those states change. The lock icons
had the same stale update problem, so I connected that notifier too.

Verification:
- added a LayerListBox test that isolates a layer and checks each row's hidden
  icon against the layer's hidden state. It fails before this change and
  passes after.
