### PR TITLE
Two minor build fixes

### DIFF
--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -49,7 +49,7 @@ cmake .. \
   -DCMAKE_INSTALL_PREFIX=/usr \
   || exit 1
 
-cmake --build . --config Release -- -j $(nproc) || exit 1
+cmake --build . --config Release --parallel || exit 1
 
 # Run tests
 

--- a/CI-macos.sh
+++ b/CI-macos.sh
@@ -56,7 +56,7 @@ cmake .. \
   -DTB_NOTARIZATION_PASSWORD="$TB_NOTARIZATION_PASSWORD" \
   || exit 1
 
-cmake --build . --config "$TB_BUILD_TYPE" || exit 1
+cmake --build . --config "$TB_BUILD_TYPE" --parallel || exit 1
 
 BUILD_DIR=$(pwd)
 ctest --test-dir "$BUILD_DIR" --output-on-failure -j || exit 1

--- a/CI-windows.bat
+++ b/CI-windows.bat
@@ -19,7 +19,7 @@ cmake .. -GNinja -DCMAKE_PREFIX_PATH="%QT_ROOT_DIR%" -DCMAKE_BUILD_TYPE=Release 
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-cmake --build . --config Release
+cmake --build . --config Release --parallel
 
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 

--- a/lib/TbVersionLib/CMakeLists.txt
+++ b/lib/TbVersionLib/CMakeLists.txt
@@ -5,12 +5,26 @@ target_sources(TbVersionLib
     BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/generated
 )
 
-# Create the cmake script for generating the version information
-add_custom_target(TbVersionLib_GenerateVersion ${CMAKE_COMMAND}
-  -D UTILS="${CMAKE_SOURCE_DIR}/cmake/Utils.cmake"
-  -D APP_BUILD_TYPE="${APP_BUILD_TYPE}"
-  -D SRC="${CMAKE_CURRENT_SOURCE_DIR}/include/version/Version.h.in"
-  -D DST="${CMAKE_CURRENT_BINARY_DIR}/generated/version/Version.h"
-  -D GIT_EXECUTABLE="${GIT_EXECUTABLE}"
-  -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateVersion.cmake")
+set(TbVersionLib_GENERATED_HEADER
+  ${CMAKE_CURRENT_BINARY_DIR}/generated/version/Version.h)
+
+# A custom_target's COMMAND always reruns, every build, with no way to opt out -- that's
+# exactly what's wanted here, since the git describe output can change without any
+# tracked input file changing. GenerateVersion.cmake only touches
+# TbVersionLib_GENERATED_HEADER's mtime if its contents actually changed, and declaring
+# it as a BYPRODUCT (rather than leaving it untracked, as a plain custom_target with no
+# BYPRODUCTS did before) gives Ninja a real, restat-tracked graph edge for it: consumers
+# are correctly ordered after this command, but only actually rebuilt when the header's
+# mtime genuinely changes, not on every rerun of the always-dirty target.
+add_custom_target(TbVersionLib_GenerateVersion
+  COMMAND ${CMAKE_COMMAND}
+    -D UTILS=${CMAKE_SOURCE_DIR}/cmake/Utils.cmake
+    -D APP_BUILD_TYPE=${APP_BUILD_TYPE}
+    -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/include/version/Version.h.in
+    -D DST=${TbVersionLib_GENERATED_HEADER}
+    -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateVersion.cmake
+  BYPRODUCTS "${TbVersionLib_GENERATED_HEADER}"
+  COMMENT "Generating version information"
+  VERBATIM)
 add_dependencies(TbVersionLib TbVersionLib_GenerateVersion)


### PR DESCRIPTION
- Fix Version.h racing with its consumers in incremental builds: This could break a build in rare occurrences.
- Run builds in parallel on CI: We already ran the builds in parallel using `-j` on macOS and Linux, but not on Windows. However, I think MSVC also parallelizes builds, but I haven't checked, so this might actually improve CI build times for Windows.