### PR TITLE
Don't crash when a face's UV coordinate system isn't invertible

### DIFF
--- a/lib/TbAppLib/include/ui/UvViewHelper.h
+++ b/lib/TbAppLib/include/ui/UvViewHelper.h
@@ -95,9 +95,13 @@ public:
   vm::vec2f snapDelta(const vm::vec2f& delta, const vm::vec2f& distance) const;
   vm::vec2f computeDistanceFromUvGrid(const vm::vec3d& position) const;
 
-  void computeOriginHandleVertices(
+  /**
+   * Computes the handle vertices, or returns false if the face's UV coordinate system
+   * cannot currently be inverted (e.g. degenerate or extreme scale/rotation values).
+   */
+  bool computeOriginHandleVertices(
     vm::vec3d& x1, vm::vec3d& x2, vm::vec3d& y1, vm::vec3d& y2) const;
-  void computeScaleHandleVertices(
+  bool computeScaleHandleVertices(
     const vm::vec2d& pos,
     vm::vec3d& x1,
     vm::vec3d& x2,
@@ -113,9 +117,10 @@ public:
     const vm::mat4x4d& toWorld) const;
 
   /**
-   * Converts UV space to view space (pixels in the UV viewport).
+   * Converts UV space to view space (pixels in the UV viewport), or returns std::nullopt
+   * if the face's UV coordinate system cannot currently be inverted.
    */
-  vm::vec2f uvToViewCoords(const vm::vec2f& pos) const;
+  std::optional<vm::vec2f> uvToViewCoords(const vm::vec2f& pos) const;
 
 private:
   void resetOrigin();

--- a/lib/TbAppLib/src/UvOriginTool.cpp
+++ b/lib/TbAppLib/src/UvOriginTool.cpp
@@ -50,6 +50,7 @@
 #include "vm/mat_ext.h"
 #include "vm/vec.h"
 
+#include <optional>
 #include <vector>
 
 namespace tb::ui
@@ -57,17 +58,22 @@ namespace tb::ui
 namespace
 {
 
-std::tuple<vm::line3d, vm::line3d> computeOriginHandles(const UvViewHelper& helper)
+std::optional<std::tuple<vm::line3d, vm::line3d>> computeOriginHandles(
+  const UvViewHelper& helper)
 {
   const auto toWorld =
     helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+  if (!toWorld)
+  {
+    return std::nullopt;
+  }
 
   const auto origin = vm::vec3d{helper.originInFaceCoords()};
-  const auto linePoint = toWorld * origin;
-  return {
+  const auto linePoint = *toWorld * origin;
+  return std::tuple{
     vm::line3d{
-      linePoint, vm::normalize(toWorld * (origin + vm::vec3d{0, 1, 0}) - linePoint)},
-    vm::line3d{linePoint, (toWorld * (origin + vm::vec3d{1, 0, 0}) - linePoint)},
+      linePoint, vm::normalize(*toWorld * (origin + vm::vec3d{0, 1, 0}) - linePoint)},
+    vm::line3d{linePoint, (*toWorld * (origin + vm::vec3d{1, 0, 0}) - linePoint)},
   };
 }
 
@@ -94,7 +100,7 @@ vm::vec2f computeHitPoint(const UvViewHelper& helper, const vm::ray3d& ray)
   return vm::vec2f{transform * hitPoint};
 }
 
-vm::vec2f snapDelta(const UvViewHelper& helper, const vm::vec2f& delta)
+std::optional<vm::vec2f> snapDelta(const UvViewHelper& helper, const vm::vec2f& delta)
 {
   contract_pre(helper.valid());
 
@@ -117,8 +123,13 @@ vm::vec2f snapDelta(const UvViewHelper& helper, const vm::vec2f& delta)
     helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
   const auto t2wTransform = helper.face()->fromUvCoordSystemMatrix(
     helper.face()->uvAttributes().offset, helper.face()->uvAttributes().scale);
-  const auto f2tTransform = w2tTransform * f2wTransform;
-  const auto t2fTransform = w2fTransform * t2wTransform;
+  if (!f2wTransform || !t2wTransform)
+  {
+    return std::nullopt;
+  }
+
+  const auto f2tTransform = w2tTransform * *f2wTransform;
+  const auto t2fTransform = w2fTransform * *t2wTransform;
 
   const auto newOriginInFaceCoords = helper.originInFaceCoords() + delta;
   const auto newOriginInUvCoords =
@@ -158,7 +169,7 @@ vm::vec2f snapDelta(const UvViewHelper& helper, const vm::vec2f& delta)
 
 using EdgeVertex = gl::VertexTypes::P3C4::Vertex;
 
-std::vector<EdgeVertex> getHandleVertices(
+std::optional<std::vector<EdgeVertex>> getHandleVertices(
   const UvViewHelper& helper, const vm::vec2b& highlightHandle)
 {
   const auto xColor =
@@ -167,9 +178,12 @@ std::vector<EdgeVertex> getHandleVertices(
     highlightHandle.y() ? RgbaF{1.0f, 0.0f, 0.0f, 1.0f} : RgbaF{0.7f, 0.0f, 0.0f, 1.0f};
 
   vm::vec3d x1, x2, y1, y2;
-  helper.computeOriginHandleVertices(x1, x2, y1, y2);
+  if (!helper.computeOriginHandleVertices(x1, x2, y1, y2))
+  {
+    return std::nullopt;
+  }
 
-  return {
+  return std::vector<EdgeVertex>{
     EdgeVertex{vm::vec3f{x1}, xColor.toVec()},
     EdgeVertex{vm::vec3f{x2}, xColor.toVec()},
     EdgeVertex{vm::vec3f{y1}, yColor.toVec()},
@@ -181,10 +195,12 @@ void renderLineHandles(
   const vm::vec2b& highlightHandles,
   render::RenderBatch& renderBatch)
 {
-  auto edgeRenderer = render::DirectEdgeRenderer{
-    gl::VertexArray::move(getHandleVertices(helper, highlightHandles)),
-    gl::PrimType::Lines};
-  edgeRenderer.renderOnTop(renderBatch, 0.5f);
+  if (auto vertices = getHandleVertices(helper, highlightHandles))
+  {
+    auto edgeRenderer = render::DirectEdgeRenderer{
+      gl::VertexArray::move(std::move(*vertices)), gl::PrimType::Lines};
+    edgeRenderer.renderOnTop(renderBatch, 0.5f);
+  }
 }
 
 class RenderOrigin : public render::DirectRenderable
@@ -224,12 +240,16 @@ private:
 
     const auto fromFace =
       m_helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+    if (!fromFace)
+    {
+      return;
+    }
 
     const auto& boundary = m_helper.face()->boundary();
     const auto toPlane = vm::plane_projection_matrix(boundary.distance, boundary.normal);
     const auto fromPlane = vm::invert(toPlane);
     const auto originPosition(
-      toPlane * fromFace * vm::vec3d{m_helper.originInFaceCoords()});
+      toPlane * *fromFace * vm::vec3d{m_helper.originInFaceCoords()});
 
     const auto& handleColor = pref(Preferences::HandleColor);
     const auto& highlightColor = pref(Preferences::SelectedHandleColor);
@@ -276,14 +296,14 @@ public:
 
     const auto snapped = !inputState.modifierKeysDown(ModifierKeys::CtrlCmd)
                            ? snapDelta(m_helper, delta * m_selector)
-                           : delta * m_selector;
-    if (vm::is_zero(snapped, vm::Cf::almost_zero()))
+                           : std::optional{delta * m_selector};
+    if (!snapped || vm::is_zero(*snapped, vm::Cf::almost_zero()))
     {
       return true;
     }
 
-    m_helper.setOriginInFaceCoords(m_helper.originInFaceCoords() + snapped);
-    m_lastPoint = m_lastPoint + snapped;
+    m_helper.setOriginInFaceCoords(m_helper.originInFaceCoords() + *snapped);
+    m_lastPoint = m_lastPoint + *snapped;
 
     return true;
   }
@@ -327,13 +347,18 @@ const Tool& UvOriginTool::tool() const
 
 void UvOriginTool::pick(const InputState& inputState, mdl::PickResult& pickResult)
 {
-  if (m_helper.valid())
+  if (!m_helper.valid())
   {
-    const auto [xHandle, yHandle] = computeOriginHandles(m_helper);
+    return;
+  }
 
-    const auto fromTex =
-      m_helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
-    const auto origin = fromTex * vm::vec3d{m_helper.originInFaceCoords()};
+  const auto handles = computeOriginHandles(m_helper);
+  const auto fromTex =
+    m_helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+  if (handles && fromTex)
+  {
+    const auto& [xHandle, yHandle] = *handles;
+    const auto origin = *fromTex * vm::vec3d{m_helper.originInFaceCoords()};
 
     const auto& pickRay = inputState.pickRay();
     const auto oDistance = vm::distance(pickRay, origin);

--- a/lib/TbAppLib/src/UvRotateTool.cpp
+++ b/lib/TbAppLib/src/UvRotateTool.cpp
@@ -147,13 +147,17 @@ public:
 
     const auto fromFace =
       m_helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+    if (!fromFace)
+    {
+      return;
+    }
 
     const auto& boundary = m_helper.face()->boundary();
     const auto toPlane = vm::plane_projection_matrix(boundary.distance, boundary.normal);
     const auto fromPlane = vm::invert(toPlane);
 
     const auto originPosition =
-      toPlane * fromFace * vm::vec3d{m_helper.originInFaceCoords()};
+      toPlane * *fromFace * vm::vec3d{m_helper.originInFaceCoords()};
     const auto faceCenterPosition = toPlane * m_helper.face()->boundsCenter();
 
     const auto& handleColor = pref(Preferences::HandleColor);
@@ -211,6 +215,10 @@ public:
       m_helper.face()->toUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
     const auto toWorld =
       m_helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+    if (!toWorld)
+    {
+      return true;
+    }
 
     const auto curPointInFaceCoords = vm::vec2f{toFaceOld * curPoint};
     const auto curAngle = measureAngle(m_helper, curPointInFaceCoords);
@@ -224,7 +232,7 @@ public:
       0.0f);
 
     const auto oldCenterInFaceCoords = m_helper.originInFaceCoords();
-    const auto oldCenterInWorldCoords = toWorld * vm::vec3d{oldCenterInFaceCoords};
+    const auto oldCenterInWorldCoords = *toWorld * vm::vec3d{oldCenterInFaceCoords};
 
     setBrushFaceAttributes(m_map, {.rotation = mdl::SetValue{snappedAngle}});
 
@@ -337,10 +345,14 @@ void UvRotateTool::pick(const InputState& inputState, mdl::PickResult& pickResul
 
     const auto fromFace =
       m_helper.face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+    if (!fromFace)
+    {
+      return;
+    }
     const auto toPlane = vm::plane_projection_matrix(boundary.distance, boundary.normal);
 
     const auto originOnPlane =
-      toPlane * fromFace * vm::vec3d{m_helper.originInFaceCoords()};
+      toPlane * *fromFace * vm::vec3d{m_helper.originInFaceCoords()};
     const auto hitPointOnPlane = toPlane * hitPoint;
 
     const auto zoom = double(m_helper.camera().zoom());

--- a/lib/TbAppLib/src/UvScaleTool.cpp
+++ b/lib/TbAppLib/src/UvScaleTool.cpp
@@ -89,15 +89,17 @@ vm::vec2f getScaledTranslatedHandlePos(const UvViewHelper& helper, const vm::vec
   return vm::vec2f{handle} * vm::vec2f{helper.stripeSize()};
 }
 
-vm::vec2f getHandlePos(const UvViewHelper& helper, const vm::vec2i handle)
+std::optional<vm::vec2f> getHandlePos(const UvViewHelper& helper, const vm::vec2i handle)
 {
-  const auto toWorld = helper.face()->fromUvCoordSystemMatrix(
-    helper.face()->uvAttributes().offset, helper.face()->uvAttributes().scale);
   const auto toTex =
     helper.face()->toUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
 
-  return vm::vec2f{
-    toTex * toWorld * vm::vec3d{getScaledTranslatedHandlePos(helper, handle)}};
+  return helper.face()->fromUvCoordSystemMatrix(
+           helper.face()->uvAttributes().offset, helper.face()->uvAttributes().scale)
+         | kdl::optional_transform([&](const auto& toWorld) {
+             return vm::vec2f{
+               toTex * toWorld * vm::vec3d{getScaledTranslatedHandlePos(helper, handle)}};
+           });
 }
 
 vm::vec2f snap(const UvViewHelper& helper, const vm::vec2f& position)
@@ -128,14 +130,17 @@ vm::vec2f snap(const UvViewHelper& helper, const vm::vec2f& position)
 
 using EdgeVertex = gl::VertexTypes::P3::Vertex;
 
-std::vector<EdgeVertex> getHandleVertices(
+std::optional<std::vector<EdgeVertex>> getHandleVertices(
   const UvViewHelper& helper, const vm::vec2i& handle, const vm::vec2b& selector)
 {
   const auto stripeSize = helper.stripeSize();
   const auto pos = stripeSize * vm::vec2d{handle};
 
   vm::vec3d h1, h2, v1, v2;
-  helper.computeScaleHandleVertices(pos, v1, v2, h1, h2);
+  if (!helper.computeScaleHandleVertices(pos, v1, v2, h1, h2))
+  {
+    return std::nullopt;
+  }
 
   auto vertices = std::vector<EdgeVertex>{};
   vertices.reserve(4);
@@ -163,10 +168,12 @@ void renderHighlight(
 {
   static const auto color = RgbaF{1.0f, 0.0f, 0.0f, 1.0f};
 
-  auto handleRenderer = render::DirectEdgeRenderer{
-    gl::VertexArray::move(getHandleVertices(helper, handle, selector)),
-    gl::PrimType::Lines};
-  handleRenderer.render(renderBatch, color, 1.0f);
+  if (auto vertices = getHandleVertices(helper, handle, selector))
+  {
+    auto handleRenderer = render::DirectEdgeRenderer{
+      gl::VertexArray::move(std::move(*vertices)), gl::PrimType::Lines};
+    handleRenderer.render(renderBatch, color, 1.0f);
+  }
 }
 
 class UvScaleDragTracker : public GestureTracker
@@ -203,9 +210,14 @@ public:
 
     const auto dragDeltaFaceCoords = *curPoint - m_lastHitPoint;
 
+    const auto handlePos = getHandlePos(m_helper, m_handle);
+    if (!handlePos)
+    {
+      return true;
+    }
+
     const auto curHandlePosUvCoords = getScaledTranslatedHandlePos(m_helper, m_handle);
-    const auto newHandlePosFaceCoords =
-      getHandlePos(m_helper, m_handle) + dragDeltaFaceCoords;
+    const auto newHandlePosFaceCoords = *handlePos + dragDeltaFaceCoords;
     const auto newHandlePosSnapped = !inputState.modifierKeysDown(ModifierKeys::CtrlCmd)
                                        ? snap(m_helper, newHandlePosFaceCoords)
                                        : newHandlePosFaceCoords;

--- a/lib/TbAppLib/src/UvViewHelper.cpp
+++ b/lib/TbAppLib/src/UvViewHelper.cpp
@@ -128,8 +128,12 @@ const vm::vec2f UvViewHelper::originInUvCoords() const
 
 void UvViewHelper::setOriginInFaceCoords(const vm::vec2f& originInFaceCoords)
 {
-  const auto fromFace = face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
-  m_origin = fromFace * vm::vec3d{originInFaceCoords};
+  if (
+    const auto fromFace =
+      face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1}))
+  {
+    m_origin = *fromFace * vm::vec3d{originInFaceCoords};
+  }
 }
 
 const gl::OrthographicCamera& UvViewHelper::camera() const
@@ -155,6 +159,10 @@ void UvViewHelper::pickUvGrid(
           face()->uvAttributes().offset, face()->uvAttributes().scale)
         * hitPointInWorldCoords};
       const auto hitPointInViewCoords = uvToViewCoords(hitPointInUvCoords);
+      if (!hitPointInViewCoords)
+      {
+        return;
+      }
 
       // X and Y distance in texels to the closest grid intersection.
       // (i.e. so the X component is the distance to the closest vertical gridline, and
@@ -172,9 +180,11 @@ void UvViewHelper::pickUvGrid(
       // FIXME: should be measured in points so the grid isn't harder to hit with high-DPI
       const float distToClosestGridInViewCoords[2] = {
         vm::distance(
-          hitPointInViewCoords, uvToViewCoords(closestPointsOnGridInUvCoords[0])),
+          *hitPointInViewCoords,
+          uvToViewCoords(closestPointsOnGridInUvCoords[0]).value()),
         vm::distance(
-          hitPointInViewCoords, uvToViewCoords(closestPointsOnGridInUvCoords[1]))};
+          *hitPointInViewCoords,
+          uvToViewCoords(closestPointsOnGridInUvCoords[1]).value())};
 
       // FIXME: factor out and share with other tools
       constexpr auto maxDistance = 5.0f;
@@ -217,17 +227,22 @@ vm::vec2f UvViewHelper::computeDistanceFromUvGrid(const vm::vec3d& position) con
   return vm::vec2f{closest - position.xy()};
 }
 
-void UvViewHelper::computeOriginHandleVertices(
+bool UvViewHelper::computeOriginHandleVertices(
   vm::vec3d& x1, vm::vec3d& x2, vm::vec3d& y1, vm::vec3d& y2) const
 {
   contract_pre(valid());
 
   const auto toTex = face()->toUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
   const auto toWorld = face()->fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
-  computeLineVertices(vm::vec2d{originInFaceCoords()}, x1, x2, y1, y2, toTex, toWorld);
+  if (!toWorld)
+  {
+    return false;
+  }
+  computeLineVertices(vm::vec2d{originInFaceCoords()}, x1, x2, y1, y2, toTex, *toWorld);
+  return true;
 }
 
-void UvViewHelper::computeScaleHandleVertices(
+bool UvViewHelper::computeScaleHandleVertices(
   const vm::vec2d& pos, vm::vec3d& x1, vm::vec3d& x2, vm::vec3d& y1, vm::vec3d& y2) const
 {
   contract_pre(valid());
@@ -236,7 +251,12 @@ void UvViewHelper::computeScaleHandleVertices(
     face()->uvAttributes().offset, face()->uvAttributes().scale);
   const auto toWorld = face()->fromUvCoordSystemMatrix(
     face()->uvAttributes().offset, face()->uvAttributes().scale);
-  computeLineVertices(pos, x1, x2, y1, y2, toTex, toWorld);
+  if (!toWorld)
+  {
+    return false;
+  }
+  computeLineVertices(pos, x1, x2, y1, y2, toTex, *toWorld);
+  return true;
 }
 
 void UvViewHelper::computeLineVertices(
@@ -260,12 +280,16 @@ void UvViewHelper::computeLineVertices(
   y2 = toWorld * vm::vec3d{max.x(), pos.y(), 0.0};
 }
 
-vm::vec2f UvViewHelper::uvToViewCoords(const vm::vec2f& pos) const
+std::optional<vm::vec2f> UvViewHelper::uvToViewCoords(const vm::vec2f& pos) const
 {
-  const auto posInWorldCoords =
-    face()->fromUvCoordSystemMatrix(
-      face()->uvAttributes().offset, face()->uvAttributes().scale)
-    * vm::vec3d{pos, 0.0};
+  const auto fromFace = face()->fromUvCoordSystemMatrix(
+    face()->uvAttributes().offset, face()->uvAttributes().scale);
+  if (!fromFace)
+  {
+    return std::nullopt;
+  }
+
+  const auto posInWorldCoords = *fromFace * vm::vec3d{pos, 0.0};
   return m_camera.project(vm::vec3f(posInWorldCoords)).xy();
 }
 

--- a/lib/TbAppLib/test/src/tst_UvOriginTool.cpp
+++ b/lib/TbAppLib/test/src/tst_UvOriginTool.cpp
@@ -31,6 +31,7 @@
 #include "mdl/HitFilter.h"
 #include "mdl/MapFormat.h"
 #include "mdl/PickResult.h"
+#include "mdl/TestUtils.h"
 #include "ui/GestureTracker.h"
 #include "ui/InputState.h"
 #include "ui/PickRequest.h"
@@ -88,6 +89,18 @@ TEST_CASE("UvOriginTool")
     controller.pick(inputState, pickResult);
     inputState.setPickResult(std::move(pickResult));
     return inputState;
+  };
+
+  // uAxis and vAxis are parallel, so the resulting face's UV matrix is not invertible;
+  // sets the helper's face to one and keeps it alive for the calling section
+  const auto setDegenerateFaceHandle = [&](std::unique_ptr<mdl::BrushNode>& owner) {
+    auto degenerateBrush =
+      mdl::createCubeWithTopUvAxes(vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0}, "material");
+    const auto degenerateTopFaceIndex = *degenerateBrush.findFace(vm::vec3d{0, 0, 1});
+    degenerateBrush.face(degenerateTopFaceIndex).setMaterial(&material);
+
+    owner = std::make_unique<mdl::BrushNode>(std::move(degenerateBrush));
+    helper.setFaceHandle(mdl::BrushFaceHandle{owner.get(), degenerateTopFaceIndex});
   };
 
   SECTION("cancel always returns false")
@@ -166,6 +179,16 @@ TEST_CASE("UvOriginTool")
 
       CHECK(inputState.pickResult().empty());
     }
+
+    SECTION("does not add a hit for a non-invertible UV coordinate system")
+    {
+      auto degenerateBrushNode = std::unique_ptr<mdl::BrushNode>{};
+      setDegenerateFaceHandle(degenerateBrushNode);
+
+      const auto inputState = inputStateFor(rayAt(helper.origin()));
+
+      CHECK(inputState.pickResult().empty());
+    }
   }
 
   SECTION("acceptMouseDrag")
@@ -237,6 +260,17 @@ TEST_CASE("UvOriginTool")
       CHECK(tracker->update(dragInputState));
 
       CHECK(helper.originInFaceCoords() != originBefore);
+    }
+
+    SECTION("returns nullptr for a non-invertible UV coordinate system")
+    {
+      auto degenerateBrushNode = std::unique_ptr<mdl::BrushNode>{};
+      setDegenerateFaceHandle(degenerateBrushNode);
+
+      auto inputState = inputStateFor(rayAt(helper.origin()));
+      inputState.mouseDown(MouseButtons::Left);
+
+      CHECK(controller.acceptMouseDrag(inputState) == nullptr);
     }
   }
 }

--- a/lib/TbAppLib/test/src/tst_UvRotateTool.cpp
+++ b/lib/TbAppLib/test/src/tst_UvRotateTool.cpp
@@ -35,6 +35,7 @@
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/PickResult.h"
+#include "mdl/TestUtils.h"
 #include "mdl/UvAttributes.h"
 #include "mdl/WorldNode.h"
 #include "ui/GestureTracker.h"
@@ -117,6 +118,18 @@ TEST_CASE("UvRotateTool")
     return inputState;
   };
 
