### PR TITLE
Don't warn about unquoted default values for float FGD properties

### DIFF
--- a/lib/TbMdlLib/src/FgdParser.cpp
+++ b/lib/TbMdlLib/src/FgdParser.cpp
@@ -989,13 +989,15 @@ std::optional<float> FgdParser::parseDefaultFloatValue(ParserStatus& status)
   if (token.type() == FgdToken::Colon)
   {
     m_tokenizer.nextToken();
-    // the default value should have quotes around it, but sometimes they're missing
+    // the default value should have quotes around it unless it is a whole number with no
+    // decimal point in base10 standard notation
+    // see https://developer.valvesoftware.com/wiki/FGD
     token = m_tokenizer.peekToken(
       FgdToken::String | FgdToken::Decimal | FgdToken::Integer | FgdToken::Colon);
     if (token.type() != FgdToken::Colon)
     {
       token = m_tokenizer.nextToken();
-      if (token.type() != FgdToken::String)
+      if (!token.hasType(FgdToken::String | FgdToken::Integer))
       {
         status.warn(
           token.location(), fmt::format("Unquoted float default value {}", token.data()));

--- a/lib/TbMdlLib/test/src/tst_FgdParser.cpp
+++ b/lib/TbMdlLib/test/src/tst_FgdParser.cpp
@@ -757,6 +757,7 @@ TEST_CASE("FgdParser")
       [
          test(float) : "Some test propertyDefinition" : : "Longer description 1"
          test2(float) : "Some test propertyDefinition with default" : "2.7" : "Longer description 2"
+         test3(float) : "Some test propertyDefinition with integer default" : 2 : "Longer description 3"
       ]
   )";
 
@@ -779,10 +780,15 @@ TEST_CASE("FgdParser")
                mdl::PropertyValueTypes::Float{2.7f},
                "Some test propertyDefinition with default",
                "Longer description 2"},
+              {"test3",
+               mdl::PropertyValueTypes::Float{2.0f},
+               "Some test propertyDefinition with integer default",
+               "Longer description 3"},
             },
             mdl::PointEntityDefinition{{{-8, -8, -8}, {8, 8, 8}}, {}, {}},
           },
         });
+      CHECK(status.messages(LogLevel::Warn) == std::vector<std::string>{});
     }
 
     SECTION("parseChoicePropertyDefinition")


### PR DESCRIPTION
In an FGD file, the default value for a float property can be unquoted if it is just a whole number with no decimal point.

Closes #5431 