### PR TITLE
Fix UV editor crash on faces with a texture that failed to load

### DIFF
--- a/lib/TbAppLib/src/UvOffsetTool.cpp
+++ b/lib/TbAppLib/src/UvOffsetTool.cpp
@@ -19,6 +19,7 @@
 
 #include "ui/UvOffsetTool.h"
 
+#include "gl/Material.h"
 #include "mdl/BrushFace.h"
 #include "mdl/Map.h"
 #include "mdl/Map_Brushes.h"
@@ -57,7 +58,7 @@ vm::vec2f snapDelta(const UvViewHelper& helper, const vm::vec2f& delta)
 {
   contract_pre(helper.valid());
 
-  if (helper.material())
+  if (gl::getTexture(helper.material()))
   {
     const auto transform = helper.face()->toUvCoordSystemMatrix(
       helper.face()->uvAttributes().offset - delta, helper.face()->uvAttributes().scale);

--- a/lib/TbAppLib/src/UvOriginTool.cpp
+++ b/lib/TbAppLib/src/UvOriginTool.cpp
@@ -21,6 +21,7 @@
 
 #include "base/PreferenceManager.h"
 #include "gl/ActiveShader.h"
+#include "gl/Material.h"
 #include "gl/OrthographicCamera.h"
 #include "gl/PrimType.h"
 #include "gl/Shaders.h"
@@ -136,7 +137,7 @@ vm::vec2f snapDelta(const UvViewHelper& helper, const vm::vec2f& delta)
   }
 
   // and to the UV grid
-  if (helper.face()->material())
+  if (gl::getTexture(helper.material()))
   {
     distanceInUvCoords = vm::abs_min(
       distanceInUvCoords,

--- a/lib/TbAppLib/src/UvViewHelper.cpp
+++ b/lib/TbAppLib/src/UvViewHelper.cpp
@@ -91,7 +91,7 @@ vm::vec2d UvViewHelper::stripeSize() const
 {
   contract_pre(valid());
 
-  if (const auto* texture = getTexture(face()->material()))
+  if (const auto* texture = gl::getTexture(face()->material()))
   {
     return vm::vec2d{texture->sizef()} / vm::vec2d{m_subDivisions};
   }
@@ -144,7 +144,7 @@ void UvViewHelper::pickUvGrid(
 {
   contract_pre(valid());
 
-  if (face()->material())
+  if (gl::getTexture(material()))
   {
     const auto& boundary = face()->boundary();
     if (const auto distance = vm::intersect_ray_plane(ray, boundary))


### PR DESCRIPTION
Several UV-editing code paths checked whether a face had a material assigned, rather than whether that material's texture actually loaded. Guard these code paths against unloaded textures, matching the pattern already used by the renderers.

Closes #5449.