+  // uAxis and vAxis are parallel, so the resulting face's UV matrix is not invertible
+  const auto setDegenerateFaceHandle = [&] {
+    auto* degenerateBrushNode = new mdl::BrushNode{
+      mdl::createCubeWithTopUvAxes(vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0}, "material")};
+    mdl::addNodes(map, {{map.editorContext().currentLayer(), {degenerateBrushNode}}});
+
+    const auto degenerateTopFaceIndex =
+      *degenerateBrushNode->brush().findFace(vm::vec3d{0, 0, 1});
+    helper.setFaceHandle(
+      mdl::BrushFaceHandle{degenerateBrushNode, degenerateTopFaceIndex});
+  };
+
   SECTION("cancel always returns false")
   {
     CHECK(!controller.cancel());
@@ -172,6 +185,17 @@ TEST_CASE("UvRotateTool")
       controller.pick(inputState, pickResult);
 
       CHECK(pickResult.empty());
+    }
+
+    SECTION("does not hit for a non-invertible UV coordinate system")
+    {
+      setDegenerateFaceHandle();
+
+      const auto inputState = inputStateFor(rayAt(pointOnRing()));
+
+      CHECK(!inputState.pickResult()
+               .first(mdl::HitFilters::type(UvRotateTool::AngleHandleHitType))
+               .isMatch());
     }
   }
 
