### PR TITLE
Ensure that UV attributes are always valid

### DIFF
--- a/lib/TbMdlLib/include/mdl/Brush.h
+++ b/lib/TbMdlLib/include/mdl/Brush.h
@@ -354,8 +354,8 @@ private:
     const std::vector<const Brush*>& subtrahends) const;
 
 public: // UV format conversion
-  Brush convertToParaxial() const;
-  Brush convertToParallel() const;
+  Result<Brush> convertToParaxial() const;
+  Result<Brush> convertToParallel() const;
 
 private:
   bool checkFaceLinks() const;

--- a/lib/TbMdlLib/include/mdl/BrushFace.h
+++ b/lib/TbMdlLib/include/mdl/BrushFace.h
@@ -255,8 +255,8 @@ public:
   void resetUvAxes();
   void resetUvAxesToParaxial();
 
-  void convertToParaxial();
-  void convertToParallel();
+  Result<void> convertToParaxial();
+  Result<void> convertToParallel();
 
   void translateUv(const vm::vec3d& up, const vm::vec3d& right, const vm::vec2f& offset);
   void rotateUv(float angle);

--- a/lib/TbMdlLib/include/mdl/BrushFace.h
+++ b/lib/TbMdlLib/include/mdl/BrushFace.h
@@ -222,7 +222,7 @@ public:
   bool setMaterialName(std::string materialName);
 
   UvAttributes uvAttributes() const;
-  void setUvAttributes(const UvAttributes& uvAttributes);
+  Result<void> setUvAttributes(const UvAttributes& uvAttributes);
 
   const SurfaceAttributes& surfaceAttributes() const;
   void setSurfaceAttributes(const SurfaceAttributes& surfaceAttributes);
@@ -259,7 +259,7 @@ public:
   Result<void> convertToParallel();
 
   void translateUv(const vm::vec3d& up, const vm::vec3d& right, const vm::vec2f& offset);
