### PR TITLE
Improve caching for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# TrenchBroom doesn't use C++20 modules. With Ninja and a scanning-capable compiler,
+# CMake defaults this to ON for C++20+, adding a "Scanning ... for CXX dependencies"
+# compiler invocation per translation unit that ccache cannot cache.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 project(TrenchBroom C CXX)
 
 include(CTest)

--- a/cmake/CompilerConfig.cmake
+++ b/cmake/CompilerConfig.cmake
@@ -57,8 +57,16 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_definitions(CompilerConfig INTERFACE _CRT_SECURE_NO_DEPRECATE _CRT_NONSTDC_NO_DEPRECATE)
-  target_compile_options(CompilerConfig INTERFACE /EHsc /MP)
-  
+  target_compile_options(CompilerConfig INTERFACE /EHsc)
+
+  # /MP tells cl.exe to parallelize compilation of the source files passed to a single
+  # invocation. That only matters for generators like Visual Studio that batch multiple
+  # files per cl.exe call; with Ninja, each invocation compiles exactly one file, so /MP
+  # is a no-op there that just makes every compile uncacheable by ccache.
+  if(CMAKE_GENERATOR MATCHES "Visual Studio")
+    target_compile_options(CompilerConfig INTERFACE /MP)
+  endif()
+
   target_compile_options(CompilerConfig INTERFACE /W4
     /w14242 # 'identfier': conversion from 'type1' to 'type1', possible loss of data
     /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data


### PR DESCRIPTION
On Windows, we pass /MP to the compiler regardless of the generator. /MP instructs cl.exe to parallelize compilation, but it's only relevant for generators like Visual Studio and not ninja, which does its own parallelization. At the same time, /MP disables ccache, and since we use Ninja on CI, we disable /MP unless we use the Visual Studio generator.