@@ -250,6 +274,16 @@ TEST_CASE("UvRotateTool")
         tracker->cancel();
         CHECK(faceHandle.face().uvAttributes().rotation == 0.0f);
       }
+    }
+
+    SECTION("returns nullptr for a non-invertible UV coordinate system")
+    {
+      setDegenerateFaceHandle();
+
+      auto inputState = inputStateFor(rayAt(pointOnRing()));
+      inputState.mouseDown(MouseButtons::Left);
+
+      CHECK(controller.acceptMouseDrag(inputState) == nullptr);
     }
   }
 }

--- a/lib/TbAppLib/test/src/tst_UvScaleTool.cpp
+++ b/lib/TbAppLib/test/src/tst_UvScaleTool.cpp
@@ -32,9 +32,11 @@
 #include "mdl/Hit.h"
 #include "mdl/LayerNode.h" // IWYU pragma: keep
 #include "mdl/Map.h"
+#include "mdl/Map_Brushes.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/PickResult.h"
+#include "mdl/UpdateBrushFaceAttributes.h"
 #include "mdl/UvAttributes.h"
 #include "mdl/WorldNode.h"
 #include "ui/GestureTracker.h"
@@ -215,6 +217,31 @@ TEST_CASE("UvScaleTool")
         CHECK(faceHandle.face().uvAttributes().scale == vm::vec2f{1, 1});
         CHECK(faceHandle.face().uvAttributes().offset == vm::vec2f{0, 0});
       }
