### PR TITLE
Suppress dependency install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Using target_link_library to link an object library to qt requires 3.12
 # 3.14 is required for generator expressions in install(CODE)
-cmake_minimum_required(VERSION 3.25)
+# 3.28 is required for FetchContent_Declare's EXCLUDE_FROM_ALL option, used in
+# cmake/dependencies/ to keep fetched dependencies' own install() rules out of
+# the packaged build.
+cmake_minimum_required(VERSION 3.28)
 
 # Fix warning with Ninja and cotire (see https://github.com/sakra/cotire/issues/81)
 if(POLICY CMP0058)

--- a/app/TrenchBroom/CMakeLists.txt
+++ b/app/TrenchBroom/CMakeLists.txt
@@ -490,13 +490,14 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(CPACK_GENERATOR "External")
 endif()
 
-# FetchContent'd dependencies (cpptrace, tinyxml2, ...) register their own
-# install components (headers, pkgconfig, *_development, Unspecified) for
-# their dev artifacts, none of which belong in a packaged TrenchBroom build.
-# On Linux, having more than one component present also makes CPack stage
-# each into its own <component>/usr/... subdirectory instead of merging them
-# into usr/ directly, which broke linuxdeploy's executable lookup. Restrict
-# packaging to just the component we actually ship, on every platform.
+# FetchContent_Declare(... EXCLUDE_FROM_ALL) on every dependency in
+# cmake/dependencies/ keeps their install() rules from running at all, so no
+# dev artifacts (headers, pkgconfig, *_development, Unspecified components)
+# reach the install tree. This is a second line of defense: on Linux, having
+# more than one component present makes CPack stage each into its own
+# <component>/usr/... subdirectory instead of merging them into usr/
+# directly, which broke linuxdeploy's executable lookup. Restrict packaging
+# to just the component we actually ship, on every platform.
 set(CPACK_COMPONENTS_ALL "TrenchBroom")
 
 include(CPack)

--- a/cmake/dependencies/assimp.cmake
+++ b/cmake/dependencies/assimp.cmake
@@ -4,11 +4,12 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/assimp/assimp
   GIT_TAG        fb375dd8c0a032106a2122815fb18dffe0283721 # v6.0.2
   SYSTEM
+  EXCLUDE_FROM_ALL
   PATCH_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/patches/assimp-strip-msvc-flags.cmake
 )
 
-# We only import models, so skip exporters, tests, tools and samples, and don't
-# install anything. Disable warnings-as-errors so assimp builds under CMake 4.
+# We only import models, so skip exporters, tests, tools and samples. Disable
+# warnings-as-errors so assimp builds under CMake 4.
 set(ASSIMP_NO_EXPORT ON)
 # Use the system zlib (assimp's bundled copy is too old to compile against
 # recent SDKs), but force assimp's bundled minizip/unzip. Otherwise assimp's
@@ -18,7 +19,6 @@ set(ASSIMP_BUILD_MINIZIP ON)
 set(ASSIMP_BUILD_TESTS OFF)
 set(ASSIMP_BUILD_ASSIMP_TOOLS OFF)
 set(ASSIMP_BUILD_SAMPLES OFF)
-set(ASSIMP_INSTALL OFF)
 set(ASSIMP_WARNINGS_AS_ERRORS OFF)
 # assimp otherwise appends "/Zi" to CMAKE_CXX_FLAGS_RELEASE for MSVC to build
 # its own PDBs, which conflicts with the debug-info format this project

--- a/cmake/dependencies/catch2.cmake
+++ b/cmake/dependencies/catch2.cmake
@@ -4,10 +4,9 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/catchorg/Catch2
   GIT_TAG        5af20cabb990f36f1671a6a95aef0e6a4cb2573d # v3.10.0
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
-set(CATCH_INSTALL_DOCS OFF)
-set(CATCH_INSTALL_EXTRAS OFF)
 # Catch2 forces default symbol visibility and warns when a hidden visibility
 # preset is set globally (as this project does). Set it to default around Catch2
 # to avoid the warning; the resulting visibility is identical.

--- a/cmake/dependencies/cpptrace.cmake
+++ b/cmake/dependencies/cpptrace.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace
   GIT_TAG        3db8da80111171c219ab5839905771386bee06b3 # v1.0.4
   SYSTEM
