### PR TITLE
Reload entity and material browsers when the underlying data changes

### DIFF
--- a/lib/TbUiLib/src/EntityBrowser.cpp
+++ b/lib/TbUiLib/src/EntityBrowser.cpp
@@ -139,6 +139,8 @@ void EntityBrowser::connectObservers()
     m_document.documentDidChangeNotifier.connect([&]() { reload(); });
   m_notifierConnection +=
     m_document.resourcesWereProcessedNotifier.connect([&](const auto&) { reload(); });
+  m_notifierConnection +=
+    m_document.entityDefinitionsDidChangeNotifier.connect([&]() { reload(); });
 
   auto& prefs = PreferenceManager::instance();
   m_notifierConnection +=

--- a/lib/TbUiLib/src/MaterialBrowser.cpp
+++ b/lib/TbUiLib/src/MaterialBrowser.cpp
@@ -185,6 +185,8 @@ void MaterialBrowser::connectObservers()
 {
   m_notifierConnection += m_document.documentWasLoadedNotifier.connect([&] { reload(); });
   m_notifierConnection += m_document.documentDidChangeNotifier.connect([&] { reload(); });
+  m_notifierConnection +=
+    m_document.materialCollectionsDidChangeNotifier.connect([&] { reload(); });
   m_notifierConnection += m_document.currentMaterialNameDidChangeNotifier.connect(
     [&] { updateSelectedMaterial(); });
 


### PR DESCRIPTION
We must reload the entity browser when entity definitions are changed and likewise the material browser when the material collections are changed so that we don't run into a use-after-free crash when either browser redraws before its unterlying data is reloaded, which would eventually happen when any of the newly loaded resources have been processed.

Closes #5460