+    }
+
+    SECTION("becoming non-invertible mid-drag does not crash")
+    {
+      auto inputState = inputStateFor(vm::ray3d{{0, 0, 100}, {0, 0, -1}});
+      inputState.mouseDown(MouseButtons::Left);
+
+      auto tracker = controller.acceptMouseDrag(inputState);
+      REQUIRE(tracker != nullptr);
+
+      // an extreme scale (reachable by typing a large value into the Face Attributes
+      // panel) shrinks the UV axes until the face's UV matrix is no longer invertible
+      REQUIRE(mdl::setBrushFaceAttributes(
+        map,
+        {
+          .xScale = mdl::SetValue{1e20f},
+          .yScale = mdl::SetValue{1e20f},
+        }));
+
+      const auto dragInputState = inputStateFor(vm::ray3d{{32, 0, 100}, {0, 0, -1}});
+      CHECK(tracker->update(dragInputState));
+
+      // the drag update was skipped rather than crashing, so the extreme scale is
+      // left untouched
+      CHECK(faceHandle.face().uvAttributes().scale == vm::vec2f{1e20f, 1e20f});
     }
   }
 }

--- a/lib/TbAppLib/test/src/tst_UvViewHelper.cpp
+++ b/lib/TbAppLib/test/src/tst_UvViewHelper.cpp
@@ -31,6 +31,7 @@
 #include "mdl/HitType.h"
 #include "mdl/MapFormat.h"
 #include "mdl/PickResult.h"
+#include "mdl/TestUtils.h"
 #include "ui/UvViewHelper.h"
 
 #include "kd/result.h"
@@ -38,6 +39,7 @@
 #include "vm/approx.h"
 
 #include <memory>
+#include <optional>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -68,6 +70,18 @@ TEST_CASE("UvViewHelper")
     vm::vec3f{0, 1, 0}};
 
   auto helper = UvViewHelper{camera};