-  void rotateUv(float angle);
+  Result<void> rotateUv(float angle);
   void shearUv(const vm::vec2f& factors);
   void flipUv(
     const vm::vec3d& cameraUp,

--- a/lib/TbMdlLib/include/mdl/ParallelUvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParallelUvCoordSystem.h
@@ -52,7 +52,7 @@ public:
   ParallelUvCoordSystem(
     const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes);
 
-  static ParallelUvCoordSystem fromParaxial(
+  static ParallelUvCoordSystem createFromParaxial(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
     const vm::vec3d& point2,

--- a/lib/TbMdlLib/include/mdl/ParallelUvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParallelUvCoordSystem.h
@@ -44,7 +44,7 @@ private:
 
   kdl_reflect_decl(ParallelUvCoordSystem, m_uAxis, m_vAxis, m_uvAttributes);
 
-public:
+private:
   ParallelUvCoordSystem(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
@@ -53,6 +53,7 @@ public:
   ParallelUvCoordSystem(
     const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes);
 
+public:
   /**
    * Creates a UV coordinate system projected from the plane defined by the given points,
    * with its axes rotated by the rotation of the given UV attributes.
@@ -72,7 +73,13 @@ public:
   static Result<ParallelUvCoordSystem> createFromAxes(
     const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes);
 
-  static ParallelUvCoordSystem createFromParaxial(
+  /**
+   * Creates a parallel UV coordinate system with axes matching the given paraxial UV
+   * coordinate system.
+   *
+   * Returns an error if the given points do not define a plane.
+   */
+  static Result<ParallelUvCoordSystem> createFromParaxial(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
     const vm::vec3d& point2,

--- a/lib/TbMdlLib/include/mdl/ParallelUvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParallelUvCoordSystem.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "base/Result.h"
 #include "mdl/UvAttributes.h"
 
 #include "kd/reflection_decl.h"
@@ -50,6 +51,25 @@ public:
     const vm::vec3d& point2,
     const UvAttributes& uvAttributes);
   ParallelUvCoordSystem(
+    const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes);
+
+  /**
+   * Creates a UV coordinate system projected from the plane defined by the given points,
+   * with its axes rotated by the rotation of the given UV attributes.
+   *
+   * Returns an error if the given points do not define a plane.
+   */
+  static Result<ParallelUvCoordSystem> createFromPoints(
+    const vm::vec3d& point0,
+    const vm::vec3d& point1,
+    const vm::vec3d& point2,
+    const UvAttributes& uvAttributes);
+
+  /**
+   * Creates a UV coordinate system with the given axes, e.g. as read from a Valve format
+   * map file.
+   */
+  static Result<ParallelUvCoordSystem> createFromAxes(
     const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes);
 
   static ParallelUvCoordSystem createFromParaxial(

--- a/lib/TbMdlLib/include/mdl/ParaxialUvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParaxialUvCoordSystem.h
@@ -54,7 +54,7 @@ public:
     const UvAttributes& uvAttributes);
   ParaxialUvCoordSystem(const vm::vec3d& normal, const UvAttributes& uvAttributes);
 
-  static ParaxialUvCoordSystem fromParallel(
+  static ParaxialUvCoordSystem createFromParallel(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
     const vm::vec3d& point2,

--- a/lib/TbMdlLib/include/mdl/ParaxialUvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParaxialUvCoordSystem.h
@@ -47,7 +47,7 @@ private:
 
   kdl_reflect_decl(ParaxialUvCoordSystem, m_index, m_uAxis, m_vAxis, m_uvAttributes);
 
-public:
+private:
   ParaxialUvCoordSystem(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
@@ -55,6 +55,7 @@ public:
     const UvAttributes& uvAttributes);
   ParaxialUvCoordSystem(const vm::vec3d& normal, const UvAttributes& uvAttributes);
 
+public:
   /**
    * Creates a UV coordinate system snapped to the axis plane which best matches the
    * plane defined by the given points.
@@ -74,7 +75,13 @@ public:
   static Result<ParaxialUvCoordSystem> createFromNormal(
     const vm::vec3d& normal, const UvAttributes& uvAttributes);
 
-  static ParaxialUvCoordSystem createFromParallel(
+  /**
+   * Creates a paraxial UV coordinate system that approximates the given Valve format UV
+   * coordinate system as closely as possible.
+   *
+   * Returns an error if the given points do not define a plane.
+   */
+  static Result<ParaxialUvCoordSystem> createFromParallel(
     const vm::vec3d& point0,
     const vm::vec3d& point1,
     const vm::vec3d& point2,

--- a/lib/TbMdlLib/include/mdl/ParaxialUvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/ParaxialUvCoordSystem.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "base/Result.h"
 #include "mdl/UvAttributes.h"
 
 #include "kd/reflection_decl.h"
@@ -53,6 +54,25 @@ public:
     const vm::vec3d& point2,
     const UvAttributes& uvAttributes);
   ParaxialUvCoordSystem(const vm::vec3d& normal, const UvAttributes& uvAttributes);
+
+  /**
+   * Creates a UV coordinate system snapped to the axis plane which best matches the
+   * plane defined by the given points.
+   *
+   * Returns an error if the given points do not define a plane.
+   */
+  static Result<ParaxialUvCoordSystem> createFromPoints(
+    const vm::vec3d& point0,
+    const vm::vec3d& point1,
+    const vm::vec3d& point2,
+    const UvAttributes& uvAttributes);
+
+  /**
+   * Creates a UV coordinate system snapped to the axis plane which best matches the
+   * given normal.
+   */
+  static Result<ParaxialUvCoordSystem> createFromNormal(
+    const vm::vec3d& normal, const UvAttributes& uvAttributes);
 
   static ParaxialUvCoordSystem createFromParallel(
     const vm::vec3d& point0,

--- a/lib/TbMdlLib/include/mdl/UpdateBrushFaceAttributes.h
+++ b/lib/TbMdlLib/include/mdl/UpdateBrushFaceAttributes.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "base/Color.h"
+#include "base/Result.h"
 
 #include "kd/reflection_decl.h"
 
@@ -137,7 +138,7 @@ UpdateBrushFaceAttributes copyAllExceptContentFlags(const BrushFace& brushFace);
 UpdateBrushFaceAttributes resetAll(const UvAttributes& defaultUvAttributes);
 UpdateBrushFaceAttributes resetAllToParaxial(const UvAttributes& defaultUvAttributes);
 
-void evaluate(
+Result<void> evaluate(
   const UpdateBrushFaceAttributes& updateBrushFaceAttributes, BrushFace& brushFace);
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/UvAttributes.h
+++ b/lib/TbMdlLib/include/mdl/UvAttributes.h
@@ -37,6 +37,13 @@ struct UvAttributes
   bool valid() const;
 };
 
+/**
+ * Checks that offset, scale and rotation are all finite. A scale of 0 is allowed -- use
+ * UvAttributes::valid() to also reject that.
+ */
+bool validateUvAttributes(
+  const vm::vec2f& offset, const vm::vec2f& scale, float rotation);
+
 vm::vec2f modOffset(const vm::vec2f& offset, const vm::vec2f& size);
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/include/mdl/UvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/UvCoordSystem.h
@@ -96,7 +96,7 @@ public:
   /**
    * Sets the given UV attributes and updates the UV axes to match their rotation.
    */
-  void setUvAttributes(const vm::vec3d& normal, const UvAttributes& uvAttributes);
+  Result<void> setUvAttributes(const vm::vec3d& normal, const UvAttributes& uvAttributes);
 
   /**
    * Sets the given UV attributes without updating the UV axes.
@@ -138,7 +138,7 @@ public:
     const vm::vec3d& up,
     const vm::vec3d& right,
     const vm::vec2f& offset);
-  void rotate(const vm::vec3d& normal, float angle);
+  Result<void> rotate(const vm::vec3d& normal, float angle);
   void shear(const vm::vec3d& normal, const vm::vec2f& factors);
 
   vm::mat4x4d toMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;

--- a/lib/TbMdlLib/include/mdl/UvCoordSystem.h
+++ b/lib/TbMdlLib/include/mdl/UvCoordSystem.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "base/Result.h"
 #include "mdl/ParallelUvCoordSystem.h"
 #include "mdl/ParaxialUvCoordSystem.h"
 #include "mdl/UvAttributes.h"
@@ -69,6 +70,10 @@ private:
 public:
   explicit UvCoordSystem(ParaxialUvCoordSystem system);
   explicit UvCoordSystem(ParallelUvCoordSystem system);
+
+  static constexpr auto wrap = [](auto uvCoordSystem) {
+    return UvCoordSystem{std::move(uvCoordSystem)};
+  };
 
   /**
    * Indicates whether this is a UV coordinate system of the given type.
@@ -141,9 +146,9 @@ public:
 
   float measureAngle(const vm::vec2f& center, const vm::vec2f& point) const;
 
-  UvCoordSystem toParallel(
+  Result<UvCoordSystem> toParallel(
     const vm::vec3d& point0, const vm::vec3d& point1, const vm::vec3d& point2) const;
-  UvCoordSystem toParaxial(
+  Result<UvCoordSystem> toParaxial(
     const vm::vec3d& point0, const vm::vec3d& point1, const vm::vec3d& point2) const;
 
 private:

--- a/lib/TbMdlLib/include/mdl/UvUtils.h
+++ b/lib/TbMdlLib/include/mdl/UvUtils.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "base/Result.h"
+
 #include "vm/constants.h"
 #include "vm/mat.h"
 #include "vm/scalar.h"
@@ -29,10 +31,24 @@
 namespace tb::mdl
 {
 
+struct UvAttributes;
+
 /**
  * Return the up and right axes for a camera that looks at the given face.
  */
 std::tuple<vm::vec3d, vm::vec3d> computeCameraAxesForFaceNormal(const vm::vec3d& normal);
+
+/**
+ * Checks that the given UV axes are finite and that they produce an invertible UV
+ * coordinate system matrix, both with a neutral offset/scale and with the given
+ * uvAttributes' actual offset/scale -- a finite but extreme scale can make an otherwise
+ * fine pair of axes non-invertible even though the axes alone would be fine.
+ */
+Result<void> validateUvCoordSystem(
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const vm::vec3d& normal,
+  const UvAttributes& uvAttributes);
 
 /**
  * Returns the given scaling factor, or 1 if it is 0.

--- a/lib/TbMdlLib/src/Brush.cpp
+++ b/lib/TbMdlLib/src/Brush.cpp
@@ -1275,24 +1275,20 @@ Result<Brush> Brush::createBrush(
            });
 }
 
-Brush Brush::convertToParaxial() const
+Result<Brush> Brush::convertToParaxial() const
 {
   auto result = Brush{*this};
-  for (auto& face : result.m_faces)
-  {
-    face.convertToParaxial();
-  }
-  return result;
+  return result.m_faces
+         | std::views::transform([](auto& face) { return face.convertToParaxial(); })
+         | kdl::fold | kdl::transform([&]() { return std::move(result); });
 }
 
-Brush Brush::convertToParallel() const
+Result<Brush> Brush::convertToParallel() const
 {
   auto result = Brush{*this};
-  for (auto& face : result.m_faces)
-  {
-    face.convertToParallel();
-  }
-  return result;
+  return result.m_faces
+         | std::views::transform([](auto& face) { return face.convertToParallel(); })
+         | kdl::fold | kdl::transform([&]() { return std::move(result); });
 }
 
 bool Brush::checkFaceLinks() const

--- a/lib/TbMdlLib/src/Brush.cpp
+++ b/lib/TbMdlLib/src/Brush.cpp
@@ -335,7 +335,7 @@ void Brush::cloneFaceAttributesFrom(const Brush& brush)
     {
       const auto& source = brush.face(*sourceIndex);
       destination.setMaterialName(source.materialName());
-      destination.setUvAttributes(source.uvAttributes());
+      destination.setUvAttributes(source.uvAttributes()) | kdl::ignore();
       destination.setSurfaceAttributes(source.surfaceAttributes());
 
       if (auto snapshot = source.takeUvCoordSystemSnapshot())
@@ -363,7 +363,7 @@ void Brush::cloneFaceAttributesFrom(const std::vector<const Brush*>& brushes)
     if (const auto* bestMatch = findBestMatchingFace(face, candidates))
     {
       face.setMaterialName(bestMatch->materialName());
-      face.setUvAttributes(bestMatch->uvAttributes());
+      face.setUvAttributes(bestMatch->uvAttributes()) | kdl::ignore();
       face.setSurfaceAttributes(bestMatch->surfaceAttributes());
 
       if (auto snapshot = bestMatch->takeUvCoordSystemSnapshot())
@@ -384,7 +384,7 @@ void Brush::cloneInvertedFaceAttributesFrom(const Brush& brush)
       const auto& source = brush.face(*sourceIndex);
       // Todo: invert the face attributes?
       destination.setMaterialName(source.materialName());
-      destination.setUvAttributes(source.uvAttributes());
+      destination.setUvAttributes(source.uvAttributes()) | kdl::ignore();
       destination.setSurfaceAttributes(source.surfaceAttributes());
 
       if (auto snapshot = source.takeUvCoordSystemSnapshot())
@@ -1087,7 +1087,7 @@ void Brush::applyUvLock(
     auto leftClone = BrushFace{leftFace};
     leftClone.transform(*M, true) | kdl::transform([&]() {
       const auto snapshot = leftClone.takeUvCoordSystemSnapshot();
-      rightFace.setUvAttributes(leftClone.uvAttributes());
+      rightFace.setUvAttributes(leftClone.uvAttributes()) | kdl::ignore();
       rightFace.setSurfaceAttributes(leftClone.surfaceAttributes());
       if (snapshot)
       {

--- a/lib/TbMdlLib/src/BrushFace.cpp
+++ b/lib/TbMdlLib/src/BrushFace.cpp
@@ -23,8 +23,6 @@
 #include "gl/Texture.h"
 #include "mdl/BrushGeometry.h"
 #include "mdl/MapFormat.h"
-#include "mdl/ParallelUvCoordSystem.h"
-#include "mdl/ParaxialUvCoordSystem.h"
 #include "mdl/TagMatcher.h"
 #include "mdl/TagVisitor.h"
 #include "mdl/UvCoordSystem.h"
@@ -47,6 +45,41 @@
 
 namespace tb::mdl
 {
+namespace
+{
+
+auto createUvCoordSystemFromPoints(
+  const vm::vec3d& point0,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const UvAttributes& uvAttributes,
+  const MapFormat mapFormat)
+{
+  return isParallelUvCoordSystem(mapFormat)
+           ? ParallelUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes)
+               | kdl::transform(UvCoordSystem::wrap)
+           : ParaxialUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes)
+               | kdl::transform(UvCoordSystem::wrap);
+}
+
+auto createUvCoordSystemFromAxes(
+  const vm::vec3d& point0,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const UvAttributes& uvAttributes,
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const MapFormat mapFormat)
+{
+  return isParallelUvCoordSystem(mapFormat)
+           ? ParallelUvCoordSystem::createFromAxes(uAxis, vAxis, uvAttributes)
+               | kdl::transform(UvCoordSystem::wrap)
+           : ParaxialUvCoordSystem::createFromParallel(
+               point0, point1, point2, uvAttributes, uAxis, vAxis)
+               | kdl::transform(UvCoordSystem::wrap);
+}
+
+} // namespace
 
 const std::string BrushFace::NoMaterialName = "__TB_empty";
 
@@ -131,18 +164,16 @@ Result<BrushFace> BrushFace::create(
   const SurfaceAttributes& surfaceAttributes,
   const MapFormat mapFormat)
 {
-  auto uvCoordSystem =
-    isParallelUvCoordSystem(mapFormat)
-      ? UvCoordSystem{ParallelUvCoordSystem{point0, point1, point2, uvAttributes}}
-      : UvCoordSystem{ParaxialUvCoordSystem{point0, point1, point2, uvAttributes}};
-
-  return BrushFace::create(
-    point0,
-    point1,
-    point2,
-    std::move(materialName),
-    std::move(uvCoordSystem),
-    surfaceAttributes);
+  return createUvCoordSystemFromPoints(point0, point1, point2, uvAttributes, mapFormat)
+         | kdl::and_then([&](auto uvCoordSystem) {
+             return BrushFace::create(
+               point0,
+               point1,
+               point2,
+               std::move(materialName),
+               std::move(uvCoordSystem),
+               surfaceAttributes);
+           });
 }
 
 Result<BrushFace> BrushFace::createFromStandard(
@@ -157,19 +188,16 @@ Result<BrushFace> BrushFace::createFromStandard(
   contract_pre(mapFormat != MapFormat::Unknown);
 
   // Converting paraxial to parallel preserves the UV attributes
-  auto uvCoordSystem =
-    isParallelUvCoordSystem(mapFormat)
-      ? UvCoordSystem{ParallelUvCoordSystem::createFromParaxial(
-          point0, point1, point2, uvAttributes)}
-      : UvCoordSystem{ParaxialUvCoordSystem{point0, point1, point2, uvAttributes}};
-
-  return BrushFace::create(
-    point0,
-    point1,
-    point2,
-    std::move(materialName),
-    std::move(uvCoordSystem),
-    surfaceAttributes);
+  return createUvCoordSystemFromPoints(point0, point1, point2, uvAttributes, mapFormat)
+         | kdl::and_then([&](auto uvCoordSystem) {
+             return BrushFace::create(
+               point0,
+               point1,
+               point2,
+               std::move(materialName),
+               std::move(uvCoordSystem),
+               surfaceAttributes);
+           });
 }
 
 Result<BrushFace> BrushFace::createFromValve(
@@ -181,31 +209,21 @@ Result<BrushFace> BrushFace::createFromValve(
   const SurfaceAttributes& surfaceAttributes,
   const vm::vec3d& uAxis,
   const vm::vec3d& vAxis,
-  MapFormat mapFormat)
+  const MapFormat mapFormat)
 {
   contract_pre(mapFormat != MapFormat::Unknown);
 
-  if (isParallelUvCoordSystem(mapFormat))
-  {
-    // Pass through parallel
-    return BrushFace::create(
-      point1,
-      point2,
-      point3,
-      std::move(materialName),
-      UvCoordSystem{ParallelUvCoordSystem{uAxis, vAxis, uvAttributes}},
-      surfaceAttributes);
-  }
-
-  // Convert parallel to paraxial
-  return BrushFace::create(
-    point1,
-    point2,
-    point3,
-    std::move(materialName),
-    UvCoordSystem{ParaxialUvCoordSystem::createFromParallel(
-      point1, point2, point3, uvAttributes, uAxis, vAxis)},
-    surfaceAttributes);
+  return createUvCoordSystemFromAxes(
+           point1, point2, point3, uvAttributes, uAxis, vAxis, mapFormat)
+         | kdl::and_then([&](auto uvCoordSystem) {
+             return BrushFace::create(
+               point1,
+               point2,
+               point3,
+               std::move(materialName),
+               std::move(uvCoordSystem),
+               surfaceAttributes);
+           });
 }
 
 Result<BrushFace> BrushFace::create(
@@ -584,14 +602,18 @@ void BrushFace::resetUvAxesToParaxial()
   m_uvCoordSystem.resetToParaxial(m_boundary.normal, 0.0f);
 }
 
-void BrushFace::convertToParaxial()
+Result<void> BrushFace::convertToParaxial()
 {
-  m_uvCoordSystem = m_uvCoordSystem.toParaxial(m_points[0], m_points[1], m_points[2]);
+  return m_uvCoordSystem.toParaxial(m_points[0], m_points[1], m_points[2])
+         | kdl::transform(
+           [&](auto uvCoordSystem) { m_uvCoordSystem = std::move(uvCoordSystem); });
 }
 
-void BrushFace::convertToParallel()
+Result<void> BrushFace::convertToParallel()
 {
-  m_uvCoordSystem = m_uvCoordSystem.toParallel(m_points[0], m_points[1], m_points[2]);
+  return m_uvCoordSystem.toParallel(m_points[0], m_points[1], m_points[2])
+         | kdl::transform(
+           [&](auto uvCoordSystem) { m_uvCoordSystem = std::move(uvCoordSystem); });
 }
 
 void BrushFace::translateUv(

--- a/lib/TbMdlLib/src/BrushFace.cpp
+++ b/lib/TbMdlLib/src/BrushFace.cpp
@@ -452,9 +452,9 @@ UvAttributes BrushFace::uvAttributes() const
   return m_uvCoordSystem.uvAttributes();
 }
 
-void BrushFace::setUvAttributes(const UvAttributes& uvAttributes)
+Result<void> BrushFace::setUvAttributes(const UvAttributes& uvAttributes)
 {
-  m_uvCoordSystem.setUvAttributes(m_boundary.normal, uvAttributes);
+  return m_uvCoordSystem.setUvAttributes(m_boundary.normal, uvAttributes);
 }
 
 const SurfaceAttributes& BrushFace::surfaceAttributes() const
@@ -622,9 +622,9 @@ void BrushFace::translateUv(
   m_uvCoordSystem.translate(m_boundary.normal, up, right, offset);
 }
 
-void BrushFace::rotateUv(const float angle)
+Result<void> BrushFace::rotateUv(const float angle)
 {
-  m_uvCoordSystem.rotate(m_boundary.normal, angle);
+  return m_uvCoordSystem.rotate(m_boundary.normal, angle);
 }
 
 void BrushFace::shearUv(const vm::vec2f& factors)

--- a/lib/TbMdlLib/src/BrushFace.cpp
+++ b/lib/TbMdlLib/src/BrushFace.cpp
@@ -159,7 +159,7 @@ Result<BrushFace> BrushFace::createFromStandard(
   // Converting paraxial to parallel preserves the UV attributes
   auto uvCoordSystem =
     isParallelUvCoordSystem(mapFormat)
-      ? UvCoordSystem{ParallelUvCoordSystem::fromParaxial(
+      ? UvCoordSystem{ParallelUvCoordSystem::createFromParaxial(
           point0, point1, point2, uvAttributes)}
       : UvCoordSystem{ParaxialUvCoordSystem{point0, point1, point2, uvAttributes}};
 
@@ -203,7 +203,7 @@ Result<BrushFace> BrushFace::createFromValve(
     point2,
     point3,
     std::move(materialName),
-    UvCoordSystem{ParaxialUvCoordSystem::fromParallel(
+    UvCoordSystem{ParaxialUvCoordSystem::createFromParallel(
       point1, point2, point3, uvAttributes, uAxis, vAxis)},
     surfaceAttributes);
 }

--- a/lib/TbMdlLib/src/Map_Brushes.cpp
+++ b/lib/TbMdlLib/src/Map_Brushes.cpp
@@ -155,12 +155,14 @@ void compensateOffset(
       * *vertex};
     const auto delta = previousUvCoords - newUvCoords;
 
+    // cannot fail: only compensates the offset of an already-valid face
     evaluate(
       UpdateBrushFaceAttributes{
         .xOffset = mdl::AddValue{delta.x()},
         .yOffset = mdl::AddValue{delta.y()},
       },
-      brushFace);
+      brushFace)
+      | kdl::ignore();
   }
   else
   {
@@ -206,8 +208,10 @@ bool setBrushFaceAttributes(Map& map, const UpdateBrushFaceAttributes& update)
 {
   return applyAndSwap(
     map, "Change Face Attributes", map.selection().allBrushFaces(), [&](auto& brushFace) {
-      evaluate(update, brushFace);
-      return true;
+      return evaluate(update, brushFace) | kdl::if_error([&](auto e) {
+               map.logger().error() << "Could not set face attributes: " << e.msg;
+             })
+             | kdl::is_success();
     });
 }
 
@@ -242,8 +246,10 @@ bool translateUv(
 bool rotateUv(Map& map, const float angle)
 {
   return applyAndSwap(map, "Rotate UV", map.selection().allBrushFaces(), [&](auto& face) {
-    face.rotateUv(angle);
-    return true;
+    return face.rotateUv(angle) | kdl::if_error([&](auto e) {
+             map.logger().error() << "Could not rotate UV: " << e.msg;
+           })
+           | kdl::is_success();
   });
 }
 
@@ -279,7 +285,8 @@ void alignUv(Map& map, const UvPolicy uvPolicy)
 {
   applyAndSwap(
     map, "Align Texture", map.selection().allBrushFaces(), [&](auto& brushFace) {
-      evaluate(mdl::align(brushFace, uvPolicy), brushFace);
+      // cannot fail: only adjusts the offset of an already-valid face
+      evaluate(mdl::align(brushFace, uvPolicy), brushFace) | kdl::ignore();
       return true;
     });
 }
@@ -292,7 +299,9 @@ void justifyUv(
       const auto [uvAxis, uvSign] =
         convertJustifyDirection(brushFace, uvJustifyDirection);
 
-      evaluate(mdl::justify(brushFace, uvAxis, uvSign, uvPolicy), brushFace);
+      // cannot fail: only adjusts the offset of an already-valid face
+      evaluate(mdl::justify(brushFace, uvAxis, uvSign, uvPolicy), brushFace)
+        | kdl::ignore();
       return true;
     });
 }
@@ -308,7 +317,9 @@ void fitUv(
 
     const auto invariantVertex = anchorVertex(brushFace, uvAxis, uvSign);
     compensateOffset(brushFace, invariantVertex, [&] {
-      evaluate(mdl::fit(brushFace, uvAxis, uvPolicy, uvFitMode), brushFace);
+      // cannot fail: only adjusts the scale/offset of an already-valid face
+      evaluate(mdl::fit(brushFace, uvAxis, uvPolicy, uvFitMode), brushFace)
+        | kdl::ignore();
     });
     return true;
   });
@@ -318,25 +329,28 @@ void autoFitUv(Map& map)
 {
   applyAndSwap(
     map, "Auto Fit Texture", map.selection().allBrushFaces(), [&](auto& brushFace) {
-      evaluate(mdl::align(brushFace, UvPolicy::best), brushFace);
+      // cannot fail: these calls only adjust the scale/offset of an already-valid face
+      evaluate(mdl::align(brushFace, UvPolicy::best), brushFace) | kdl::ignore();
 
       evaluate(
-        mdl::justify(brushFace, UvAxis::u, UvSign::plus, UvPolicy::best), brushFace);
+        mdl::justify(brushFace, UvAxis::u, UvSign::plus, UvPolicy::best), brushFace)
+        | kdl::ignore();
       evaluate(
-        mdl::justify(brushFace, UvAxis::v, UvSign::plus, UvPolicy::best), brushFace);
+        mdl::justify(brushFace, UvAxis::v, UvSign::plus, UvPolicy::best), brushFace)
+        | kdl::ignore();
 
       const auto invariantUVertex = anchorVertex(brushFace, UvAxis::u, UvSign::plus);
       compensateOffset(brushFace, invariantUVertex, [&] {
         evaluate(
-          mdl::fit(brushFace, UvAxis::u, UvPolicy::best, UvFitMode::fitToFace),
-          brushFace);
+          mdl::fit(brushFace, UvAxis::u, UvPolicy::best, UvFitMode::fitToFace), brushFace)
+          | kdl::ignore();
       });
 
       const auto invariantVVertex = anchorVertex(brushFace, UvAxis::v, UvSign::plus);
       compensateOffset(brushFace, invariantVVertex, [&] {
         evaluate(
-          mdl::fit(brushFace, UvAxis::v, UvPolicy::best, UvFitMode::fitToFace),
-          brushFace);
+          mdl::fit(brushFace, UvAxis::v, UvPolicy::best, UvFitMode::fitToFace), brushFace)
+          | kdl::ignore();
       });
 
       return true;

--- a/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
@@ -100,7 +100,7 @@ ParallelUvCoordSystem::ParallelUvCoordSystem(
 {
 }
 
-ParallelUvCoordSystem ParallelUvCoordSystem::fromParaxial(
+ParallelUvCoordSystem ParallelUvCoordSystem::createFromParaxial(
   const vm::vec3d& point0,
   const vm::vec3d& point1,
   const vm::vec3d& point2,

--- a/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
@@ -123,7 +123,16 @@ Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromPoints(
 Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromAxes(
   const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes)
 {
-  return ParallelUvCoordSystem{uAxis, vAxis, uvAttributes};
+  if (!validateUvAttributes(
+        uvAttributes.offset, uvAttributes.scale, uvAttributes.rotation))
+  {
+    return Error{"UV attributes are invalid"};
+  }
+
+  const auto normal = vm::normalize(vm::cross(uAxis, vAxis));
+  return validateUvCoordSystem(uAxis, vAxis, normal, uvAttributes)
+         | kdl::transform(
+           [&]() { return ParallelUvCoordSystem{uAxis, vAxis, uvAttributes}; });
 }
 
 Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromParaxial(

--- a/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
@@ -27,6 +27,7 @@
 
 #include "vm/mat.h"
 #include "vm/mat_ext.h"
+#include "vm/plane.h"
 #include "vm/vec.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
@@ -98,6 +99,30 @@ ParallelUvCoordSystem::ParallelUvCoordSystem(
   , m_vAxis{vAxis}
   , m_uvAttributes{uvAttributes}
 {
+}
+
+Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromPoints(
+  const vm::vec3d& point0,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const UvAttributes& uvAttributes)
+{
+  const auto normal = vm::plane_normal(point0, point1, point2);
+  if (!normal)
+  {
+    return Error{"Face points do not define a plane"};
+  }
+
+  auto [uAxis, vAxis] = computeInitialAxes(*normal);
+  std::tie(uAxis, vAxis) =
+    applyRotation(uAxis, vAxis, *normal, double(uvAttributes.rotation));
+  return createFromAxes(uAxis, vAxis, uvAttributes);
+}
+
+Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromAxes(
+  const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes)
+{
+  return ParallelUvCoordSystem{uAxis, vAxis, uvAttributes};
 }
 
 ParallelUvCoordSystem ParallelUvCoordSystem::createFromParaxial(

--- a/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParallelUvCoordSystem.cpp
@@ -24,6 +24,7 @@
 
 #include "kd/contracts.h"
 #include "kd/reflection_impl.h"
+#include "kd/result.h"
 
 #include "vm/mat.h"
 #include "vm/mat_ext.h"
@@ -125,14 +126,16 @@ Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromAxes(
   return ParallelUvCoordSystem{uAxis, vAxis, uvAttributes};
 }
 
-ParallelUvCoordSystem ParallelUvCoordSystem::createFromParaxial(
+Result<ParallelUvCoordSystem> ParallelUvCoordSystem::createFromParaxial(
   const vm::vec3d& point0,
   const vm::vec3d& point1,
   const vm::vec3d& point2,
   const UvAttributes& uvAttributes)
 {
-  const auto tempParaxial = ParaxialUvCoordSystem{point0, point1, point2, uvAttributes};
-  return ParallelUvCoordSystem{tempParaxial.uAxis(), tempParaxial.vAxis(), uvAttributes};
+  return ParaxialUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes)
+         | kdl::and_then([&](const auto& paraxial) {
+             return createFromAxes(paraxial.uAxis(), paraxial.vAxis(), uvAttributes);
+           });
 }
 
 const UvAttributes& ParallelUvCoordSystem::uvAttributes() const

--- a/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
@@ -744,8 +744,6 @@ void ParaxialUvCoordSystem::transform(
     contract_assert(!vm::is_nan(newOffset));
     contract_assert(!vm::is_nan(newScale));
     contract_assert(!vm::is_nan(newRotation));
-    contract_assert(!vm::is_zero(newScale.x(), vm::Cf::almost_zero()));
-    contract_assert(!vm::is_zero(newScale.y(), vm::Cf::almost_zero()));
 
     m_uvAttributes = UvAttributes{
       .offset = newOffset,

--- a/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
@@ -495,6 +495,25 @@ ParaxialUvCoordSystem ParaxialUvCoordSystem::createFromParallel(
   return ParaxialUvCoordSystem{point0, point1, point2, newUvAttributes};
 }
 
+Result<ParaxialUvCoordSystem> ParaxialUvCoordSystem::createFromPoints(
+  const vm::vec3d& point0,
+  const vm::vec3d& point1,
+  const vm::vec3d& point2,
+  const UvAttributes& uvAttributes)
+{
+  if (const auto normal = vm::plane_normal(point0, point1, point2))
+  {
+    return createFromNormal(*normal, uvAttributes);
+  }
+  return Error{"Face points do not define a plane"};
+}
+
+Result<ParaxialUvCoordSystem> ParaxialUvCoordSystem::createFromNormal(
+  const vm::vec3d& normal, const UvAttributes& uvAttributes)
+{
+  return ParaxialUvCoordSystem{normal, uvAttributes};
+}
+
 size_t ParaxialUvCoordSystem::planeNormalIndex(const vm::vec3d& normal)
 {
   size_t bestIndex = 0;

--- a/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
@@ -136,20 +136,23 @@ float mat2x2_extract_rotation_degrees(const vm::mat2x2f& m)
   return vm::to_degrees(rotation);
 }
 
+std::tuple<vm::vec3d, vm::vec3d> rotatedBaseAxes(const size_t index, const float rotation)
+{
+  auto uAxis = vm::vec3d{};
+  auto vAxis = vm::vec3d{};
+  std::tie(uAxis, vAxis, std::ignore) = ParaxialUvCoordSystem::axes(index);
+  return rotateAxes(uAxis, vAxis, vm::to_radians(double(rotation)), index);
+}
+
 vm::vec2f getUvCoordsAtPoint(
   const ParaxialAttribs& paraxialAttribs,
   const vm::plane3d& facePlane,
   const vm::vec3d& point)
 {
-  const auto uvAttributes = UvAttributes{
-    .offset = paraxialAttribs.offset,
-    .scale = paraxialAttribs.scale,
-    .rotation = paraxialAttribs.rotation,
-  };
-
-  const auto temp = ParaxialUvCoordSystem{facePlane.normal, uvAttributes};
-  return computeUvCoords(point, temp.uAxis(), temp.vAxis(), uvAttributes.scale)
-         + uvAttributes.offset;
+  const auto index = ParaxialUvCoordSystem::planeNormalIndex(facePlane.normal);
+  const auto [uAxis, vAxis] = rotatedBaseAxes(index, paraxialAttribs.rotation);
+  return computeUvCoords(point, uAxis, vAxis, paraxialAttribs.scale)
+         + paraxialAttribs.offset;
 }
 
 ParaxialAttribs appendOffset(
@@ -466,7 +469,7 @@ ParaxialUvCoordSystem::ParaxialUvCoordSystem(
   setRotation(normal, 0.0f, uvAttributes.rotation);
 }
 
-ParaxialUvCoordSystem ParaxialUvCoordSystem::createFromParallel(
+Result<ParaxialUvCoordSystem> ParaxialUvCoordSystem::createFromParallel(
   const vm::vec3d& point0,
   const vm::vec3d& point1,
   const vm::vec3d& point2,
@@ -475,6 +478,11 @@ ParaxialUvCoordSystem ParaxialUvCoordSystem::createFromParallel(
   const vm::vec3d& vAxis)
 {
   const auto facePlane = vm::from_points(point0, point1, point2);
+  if (!facePlane)
+  {
+    return Error{"Face points do not define a plane"};
+  }
+
   const auto worldToTexSpace = valveTo4x4Matrix(*facePlane, uvAttributes, uAxis, vAxis);
   const auto facePoints = std::array<vm::vec3f, 3>{
     vm::vec3f{point0},
@@ -492,7 +500,7 @@ ParaxialUvCoordSystem ParaxialUvCoordSystem::createFromParallel(
                                              }
                                            : UvAttributes{};
 
-  return ParaxialUvCoordSystem{point0, point1, point2, newUvAttributes};
+  return createFromNormal(facePlane->normal, newUvAttributes);
 }
 
 Result<ParaxialUvCoordSystem> ParaxialUvCoordSystem::createFromPoints(

--- a/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
@@ -23,6 +23,7 @@
 
 #include "kd/contracts.h"
 #include "kd/reflection_impl.h"
+#include "kd/result.h"
 
 #include "vm/plane.h"
 #include "vm/quat.h"
@@ -519,7 +520,16 @@ Result<ParaxialUvCoordSystem> ParaxialUvCoordSystem::createFromPoints(
 Result<ParaxialUvCoordSystem> ParaxialUvCoordSystem::createFromNormal(
   const vm::vec3d& normal, const UvAttributes& uvAttributes)
 {
-  return ParaxialUvCoordSystem{normal, uvAttributes};
+  if (!validateUvAttributes(
+        uvAttributes.offset, uvAttributes.scale, uvAttributes.rotation))
+  {
+    return Error{"UV attributes are invalid"};
+  }
+
+  auto system = ParaxialUvCoordSystem{normal, uvAttributes};
+  return validateUvCoordSystem(
+           system.uAxis(), system.vAxis(), system.normal(), uvAttributes)
+         | kdl::transform([&]() { return system; });
 }
 
 size_t ParaxialUvCoordSystem::planeNormalIndex(const vm::vec3d& normal)

--- a/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/ParaxialUvCoordSystem.cpp
@@ -466,7 +466,7 @@ ParaxialUvCoordSystem::ParaxialUvCoordSystem(
   setRotation(normal, 0.0f, uvAttributes.rotation);
 }
 
-ParaxialUvCoordSystem ParaxialUvCoordSystem::fromParallel(
+ParaxialUvCoordSystem ParaxialUvCoordSystem::createFromParallel(
   const vm::vec3d& point0,
   const vm::vec3d& point1,
   const vm::vec3d& point2,

--- a/lib/TbMdlLib/src/UpdateBrushFaceAttributes.cpp
+++ b/lib/TbMdlLib/src/UpdateBrushFaceAttributes.cpp
@@ -25,6 +25,7 @@
 
 #include "kd/optional_utils.h"
 #include "kd/reflection_impl.h"
+#include "kd/result.h"
 
 #include "vm/scalar.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
@@ -179,7 +180,7 @@ UpdateBrushFaceAttributes resetAllToParaxial(const UvAttributes& defaultUvAttrib
   };
 }
 
-void evaluate(const UpdateBrushFaceAttributes& update, BrushFace& brushFace)
+Result<void> evaluate(const UpdateBrushFaceAttributes& update, BrushFace& brushFace)
 {
   if (update.materialName)
   {
@@ -187,44 +188,46 @@ void evaluate(const UpdateBrushFaceAttributes& update, BrushFace& brushFace)
   }
 
   const auto& uvAttributes = brushFace.uvAttributes();
-  brushFace.setUvAttributes(UvAttributes{
-    .offset =
-      {*evaluate(update.xOffset, uvAttributes.offset.x()),
-       *evaluate(update.yOffset, uvAttributes.offset.y())},
-    .scale =
-      {*evaluate(update.xScale, uvAttributes.scale.x()),
-       *evaluate(update.yScale, uvAttributes.scale.y())},
-    .rotation = vm::normalize_degrees(*evaluate(update.rotation, uvAttributes.rotation)),
-  });
+  return brushFace.setUvAttributes(UvAttributes{
+           .offset =
+             {*evaluate(update.xOffset, uvAttributes.offset.x()),
+              *evaluate(update.yOffset, uvAttributes.offset.y())},
+           .scale =
+             {*evaluate(update.xScale, uvAttributes.scale.x()),
+              *evaluate(update.yScale, uvAttributes.scale.y())},
+           .rotation =
+             vm::normalize_degrees(*evaluate(update.rotation, uvAttributes.rotation)),
+         })
+         | kdl::transform([&]() {
+             auto surfaceAttributes = brushFace.surfaceAttributes();
 
-  auto surfaceAttributes = brushFace.surfaceAttributes();
+             if (update.surfaceFlags)
+             {
+               surfaceAttributes.flags =
+                 evaluate(update.surfaceFlags, brushFace.resolvedSurfaceFlags());
+             }
 
-  if (update.surfaceFlags)
-  {
-    surfaceAttributes.flags =
-      evaluate(update.surfaceFlags, brushFace.resolvedSurfaceFlags());
-  }
+             if (update.surfaceContents)
+             {
+               surfaceAttributes.contents =
+                 evaluate(update.surfaceContents, brushFace.resolvedSurfaceContents());
+             }
 
-  if (update.surfaceContents)
-  {
-    surfaceAttributes.contents =
-      evaluate(update.surfaceContents, brushFace.resolvedSurfaceContents());
-  }
+             if (update.surfaceValue)
+             {
+               surfaceAttributes.value =
+                 evaluate(update.surfaceValue, brushFace.resolvedSurfaceValue());
+             }
 
-  if (update.surfaceValue)
-  {
-    surfaceAttributes.value =
-      evaluate(update.surfaceValue, brushFace.resolvedSurfaceValue());
-  }
+             if (update.color)
+             {
+               surfaceAttributes.color = *update.color;
+             }
 
-  if (update.color)
-  {
-    surfaceAttributes.color = *update.color;
-  }
+             brushFace.setSurfaceAttributes(surfaceAttributes);
 
-  brushFace.setSurfaceAttributes(surfaceAttributes);
-
-  evaluate(update.axis, brushFace);
+             evaluate(update.axis, brushFace);
+           });
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/src/UpdateBrushFaceAttributes.cpp
+++ b/lib/TbMdlLib/src/UpdateBrushFaceAttributes.cpp
@@ -182,11 +182,8 @@ UpdateBrushFaceAttributes resetAllToParaxial(const UvAttributes& defaultUvAttrib
 
 Result<void> evaluate(const UpdateBrushFaceAttributes& update, BrushFace& brushFace)
 {
-  if (update.materialName)
-  {
-    brushFace.setMaterialName(*update.materialName);
-  }
-
+  // validate the (possibly invalid) UV update before touching anything else, so that a
+  // rejected update leaves the whole face -- not just its UV attributes -- unchanged
   const auto& uvAttributes = brushFace.uvAttributes();
   return brushFace.setUvAttributes(UvAttributes{
            .offset =
@@ -199,6 +196,11 @@ Result<void> evaluate(const UpdateBrushFaceAttributes& update, BrushFace& brushF
              vm::normalize_degrees(*evaluate(update.rotation, uvAttributes.rotation)),
          })
          | kdl::transform([&]() {
+             if (update.materialName)
+             {
+               brushFace.setMaterialName(*update.materialName);
+             }
+
              auto surfaceAttributes = brushFace.surfaceAttributes();
 
              if (update.surfaceFlags)

--- a/lib/TbMdlLib/src/UvAttributes.cpp
+++ b/lib/TbMdlLib/src/UvAttributes.cpp
@@ -22,6 +22,7 @@
 #include "kd/reflection_impl.h"
 
 #include "vm/scalar.h"
+#include "vm/vec.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
 namespace tb::mdl
@@ -29,9 +30,16 @@ namespace tb::mdl
 
 kdl_reflect_impl(UvAttributes);
 
+bool validateUvAttributes(
+  const vm::vec2f& offset, const vm::vec2f& scale, const float rotation)
+{
+  return vm::is_finite(offset) && vm::is_finite(scale) && vm::is_finite(rotation);
+}
+
 bool UvAttributes::valid() const
 {
-  return !vm::is_zero(scale.x(), vm::Cf::almost_zero())
+  return validateUvAttributes(offset, scale, rotation)
+         && !vm::is_zero(scale.x(), vm::Cf::almost_zero())
          && !vm::is_zero(scale.y(), vm::Cf::almost_zero());
 }
 

--- a/lib/TbMdlLib/src/UvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/UvCoordSystem.cpp
@@ -315,7 +315,7 @@ UvCoordSystem UvCoordSystem::toParallel(
   return std::visit(
     kdl::overload(
       [&](const ParaxialUvCoordSystem& system) {
-        return UvCoordSystem{ParallelUvCoordSystem::fromParaxial(
+        return UvCoordSystem{ParallelUvCoordSystem::createFromParaxial(
           point0, point1, point2, system.uvAttributes())};
       },
       [&](const ParallelUvCoordSystem& system) {
@@ -335,7 +335,7 @@ UvCoordSystem UvCoordSystem::toParaxial(
         return UvCoordSystem{system};
       },
       [&](const ParallelUvCoordSystem& system) {
-        return UvCoordSystem{ParaxialUvCoordSystem::fromParallel(
+        return UvCoordSystem{ParaxialUvCoordSystem::createFromParallel(
           point0, point1, point2, system.uvAttributes(), system.uAxis(), system.vAxis())};
       }),
     m_system);

--- a/lib/TbMdlLib/src/UvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/UvCoordSystem.cpp
@@ -24,6 +24,7 @@
 #include "kd/contracts.h"
 #include "kd/overload.h"
 #include "kd/reflection_impl.h"
+#include "kd/result.h"
 
 #include "vm/mat.h"
 #include "vm/mat_ext.h"
@@ -309,34 +310,41 @@ float UvCoordSystem::measureAngle(const vm::vec2f& center, const vm::vec2f& poin
     [&](const auto& system) { return system.measureAngle(center, point); }, m_system);
 }
 
-UvCoordSystem UvCoordSystem::toParallel(
+Result<UvCoordSystem> UvCoordSystem::toParallel(
   const vm::vec3d& point0, const vm::vec3d& point1, const vm::vec3d& point2) const
 {
   return std::visit(
     kdl::overload(
-      [&](const ParaxialUvCoordSystem& system) {
-        return UvCoordSystem{ParallelUvCoordSystem::createFromParaxial(
-          point0, point1, point2, system.uvAttributes())};
+      [&](const ParaxialUvCoordSystem& paraxialUvCoordSystem) {
+        return ParallelUvCoordSystem::createFromParaxial(
+                 point0, point1, point2, paraxialUvCoordSystem.uvAttributes())
+               | kdl::transform(UvCoordSystem::wrap);
       },
-      [&](const ParallelUvCoordSystem& system) {
+      [&](const ParallelUvCoordSystem& parallelUvCoordSystem) -> Result<UvCoordSystem> {
         // Already in the requested format
-        return UvCoordSystem{system};
+        return UvCoordSystem{parallelUvCoordSystem};
       }),
     m_system);
 }
 
-UvCoordSystem UvCoordSystem::toParaxial(
+Result<UvCoordSystem> UvCoordSystem::toParaxial(
   const vm::vec3d& point0, const vm::vec3d& point1, const vm::vec3d& point2) const
 {
   return std::visit(
     kdl::overload(
-      [&](const ParaxialUvCoordSystem& system) {
+      [&](const ParaxialUvCoordSystem& paraxialUvCoordSystem) -> Result<UvCoordSystem> {
         // Already in the requested format
-        return UvCoordSystem{system};
+        return UvCoordSystem{paraxialUvCoordSystem};
       },
-      [&](const ParallelUvCoordSystem& system) {
-        return UvCoordSystem{ParaxialUvCoordSystem::createFromParallel(
-          point0, point1, point2, system.uvAttributes(), system.uAxis(), system.vAxis())};
+      [&](const ParallelUvCoordSystem& parallelUvCoordSystem) {
+        return ParaxialUvCoordSystem::createFromParallel(
+                 point0,
+                 point1,
+                 point2,
+                 parallelUvCoordSystem.uvAttributes(),
+                 parallelUvCoordSystem.uAxis(),
+                 parallelUvCoordSystem.vAxis())
+               | kdl::transform(UvCoordSystem::wrap);
       }),
     m_system);
 }

--- a/lib/TbMdlLib/src/UvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/UvCoordSystem.cpp
@@ -82,10 +82,20 @@ UvAttributes UvCoordSystem::uvAttributes() const
 Result<void> UvCoordSystem::setUvAttributes(
   const vm::vec3d& normal, const UvAttributes& uvAttributes)
 {
-  const auto oldRotation = this->uvAttributes().rotation;
-  copyUvAttributes(uvAttributes);
-  setRotation(normal, oldRotation, uvAttributes.rotation);
-  return kdl::void_success;
+  if (!validateUvAttributes(
+        uvAttributes.offset, uvAttributes.scale, uvAttributes.rotation))
+  {
+    return Error{"UV attributes are invalid"};
+  }
+
+  auto candidate = *this;
+  const auto oldRotation = candidate.uvAttributes().rotation;
+  candidate.copyUvAttributes(uvAttributes);
+  candidate.setRotation(normal, oldRotation, uvAttributes.rotation);
+
+  return validateUvCoordSystem(
+           candidate.uAxis(), candidate.vAxis(), candidate.normal(), uvAttributes)
+         | kdl::transform([&]() { *this = std::move(candidate); });
 }
 
 void UvCoordSystem::copyUvAttributes(const UvAttributes& uvAttributes)

--- a/lib/TbMdlLib/src/UvCoordSystem.cpp
+++ b/lib/TbMdlLib/src/UvCoordSystem.cpp
@@ -79,12 +79,13 @@ UvAttributes UvCoordSystem::uvAttributes() const
   return std::visit([](const auto& system) { return system.uvAttributes(); }, m_system);
 }
 
-void UvCoordSystem::setUvAttributes(
+Result<void> UvCoordSystem::setUvAttributes(
   const vm::vec3d& normal, const UvAttributes& uvAttributes)
 {
   const auto oldRotation = this->uvAttributes().rotation;
   copyUvAttributes(uvAttributes);
   setRotation(normal, oldRotation, uvAttributes.rotation);
+  return kdl::void_success;
 }
 
 void UvCoordSystem::copyUvAttributes(const UvAttributes& uvAttributes)
@@ -279,13 +280,13 @@ void UvCoordSystem::translate(
   copyUvAttributes(uvAttributes);
 }
 
-void UvCoordSystem::rotate(const vm::vec3d& normal, const float angle)
+Result<void> UvCoordSystem::rotate(const vm::vec3d& normal, const float angle)
 {
   const auto actualAngle = isRotationInverted(normal) ? -angle : angle;
 
   auto uvAttributes = this->uvAttributes();
   uvAttributes.rotation = uvAttributes.rotation + actualAngle;
-  setUvAttributes(normal, uvAttributes);
+  return setUvAttributes(normal, uvAttributes);
 }
 
 void UvCoordSystem::shear(const vm::vec3d& normal, const vm::vec2f& factors)

--- a/lib/TbMdlLib/src/UvUtils.cpp
+++ b/lib/TbMdlLib/src/UvUtils.cpp
@@ -19,7 +19,10 @@
 
 #include "mdl/UvUtils.h"
 
+#include "mdl/UvAttributes.h"
+
 #include "kd/contracts.h"
+#include "kd/result.h"
 
 #include "vm/mat_ext.h"
 
@@ -86,6 +89,34 @@ vm::mat4x4d computeUvToWorldMatrix(
   contract_assert(result);
 
   return *result;
+}
+
+Result<void> validateUvCoordSystem(
+  const vm::vec3d& uAxis,
+  const vm::vec3d& vAxis,
+  const vm::vec3d& normal,
+  const UvAttributes& uvAttributes)
+{
+  if (!vm::is_finite(uAxis) || !vm::is_finite(vAxis))
+  {
+    return Error{"UV axes are invalid"};
+  }
+
+  const auto neutralMatrix =
+    computeWorldToUvMatrix(uAxis, vAxis, normal, vm::vec2f{0, 0}, vm::vec2f{1, 1});
+  if (!vm::invert(neutralMatrix))
+  {
+    return Error{"UV axes do not form an invertible coordinate system"};
+  }
+
+  const auto actualMatrix =
+    computeWorldToUvMatrix(uAxis, vAxis, normal, uvAttributes.offset, uvAttributes.scale);
+  if (!vm::invert(actualMatrix))
+  {
+    return Error{"UV coordinate system is not invertible"};
+  }
+
+  return kdl::void_success;
 }
 
 } // namespace tb::mdl

--- a/lib/TbMdlLib/src/UvUtils.cpp
+++ b/lib/TbMdlLib/src/UvUtils.cpp
@@ -24,8 +24,6 @@
 #include "kd/contracts.h"
 #include "kd/result.h"
 
-#include "vm/mat_ext.h"
-
 namespace tb::mdl
 {
 

--- a/lib/TbMdlLib/test-utils/src/TestUtils.cpp
+++ b/lib/TbMdlLib/test-utils/src/TestUtils.cpp
@@ -170,7 +170,10 @@ BrushFace createParaxial(
            point1,
            point2,
            materialName,
-           UvCoordSystem{ParaxialUvCoordSystem{point0, point1, point2, UvAttributes{}}},
+           UvCoordSystem{
+             ParaxialUvCoordSystem::createFromPoints(
+               point0, point1, point2, UvAttributes{})
+             | kdl::value()},
            SurfaceAttributes{})
          | kdl::value();
 }

--- a/lib/TbMdlLib/test/CMakeLists.txt
+++ b/lib/TbMdlLib/test/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(TbMdlLibTest PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UvAlignment.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UpdateLinkedGroupsCommand.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UpdateLinkedGroupsHelper.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UvAttributes.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UvCoordSystem.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_UvUtils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_Validation.cpp

--- a/lib/TbMdlLib/test/src/tst_Brush.cpp
+++ b/lib/TbMdlLib/test/src/tst_Brush.cpp
@@ -358,7 +358,7 @@ TEST_CASE("Brush")
 
     auto& topFace = brush.face(*topFaceIndex);
 
-    topFace.setUvAttributes({.offset = {64.0f, -48.0f}});
+    REQUIRE(topFace.setUvAttributes({.offset = {64.0f, -48.0f}}).is_success());
 
     auto newBrush = brush;
     newBrush.cloneFaceAttributesFrom(brush);

--- a/lib/TbMdlLib/test/src/tst_BrushFace.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushFace.cpp
@@ -45,6 +45,7 @@
 #include "vm/vec.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
+#include <limits>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
@@ -504,6 +505,55 @@ TEST_CASE("BrushFace")
           ParaxialUvCoordSystem::createFromNormal(vm::vec3d{0, 0, 1}, UvAttributes{})
           | kdl::value()},
         SurfaceAttributes{}));
+    }
+
+    SECTION("with an invalid UV attribute")
+    {
+      const auto p0 = vm::vec3d{0, 0, 4};
+      const auto p1 = vm::vec3d{1, 0, 4};
+      const auto p2 = vm::vec3d{0, -1, 4};
+      const auto nan = std::numeric_limits<float>::quiet_NaN();
+      const auto invalidUvAttributes = UvAttributes{{0, 0}, {1, 1}, nan};
+
+      // Standard format goes through ParaxialUvCoordSystem
+      CHECK(!BrushFace::create(
+        p0, p1, p2, "", invalidUvAttributes, SurfaceAttributes{}, MapFormat::Standard));
+
+      // Valve format goes through ParallelUvCoordSystem
+      CHECK(!BrushFace::create(
+        p0, p1, p2, "", invalidUvAttributes, SurfaceAttributes{}, MapFormat::Valve));
+    }
+
+    SECTION("with degenerate Valve axes")
+    {
+      const auto p0 = vm::vec3d{0, 0, 4};
+      const auto p1 = vm::vec3d{1, 0, 4};
+      const auto p2 = vm::vec3d{0, -1, 4};
+      const auto uAxis = vm::vec3d{1, 0, 0};
+
+      // Valve format passes the axes through to ParallelUvCoordSystem unchanged
+      CHECK(!BrushFace::createFromValve(
+        p0,
+        p1,
+        p2,
+        "",
+        UvAttributes{},
+        SurfaceAttributes{},
+        uAxis,
+        uAxis,
+        MapFormat::Valve));
+    }
+
+    SECTION("createFromStandard with an extreme scale")
+    {
+      const auto p0 = vm::vec3d{0, 0, 4};
+      const auto p1 = vm::vec3d{1, 0, 4};
+      const auto p2 = vm::vec3d{0, -1, 4};
+      const auto extremeUvAttributes = UvAttributes{{0, 0}, {1e30f, 1e30f}, 0.0f};
+
+      // converting from Paraxial to Parallel preserves the (here, extreme) UV attributes
+      CHECK(!BrushFace::createFromStandard(
+        p0, p1, p2, "", extremeUvAttributes, SurfaceAttributes{}, MapFormat::Valve));
     }
   }
 

--- a/lib/TbMdlLib/test/src/tst_BrushFace.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushFace.cpp
@@ -475,7 +475,9 @@ TEST_CASE("BrushFace")
                     p1,
                     p2,
                     "",
-                    UvCoordSystem{ParaxialUvCoordSystem{p0, p1, p2, UvAttributes{}}},
+                    UvCoordSystem{
+                      ParaxialUvCoordSystem::createFromPoints(p0, p1, p2, UvAttributes{})
+                      | kdl::value()},
                     SurfaceAttributes{})
                   | kdl::value();
       CHECK(face.points()[0] == vm::approx{p0});
@@ -491,12 +493,16 @@ TEST_CASE("BrushFace")
       const auto p1 = vm::vec3d{1, 0, 4};
       const auto p2 = vm::vec3d{2, 0, 4};
 
+      // the UV coordinate system's own axes are independent of the (colinear) face
+      // points here -- this exercises BrushFace::create's own plane-degeneracy check
       CHECK(!BrushFace::create(
         p0,
         p1,
         p2,
         "",
-        UvCoordSystem{ParaxialUvCoordSystem{p0, p1, p2, UvAttributes{}}},
+        UvCoordSystem{
+          ParaxialUvCoordSystem::createFromNormal(vm::vec3d{0, 0, 1}, UvAttributes{})
+          | kdl::value()},
         SurfaceAttributes{}));
     }
   }
@@ -521,7 +527,9 @@ TEST_CASE("BrushFace")
                     p1,
                     p2,
                     "",
-                    UvCoordSystem{ParaxialUvCoordSystem{p0, p1, p2, UvAttributes{}}},
+                    UvCoordSystem{
+                      ParaxialUvCoordSystem::createFromPoints(p0, p1, p2, UvAttributes{})
+                      | kdl::value()},
                     SurfaceAttributes{})
                   | kdl::value();
       CHECK(material.usageCount() == 0u);
@@ -908,11 +916,15 @@ TEST_CASE("BrushFace")
       REQUIRE(standardCube.transform(worldBounds, transform, true));
       CHECK(standardCube.face(0).uvCoordSystem().is<ParaxialUvCoordSystem>());
 
-      const auto valveCube = standardCube.convertToParallel();
+      const auto valveCubeResult = standardCube.convertToParallel();
+      REQUIRE(valveCubeResult);
+      const auto& valveCube = valveCubeResult.value();
       CHECK(valveCube.face(0).uvCoordSystem().is<ParallelUvCoordSystem>());
       checkBrushUvsEqual(standardCube, valveCube);
 
-      const auto standardCubeRoundTrip = valveCube.convertToParaxial();
+      const auto standardCubeRoundTripResult = valveCube.convertToParaxial();
+      REQUIRE(standardCubeRoundTripResult);
+      const auto& standardCubeRoundTrip = standardCubeRoundTripResult.value();
       CHECK(standardCubeRoundTrip.face(0).uvCoordSystem().is<ParaxialUvCoordSystem>());
       checkBrushUvsEqual(standardCube, standardCubeRoundTrip);
     };

--- a/lib/TbMdlLib/test/src/tst_BrushFace.cpp
+++ b/lib/TbMdlLib/test/src/tst_BrushFace.cpp
@@ -71,7 +71,7 @@ void getFaceVertsAndUvCoords(
 
 void resetFaceUvAlignment(BrushFace& face)
 {
-  face.setUvAttributes({});
+  REQUIRE(face.setUvAttributes({}).is_success());
   face.resetUvAxes();
 }
 
@@ -660,7 +660,7 @@ TEST_CASE("BrushFace")
     const auto newXAxis = vm::vec3d{rot45 * face.uAxis()};
     const auto newYAxis = vm::vec3d{rot45 * face.vAxis()};
 
-    face.setUvAttributes({.rotation = -45.0f});
+    REQUIRE(face.setUvAttributes({.rotation = -45.0f}).is_success());
 
     CHECK(face.uAxis() == vm::approx{newXAxis});
     CHECK(face.vAxis() == vm::approx{newYAxis});
@@ -761,7 +761,7 @@ TEST_CASE("BrushFace")
 
     // Rotate by 45 degrees CCW
     CHECK(negXFace->uvAttributes().rotation == vm::approx{0.0f});
-    negXFace->rotateUv(45.0);
+    REQUIRE(negXFace->rotateUv(45.0).is_success());
     CHECK(negXFace->uvAttributes().rotation == vm::approx{45.0f});
 
     CHECK(negXFace->uAxis() == vm::approx{newXAxis});

--- a/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
@@ -40,6 +40,8 @@
 
 #include "vm/approx.h"
 
+#include <limits>
+
 #include <catch2/catch_test_macros.hpp>
 
 namespace tb::mdl
@@ -415,6 +417,28 @@ TEST_CASE("Map_Brushes")
         }
       }
     }
+
+    SECTION("rejects an invalid value")
+    {
+      auto& map = fixture.create();
+
+      auto* brushNode = createBrushNode(map);
+      addNodes(map, {{&parentForNodes(map), {brushNode}}});
+
+      const size_t faceIndex = 0u;
+      deselectAll(map);
+      selectBrushFaces(map, {{brushNode, faceIndex}});
+
+      const auto originalFace = getFace(*brushNode, faceIndex);
+      const auto canUndoBefore = map.canUndoCommand();
+
+      const auto nan = std::numeric_limits<float>::quiet_NaN();
+      CHECK(!setBrushFaceAttributes(map, {.rotation = SetValue{nan}}));
+
+      CHECK_THAT(
+        getFace(*brushNode, faceIndex), MatchesBrushFaceAttributes(originalFace));
+      CHECK(map.canUndoCommand() == canUndoBefore);
+    }
   }
 
   SECTION("copyUv")
@@ -585,61 +609,87 @@ TEST_CASE("Map_Brushes")
     auto* brushNode = createBrushNode(map);
     addNodes(map, {{&parentForNodes(map), {brushNode}}});
 
-    const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
-    REQUIRE(faceIndex);
-
-    const auto otherFaceIndex = brushNode->brush().findFace(vm::vec3d{1, 0, 0});
-    REQUIRE(otherFaceIndex);
-
-    deselectAll(map);
-    selectBrushFaces(map, {{brushNode, *faceIndex}});
-
-    REQUIRE(setBrushFaceAttributes(map, {.rotation = SetValue{10.0f}}));
-
-    const auto originalFace = getFace(*brushNode, *faceIndex);
-    const auto originalUAxis = getFace(*brushNode, *faceIndex).uAxis();
-    const auto originalVAxis = getFace(*brushNode, *faceIndex).vAxis();
-
-    const auto originalOtherFace = getFace(*brushNode, *otherFaceIndex);
-
-    auto expectedBrush = brushNode->brush();
-    REQUIRE(expectedBrush.face(*faceIndex).rotateUv(15.0f).is_success());
-    const auto expectedFaceCopy = expectedBrush.face(*faceIndex);
-    const auto expectedUAxis = expectedBrush.face(*faceIndex).uAxis();
-    const auto expectedVAxis = expectedBrush.face(*faceIndex).vAxis();
-
-    REQUIRE(rotateUv(map, 15.0f));
-
-    const auto& rotatedFace = getFace(*brushNode, *faceIndex);
-    CHECK_THAT(rotatedFace, MatchesBrushFaceAttributes(expectedFaceCopy));
-    CHECK(rotatedFace.uAxis() == vm::approx{expectedUAxis});
-    CHECK(rotatedFace.vAxis() == vm::approx{expectedVAxis});
-
-    CHECK_THAT(
-      getFace(*brushNode, *otherFaceIndex),
-      MatchesBrushFaceAttributes(originalOtherFace));
-
-    SECTION("Undo and redo")
+    SECTION("accepts valid rotations")
     {
-      map.undoCommand();
+      const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
+      REQUIRE(faceIndex);
 
-      const auto& undoneFace = getFace(*brushNode, *faceIndex);
-      CHECK_THAT(undoneFace, MatchesBrushFaceAttributes(originalFace));
-      CHECK(undoneFace.uAxis() == vm::approx{originalUAxis});
-      CHECK(undoneFace.vAxis() == vm::approx{originalVAxis});
+      const auto otherFaceIndex = brushNode->brush().findFace(vm::vec3d{1, 0, 0});
+      REQUIRE(otherFaceIndex);
+
+      deselectAll(map);
+      selectBrushFaces(map, {{brushNode, *faceIndex}});
+
+      REQUIRE(setBrushFaceAttributes(map, {.rotation = SetValue{10.0f}}));
+
+      const auto originalFace = getFace(*brushNode, *faceIndex);
+      const auto originalUAxis = getFace(*brushNode, *faceIndex).uAxis();
+      const auto originalVAxis = getFace(*brushNode, *faceIndex).vAxis();
+
+      const auto originalOtherFace = getFace(*brushNode, *otherFaceIndex);
+
+      auto expectedBrush = brushNode->brush();
+      REQUIRE(expectedBrush.face(*faceIndex).rotateUv(15.0f).is_success());
+      const auto expectedFaceCopy = expectedBrush.face(*faceIndex);
+      const auto expectedUAxis = expectedBrush.face(*faceIndex).uAxis();
+      const auto expectedVAxis = expectedBrush.face(*faceIndex).vAxis();
+
+      REQUIRE(rotateUv(map, 15.0f));
+
+      const auto& rotatedFace = getFace(*brushNode, *faceIndex);
+      CHECK_THAT(rotatedFace, MatchesBrushFaceAttributes(expectedFaceCopy));
+      CHECK(rotatedFace.uAxis() == vm::approx{expectedUAxis});
+      CHECK(rotatedFace.vAxis() == vm::approx{expectedVAxis});
+
       CHECK_THAT(
         getFace(*brushNode, *otherFaceIndex),
         MatchesBrushFaceAttributes(originalOtherFace));
 
-      map.redoCommand();
+      SECTION("Undo and redo")
+      {
+        map.undoCommand();
 
-      const auto& redoneFace = getFace(*brushNode, *faceIndex);
-      CHECK_THAT(redoneFace, MatchesBrushFaceAttributes(expectedFaceCopy));
-      CHECK(redoneFace.uAxis() == vm::approx{expectedUAxis});
-      CHECK(redoneFace.vAxis() == vm::approx{expectedVAxis});
+        const auto& undoneFace = getFace(*brushNode, *faceIndex);
+        CHECK_THAT(undoneFace, MatchesBrushFaceAttributes(originalFace));
+        CHECK(undoneFace.uAxis() == vm::approx{originalUAxis});
+        CHECK(undoneFace.vAxis() == vm::approx{originalVAxis});
+        CHECK_THAT(
+          getFace(*brushNode, *otherFaceIndex),
+          MatchesBrushFaceAttributes(originalOtherFace));
+
+        map.redoCommand();
+
+        const auto& redoneFace = getFace(*brushNode, *faceIndex);
+        CHECK_THAT(redoneFace, MatchesBrushFaceAttributes(expectedFaceCopy));
+        CHECK(redoneFace.uAxis() == vm::approx{expectedUAxis});
+        CHECK(redoneFace.vAxis() == vm::approx{expectedVAxis});
+        CHECK_THAT(
+          getFace(*brushNode, *otherFaceIndex),
+          MatchesBrushFaceAttributes(originalOtherFace));
+      }
+    }
+
+    SECTION("rejects an invalid rotations")
+    {
+      const auto faceIndex = brushNode->brush().findFace(vm::vec3d{0, 0, 1});
+      REQUIRE(faceIndex);
+
+      deselectAll(map);
+      selectBrushFaces(map, {{brushNode, *faceIndex}});
+
+      const auto max = std::numeric_limits<float>::max();
+      REQUIRE(setBrushFaceAttributes(map, {.rotation = SetValue{max}}));
+
+      const auto originalFace = getFace(*brushNode, *faceIndex);
+      const auto canUndoBefore = map.canUndoCommand();
+
+      // rotating the already-huge rotation by another huge angle overflows it to
+      // infinity -- this is the original crash this branch set out to fix
+      CHECK(!rotateUv(map, max));
+
       CHECK_THAT(
-        getFace(*brushNode, *otherFaceIndex),
-        MatchesBrushFaceAttributes(originalOtherFace));
+        getFace(*brushNode, *faceIndex), MatchesBrushFaceAttributes(originalFace));
+      CHECK(map.canUndoCommand() == canUndoBefore);
     }
   }
 

--- a/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
@@ -601,7 +601,7 @@ TEST_CASE("Map_Brushes")
     const auto originalOtherFace = getFace(*brushNode, *otherFaceIndex);
 
     auto expectedBrush = brushNode->brush();
-    expectedBrush.face(*faceIndex).rotateUv(15.0f);
+    REQUIRE(expectedBrush.face(*faceIndex).rotateUv(15.0f).is_success());
     const auto expectedFaceCopy = expectedBrush.face(*faceIndex);
     const auto expectedUAxis = expectedBrush.face(*faceIndex).uAxis();
     const auto expectedVAxis = expectedBrush.face(*faceIndex).vAxis();

--- a/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
+++ b/lib/TbMdlLib/test/src/tst_Map_Brushes.cpp
@@ -36,6 +36,8 @@
 #include "mdl/UvAlignment.h"
 #include "mdl/UvCoordSystem.h"
 
+#include "kd/result.h"
+
 #include "vm/approx.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -808,7 +810,8 @@ TEST_CASE("Map_Brushes")
     auto expectedBrush = brushNode->brush();
     evaluate(
       align(expectedBrush.face(*faceIndex), UvPolicy::next),
-      expectedBrush.face(*faceIndex));
+      expectedBrush.face(*faceIndex))
+      | kdl::ignore();
     const auto expectedFaceCopy = expectedBrush.face(*faceIndex);
     const auto expectedUAxis = expectedBrush.face(*faceIndex).uAxis();
     const auto expectedVAxis = expectedBrush.face(*faceIndex).vAxis();
@@ -881,7 +884,8 @@ TEST_CASE("Map_Brushes")
     auto expectedBrush = brushNode->brush();
     evaluate(
       justify(expectedBrush.face(*faceIndex), UvAxis::u, UvSign::plus, UvPolicy::best),
-      expectedBrush.face(*faceIndex));
+      expectedBrush.face(*faceIndex))
+      | kdl::ignore();
     const auto expectedFaceCopy = expectedBrush.face(*faceIndex);
     const auto expectedUAxis = expectedBrush.face(*faceIndex).uAxis();
     const auto expectedVAxis = expectedBrush.face(*faceIndex).vAxis();
@@ -962,7 +966,8 @@ TEST_CASE("Map_Brushes")
       * invariantVertex};
 
     evaluate(
-      fit(expectedFace, UvAxis::u, UvPolicy::next, UvFitMode::fitToFace), expectedFace);
+      fit(expectedFace, UvAxis::u, UvPolicy::next, UvFitMode::fitToFace), expectedFace)
+      | kdl::ignore();
 
     const auto newUvCoords = vm::vec2f{
       expectedFace.toUvCoordSystemMatrix(
@@ -975,7 +980,8 @@ TEST_CASE("Map_Brushes")
         .xOffset = AddValue{delta.x()},
         .yOffset = AddValue{delta.y()},
       },
-      expectedFace);
+      expectedFace)
+      | kdl::ignore();
 
     const auto expectedUAxis = expectedFace.uAxis();
     const auto expectedVAxis = expectedFace.vAxis();

--- a/lib/TbMdlLib/test/src/tst_NodeReader.cpp
+++ b/lib/TbMdlLib/test/src/tst_NodeReader.cpp
@@ -137,6 +137,80 @@ TEST_CASE("NodeReader")
       == std::vector<std::string>{"At line 4, column 1: Brush is incomplete"});
   }
 
+  SECTION("skipsAndLogsFaceWithInvalidUvAttributes")
+  {
+    // brush 0's last face has a scale so large that its UV coordinate system matrix
+    // isn't invertible; the face gets skipped, which leaves the brush incomplete (this
+    // is otherwise the same brush geometry as reportsBrushErrorsWithLocation). brush 1
+    // is unaffected and should still load.
+    const auto data = R"(
+{
+"classname" "worldspawn"
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty 0 0 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) __TB_empty 0 0 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty 0 0 0 1e30 1e30
+}
+{
+( -256 -256 -256 ) ( -256 -255 -256 ) ( -256 -256 -255 ) __TB_empty 0 0 0 1 1
+( -256 -256 -256 ) ( -256 -256 -255 ) ( -255 -256 -256 ) __TB_empty 0 0 0 1 1
+( -256 -256 -256 ) ( -255 -256 -256 ) ( -256 -255 -256 ) __TB_empty 0 0 0 1 1
+( 256 256 256 ) ( 256 257 256 ) ( 257 256 256 ) __TB_empty 0 0 0 1 1
+( 256 256 256 ) ( 257 256 256 ) ( 256 256 257 ) __TB_empty 0 0 0 1 1
+( 256 256 256 ) ( 256 256 257 ) ( 256 257 256 ) __TB_empty 0 0 0 1 1
+}
+}
+)";
+
+    auto nodes =
+      NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status, taskManager);
+    REQUIRE(nodes);
+
+    CHECK(
+      status.messages(LogLevel::Error)
+      == std::vector<std::string>{
+        "At line 9, column 60: Skipping face: UV coordinate system is not invertible",
+        "At line 4, column 1: Brush is incomplete",
+      });
+
+    const auto& children = nodes.value().at(0)->children();
+    REQUIRE(children.size() == 1u);
+
+    auto* brushNode = dynamic_cast<BrushNode*>(children.at(0));
+    REQUIRE(brushNode != nullptr);
+    CHECK(brushNode->brush().bounds() == vm::bbox3d{{-256, -256, -256}, {256, 256, 256}});
+  }
+
+  SECTION("loadsFaceWithZeroUvScale")
+  {
+    // a scale of 0 is invalid for editing (InvalidUvScaleValidator flags it and offers a
+    // quick fix), but it must still load rather than being rejected outright
+    const auto data = R"(
+{
+"classname" "worldspawn"
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty 0 0 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) __TB_empty 0 0 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty 0 0 0 0 0
+}
+}
+)";
+
+    auto nodes =
+      NodeReader::read(data, MapFormat::Standard, worldBounds, {}, status, taskManager);
+    REQUIRE(nodes);
+    CHECK(status.messages(LogLevel::Error).empty());
+
+    auto* brushNode = dynamic_cast<BrushNode*>(nodes.value().at(0)->children().at(0));
+    REQUIRE(brushNode != nullptr);
+  }
+
   SECTION("readScientificNotation")
   {
     // https://github.com/TrenchBroom/TrenchBroom/issues/4270

--- a/lib/TbMdlLib/test/src/tst_UpdateBrushFaceAttributes.cpp
+++ b/lib/TbMdlLib/test/src/tst_UpdateBrushFaceAttributes.cpp
@@ -199,10 +199,11 @@ TEST_CASE("UpdateBrushFaceAttributes")
       const auto update = UpdateBrushFaceAttributes{.xOffset = valueOp};
 
       {
-        brushFace.setUvAttributes({.offset = {originalValue, 0.0f}});
+        REQUIRE(
+          brushFace.setUvAttributes({.offset = {originalValue, 0.0f}}).is_success());
       }
 
-      evaluate(update, brushFace);
+      REQUIRE(evaluate(update, brushFace).is_success());
 
       CHECK(brushFace.uvAttributes().offset.x() == expectedValue);
     }
@@ -229,7 +230,7 @@ TEST_CASE("UpdateBrushFaceAttributes")
         brushFace.setSurfaceAttributes({.flags = originalFlags});
       }
 
-      evaluate(update, brushFace);
+      REQUIRE(evaluate(update, brushFace).is_success());
 
       CHECK(brushFace.surfaceAttributes().flags == expectedFlags);
     }
@@ -261,7 +262,7 @@ TEST_CASE("UpdateBrushFaceAttributes")
         .color = RgbaB{1, 2, 3, 4},
       };
 
-      evaluate(update, brushFace);
+      REQUIRE(evaluate(update, brushFace).is_success());
 
       CHECK(brushFace.materialName() == "other_material");
       CHECK(brushFace.uvAttributes() == expectedUvAttributes);
@@ -287,7 +288,7 @@ TEST_CASE("UpdateBrushFaceAttributes")
       const auto expectedUvAttributes = brushFace.uvAttributes();
       const auto expectedSurfaceAttributes = brushFace.surfaceAttributes();
 
-      evaluate(update, brushFace);
+      REQUIRE(evaluate(update, brushFace).is_success());
 
       CHECK(brushFace.materialName() == expectedMaterialName);
       CHECK(brushFace.uvAttributes() == expectedUvAttributes);

--- a/lib/TbMdlLib/test/src/tst_UpdateBrushFaceAttributes.cpp
+++ b/lib/TbMdlLib/test/src/tst_UpdateBrushFaceAttributes.cpp
@@ -30,6 +30,8 @@
 
 #include "kd/k.h"
 
+#include <limits>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
@@ -267,6 +269,70 @@ TEST_CASE("UpdateBrushFaceAttributes")
       CHECK(brushFace.materialName() == "other_material");
       CHECK(brushFace.uvAttributes() == expectedUvAttributes);
       CHECK(brushFace.surfaceAttributes() == expectedSurfaceAttributes);
+    }
+
+    SECTION("rejects an extreme rotation and leaves the face unchanged")
+    {
+      const auto max = std::numeric_limits<float>::max();
+      REQUIRE(brushFace.setUvAttributes({.rotation = max}).is_success());
+
+      const auto expectedMaterialName = brushFace.materialName();
+      const auto expectedUvAttributes = brushFace.uvAttributes();
+      const auto expectedSurfaceAttributes = brushFace.surfaceAttributes();
+
+      // adding another huge delta overflows the rotation to infinity -- this is the
+      // original crash this branch set out to fix
+      const auto update = UpdateBrushFaceAttributes{
+        .materialName = "other_material",
+        .rotation = AddValue{max},
+      };
+      CHECK(!evaluate(update, brushFace));
+
+      CHECK(brushFace.materialName() == expectedMaterialName);
+      CHECK(brushFace.uvAttributes() == expectedUvAttributes);
+      CHECK(brushFace.surfaceAttributes() == expectedSurfaceAttributes);
+    }
+
+    SECTION("rejects an extreme negative rotation without hanging")
+    {
+      const auto lowest = std::numeric_limits<float>::lowest();
+      REQUIRE(brushFace.setUvAttributes({.rotation = lowest}).is_success());
+
+      // adding another huge negative delta overflows the rotation to -infinity; this is
+      // a regression guard for the normalize_degrees hang this branch also fixed
+      const auto update = UpdateBrushFaceAttributes{.rotation = AddValue{lowest}};
+      CHECK(!evaluate(update, brushFace));
+    }
+
+    SECTION("rejects an extreme scale via SetValue")
+    {
+      const auto expectedUvAttributes = brushFace.uvAttributes();
+
+      const auto update =
+        UpdateBrushFaceAttributes{.xScale = SetValue{1e30f}, .yScale = SetValue{1e30f}};
+      CHECK(!evaluate(update, brushFace));
+      CHECK(brushFace.uvAttributes() == expectedUvAttributes);
+    }
+
+    SECTION("rejects an extreme scale accumulated via repeated MultiplyValue")
+    {
+      REQUIRE(brushFace.setUvAttributes({.scale = {1e15f, 1e15f}}).is_success());
+      const auto expectedUvAttributes = brushFace.uvAttributes();
+
+      const auto update = UpdateBrushFaceAttributes{
+        .xScale = MultiplyValue{1e15f}, .yScale = MultiplyValue{1e15f}};
+      CHECK(!evaluate(update, brushFace));
+      CHECK(brushFace.uvAttributes() == expectedUvAttributes);
+    }
+
+    SECTION("accepts a scale of 0")
+    {
+      // InvalidUvScaleValidator relies on zero-scale faces being able to load and be
+      // edited so it can flag and fix them
+      const auto update =
+        UpdateBrushFaceAttributes{.xScale = SetValue{0.0f}, .yScale = SetValue{0.0f}};
+      REQUIRE(evaluate(update, brushFace).is_success());
+      CHECK(brushFace.uvAttributes().scale == vm::vec2f{0, 0});
     }
 
     SECTION("No evaluation")

--- a/lib/TbMdlLib/test/src/tst_UvAlignment.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvAlignment.cpp
@@ -75,17 +75,18 @@ TEST_CASE("UvAlignment")
     SECTION("uses preferred sign when currently justified")
     {
       withFrontFace([&](auto& frontFace) {
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{0.0f},
-            .yOffset = SetValue{0.0f},
-            .rotation = SetValue{0.0f},
-            .xScale = SetValue{1.2f},
-            .yScale = SetValue{0.9f},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{0.0f},
+                    .yOffset = SetValue{0.0f},
+                    .rotation = SetValue{0.0f},
+                    .xScale = SetValue{1.2f},
+                    .yScale = SetValue{0.9f},
+                  },
+                  frontFace)
+                  .is_success());
 
-        evaluate(justify(frontFace, UvU, UvPls, UvBest), frontFace);
+        REQUIRE(evaluate(justify(frontFace, UvU, UvPls, UvBest), frontFace).is_success());
 
         CHECK(anchorVertex(frontFace, UvU, UvPls) == vm::vec3d{32, -32, 32});
       });
@@ -94,17 +95,18 @@ TEST_CASE("UvAlignment")
     SECTION("falls back to opposite sign when preferred sign is not justified")
     {
       withFrontFace([&](auto& frontFace) {
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{0.0f},
-            .yOffset = SetValue{0.0f},
-            .rotation = SetValue{0.0f},
-            .xScale = SetValue{1.2f},
-            .yScale = SetValue{0.9f},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{0.0f},
+                    .yOffset = SetValue{0.0f},
+                    .rotation = SetValue{0.0f},
+                    .xScale = SetValue{1.2f},
+                    .yScale = SetValue{0.9f},
+                  },
+                  frontFace)
+                  .is_success());
 
-        evaluate(justify(frontFace, UvU, UvMns, UvBest), frontFace);
+        REQUIRE(evaluate(justify(frontFace, UvU, UvMns, UvBest), frontFace).is_success());
 
         CHECK(anchorVertex(frontFace, UvU, UvPls) == vm::vec3d{-32, -32, 32});
       });
@@ -113,15 +115,16 @@ TEST_CASE("UvAlignment")
     SECTION("uses preferred sign when neither sign is justified")
     {
       withFrontFace([&](auto& frontFace) {
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{7.0f},
-            .yOffset = SetValue{11.0f},
-            .rotation = SetValue{0.0f},
-            .xScale = SetValue{1.2f},
-            .yScale = SetValue{0.9f},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{7.0f},
+                    .yOffset = SetValue{11.0f},
+                    .rotation = SetValue{0.0f},
+                    .xScale = SetValue{1.2f},
+                    .yScale = SetValue{0.9f},
+                  },
+                  frontFace)
+                  .is_success());
 
         CHECK(anchorVertex(frontFace, UvU, UvPls) == vm::vec3d{32, -32, 32});
       });
@@ -157,11 +160,12 @@ TEST_CASE("UvAlignment")
             REQUIRE(frontFaceIndex);
 
             auto& frontFace = brush.face(*frontFaceIndex);
-            evaluate(
-              UpdateBrushFaceAttributes{
-                .rotation = SetValue{initialRotation},
-              },
-              frontFace);
+            REQUIRE(evaluate(
+                      UpdateBrushFaceAttributes{
+                        .rotation = SetValue{initialRotation},
+                      },
+                      frontFace)
+                      .is_success());
 
             CHECK(isAligned(frontFace) == expectedAligned);
           })
@@ -204,11 +208,12 @@ TEST_CASE("UvAlignment")
             REQUIRE(topFaceIndex);
 
             auto& topFace = brush.face(*topFaceIndex);
-            evaluate(
-              UpdateBrushFaceAttributes{
-                .rotation = SetValue{initialRotation},
-              },
-              topFace);
+            REQUIRE(evaluate(
+                      UpdateBrushFaceAttributes{
+                        .rotation = SetValue{initialRotation},
+                      },
+                      topFace)
+                      .is_success());
 
             CHECK(isAligned(topFace) == expectedAligned);
           })
@@ -251,11 +256,12 @@ TEST_CASE("UvAlignment")
             REQUIRE(topFaceIndex);
 
             auto& topFace = brush.face(*topFaceIndex);
-            evaluate(
-              UpdateBrushFaceAttributes{
-                .rotation = SetValue{initialRotation},
-              },
-              topFace);
+            REQUIRE(evaluate(
+                      UpdateBrushFaceAttributes{
+                        .rotation = SetValue{initialRotation},
+                      },
+                      topFace)
+                      .is_success());
 
             CHECK(isAligned(topFace) == expectedAligned);
           })
@@ -334,15 +340,16 @@ TEST_CASE("UvAlignment")
         auto& frontFace = brush.face(*frontFaceIndex);
         frontFace.setMaterial(&material);
 
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{float(initialOffset.x())},
-            .yOffset = SetValue{float(initialOffset.y())},
-            .rotation = SetValue{float(initialRotation)},
-            .xScale = SetValue{float(initialScale.x())},
-            .yScale = SetValue{float(initialScale.y())},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{float(initialOffset.x())},
+                    .yOffset = SetValue{float(initialOffset.y())},
+                    .rotation = SetValue{float(initialRotation)},
+                    .xScale = SetValue{float(initialScale.x())},
+                    .yScale = SetValue{float(initialScale.y())},
+                  },
+                  frontFace)
+                  .is_success());
 
         CHECK(isJustified(frontFace, axis, sign) == expectedJustified);
       }) | kdl::transform_error([](const auto e) { FAIL(e); });
@@ -402,15 +409,16 @@ TEST_CASE("UvAlignment")
         auto& frontFace = brush.face(*frontFaceIndex);
         frontFace.setMaterial(&material);
 
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{float(initialOffset.x())},
-            .yOffset = SetValue{float(initialOffset.y())},
-            .rotation = SetValue{float(initialRotation)},
-            .xScale = SetValue{float(initialScale.x())},
-            .yScale = SetValue{float(initialScale.y())},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{float(initialOffset.x())},
+                    .yOffset = SetValue{float(initialOffset.y())},
+                    .rotation = SetValue{float(initialRotation)},
+                    .xScale = SetValue{float(initialScale.x())},
+                    .yScale = SetValue{float(initialScale.y())},
+                  },
+                  frontFace)
+                  .is_success());
 
         CHECK(isFitted(frontFace, axis) == expectedFitted);
       }) | kdl::transform_error([](const auto e) { FAIL(e); });
@@ -484,15 +492,16 @@ TEST_CASE("UvAlignment")
             REQUIRE(frontFaceIndex);
 
             auto& frontFace = brush.face(*frontFaceIndex);
-            evaluate(
-              UpdateBrushFaceAttributes{
-                .xOffset = SetValue{initialOffset.x()},
-                .yOffset = SetValue{initialOffset.y()},
-                .rotation = SetValue{initialRotation},
-                .xScale = SetValue{initialScale.x()},
-                .yScale = SetValue{initialScale.y()},
-              },
-              frontFace);
+            REQUIRE(evaluate(
+                      UpdateBrushFaceAttributes{
+                        .xOffset = SetValue{initialOffset.x()},
+                        .yOffset = SetValue{initialOffset.y()},
+                        .rotation = SetValue{initialRotation},
+                        .xScale = SetValue{initialScale.x()},
+                        .yScale = SetValue{initialScale.y()},
+                      },
+                      frontFace)
+                      .is_success());
 
             CHECK_THAT(
               align(frontFace, policy),
@@ -568,15 +577,16 @@ TEST_CASE("UvAlignment")
             REQUIRE(topFaceIndex);
 
             auto& topFace = brush.face(*topFaceIndex);
-            evaluate(
-              UpdateBrushFaceAttributes{
-                .xOffset = SetValue{initialOffset.x()},
-                .yOffset = SetValue{initialOffset.y()},
-                .rotation = SetValue{initialRotation},
-                .xScale = SetValue{initialScale.x()},
-                .yScale = SetValue{initialScale.y()},
-              },
-              topFace);
+            REQUIRE(evaluate(
+                      UpdateBrushFaceAttributes{
+                        .xOffset = SetValue{initialOffset.x()},
+                        .yOffset = SetValue{initialOffset.y()},
+                        .rotation = SetValue{initialRotation},
+                        .xScale = SetValue{initialScale.x()},
+                        .yScale = SetValue{initialScale.y()},
+                      },
+                      topFace)
+                      .is_success());
 
             CHECK_THAT(
               align(topFace, policy),
@@ -644,15 +654,16 @@ TEST_CASE("UvAlignment")
             REQUIRE(topFaceIndex);
 
             auto& topFace = brush.face(*topFaceIndex);
-            evaluate(
-              UpdateBrushFaceAttributes{
-                .xOffset = SetValue{initialOffset.x()},
-                .yOffset = SetValue{initialOffset.y()},
-                .rotation = SetValue{initialRotation},
-                .xScale = SetValue{initialScale.x()},
-                .yScale = SetValue{initialScale.y()},
-              },
-              topFace);
+            REQUIRE(evaluate(
+                      UpdateBrushFaceAttributes{
+                        .xOffset = SetValue{initialOffset.x()},
+                        .yOffset = SetValue{initialOffset.y()},
+                        .rotation = SetValue{initialRotation},
+                        .xScale = SetValue{initialScale.x()},
+                        .yScale = SetValue{initialScale.y()},
+                      },
+                      topFace)
+                      .is_success());
 
             CHECK_THAT(
               align(topFace, policy),
@@ -777,15 +788,16 @@ TEST_CASE("UvAlignment")
         auto& frontFace = brush.face(*frontFaceIndex);
         frontFace.setMaterial(&material);
 
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{float(initialOffset.x())},
-            .yOffset = SetValue{float(initialOffset.y())},
-            .rotation = SetValue{float(initialRotation)},
-            .xScale = SetValue{float(initialScale.x())},
-            .yScale = SetValue{float(initialScale.y())},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{float(initialOffset.x())},
+                    .yOffset = SetValue{float(initialOffset.y())},
+                    .rotation = SetValue{float(initialRotation)},
+                    .xScale = SetValue{float(initialScale.x())},
+                    .yScale = SetValue{float(initialScale.y())},
+                  },
+                  frontFace)
+                  .is_success());
 
         CHECK_THAT(
           justify(frontFace, axis, sign, policy),
@@ -917,15 +929,16 @@ TEST_CASE("UvAlignment")
         auto& frontFace = brush.face(*frontFaceIndex);
         frontFace.setMaterial(&material);
 
-        evaluate(
-          UpdateBrushFaceAttributes{
-            .xOffset = SetValue{float(initialOffset.x())},
-            .yOffset = SetValue{float(initialOffset.y())},
-            .rotation = SetValue{float(initialRotation)},
-            .xScale = SetValue{float(initialScale.x())},
-            .yScale = SetValue{float(initialScale.y())},
-          },
-          frontFace);
+        REQUIRE(evaluate(
+                  UpdateBrushFaceAttributes{
+                    .xOffset = SetValue{float(initialOffset.x())},
+                    .yOffset = SetValue{float(initialOffset.y())},
+                    .rotation = SetValue{float(initialRotation)},
+                    .xScale = SetValue{float(initialScale.x())},
+                    .yScale = SetValue{float(initialScale.y())},
+                  },
+                  frontFace)
+                  .is_success());
 
         CHECK_THAT(
           fit(frontFace, axis, policy, fitMode),

--- a/lib/TbMdlLib/test/src/tst_UvAttributes.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvAttributes.cpp
@@ -1,0 +1,86 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mdl/CatchConfig.h"
+#include "mdl/UvAttributes.h"
+
+#include "vm/vec_io.h" // IWYU pragma: keep
+
+#include <limits>
+#include <tuple>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+namespace tb::mdl
+{
+
+TEST_CASE("UvAttributes")
+{
+  static constexpr auto nan = std::numeric_limits<float>::quiet_NaN();
+  static constexpr auto inf = std::numeric_limits<float>::infinity();
+
+  SECTION("validateUvAttributes")
+  {
+    // clang-format off
+    const auto
+    [uvAttributes,             expected] = GENERATE(table<UvAttributes, bool>({
+    // finite offset, scale and rotation
+    {{{1, 2}, {3, 4}, 45.0f},  true},
+    // a scale of 0 is still finite
+    {{{0, 0}, {0, 0}, 0.0f},   true},
+    // non-finite offset
+    {{{nan, 0}, {1, 1}, 0.0f}, false},
+    {{{0, inf}, {1, 1}, 0.0f}, false},
+    // non-finite scale
+    {{{0, 0}, {nan, 1}, 0.0f}, false},
+    {{{0, 0}, {1, inf}, 0.0f}, false},
+    // non-finite rotation
+    {{{0, 0}, {1, 1}, nan},    false},
+    {{{0, 0}, {1, 1}, inf},    false},
+    }));
+    // clang-format on
+
+    CAPTURE(uvAttributes);
+    CHECK(
+      validateUvAttributes(uvAttributes.offset, uvAttributes.scale, uvAttributes.rotation)
+      == expected);
+  }
+
+  SECTION("valid")
+  {
+    // clang-format off
+    const auto 
+    [uvAttributes,             expected] = GENERATE(table<UvAttributes, bool>({
+    // finite, non-zero scale
+    {{{1, 2}, {3, 4}, 45.0f},  true},
+    // a scale of 0 in either component is invalid, even though it's finite
+    {{{0, 0}, {0, 1}, 0.0f},   false},
+    {{{0, 0}, {1, 0}, 0.0f},   false},
+    // non-finite values are invalid too
+    {{{nan, 0}, {1, 1}, 0.0f}, false},
+    }));
+    // clang-format on
+
+    CAPTURE(uvAttributes);
+    CHECK(uvAttributes.valid() == expected);
+  }
+}
+
+} // namespace tb::mdl

--- a/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
@@ -24,6 +24,8 @@
 #include "mdl/UvAttributes.h"
 #include "mdl/UvCoordSystem.h"
 
+#include "kd/result.h"
+
 #include "vm/vec_io.h" // IWYU pragma: keep
 
 #include <optional>
@@ -32,6 +34,21 @@
 
 namespace tb::mdl
 {
+namespace
+{
+
+auto createParaxial(const vm::vec3d& normal, const UvAttributes& uvAttributes = {})
+{
+  return ParaxialUvCoordSystem::createFromNormal(normal, uvAttributes) | kdl::value();
+}
+
+auto createParallel(
+  const vm::vec3d& uAxis, const vm::vec3d& vAxis, const UvAttributes& uvAttributes = {})
+{
+  return ParallelUvCoordSystem::createFromAxes(uAxis, vAxis, uvAttributes) | kdl::value();
+}
+
+} // namespace
 
 TEST_CASE("UvCoordSystem")
 {
@@ -39,15 +56,14 @@ TEST_CASE("UvCoordSystem")
   {
     SECTION("paraxial UV axes cannot be snapshotted")
     {
-      const auto paraxial =
-        UvCoordSystem{ParaxialUvCoordSystem{vm::vec3d{0, 0, 1}, UvAttributes{}}};
+      const auto paraxial = UvCoordSystem{createParaxial(vm::vec3d{0, 0, 1})};
       CHECK(paraxial.takeSnapshot() == std::nullopt);
     }
 
     SECTION("parallel UV axes can be snapshotted and restored")
     {
-      auto parallel = UvCoordSystem{
-        ParallelUvCoordSystem{vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, UvAttributes{}}};
+      auto parallel =
+        UvCoordSystem{createParallel(vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0})};
       const auto snapshot = parallel.takeSnapshot();
       REQUIRE(
         snapshot
@@ -69,16 +85,14 @@ TEST_CASE("UvCoordSystem")
 
     SECTION("uses the U axis as horizontal if it is closer to the right axis")
     {
-      auto system = UvCoordSystem{
-        ParallelUvCoordSystem{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{}}};
+      auto system = UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
       system.translate(normal, vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, offset);
       CHECK(system.uvAttributes().offset == vm::vec2f{-2, -3});
     }
 
     SECTION("uses the V axis as horizontal if it is closer to the right axis")
     {
-      auto system = UvCoordSystem{
-        ParallelUvCoordSystem{vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, UvAttributes{}}};
+      auto system = UvCoordSystem{createParallel(vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0})};
       system.translate(normal, vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, offset);
       CHECK(system.uvAttributes().offset == vm::vec2f{-3, -2});
     }
@@ -91,24 +105,24 @@ TEST_CASE("UvCoordSystem")
 
       SECTION("uses the V axis as horizontal if the U axis is closer to the up axis")
       {
-        auto system = UvCoordSystem{
-          ParallelUvCoordSystem{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{}}};
+        auto system =
+          UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
         system.translate(normal, vm::vec3d{1, 0, 0}, right, offset);
         CHECK(system.uvAttributes().offset == vm::vec2f{-3, -2});
       }
 
       SECTION("uses the U axis as horizontal if the V axis is closer to the up axis")
       {
-        auto system = UvCoordSystem{
-          ParallelUvCoordSystem{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{}}};
+        auto system =
+          UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
         system.translate(normal, vm::vec3d{0, 1, 0}, right, offset);
         CHECK(system.uvAttributes().offset == vm::vec2f{-2, -3});
       }
 
       SECTION("does nothing if neither axis can be clearly chosen")
       {
-        auto system = UvCoordSystem{
-          ParallelUvCoordSystem{vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{}}};
+        auto system =
+          UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
         const auto up = vm::normalize(vm::vec3d{1, -1, 0});
         system.translate(normal, up, right, offset);
         CHECK(system.uvAttributes().offset == vm::vec2f{0, 0});
@@ -117,8 +131,8 @@ TEST_CASE("UvCoordSystem")
 
     SECTION("flips the offset direction for a negative scale")
     {
-      auto system = UvCoordSystem{ParallelUvCoordSystem{
-        vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{{}, {-1, -1}, 0.0f}}};
+      auto system = UvCoordSystem{createParallel(
+        vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{{}, {-1, -1}, 0.0f})};
       system.translate(normal, vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, offset);
       CHECK(system.uvAttributes().offset == vm::vec2f{2, 3});
     }
@@ -135,16 +149,20 @@ TEST_CASE("ParallelUvCoordSystem")
     const auto point1 = vm::vec3d{1, 0, 0};
     const auto point2 = vm::vec3d{0, 1, 0};
 
-    SECTION("returns the same axes and attributes as the constructor")
+    SECTION("returns an orthonormal UV coordinate system with the given attributes")
     {
-      const auto expected = ParallelUvCoordSystem{point0, point1, point2, uvAttributes};
-
       const auto actual =
         ParallelUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes);
       REQUIRE(actual);
-      CHECK(actual.value().uAxis() == expected.uAxis());
-      CHECK(actual.value().vAxis() == expected.vAxis());
-      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+      CHECK(actual.value().uvAttributes() == uvAttributes);
+      CHECK(vm::is_unit(actual.value().uAxis(), vm::Cd::almost_zero()));
+      CHECK(vm::is_unit(actual.value().vAxis(), vm::Cd::almost_zero()));
+      CHECK(vm::is_zero(
+        vm::dot(actual.value().uAxis(), actual.value().vAxis()), vm::Cd::almost_zero()));
+      CHECK(vm::is_zero(
+        vm::dot(actual.value().uAxis(), actual.value().normal()), vm::Cd::almost_zero()));
+      CHECK(vm::is_zero(
+        vm::dot(actual.value().vAxis(), actual.value().normal()), vm::Cd::almost_zero()));
     }
 
     SECTION("returns an error if the points do not define a plane")
@@ -164,16 +182,14 @@ TEST_CASE("ParallelUvCoordSystem")
     const auto uAxis = vm::vec3d{1, 0, 0};
     const auto vAxis = vm::vec3d{0, 1, 0};
 
-    SECTION("returns the same axes and attributes as the constructor")
+    SECTION("returns the given axes and attributes unchanged")
     {
-      const auto expected = ParallelUvCoordSystem{uAxis, vAxis, uvAttributes};
-
       const auto actual =
         ParallelUvCoordSystem::createFromAxes(uAxis, vAxis, uvAttributes);
       REQUIRE(actual);
-      CHECK(actual.value().uAxis() == expected.uAxis());
-      CHECK(actual.value().vAxis() == expected.vAxis());
-      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+      CHECK(actual.value().uAxis() == uAxis);
+      CHECK(actual.value().vAxis() == vAxis);
+      CHECK(actual.value().uvAttributes() == uvAttributes);
     }
   }
 }
@@ -188,16 +204,16 @@ TEST_CASE("ParaxialUvCoordSystem")
     const auto point1 = vm::vec3d{1, 0, 0};
     const auto point2 = vm::vec3d{0, 1, 0};
 
-    SECTION("returns the same axes and attributes as the constructor")
+    SECTION("returns an orthonormal UV coordinate system with the given attributes")
     {
-      const auto expected = ParaxialUvCoordSystem{point0, point1, point2, uvAttributes};
-
       const auto actual =
         ParaxialUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes);
       REQUIRE(actual);
-      CHECK(actual.value().uAxis() == expected.uAxis());
-      CHECK(actual.value().vAxis() == expected.vAxis());
-      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+      CHECK(actual.value().uvAttributes() == uvAttributes);
+      CHECK(vm::is_unit(actual.value().uAxis(), vm::Cd::almost_zero()));
+      CHECK(vm::is_unit(actual.value().vAxis(), vm::Cd::almost_zero()));
+      CHECK(vm::is_zero(
+        vm::dot(actual.value().uAxis(), actual.value().vAxis()), vm::Cd::almost_zero()));
     }
 
     SECTION("returns an error if the points do not define a plane")
@@ -216,15 +232,15 @@ TEST_CASE("ParaxialUvCoordSystem")
 
     const auto normal = vm::vec3d{0, 0, 1};
 
-    SECTION("returns the same axes and attributes as the constructor")
+    SECTION("returns an orthonormal UV coordinate system with the given attributes")
     {
-      const auto expected = ParaxialUvCoordSystem{normal, uvAttributes};
-
       const auto actual = ParaxialUvCoordSystem::createFromNormal(normal, uvAttributes);
       REQUIRE(actual);
-      CHECK(actual.value().uAxis() == expected.uAxis());
-      CHECK(actual.value().vAxis() == expected.vAxis());
-      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+      CHECK(actual.value().uvAttributes() == uvAttributes);
+      CHECK(vm::is_unit(actual.value().uAxis(), vm::Cd::almost_zero()));
+      CHECK(vm::is_unit(actual.value().vAxis(), vm::Cd::almost_zero()));
+      CHECK(vm::is_zero(
+        vm::dot(actual.value().uAxis(), actual.value().vAxis()), vm::Cd::almost_zero()));
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
@@ -17,6 +17,7 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "base/Result.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/ParallelUvCoordSystem.h"
 #include "mdl/ParaxialUvCoordSystem.h"
@@ -120,6 +121,110 @@ TEST_CASE("UvCoordSystem")
         vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{{}, {-1, -1}, 0.0f}}};
       system.translate(normal, vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}, offset);
       CHECK(system.uvAttributes().offset == vm::vec2f{2, 3});
+    }
+  }
+}
+
+TEST_CASE("ParallelUvCoordSystem")
+{
+  SECTION("createFromPoints")
+  {
+    const auto uvAttributes = UvAttributes{{1, 2}, {3, 4}, 45.0f};
+
+    const auto point0 = vm::vec3d{0, 0, 0};
+    const auto point1 = vm::vec3d{1, 0, 0};
+    const auto point2 = vm::vec3d{0, 1, 0};
+
+    SECTION("returns the same axes and attributes as the constructor")
+    {
+      const auto expected = ParallelUvCoordSystem{point0, point1, point2, uvAttributes};
+
+      const auto actual =
+        ParallelUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes);
+      REQUIRE(actual);
+      CHECK(actual.value().uAxis() == expected.uAxis());
+      CHECK(actual.value().vAxis() == expected.vAxis());
+      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+    }
+
+    SECTION("returns an error if the points do not define a plane")
+    {
+      const auto degeneratePoint2 = vm::vec3d{2, 0, 0};
+      CHECK(
+        ParallelUvCoordSystem::createFromPoints(
+          point0, point1, degeneratePoint2, uvAttributes)
+        == Result<ParallelUvCoordSystem>{Error{"Face points do not define a plane"}});
+    }
+  }
+
+  SECTION("createFromAxes")
+  {
+    const auto uvAttributes = UvAttributes{{1, 2}, {3, 4}, 45.0f};
+
+    const auto uAxis = vm::vec3d{1, 0, 0};
+    const auto vAxis = vm::vec3d{0, 1, 0};
+
+    SECTION("returns the same axes and attributes as the constructor")
+    {
+      const auto expected = ParallelUvCoordSystem{uAxis, vAxis, uvAttributes};
+
+      const auto actual =
+        ParallelUvCoordSystem::createFromAxes(uAxis, vAxis, uvAttributes);
+      REQUIRE(actual);
+      CHECK(actual.value().uAxis() == expected.uAxis());
+      CHECK(actual.value().vAxis() == expected.vAxis());
+      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+    }
+  }
+}
+
+TEST_CASE("ParaxialUvCoordSystem")
+{
+  SECTION("createFromPoints")
+  {
+    const auto uvAttributes = UvAttributes{{1, 2}, {3, 4}, 45.0f};
+
+    const auto point0 = vm::vec3d{0, 0, 0};
+    const auto point1 = vm::vec3d{1, 0, 0};
+    const auto point2 = vm::vec3d{0, 1, 0};
+
+    SECTION("returns the same axes and attributes as the constructor")
+    {
+      const auto expected = ParaxialUvCoordSystem{point0, point1, point2, uvAttributes};
+
+      const auto actual =
+        ParaxialUvCoordSystem::createFromPoints(point0, point1, point2, uvAttributes);
+      REQUIRE(actual);
+      CHECK(actual.value().uAxis() == expected.uAxis());
+      CHECK(actual.value().vAxis() == expected.vAxis());
+      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
+    }
+
+    SECTION("returns an error if the points do not define a plane")
+    {
+      const auto degeneratePoint2 = vm::vec3d{2, 0, 0};
+      CHECK(
+        ParaxialUvCoordSystem::createFromPoints(
+          point0, point1, degeneratePoint2, uvAttributes)
+        == Result<ParaxialUvCoordSystem>{Error{"Face points do not define a plane"}});
+    }
+  }
+
+  SECTION("createFromNormal")
+  {
+    const auto uvAttributes = UvAttributes{{1, 2}, {3, 4}, 45.0f};
+
+    const auto normal = vm::vec3d{0, 0, 1};
+
+    SECTION("returns the same axes and attributes as the constructor")
+    {
+      const auto expected = ParaxialUvCoordSystem{normal, uvAttributes};
+
+      const auto actual = ParaxialUvCoordSystem::createFromNormal(normal, uvAttributes);
+      REQUIRE(actual);
+      CHECK(actual.value().uAxis() == expected.uAxis());
+      CHECK(actual.value().vAxis() == expected.vAxis());
+      CHECK(actual.value().uvAttributes() == expected.uvAttributes());
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
@@ -26,6 +26,9 @@
 
 #include "kd/result.h"
 
+#include "vm/mat_ext.h"
+#include "vm/plane.h"
+#include "vm/scalar.h"
 #include "vm/vec_io.h" // IWYU pragma: keep
 
 #include <limits>
@@ -371,6 +374,32 @@ TEST_CASE("ParaxialUvCoordSystem")
       CHECK(
         ParaxialUvCoordSystem::createFromNormal(normal, testUvAttributes)
         == Result<ParaxialUvCoordSystem>{expectedError});
+    }
+  }
+
+  SECTION("transform")
+  {
+    SECTION("does not produce a zero scale for a lock-textured translation")
+    {
+      // this face's UV attributes already carry pathological offset/scale magnitudes;
+      // translating it further reunds the resulting V scale down to exactly 0
+      auto system = createParaxial(
+        vm::vec3d{0, 1, 0},
+        UvAttributes{
+          {-43460.609375f, -11065997.0f},
+          {0.018230000510811806f, -0.00062000000616535544f},
+          97.126823425292969f});
+
+      const auto oldBoundary = vm::plane3d{-1960.0, vm::vec3d{0, 1, 0}};
+      const auto newBoundary = vm::plane3d{-1960.0, vm::vec3d{0, 1, 0}};
+      const auto transformation = vm::translation_matrix(vm::vec3d{16, 0, 0});
+      const auto invariant = vm::vec3d{-6887.666666666667, -1960.0, -59.333333333333336};
+
+      system.transform(
+        oldBoundary, newBoundary, transformation, vm::vec2f{1, 1}, true, invariant);
+
+      CHECK(!vm::is_zero(system.uvAttributes().scale.x(), vm::Cf::almost_zero()));
+      CHECK(vm::is_zero(system.uvAttributes().scale.y(), vm::Cf::almost_zero()));
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
@@ -28,9 +28,12 @@
 
 #include "vm/vec_io.h" // IWYU pragma: keep
 
+#include <limits>
 #include <optional>
+#include <tuple>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 namespace tb::mdl
 {
@@ -191,6 +194,49 @@ TEST_CASE("ParallelUvCoordSystem")
       CHECK(actual.value().vAxis() == vAxis);
       CHECK(actual.value().uvAttributes() == uvAttributes);
     }
+
+    SECTION("accepts a scale of 0")
+    {
+      const auto zeroScale = UvAttributes{{0, 0}, {0, 0}, 0.0f};
+      CHECK(ParallelUvCoordSystem::createFromAxes(uAxis, vAxis, zeroScale).is_success());
+    }
+
+    SECTION("rejects invalid input")
+    {
+      const auto nan = std::numeric_limits<float>::quiet_NaN();
+
+      using T = std::tuple<vm::vec3d, vm::vec3d, UvAttributes, Error>;
+
+      const auto [testUAxis, testVAxis, testUvAttributes, expectedError] =
+        GENERATE_COPY(values<T>({
+          // non-finite rotation
+          {uAxis,
+           vAxis,
+           UvAttributes{{0, 0}, {1, 1}, nan},
+           Error{"UV attributes are invalid"}},
+          // parallel axes
+          {uAxis,
+           uAxis,
+           uvAttributes,
+           Error{"UV axes do not form an invertible coordinate system"}},
+          // a zero axis
+          {vm::vec3d{0, 0, 0},
+           vAxis,
+           uvAttributes,
+           Error{"UV axes do not form an invertible coordinate system"}},
+          // otherwise-fine axes, but a scale this large makes the resulting matrix
+          // look singular under the fixed pivot threshold used to invert it
+          {uAxis,
+           vAxis,
+           UvAttributes{{0, 0}, {1e30f, 1e30f}, 0.0f},
+           Error{"UV coordinate system is not invertible"}},
+        }));
+
+      CAPTURE(testUAxis, testVAxis, testUvAttributes);
+      CHECK(
+        ParallelUvCoordSystem::createFromAxes(testUAxis, testVAxis, testUvAttributes)
+        == Result<ParallelUvCoordSystem>{expectedError});
+    }
   }
 }
 
@@ -241,6 +287,34 @@ TEST_CASE("ParaxialUvCoordSystem")
       CHECK(vm::is_unit(actual.value().vAxis(), vm::Cd::almost_zero()));
       CHECK(vm::is_zero(
         vm::dot(actual.value().uAxis(), actual.value().vAxis()), vm::Cd::almost_zero()));
+    }
+
+    SECTION("accepts a scale of 0")
+    {
+      const auto zeroScale = UvAttributes{{0, 0}, {0, 0}, 0.0f};
+      CHECK(ParaxialUvCoordSystem::createFromNormal(normal, zeroScale).is_success());
+    }
+
+    SECTION("rejects invalid input")
+    {
+      const auto nan = std::numeric_limits<float>::quiet_NaN();
+
+      using T = std::tuple<UvAttributes, Error>;
+
+      const auto [testUvAttributes, expectedError] = GENERATE_COPY(values<T>({
+        // non-finite offset
+        {UvAttributes{{nan, 0}, {1, 1}, 0.0f}, Error{"UV attributes are invalid"}},
+        // otherwise-fine axes (Paraxial axes are always orthonormal), but a scale this
+        // large makes the resulting matrix look singular under the fixed pivot
+        // threshold used to invert it
+        {UvAttributes{{0, 0}, {1e30f, 1e30f}, 0.0f},
+         Error{"UV coordinate system is not invertible"}},
+      }));
+
+      CAPTURE(testUvAttributes);
+      CHECK(
+        ParaxialUvCoordSystem::createFromNormal(normal, testUvAttributes)
+        == Result<ParaxialUvCoordSystem>{expectedError});
     }
   }
 }

--- a/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvCoordSystem.cpp
@@ -81,6 +81,62 @@ TEST_CASE("UvCoordSystem")
     }
   }
 
+  SECTION("setUvAttributes")
+  {
+    const auto normal = vm::vec3d{0, 0, 1};
+
+    SECTION("updates the UV attributes and axes")
+    {
+      auto system = UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
+      REQUIRE(
+        system.setUvAttributes(normal, UvAttributes{{1, 2}, {3, 4}, 45.0f}).is_success());
+      CHECK(system.uvAttributes() == UvAttributes{{1, 2}, {3, 4}, 45.0f});
+    }
+
+    SECTION("leaves the system unchanged if the given attributes are invalid")
+    {
+      auto system = UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
+      const auto before = system;
+
+      const auto nan = std::numeric_limits<float>::quiet_NaN();
+      CHECK(
+        system.setUvAttributes(normal, UvAttributes{{0, 0}, {1, 1}, nan})
+        == Result<void>{Error{"UV attributes are invalid"}});
+      CHECK(system == before);
+    }
+
+    SECTION("leaves the system unchanged if the resulting matrix is not invertible")
+    {
+      auto system = UvCoordSystem{createParallel(vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0})};
+      const auto before = system;
+
+      const auto extremeScale = UvAttributes{{0, 0}, {1e30f, 1e30f}, 0.0f};
+      CHECK(
+        system.setUvAttributes(normal, extremeScale)
+        == Result<void>{Error{"UV coordinate system is not invertible"}});
+      CHECK(system == before);
+    }
+  }
+
+  SECTION("rotate")
+  {
+    const auto normal = vm::vec3d{0, 0, 1};
+
+    SECTION("leaves the system unchanged if the resulting rotation overflows")
+    {
+      const auto max = std::numeric_limits<float>::max();
+      auto system = UvCoordSystem{createParallel(
+        vm::vec3d{1, 0, 0}, vm::vec3d{0, 1, 0}, UvAttributes{{}, {1, 1}, max})};
+      const auto before = system;
+
+      // rotating by another huge angle overflows the resulting rotation to infinity --
+      // this is the original crash this branch set out to fix
+      CHECK(
+        system.rotate(normal, max) == Result<void>{Error{"UV attributes are invalid"}});
+      CHECK(system == before);
+    }
+  }
+
   SECTION("translate")
   {
     const auto normal = vm::vec3d{0, 0, 1};

--- a/lib/TbMdlLib/test/src/tst_UvUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvUtils.cpp
@@ -17,14 +17,21 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "base/Result.h"
 #include "mdl/CatchConfig.h"
+#include "mdl/UvAttributes.h"
 #include "mdl/UvUtils.h"
 
-#include "vm/approx.h"
+#include "kd/result.h"
 
+#include "vm/approx.h"
+#include "vm/vec_io.h" // IWYU pragma: keep
+
+#include <limits>
 #include <tuple>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 namespace tb::mdl
 {
@@ -57,6 +64,36 @@ TEST_CASE("UvUtils")
       CHECK(vm::dot(upAxis, rightAxis) == vm::approx{0.0});
       CHECK(vm::cross(rightAxis, upAxis) == vm::approx(normal));
     }
+  }
+
+  SECTION("validateUvCoordSystem")
+  {
+    static constexpr auto normal = vm::vec3d{0, 0, 1};
+    static constexpr auto uAxis = vm::vec3d{1, 0, 0};
+    static constexpr auto vAxis = vm::vec3d{0, 1, 0};
+    static constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
+
+    // clang-format off
+    const auto 
+    [testUAxis,            testVAxis, uvAttributes,                   expected] = GENERATE(table<vm::vec3d, vm::vec3d, UvAttributes, Result<void>>({
+    // finite, orthonormal axes
+    {uAxis,                vAxis,     {},                             kdl::void_success},
+    // a scale of 0 doesn't affect invertibility -- safeScaleAxis treats it as 1
+    {uAxis,                vAxis,     {{0, 0}, {0, 0}, 0.0f},         kdl::void_success},
+    // a non-finite axis
+    {vm::vec3d{nan, 0, 0}, vAxis,     {},                             Error{"UV axes are invalid"}},
+    // parallel axes
+    {uAxis,                uAxis,     {},                             Error{"UV axes do not form an invertible coordinate system"}},
+    // a zero axis
+    {vm::vec3d{0, 0, 0},   vAxis,     {},                             Error{"UV axes do not form an invertible coordinate system"}},
+    // otherwise-fine axes, but a scale this large makes the resulting matrix look
+    // singular under the fixed pivot threshold used to invert it
+    {uAxis,                vAxis,     {{0, 0}, {1e30f, 1e30f}, 0.0f}, Error{"UV coordinate system is not invertible"}},
+    }));
+    // clang-format on
+
+    CAPTURE(testUAxis, testVAxis, uvAttributes);
+    CHECK(validateUvCoordSystem(testUAxis, testVAxis, normal, uvAttributes) == expected);
   }
 }
 

--- a/lib/TbMdlLib/test/src/tst_UvUtils.cpp
+++ b/lib/TbMdlLib/test/src/tst_UvUtils.cpp
@@ -29,31 +29,34 @@
 namespace tb::mdl
 {
 
-TEST_CASE("computeCameraAxesForFaceNormal")
+TEST_CASE("UvUtils")
 {
-  CHECK(
-    computeCameraAxesForFaceNormal(vm::vec3d{0, 0, 1})
-    == std::tuple{vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}});
-
-  CHECK(
-    computeCameraAxesForFaceNormal(vm::vec3d{0, 0, -1})
-    == std::tuple{vm::vec3d{0, -1, 0}, vm::vec3d{1, 0, 0}});
-
-  CHECK(
-    computeCameraAxesForFaceNormal(vm::vec3d{1, 0, 0})
-    == std::tuple{vm::vec3d{0, 0, 1}, vm::vec3d{0, 1, 0}});
-
-  SECTION("returns normalized up axis orthogonal to normal")
+  SECTION("computeCameraAxesForFaceNormal")
   {
-    const auto normal = vm::normalize(vm::vec3d{1, 2, 3});
-    const auto [upAxis, rightAxis] = computeCameraAxesForFaceNormal(normal);
+    CHECK(
+      computeCameraAxesForFaceNormal(vm::vec3d{0, 0, 1})
+      == std::tuple{vm::vec3d{0, 1, 0}, vm::vec3d{1, 0, 0}});
 
-    CHECK(vm::length(upAxis) == vm::approx{1.0});
-    CHECK(vm::length(rightAxis) == vm::approx{1.0});
-    CHECK(vm::dot(normal, upAxis) == vm::approx{0.0});
-    CHECK(vm::dot(normal, rightAxis) == vm::approx{0.0});
-    CHECK(vm::dot(upAxis, rightAxis) == vm::approx{0.0});
-    CHECK(vm::cross(rightAxis, upAxis) == vm::approx(normal));
+    CHECK(
+      computeCameraAxesForFaceNormal(vm::vec3d{0, 0, -1})
+      == std::tuple{vm::vec3d{0, -1, 0}, vm::vec3d{1, 0, 0}});
+
+    CHECK(
+      computeCameraAxesForFaceNormal(vm::vec3d{1, 0, 0})
+      == std::tuple{vm::vec3d{0, 0, 1}, vm::vec3d{0, 1, 0}});
+
+    SECTION("returns normalized up axis orthogonal to normal")
+    {
+      const auto normal = vm::normalize(vm::vec3d{1, 2, 3});
+      const auto [upAxis, rightAxis] = computeCameraAxesForFaceNormal(normal);
+
+      CHECK(vm::length(upAxis) == vm::approx{1.0});
+      CHECK(vm::length(rightAxis) == vm::approx{1.0});
+      CHECK(vm::dot(normal, upAxis) == vm::approx{0.0});
+      CHECK(vm::dot(normal, rightAxis) == vm::approx{0.0});
+      CHECK(vm::dot(upAxis, rightAxis) == vm::approx{0.0});
+      CHECK(vm::cross(rightAxis, upAxis) == vm::approx(normal));
+    }
   }
 }
 

--- a/lib/VmLib/include/vm/scalar.h
+++ b/lib/VmLib/include/vm/scalar.h
@@ -76,6 +76,21 @@ constexpr bool is_inf(const T f)
 }
 
 /**
+ * Checks whether the given float is finite, i.e. neither NaN nor positive or negative
+ * infinity.
+ *
+ * @tparam T the argument type, which must be a floating point type
+ * @param f the float to check
+ * @return true if the given float is finite
+ */
+template <typename T>
+constexpr bool is_finite(const T f)
+{
+  static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
+  return !is_nan(f) && !is_inf(f);
+}
+
+/**
  * Returns a floating point value that represents NaN.
  *
  * @tparam T the result type, which must be a floating point type
@@ -818,11 +833,8 @@ constexpr T normalize_radians(T angle)
   static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
   constexpr T z = static_cast<T>(0.0);
   constexpr T o = constants<T>::two_pi();
-  while (angle < z)
-  {
-    angle += o;
-  }
-  return mod(angle, o);
+  const auto result = mod(angle, o);
+  return result < z ? result + o : result;
 }
 
 /**
@@ -838,11 +850,8 @@ constexpr T normalize_degrees(T angle)
   static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
   constexpr T z = static_cast<T>(0.0);
   constexpr T o = static_cast<T>(360.0);
-  while (angle < z)
-  {
-    angle += o;
-  }
-  return mod(angle, o);
+  const auto result = mod(angle, o);
+  return result < z ? result + o : result;
 }
 
 /**

--- a/lib/VmLib/include/vm/vec.h
+++ b/lib/VmLib/include/vm/vec.h
@@ -1324,6 +1324,28 @@ constexpr bool is_nan(const vec<T, S>& v)
 }
 
 /**
+ * Checks whether every component of the given vector is finite, i.e. none of them is NaN
+ * or positive or negative infinity.
+ *
+ * @tparam T the component type
+ * @tparam S the number of components
+ * @param v the vector to check
+ * @return true if every component of the given vector is finite
+ */
+template <typename T, std::size_t S>
+constexpr bool is_finite(const vec<T, S>& v)
+{
+  for (size_t i = 0; i < S; ++i)
+  {
+    if (!is_finite(v[i]))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Checks whether each component of the given vector is within a distance of epsilon
  * around an integral value.
  *

--- a/lib/VmLib/test/src/tst_scalar.cpp
+++ b/lib/VmLib/test/src/tst_scalar.cpp
@@ -121,6 +121,15 @@ TEST_CASE("scalar")
     CER_CHECK_FALSE(is_inf(0.0f));
   }
 
+  SECTION("is_finite")
+  {
+    CER_CHECK(is_finite(0.0));
+    CER_CHECK(is_finite(1.0f));
+    CER_CHECK_FALSE(is_finite(std::numeric_limits<double>::quiet_NaN()));
+    CER_CHECK_FALSE(is_finite(+std::numeric_limits<double>::infinity()));
+    CER_CHECK_FALSE(is_finite(-std::numeric_limits<double>::infinity()));
+  }
+
   SECTION("nan")
   {
     CER_CHECK(is_nan(nan<double>()));
@@ -643,6 +652,12 @@ TEST_CASE("scalar")
     CER_CHECK(normalize_radians(c::half_pi()) == c::half_pi());
     CER_CHECK(normalize_radians(-c::half_pi()) == c::three_half_pi());
     CER_CHECK(normalize_radians(c::half_pi() + c::two_pi()) == c::half_pi());
+
+    CER_CHECK(normalize_radians(-1.0e15) >= 0.0);
+    CER_CHECK(normalize_radians(-1.0e15) < c::two_pi());
+
+    // an angle that has overflowed to infinity cannot be normalized to a finite angle,
+    CHECK(is_nan(normalize_radians(std::numeric_limits<double>::infinity())));
   }
 
   SECTION("normalize_degrees")
@@ -652,6 +667,15 @@ TEST_CASE("scalar")
     CER_CHECK(normalize_degrees(90.0) == 90.0);
     CER_CHECK(normalize_degrees(-90.0) == 270.0);
     CER_CHECK(normalize_degrees(360.0 + 90.0) == 90.0);
+
+    // a naive "while (angle < 0) angle += 360;" loop would never terminate for a value
+    // this large
+    CER_CHECK(normalize_degrees(-1.0e15) >= 0.0);
+    CER_CHECK(normalize_degrees(-1.0e15) < 360.0);
+
+    // an extreme angle that has overflowed to infinity cannot be normalized to a finite
+    // angle, but must not hang either
+    CHECK(is_nan(normalize_degrees(std::numeric_limits<double>::infinity())));
   }
 
   SECTION("succ")

--- a/lib/VmLib/test/src/tst_vec.cpp
+++ b/lib/VmLib/test/src/tst_vec.cpp
@@ -702,6 +702,15 @@ TEST_CASE("vec")
     CER_CHECK_FALSE(is_nan(vec3f{1, 0, 0}));
   }
 
+  SECTION("is_finite")
+  {
+    constexpr auto inf = std::numeric_limits<float>::infinity();
+    CER_CHECK(is_finite(vec3f{1, 0, 0}));
+    CER_CHECK_FALSE(is_finite(vec3f::nan()));
+    CER_CHECK_FALSE(is_finite(vec3f{inf, 0, 0}));
+    CER_CHECK_FALSE(is_finite(vec3f{0, -inf, 0}));
+  }
+
   SECTION("is_integral")
   {
     CER_CHECK(is_integral(vec3f{1, 0, 0}));


### PR DESCRIPTION
Ensure that UV attributes are always valid, meaning they yield an invertible matrix. Brushes with faces having invalid UV attributes are discarded on load with an appropriate error message. Setting invalid UV attributes on a brush fails and reverts the change properly.

Closes #5448.