### PR TITLE
Fix Linux build and caching

### DIFF
--- a/.github/actions/ccache-save/action.yml
+++ b/.github/actions/ccache-save/action.yml
@@ -13,6 +13,20 @@ inputs:
 runs:
   using: composite
   steps:
+    # We only ever save from master builds, and restores always want the newest
+    # cache for this key, so there is no reason to keep older generations around
+    # racking up storage against the repository's total cache quota.
+    - name: Delete previous ccache generations
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh cache list \
+          --key "${{ env.CCACHE_CACHE_KEY_PREFIX }}-${{ inputs.os }}-${{ inputs.build-type }}-${{ inputs.arch }}-" \
+          --json id --jq '.[].id' \
+        | xargs -r -n1 gh cache delete
+      continue-on-error: true
+
     - name: Save ccache
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -49,7 +49,7 @@ jobs:
             -v "${{ github.workspace }}:${{ github.workspace }}" \
             -w "${{ github.workspace }}" \
             "${{ env.TB_LINUX_CONTAINER_IMAGE }}" \
-            bash -lc 'mkdir -p "${CCACHE_DIR}" && ccache --set-config=max_size=1G && ccache --zero-stats'
+            bash -lc 'mkdir -p "${CCACHE_DIR}" && ccache --set-config=max_size=2G && ccache --zero-stats'
 
       - name: Build in container
         env:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   packages: write
   contents: write
+  actions: write
 
 jobs:
   linux:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -87,7 +87,11 @@ jobs:
       - name: Initialize ccache
         run: |
           mkdir -p "$CCACHE_DIR"
-          ccache --set-config=max_size=1G
+          if [[ "${{ matrix.tb-build-type }}" == "sanitize" ]]; then
+            ccache --set-config=max_size=2G
+          else
+            ccache --set-config=max_size=1G
+          fi
           ccache --zero-stats
 
       - name: Build

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   packages: write
   contents: write
+  actions: write
 
 jobs:
   macos:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -51,7 +51,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path "$env:CCACHE_DIR" -Force | Out-Null
-          ccache --set-config=max_size=1G
+          ccache --set-config=max_size=2G
           ccache --zero-stats
 
       - name: Build

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -5,7 +5,7 @@ on:
 permissions:
   packages: write
   contents: write
-  actions: read
+  actions: write
 
 jobs:
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   packages: write
   contents: write
-  actions: read
+  actions: write
 
 jobs:
   linux:

--- a/CI-linux.sh
+++ b/CI-linux.sh
@@ -50,7 +50,11 @@ cmake .. \
   -DCMAKE_INSTALL_PREFIX=/usr \
   || exit 1
 
-cmake --build . --config Release --parallel || exit 1
+# Capped at 2 (rather than the full core count) because a handful of heavy
+# third-party translation units (e.g. assimp's IFC importer) each need well
+# over 2-3 GB to compile; 4-way parallel compilation reliably OOMs the
+# 16 GB GitHub-hosted runner before TrenchBroom's own code is even reached.
+cmake --build . --config Release --parallel 2 || exit 1
 
 # Run tests
 


### PR DESCRIPTION
The Linux CI build can run out of memory. Compiling with full parallelism runs four gcc processes in parallel, and if heavy files are being compiled, they can exceed the total memory limit of 16GB. In that case, the build gets killed by OOM killer. We fix this by limiting build parallelism to 2 processes.

Furthermore, we try to improve caching by aggressively deleting old caches, and increasing the ccache sizes.