+
+  // uAxis and vAxis are parallel, so the resulting face's UV matrix is not invertible;
+  // sets the helper's face to one and keeps it alive for the calling section
+  const auto setDegenerateFaceHandle = [&](std::unique_ptr<mdl::BrushNode>& owner) {
+    auto degenerateBrush =
+      mdl::createCubeWithTopUvAxes(vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0}, "material");
+    const auto degenerateTopFaceIndex = *degenerateBrush.findFace(vm::vec3d{0, 0, 1});
+    degenerateBrush.face(degenerateTopFaceIndex).setMaterial(&material);
+
+    owner = std::make_unique<mdl::BrushNode>(std::move(degenerateBrush));
+    helper.setFaceHandle(mdl::BrushFaceHandle{owner.get(), degenerateTopFaceIndex});
+  };
 
   SECTION("valid, face and material before a face is set")
   {
@@ -137,6 +151,18 @@ TEST_CASE("UvViewHelper")
 
     helper.setOriginInFaceCoords(vm::vec2f{10, 20});
     CHECK(vm::vec2f{helper.originInFaceCoords()} == vm::vec2f{10, 20});
+
+    SECTION(
+      "setOriginInFaceCoords is a no-op for a non-invertible UV coordinate "
+      "system")
+    {
+      auto degenerateBrushNode = std::unique_ptr<mdl::BrushNode>{};
+      setDegenerateFaceHandle(degenerateBrushNode);
+
+      const auto originBefore = helper.origin();
+      helper.setOriginInFaceCoords(vm::vec2f{30, 40});
+      CHECK(helper.origin() == originBefore);
+    }
   }
 
   SECTION("computeDistanceFromUvGrid snaps to the nearest stripe corner")
@@ -198,12 +224,41 @@ TEST_CASE("UvViewHelper")
 
       CHECK(pickResult.all().size() == 2u);
     }
+
+    SECTION("no hit for a non-invertible UV coordinate system")
+    {
+      auto degenerateBrushNode = std::unique_ptr<mdl::BrushNode>{};
+      setDegenerateFaceHandle(degenerateBrushNode);
+
+      const auto ray = vm::ray3d{{0, 0, 100}, {0, 0, -1}};
+      auto pickResult = mdl::PickResult{};
+      helper.pickUvGrid(ray, hitTypes, pickResult);
+
+      CHECK(pickResult.empty());
+    }
   }
 
   SECTION("originInUvCoords")
   {
     helper.setFaceHandle(faceHandle);
     CHECK(!vm::is_nan(vm::vec2d{helper.originInUvCoords()}));
+  }
+
+  SECTION("uvToViewCoords")
+  {
+    SECTION("returns the projected view coordinates")
+    {
+      helper.setFaceHandle(faceHandle);
+      CHECK(helper.uvToViewCoords(vm::vec2f{0, 0}));
+    }
+
+    SECTION("returns std::nullopt for a non-invertible UV coordinate system")
+    {
+      auto degenerateBrushNode = std::unique_ptr<mdl::BrushNode>{};
+      setDegenerateFaceHandle(degenerateBrushNode);
+
+      CHECK(helper.uvToViewCoords(vm::vec2f{0, 0}) == std::nullopt);
+    }
   }
 
   SECTION("computeOriginHandleVertices and computeScaleHandleVertices")
@@ -225,6 +280,15 @@ TEST_CASE("UvViewHelper")
     CHECK(!vm::is_nan(x2));
     CHECK(!vm::is_nan(y1));
     CHECK(!vm::is_nan(y2));
+
+    SECTION("both return false for a non-invertible UV coordinate system")
+    {
+      auto degenerateBrushNode = std::unique_ptr<mdl::BrushNode>{};
+      setDegenerateFaceHandle(degenerateBrushNode);
+
+      CHECK(!helper.computeOriginHandleVertices(x1, x2, y1, y2));
+      CHECK(!helper.computeScaleHandleVertices(vm::vec2d{10, 20}, x1, x2, y1, y2));
+    }
   }
 
   SECTION("cameraViewportChanged resets the zoom once the viewport becomes valid")

--- a/lib/TbMdlLib/include/mdl/BrushFace.h
+++ b/lib/TbMdlLib/include/mdl/BrushFace.h
@@ -261,7 +261,7 @@ public:
   void translateUv(const vm::vec3d& up, const vm::vec3d& right, const vm::vec2f& offset);
   void rotateUv(float angle);
   void shearUv(const vm::vec2f& factors);
-  void flipUv(
+  bool flipUv(
     const vm::vec3d& cameraUp,
     const vm::vec3d& cameraRight,
     vm::direction cameraRelativeFlipDirection);
@@ -271,10 +271,10 @@ public:
 
   Result<void> updatePointsFromVertices();
 
-  vm::mat4x4d projectToBoundaryMatrix() const;
+  std::optional<vm::mat4x4d> projectToBoundaryMatrix() const;
   vm::mat4x4d toUvCoordSystemMatrix(
     const vm::vec2f& offset, const vm::vec2f& scale) const;
-  vm::mat4x4d fromUvCoordSystemMatrix(
+  std::optional<vm::mat4x4d> fromUvCoordSystemMatrix(
     const vm::vec2f& offset, const vm::vec2f& scale) const;
   float measureUvAngle(const vm::vec2f& center, const vm::vec2f& point) const;
 

--- a/lib/TbMdlLib/include/mdl/UvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/UvCoordSystem.h
@@ -137,7 +137,8 @@ public:
   void shear(const vm::vec3d& normal, const vm::vec2f& factors);
 
   vm::mat4x4d toMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;
-  vm::mat4x4d fromMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;
+  std::optional<vm::mat4x4d> fromMatrix(
+    const vm::vec2f& offset, const vm::vec2f& scale) const;
 
   float measureAngle(const vm::vec2f& center, const vm::vec2f& point) const;
 

--- a/lib/TbMdlLib/include/mdl/UvUtils.h
+++ b/lib/TbMdlLib/include/mdl/UvUtils.h
@@ -24,6 +24,7 @@
 #include "vm/scalar.h"
 #include "vm/vec.h"
 
+#include <optional>
 #include <tuple>
 
 namespace tb::mdl
@@ -76,9 +77,10 @@ vm::mat4x4d computeWorldToUvMatrix(
   const vm::vec2f& scale);
 
 /**
- * Returns the inverse of computeWorldToUvMatrix.
+ * Returns the inverse of computeWorldToUvMatrix, or std::nullopt if the axes and normal
+ * do not form an invertible matrix (e.g. degenerate or extreme scale/rotation values).
  */
-vm::mat4x4d computeUvToWorldMatrix(
+std::optional<vm::mat4x4d> computeUvToWorldMatrix(
   const vm::vec3d& uAxis,
   const vm::vec3d& vAxis,
   const vm::vec3d& normal,

--- a/lib/TbMdlLib/src/BrushFace.cpp
+++ b/lib/TbMdlLib/src/BrushFace.cpp
@@ -30,6 +30,7 @@
 #include "mdl/UvCoordSystem.h"
 
 #include "kd/contracts.h"
+#include "kd/optional_utils.h"
 #include "kd/reflection_impl.h"
 #include "kd/result.h"
 
@@ -610,15 +611,19 @@ void BrushFace::shearUv(const vm::vec2f& factors)
   m_uvCoordSystem.shear(m_boundary.normal, factors);
 }
 
-void BrushFace::flipUv(
+bool BrushFace::flipUv(
   const vm::vec3d& /* cameraUp */,
   const vm::vec3d& cameraRight,
   const vm::direction cameraRelativeFlipDirection)
 {
   const auto texToWorld = m_uvCoordSystem.fromMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1});
+  if (!texToWorld)
+  {
+    return false;
+  }
 
-  const auto texUAxisInWorld = vm::normalize((texToWorld * vm::vec4d(1, 0, 0, 0)).xyz());
-  const auto texVAxisInWorld = vm::normalize((texToWorld * vm::vec4d(0, 1, 0, 0)).xyz());
+  const auto texUAxisInWorld = vm::normalize((*texToWorld * vm::vec4d(1, 0, 0, 0)).xyz());
+  const auto texVAxisInWorld = vm::normalize((*texToWorld * vm::vec4d(0, 1, 0, 0)).xyz());
 
   // Get the cos(angle) between cameraRight and the texUAxisInWorld _line_ (so, take the
   // smaller of the angles among -texUAxisInWorld and texUAxisInWorld). Note that larger
@@ -653,6 +658,7 @@ void BrushFace::flipUv(
     newUvAttributes.scale[1] = -newUvAttributes.scale.y();
   }
   m_uvCoordSystem.copyUvAttributes(newUvAttributes);
+  return true;
 }
 
 Result<void> BrushFace::transform(const vm::mat4x4d& transform, const bool lockAlignment)
@@ -729,14 +735,20 @@ Result<void> BrushFace::updatePointsFromVertices()
            });
 }
 