+  EXCLUDE_FROM_ALL
   PATCH_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/patches/cpptrace-strip-msvc-flags.cmake
 )
 

--- a/cmake/dependencies/ctre.cmake
+++ b/cmake/dependencies/ctre.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/hanickadot/compile-time-regular-expressions
   GIT_TAG        e34c26ba149b9fd9c34aa0f678e39739641a0d1e # v3.10.0
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 set(CTRE_BUILD_TESTS OFF)

--- a/cmake/dependencies/fast-float.cmake
+++ b/cmake/dependencies/fast-float.cmake
@@ -4,13 +4,13 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/fastfloat/fast_float
   GIT_TAG        3e57d8dcfb0a04b5a8a26b486b54490a2e9b310f # v6.1.4
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 set(FASTFLOAT_TEST OFF)
-set(FASTFLOAT_INSTALL OFF)
 # fast_float declares an old cmake_minimum_required, which triggers a deprecation
-# warning under CMake 4. Use >= 3.13 so CMP0077 is NEW and the FASTFLOAT_*
-# variables above override fast_float's option() defaults without warnings.
+# warning under CMake 4. Use >= 3.13 so CMP0077 is NEW and the FASTFLOAT_TEST
+# variable above overrides fast_float's option() default without a warning.
 set(CMAKE_POLICY_VERSION_MINIMUM 3.13)
 FetchContent_MakeAvailable(fast_float)
 unset(CMAKE_POLICY_VERSION_MINIMUM)

--- a/cmake/dependencies/fmt.cmake
+++ b/cmake/dependencies/fmt.cmake
@@ -4,11 +4,11 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/fmtlib/fmt
   GIT_TAG        40626af88bd7df9a5fb80be7b25ac85b122d6c21 # 11.2.0
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 set(FMT_DOC OFF)
 set(FMT_TEST OFF)
-set(FMT_INSTALL OFF)
 FetchContent_MakeAvailable(fmt)
 
 suppress_dependency_warnings(fmt)

--- a/cmake/dependencies/freeimage.cmake
+++ b/cmake/dependencies/freeimage.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/danoli3/FreeImage
   GIT_TAG        625117b48e18a82f3f68e9be3514ae584ebfcf7b # 3.19.11
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 # This fork builds all of FreeImage's bundled codecs (zlib, libpng, libjpeg,

--- a/cmake/dependencies/freetype.cmake
+++ b/cmake/dependencies/freetype.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/freetype/freetype
   GIT_TAG        534ad3456055ee1f65ecde3bcf22a656a31514d1 # VER-2-13-3
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 # TrenchBroom only rasterizes TrueType fonts, so build a minimal freetype

--- a/cmake/dependencies/miniz.cmake
+++ b/cmake/dependencies/miniz.cmake
@@ -4,11 +4,12 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/richgel999/miniz
   GIT_TAG        174573d60290f447c13a2b1b3405de2b96e27d6c # 3.1.0
   SYSTEM
+  EXCLUDE_FROM_ALL
   PATCH_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/patches/miniz-strip-msvc-flags.cmake
 )
 
-# miniz's BUILD_EXAMPLES/BUILD_TESTS/INSTALL_PROJECT options already default to
-# off when miniz is built as a subproject, so no configuration is needed.
+# miniz's BUILD_EXAMPLES/BUILD_TESTS options already default to off when miniz
+# is built as a subproject, so no configuration is needed.
 FetchContent_MakeAvailable(miniz)
 
 suppress_dependency_warnings(miniz)

--- a/cmake/dependencies/stduuid.cmake
+++ b/cmake/dependencies/stduuid.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/mariusbancila/stduuid
   GIT_TAG        3afe7193facd5d674de709fccc44d5055e144d7a # v1.2.3
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 # stduuid declares cmake_minimum_required(VERSION 3.7.0), which triggers a

--- a/cmake/dependencies/tinyxml2.cmake
+++ b/cmake/dependencies/tinyxml2.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/leethomason/tinyxml2
   GIT_TAG        1dee28e51f9175a31955b9791c74c430fe13dc82 # 9.0.0
   SYSTEM
+  EXCLUDE_FROM_ALL
 )
 
 set(tinyxml2_BUILD_TESTING OFF)


### PR DESCRIPTION
Dependencies must not execute their install rules, lest we end up with stray include / lib folders in the release zips. Consistently applying EXCLUDE_FROM_ALL makes this problem go away.