-vm::mat4x4d BrushFace::projectToBoundaryMatrix() const
+std::optional<vm::mat4x4d> BrushFace::projectToBoundaryMatrix() const
 {
-  const auto texZAxis =
-    m_uvCoordSystem.fromMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1}) * vm::vec3d{0, 0, 1};
-  const auto worldToPlaneMatrix =
-    vm::plane_projection_matrix(m_boundary.distance, m_boundary.normal, texZAxis);
-  const auto planeToWorldMatrix = vm::invert(worldToPlaneMatrix);
-  return *planeToWorldMatrix * vm::mat4x4d::zero_out<2>() * worldToPlaneMatrix;
+  return m_uvCoordSystem.fromMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1})
+         | kdl::optional_and_then(
+           [&](const auto& fromMatrix) -> std::optional<vm::mat4x4d> {
+             const auto texZAxis = fromMatrix * vm::vec3d{0, 0, 1};
+             const auto worldToPlaneMatrix = vm::plane_projection_matrix(
+               m_boundary.distance, m_boundary.normal, texZAxis);
+             return vm::invert(worldToPlaneMatrix)
+                    | kdl::optional_transform([&](const auto& planeToWorldMatrix) {
+                        return planeToWorldMatrix * vm::mat4x4d::zero_out<2>()
+                               * worldToPlaneMatrix;
+                      });
+           });
 }
 
 vm::mat4x4d BrushFace::toUvCoordSystemMatrix(
@@ -745,10 +757,16 @@ vm::mat4x4d BrushFace::toUvCoordSystemMatrix(
   return vm::mat4x4d::zero_out<2>() * m_uvCoordSystem.toMatrix(offset, scale);
 }
 
-vm::mat4x4d BrushFace::fromUvCoordSystemMatrix(
+std::optional<vm::mat4x4d> BrushFace::fromUvCoordSystemMatrix(
   const vm::vec2f& offset, const vm::vec2f& scale) const
 {
-  return projectToBoundaryMatrix() * m_uvCoordSystem.fromMatrix(offset, scale);
+  return projectToBoundaryMatrix()
+         | kdl::optional_and_then(
+           [&](const auto& projectMatrix) -> std::optional<vm::mat4x4d> {
+             return m_uvCoordSystem.fromMatrix(offset, scale)
+                    | kdl::optional_transform(
+                      [&](const auto& fromMatrix) { return projectMatrix * fromMatrix; });
+           });
 }
 
 float BrushFace::measureUvAngle(const vm::vec2f& center, const vm::vec2f& point) const

--- a/lib/TbMdlLib/src/Map_Brushes.cpp
+++ b/lib/TbMdlLib/src/Map_Brushes.cpp
@@ -269,9 +269,8 @@ bool flipUv(
     isHFlip ? "Flip UV Horizontally" : "Flip UV Vertically",
     map.selection().allBrushFaces(),
     [&](auto& face) {
-      face.flipUv(
+      return face.flipUv(
         vm::vec3d{cameraUp}, vm::vec3d{cameraRight}, cameraRelativeFlipDirection);
-      return true;
     });
 }
 

--- a/lib/TbMdlLib/src/UvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/UvCoordSystem.cpp
@@ -297,7 +297,7 @@ vm::mat4x4d UvCoordSystem::toMatrix(const vm::vec2f& offset, const vm::vec2f& sc
   return computeWorldToUvMatrix(uAxis(), vAxis(), normal(), offset, scale);
 }
 
-vm::mat4x4d UvCoordSystem::fromMatrix(
+std::optional<vm::mat4x4d> UvCoordSystem::fromMatrix(
   const vm::vec2f& offset, const vm::vec2f& scale) const
 {
   return computeUvToWorldMatrix(uAxis(), vAxis(), normal(), offset, scale);

--- a/lib/TbMdlLib/src/UvUtils.cpp
+++ b/lib/TbMdlLib/src/UvUtils.cpp
@@ -19,8 +19,6 @@
 
 #include "mdl/UvUtils.h"
 
-#include "kd/contracts.h"
-
 #include "vm/mat_ext.h"
 
 namespace tb::mdl
@@ -75,17 +73,14 @@ vm::mat4x4d computeWorldToUvMatrix(
     1.0};
 }
 
-vm::mat4x4d computeUvToWorldMatrix(
+std::optional<vm::mat4x4d> computeUvToWorldMatrix(
   const vm::vec3d& uAxis,
   const vm::vec3d& vAxis,
   const vm::vec3d& normal,
   const vm::vec2f& offset,
   const vm::vec2f& scale)
 {
-  const auto result = invert(computeWorldToUvMatrix(uAxis, vAxis, normal, offset, scale));
-  contract_assert(result);
-
-  return *result;
+  return invert(computeWorldToUvMatrix(uAxis, vAxis, normal, offset, scale));
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/test-utils/include/mdl/TestUtils.h
+++ b/lib/TbMdlLib/test-utils/include/mdl/TestUtils.h
@@ -60,6 +60,27 @@ BrushFace createParaxial(
   const vm::vec3d& point2,
   const std::string& materialName = "");
 
+/**
+ * Creates a face with a parallel UV coordinate system using the given, possibly
+ * degenerate (e.g. parallel to each other or to the face normal), UV axes.
+ */
+BrushFace createParallel(
+  const vm::vec3d& point0,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const std::string& materialName = "");
+
+/**
+ * Creates a 16-unit cube at the origin whose "top" face (normal {0, 0, 1}) has the
+ * given, possibly degenerate, UV axes, and whose other faces have ordinary paraxial UV
+ * coordinate systems. Useful for testing that code handles a face whose UV coordinate
+ * system cannot be inverted without crashing.
+ */
+Brush createCubeWithTopUvAxes(
+  const vm::vec3d& uAxis, const vm::vec3d& vAxis, const std::string& materialName = "");
+
 std::vector<vm::vec3d> asVertexList(const std::vector<vm::segment3d>& edges);
 std::vector<vm::vec3d> asVertexList(const std::vector<vm::polygon3d>& faces);
 

--- a/lib/TbMdlLib/test-utils/src/TestUtils.cpp
+++ b/lib/TbMdlLib/test-utils/src/TestUtils.cpp
@@ -22,6 +22,7 @@
 #include "gl/Material.h"
 #include "gl/Texture.h"
 #include "mdl/BezierPatch.h"
+#include "mdl/Brush.h"
 #include "mdl/BrushFace.h"
 #include "mdl/BrushNode.h"
 #include "mdl/CatchConfig.h"
@@ -172,6 +173,58 @@ BrushFace createParaxial(
            materialName,
            UvCoordSystem{ParaxialUvCoordSystem{point0, point1, point2, UvAttributes{}}},
            SurfaceAttributes{})
+         | kdl::value();
+}
+
+BrushFace createParallel(
+  const vm::vec3d& point0,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const std::string& materialName)
+{
+  return BrushFace::create(
+           point0,
+           point1,
+           point2,
+           materialName,
+           UvCoordSystem{ParallelUvCoordSystem{uAxis, vAxis, UvAttributes{}}},
+           SurfaceAttributes{})
+         | kdl::value();
+}
+
+Brush createCubeWithTopUvAxes(
+  const vm::vec3d& uAxis, const vm::vec3d& vAxis, const std::string& materialName)
+{
+  auto left = createParaxial(
+    vm::vec3d{0, 0, 0}, vm::vec3d{0, 1, 0}, vm::vec3d{0, 0, 1}, materialName);
+  auto right = createParaxial(
+    vm::vec3d{16, 0, 0}, vm::vec3d{16, 0, 1}, vm::vec3d{16, 1, 0}, materialName);
+  auto front = createParaxial(
+    vm::vec3d{0, 0, 0}, vm::vec3d{0, 0, 1}, vm::vec3d{1, 0, 0}, materialName);
+  auto back = createParaxial(
+    vm::vec3d{0, 16, 0}, vm::vec3d{1, 16, 0}, vm::vec3d{0, 16, 1}, materialName);
+  auto top = createParallel(
+    vm::vec3d{0, 0, 16},
+    vm::vec3d{0, 1, 16},
+    vm::vec3d{1, 0, 16},
+    uAxis,
+    vAxis,
+    materialName);
+  auto bottom = createParaxial(
+    vm::vec3d{0, 0, 0}, vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, materialName);
+
+  return Brush::create(
+           vm::bbox3d{4096.0},
+           {
+             std::move(left),
+             std::move(right),
+             std::move(front),
+             std::move(back),
+             std::move(top),
+             std::move(bottom),
+           })
          | kdl::value();
 }
 

--- a/lib/TbMdlLib/test/src/tst_BrushFace.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushFace.cpp
@@ -45,6 +45,7 @@
 #include "vm/vec.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
+#include <optional>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
@@ -992,6 +993,71 @@ TEST_CASE("BrushFace")
         face.flipUv(cameraUp, cameraRight, vm::direction::up);
         CHECK(face.uvAttributes().scale == vm::vec2f{-1, 1});
       }
+    }
+
+    SECTION(
+      "returns false and leaves the face unchanged for a non-invertible UV "
+      "coordinate system")
+    {
+      // uAxis and vAxis are parallel, so the world-to-UV matrix is not invertible;
+      // this can happen with a hand-edited or corrupted Valve format map file
+      auto degenerateFace = createParallel(
+        vm::vec3d{0, 0, 4},
+        vm::vec3d{1, 0, 4},
+        vm::vec3d{0, -1, 4},
+        vm::vec3d{1, 0, 0},
+        vm::vec3d{1, 0, 0},
+        "material");
+
+      const auto uvAttributesBefore = degenerateFace.uvAttributes();
+      CHECK(!degenerateFace.flipUv(
+        vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, vm::direction::left));
+      CHECK(degenerateFace.uvAttributes() == uvAttributesBefore);
+    }
+  }
+
+  SECTION("projectToBoundaryMatrix")
+  {
+    const auto p0 = vm::vec3d{0, 0, 4};
+    const auto p1 = vm::vec3d{1, 0, 4};
+    const auto p2 = vm::vec3d{0, -1, 4};
+
+    SECTION("returns the projection matrix for independent axes")
+    {
+      auto face =
+        createParallel(p0, p1, p2, vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, "material");
+      CHECK(face.projectToBoundaryMatrix());
+    }
+
+    SECTION("returns std::nullopt for a non-invertible UV coordinate system")
+    {
+      // uAxis and vAxis are parallel, so the world-to-UV matrix is not invertible
+      auto face =
+        createParallel(p0, p1, p2, vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0}, "material");
+      CHECK(face.projectToBoundaryMatrix() == std::nullopt);
+    }
+  }
+
+  SECTION("fromUvCoordSystemMatrix")
+  {
+    const auto p0 = vm::vec3d{0, 0, 4};
+    const auto p1 = vm::vec3d{1, 0, 4};
+    const auto p2 = vm::vec3d{0, -1, 4};
+
+    SECTION("returns the transformation matrix for independent axes")
+    {
+      auto face =
+        createParallel(p0, p1, p2, vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, "material");
+      CHECK(face.fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1}));
+    }
+
+    SECTION("returns std::nullopt for a non-invertible UV coordinate system")
+    {
+      // uAxis and vAxis are parallel, so the world-to-UV matrix is not invertible
+      auto face =
+        createParallel(p0, p1, p2, vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0}, "material");
+      CHECK(
+        face.fromUvCoordSystemMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1}) == std::nullopt);
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
@@ -779,6 +779,29 @@ TEST_CASE("Map_Brushes")
         getFace(*brushNode, *otherFaceIndex),
         MatchesBrushFaceAttributes(originalOtherFace));
     }
+
+    SECTION("does nothing and returns false for a non-invertible UV coordinate system")
+    {
+      auto* degenerateBrushNode =
+        new BrushNode{createCubeWithTopUvAxes(vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0})};
+      addNodes(map, {{&parentForNodes(map), {degenerateBrushNode}}});
+
+      const auto degenerateFaceIndex =
+        degenerateBrushNode->brush().findFace(vm::vec3d{0, 0, 1});
+      REQUIRE(degenerateFaceIndex);
+
+      deselectAll(map);
+      selectBrushFaces(map, {{degenerateBrushNode, *degenerateFaceIndex}});
+
+      const auto uvAttributesBefore =
+        getFace(*degenerateBrushNode, *degenerateFaceIndex).uvAttributes();
+
+      CHECK(!flipUv(map, cameraUp, cameraRight, flipDirection));
+
+      CHECK(
+        getFace(*degenerateBrushNode, *degenerateFaceIndex).uvAttributes()
+        == uvAttributesBefore);
+    }
   }
 
   SECTION("alignUv")

--- a/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
@@ -122,6 +122,23 @@ TEST_CASE("UvCoordSystem")
       CHECK(system.uvAttributes().offset == vm::vec2f{2, 3});
     }
   }
+
+  SECTION("fromMatrix")
+  {
+    SECTION("returns the inverse of toMatrix for independent axes")
+    {
+      const auto system = UvCoordSystem{
+        ParallelUvCoordSystem{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{}}};
+      REQUIRE(system.fromMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1}));
+    }
+
+    SECTION("returns std::nullopt if the UV axes are not linearly independent")
+    {
+      const auto system = UvCoordSystem{
+        ParallelUvCoordSystem{vm::vec3d{1, 0, 0}, vm::vec3d{1, 0, 0}, UvAttributes{}}};
+      CHECK(system.fromMatrix(vm::vec2f{0, 0}, vm::vec2f{1, 1}) == std::nullopt);
+    }
+  }
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_UvUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvUtils.cpp
@@ -22,6 +22,7 @@
 
 #include "vm/approx.h"
 
+#include <optional>
 #include <tuple>
 
 #include <catch2/catch_test_macros.hpp>
@@ -56,6 +57,79 @@ TEST_CASE("UvUtils")
       CHECK(vm::dot(normal, rightAxis) == vm::approx{0.0});
       CHECK(vm::dot(upAxis, rightAxis) == vm::approx{0.0});
       CHECK(vm::cross(rightAxis, upAxis) == vm::approx(normal));
+    }
+  }
+
+  SECTION("computeUvToWorldMatrix")
+  {
+    SECTION("returns the inverse of computeWorldToUvMatrix for independent axes")
+    {
+      const auto result = computeUvToWorldMatrix(
+        vm::vec3d{1, 0, 0},
+        vm::vec3d{0, 1, 0},
+        vm::vec3d{0, 0, 1},
+        vm::vec2f{0, 0},
+        vm::vec2f{1, 1});
+      REQUIRE(result);
+      CHECK(
+        *result
+          * computeWorldToUvMatrix(
+            vm::vec3d{1, 0, 0},
+            vm::vec3d{0, 1, 0},
+            vm::vec3d{0, 0, 1},
+            vm::vec2f{0, 0},
+            vm::vec2f{1, 1})
+        == vm::approx{vm::mat4x4d::identity()});
+    }
+
+    SECTION("returns std::nullopt if the U and V axes are parallel")
+    {
+      CHECK(
+        computeUvToWorldMatrix(
+          vm::vec3d{1, 0, 0},
+          vm::vec3d{1, 0, 0},
+          vm::vec3d{0, 0, 1},
+          vm::vec2f{0, 0},
+          vm::vec2f{1, 1})
+        == std::nullopt);
+    }
+
+    SECTION("returns std::nullopt if the U axis is parallel to the normal")
+    {
+      CHECK(
+        computeUvToWorldMatrix(
+          vm::vec3d{0, 0, 1},
+          vm::vec3d{0, 1, 0},
+          vm::vec3d{0, 0, 1},
+          vm::vec2f{0, 0},
+          vm::vec2f{1, 1})
+        == std::nullopt);
+    }
+
+    SECTION("returns std::nullopt for an extreme scale, without independent axes")
+    {
+      // an extreme scale shrinks the corresponding axis until the determinant of the
+      // world-to-UV matrix underflows to exactly 0 in floating point, even though the
+      // axes and normal are otherwise independent; this is reachable from the UI, since
+      // the scale fields accept any double and are stored as float, so a large but
+      // finite value entered by a user can even overflow to infinity
+      CHECK(
+        computeUvToWorldMatrix(
+          vm::vec3d{1, 0, 0},
+          vm::vec3d{0, 1, 0},
+          vm::vec3d{0, 0, 1},
+          vm::vec2f{0, 0},
+          vm::vec2f{1e20f, 1})
+        == std::nullopt);
+
+      CHECK(
+        computeUvToWorldMatrix(
+          vm::vec3d{1, 0, 0},
+          vm::vec3d{0, 1, 0},
+          vm::vec3d{0, 0, 1},
+          vm::vec2f{0, 0},
+          vm::vec2f{float(1e50), 1}) // overflows to infinity when stored as a float
+        == std::nullopt);
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_UvUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvUtils.cpp
@@ -29,31 +29,34 @@
 namespace tb::mdl
 {
 
-TEST_CASE("computeCameraAxesForFaceNormal")
+TEST_CASE("UvUtils")
 {
-  CHECK(
-    computeCameraAxesForFaceNormal(vm::vec3d{0, 0, 1})
-    == std::tuple{vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}});
-
-  CHECK(
-    computeCameraAxesForFaceNormal(vm::vec3d{0, 0, -1})
-    == std::tuple{vm::vec3d{0, -1, 0}, vm::vec3d{1, 0, 0}});
-
-  CHECK(
-    computeCameraAxesForFaceNormal(vm::vec3d{1, 0, 0})
-    == std::tuple{vm::vec3d{0, 0, 1}, vm::vec3d{0, 1, 0}});
-
-  SECTION("returns normalized up axis orthogonal to normal")
+  SECTION("computeCameraAxesForFaceNormal")
   {
-    const auto normal = vm::normalize(vm::vec3d{1, 2, 3});
-    const auto [upAxis, rightAxis] = computeCameraAxesForFaceNormal(normal);
+    CHECK(
+      computeCameraAxesForFaceNormal(vm::vec3d{0, 0, 1})
+      == std::tuple{vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}});
 
-    CHECK(vm::length(upAxis) == vm::approx{1.0});
-    CHECK(vm::length(rightAxis) == vm::approx{1.0});
-    CHECK(vm::dot(normal, upAxis) == vm::approx{0.0});
-    CHECK(vm::dot(normal, rightAxis) == vm::approx{0.0});
-    CHECK(vm::dot(upAxis, rightAxis) == vm::approx{0.0});
-    CHECK(vm::cross(rightAxis, upAxis) == vm::approx(normal));
+    CHECK(
+      computeCameraAxesForFaceNormal(vm::vec3d{0, 0, -1})
+      == std::tuple{vm::vec3d{0, -1, 0}, vm::vec3d{1, 0, 0}});
+
+    CHECK(
+      computeCameraAxesForFaceNormal(vm::vec3d{1, 0, 0})
+      == std::tuple{vm::vec3d{0, 0, 1}, vm::vec3d{0, 1, 0}});
+
+    SECTION("returns normalized up axis orthogonal to normal")
+    {
+      const auto normal = vm::normalize(vm::vec3d{1, 2, 3});
+      const auto [upAxis, rightAxis] = computeCameraAxesForFaceNormal(normal);
+
+      CHECK(vm::length(upAxis) == vm::approx{1.0});
+      CHECK(vm::length(rightAxis) == vm::approx{1.0});
+      CHECK(vm::dot(normal, upAxis) == vm::approx{0.0});
+      CHECK(vm::dot(normal, rightAxis) == vm::approx{0.0});
+      CHECK(vm::dot(upAxis, rightAxis) == vm::approx{0.0});
+      CHECK(vm::cross(rightAxis, upAxis) == vm::approx(normal));
+    }
   }
 }
 

--- a/lib/TbUiLib/src/MapViewBase.cpp
+++ b/lib/TbUiLib/src/MapViewBase.cpp
@@ -603,7 +603,10 @@ void MapViewBase::flipUv(const vm::direction direction)
   auto& map = m_document.map();
   if (map.selection().hasBrushFaces())
   {
-    mdl::flipUv(map, camera().up(), camera().right(), direction);
+    if (!mdl::flipUv(map, camera().up(), camera().right(), direction))
+    {
+      map.logger().error() << "Could not flip UVs";
+    }
   }
 }
 


### PR DESCRIPTION
TB assumed that the UV / world conversion matrices are always invertible, but brush faces with corrupt texture axes and / or invalid attributes can yield non-invertible matrices. Instead of crashing, we detect these cases and handle them now.

Closes #5448.