### PR TITLE
Add natural string sorting via natsort

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 - [FreeImage](https://freeimage.sourceforge.io/)
 - [TinyXML](http://www.grinninglizard.com/tinyxml/)
 - miniz
+- [natsort](https://sourcefrog.net/projects/natsort/)
 - [Assimp](https://www.assimp.org/)
 - [Catch2](https://github.com/catchorg/Catch2)
 - [CMake](https://cmake.org/)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -10,6 +10,7 @@ include(cmake/dependencies/fmt.cmake)
 include(cmake/dependencies/freeimage.cmake)
 include(cmake/dependencies/freetype.cmake)
 include(cmake/dependencies/miniz.cmake)
+include(cmake/dependencies/natsort.cmake)
 include(cmake/dependencies/stduuid.cmake)
 include(cmake/dependencies/tinyxml2.cmake)
 

--- a/cmake/dependencies/natsort.cmake
+++ b/cmake/dependencies/natsort.cmake
@@ -1,0 +1,15 @@
+# natsort ships no CMake build and no releases, so we compile strnatcmp.c from a
+# pinned commit.
+CPMAddPackage(
+  URI "gh:sourcefrog/natsort#cdd8df9602e727482ae5e051cff74b7ec7ffa07a"
+  DOWNLOAD_ONLY YES
+)
+
+# assimp turns BUILD_SHARED_LIBS on globally, so say STATIC explicitly.
+add_library(natsort STATIC "${natsort_SOURCE_DIR}/strnatcmp.c")
+target_include_directories(natsort SYSTEM PUBLIC "${natsort_SOURCE_DIR}")
+# strnatcmp.c uses `static inline`, which MSVC only accepts in C11 mode.
+target_compile_features(natsort PRIVATE c_std_11)
+
+suppress_dependency_warnings(natsort)
+apply_sanitizer_options(natsort)

--- a/lib/KdLib/CMakeLists.txt
+++ b/lib/KdLib/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(KdLib
     "${CMAKE_CURRENT_SOURCE_DIR}/src/path_utils.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/result_error.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/string_compare.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/string_compare_natural.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/string_format.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/string_utils.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/task_manager.cpp"
@@ -25,6 +26,7 @@ target_link_libraries(KdLib
   PRIVATE
     CompilerConfig
     PrecompileStdHeaders
+    natsort
   PUBLIC
     Threads::Threads
 )

--- a/lib/KdLib/include/kd/string_compare_natural.h
+++ b/lib/KdLib/include/kd/string_compare_natural.h
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2010 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the "Software"), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify, merge,
+ publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <string_view>
+
+namespace kdl::ci
+{
+
+/**
+ * Compares the given strings in natural order: runs of digits compare by numeric value,
+ * so "tex16" sorts before "tex128". All other characters compare case insensitively.
+ *
+ * Wraps strnatcmp from Martin Pool's natsort, see
+ * https://sourcefrog.net/projects/natsort/. Two of its rules may surprise:
+ *
+ * - Digits with a leading '0' compare as a fraction, so "wall08" sorts before "wall1".
+ *   This keeps version numbers such as "1.001" in the correct order.
+ * - Whitespace is skipped, so "my mod" and "mymod" compare equal.
+ *
+ * Different strings can therefore compare equal. Use string_less_natural for a total
+ * order.
+ *
+ * @param s1 the first string
+ * @param s2 the second string
+ * @return -1 if s1 is less than s2, +1 if s1 is greater than s2, 0 if they are equal
+ */
+int str_compare_natural(std::string_view s1, std::string_view s2);
+
+/**
+ * Orders strings by str_compare_natural and breaks ties by exact value, so different
+ * strings never compare equal. This is safe to use as a sort predicate.
+ */
+struct string_less_natural
+{
+  bool operator()(std::string_view lhs, std::string_view rhs) const;
+};
+
+} // namespace kdl::ci

--- a/lib/KdLib/src/string_compare_natural.cpp
+++ b/lib/KdLib/src/string_compare_natural.cpp
@@ -1,0 +1,49 @@
+/*
+ Copyright (C) 2010 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the "Software"), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify, merge,
+ publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#include "kd/string_compare_natural.h"
+
+#include "kd/string_format.h"
+
+#include <strnatcmp.h>
+
+#include <string>
+#include <string_view>
+
+namespace kdl::ci
+{
+
+int str_compare_natural(const std::string_view s1, const std::string_view s2)
+{
+  // strnatcmp needs null terminated strings, so we must copy anyway. We fold to lower
+  // case here instead of using strnatcasecmp, which folds to upper case and would sort
+  // '_' after the letters, unlike ci::char_less.
+  return strnatcmp(str_to_lower(s1).c_str(), str_to_lower(s2).c_str());
+}
+
+bool string_less_natural::operator()(
+  const std::string_view lhs, const std::string_view rhs) const
+{
+  // break ties by exact string to get a total order
+  const auto compareResult = str_compare_natural(lhs, rhs);
+  return compareResult != 0 ? compareResult < 0 : lhs < rhs;
+}
+
+} // namespace kdl::ci

--- a/lib/KdLib/test/CMakeLists.txt
+++ b/lib/KdLib/test/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(KdLibTest PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_stable_remove_duplicates.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_std_io.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_string_compare.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_string_compare_natural.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_string_format.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_string_utils.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_struct_io.cpp"

--- a/lib/KdLib/test/src/tst_string_compare_natural.cpp
+++ b/lib/KdLib/test/src/tst_string_compare_natural.cpp
@@ -1,0 +1,144 @@
+/*
+ Copyright (C) 2010 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the "Software"), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify, merge,
+ publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#include "kd/collection_utils.h"
+#include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+
+namespace kdl::ci
+{
+using namespace Catch::Matchers;
+
+namespace
+{
+template <typename C>
+C sorted_natural(C c)
+{
+  return kdl::col_sort(std::move(c), string_less_natural());
+}
+} // namespace
+
+TEST_CASE("string_compare_natural")
+{
+  SECTION("str_compare_natural")
+  {
+    // runs of digits compare by numeric value
+    CHECK(str_compare_natural("16", "128") == -1);
+    CHECK(str_compare_natural("128", "16") == +1);
+    CHECK(str_compare_natural("16", "16") == 0);
+    CHECK(str_compare_natural("wall16", "wall128") == -1);
+    CHECK(str_compare_natural("16wall", "128wall") == -1);
+    CHECK(str_compare_natural("e1m2", "e1m10") == -1);
+    CHECK(str_compare_natural("a1b2", "a1b10") == -1);
+    CHECK(str_compare_natural("door1_1", "door10_1") == -1);
+    CHECK(str_compare_natural("img9", "img10") == -1);
+
+    // digits with a leading zero compare as a fraction, so zero padded numbers of
+    // different width do not compare by value
+    CHECK(str_compare_natural("007", "8") == -1);
+    CHECK(str_compare_natural("007", "7") == -1);
+    CHECK(str_compare_natural("7", "007") == +1);
+    CHECK(str_compare_natural("wall08", "wall1") == -1);
+    CHECK(str_compare_natural("img09", "img010") == +1);
+    CHECK(str_compare_natural("1", "09") == +1);
+
+    // whitespace is skipped, not compared
+    CHECK(str_compare_natural("my mod", "mymod") == 0);
+    CHECK(str_compare_natural("a b", "ab") == 0);
+    CHECK(str_compare_natural(" x", "x") == 0);
+    CHECK(str_compare_natural("wall 16", "wall128") == -1);
+
+    // a prefix sorts before the longer string
+    CHECK(str_compare_natural("", "") == 0);
+    CHECK(str_compare_natural("", "wall") == -1);
+    CHECK(str_compare_natural("wall", "wall1") == -1);
+    CHECK(str_compare_natural("wall1", "wall") == +1);
+
+    // case is ignored
+    CHECK(str_compare_natural("WALL16", "wall128") == -1);
+    CHECK(str_compare_natural("wall16", "WALL128") == -1);
+    CHECK(str_compare_natural("WALL16", "wall16") == 0);
+
+    // strings without digits or whitespace compare like str_compare. This
+    // matters for characters between 'Z' and 'a', such as '_', which is common
+    // in material and entity names. Upper case folding would sort these
+    // characters after the letters.
+    CHECK(str_compare_natural("asdf", "wxyt") == str_compare("asdf", "wxyt"));
+    CHECK(str_compare_natural("asdf", "Wxyt") == str_compare("asdf", "Wxyt"));
+    CHECK(str_compare_natural("Asdf", "Wxyt") == str_compare("Asdf", "Wxyt"));
+    CHECK(str_compare_natural("item_health", "items") == -1);
+    CHECK(str_compare_natural("items", "item_health") == +1);
+    CHECK(str_compare_natural("ITEM_HEALTH", "items") == -1);
+    CHECK(str_compare_natural("wall_x", "wallax") == str_compare("wall_x", "wallax"));
+    CHECK(str_compare_natural("a[b", "aab") == str_compare("a[b", "aab"));
+    CHECK(str_compare_natural("a`b", "aab") == str_compare("a`b", "aab"));
+  }
+
+  SECTION("sort_natural")
+  {
+    CHECK_THAT(
+      sorted_natural(std::vector<std::string>{}), Equals(std::vector<std::string>{}));
+
+    CHECK_THAT(
+      sorted_natural(std::vector<std::string>{
+        "tex128",
+        "tex16",
+        "tex2",
+        "tex",
+      }),
+      Equals(std::vector<std::string>{
+        "tex",
+        "tex2",
+        "tex16",
+        "tex128",
+      }));
+
+    // string_less_natural is a total order. str_compare_natural is not. If two
+    // different strings compare equal, string_less_natural orders them by their exact
+    // value. Thus a sort gives the same result each time, and a group by the result is
+    // correct.
+    CHECK(string_less_natural{}("my mod", "mymod"));
+    CHECK_FALSE(string_less_natural{}("mymod", "my mod"));
+    CHECK_FALSE(string_less_natural{}("my mod", "my mod"));
+    CHECK(string_less_natural{}("Wall", "wall"));
+    CHECK_FALSE(string_less_natural{}("wall", "Wall"));
+
+    CHECK_THAT(
+      sorted_natural(std::vector<std::string>{
+        "mymod",
+        "id1",
+        "my mod",
+        "id10",
+        "id2",
+      }),
+      Equals(std::vector<std::string>{
+        "id1",
+        "id2",
+        "id10",
+        "my mod",
+        "mymod",
+      }));
+  }
+}
+
+} // namespace kdl::ci

--- a/lib/TbMdlLib/include/mdl/EntityDefinitionUtils.h
+++ b/lib/TbMdlLib/include/mdl/EntityDefinitionUtils.h
@@ -23,6 +23,7 @@
 #include "mdl/EntityDefinition.h"
 
 #include "kd/ranges/to.h"
+#include "kd/string_compare_natural.h"
 
 #include <algorithm>
 #include <ranges>
@@ -52,7 +53,7 @@ std::vector<const EntityDefinition*> filterAndSort(
     switch (order)
     {
     case EntityDefinitionSortOrder::Name:
-      return lhs->name < rhs->name;
+      return kdl::ci::string_less_natural{}(lhs->name, rhs->name);
     case EntityDefinitionSortOrder::Usage:
       return lhs->usageCount() < rhs->usageCount();
       switchDefault();

--- a/lib/TbMdlLib/src/EntityDefinition.cpp
+++ b/lib/TbMdlLib/src/EntityDefinition.cpp
@@ -21,6 +21,7 @@
 
 #include "kd/reflection_impl.h"
 #include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
 
 #include "vm/bbox_io.h" // IWYU pragma: keep
 
@@ -84,7 +85,7 @@ std::string_view getShortName(const EntityDefinition& entityDefinition)
 bool compareEntityDefinitions(const EntityDefinition& lhs, const EntityDefinition& rhs)
 {
   if (const auto compareResult =
-        kdl::ci::str_compare(getShortName(lhs), getShortName(rhs));
+        kdl::ci::str_compare_natural(getShortName(lhs), getShortName(rhs));
       compareResult != 0)
   {
     return compareResult < 0;

--- a/lib/TbMdlLib/src/EntityDefinitionGroup.cpp
+++ b/lib/TbMdlLib/src/EntityDefinitionGroup.cpp
@@ -21,6 +21,7 @@
 
 #include "kd/reflection_impl.h"
 #include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
 #include "kd/string_format.h"
 
 namespace tb::mdl
@@ -36,7 +37,8 @@ std::string displayName(const EntityDefinitionGroup& group)
 bool compareEntityDefinitionGroups(
   const EntityDefinitionGroup& lhs, const EntityDefinitionGroup& rhs)
 {
-  if (const auto compareResult = kdl::ci::str_compare(displayName(lhs), displayName(rhs));
+  if (const auto compareResult =
+        kdl::ci::str_compare_natural(displayName(lhs), displayName(rhs));
       compareResult != 0)
   {
     return compareResult < 0;

--- a/lib/TbMdlLib/src/LoadMaterialCollections.cpp
+++ b/lib/TbMdlLib/src/LoadMaterialCollections.cpp
@@ -47,6 +47,7 @@
 #include "kd/result.h"
 #include "kd/result_fold.h"
 #include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
 #include "kd/string_format.h"
 #include "kd/vector_utils.h"
 
@@ -349,10 +350,12 @@ std::string materialCollectionName(
 std::vector<gl::MaterialCollection> groupMaterialsIntoCollections(
   std::vector<gl::Material> materials)
 {
-  materials = kdl::vec_sort(std::move(materials), [&](const auto& lhs, const auto& rhs) {
-    return lhs.collectionName() < rhs.collectionName()   ? true
-           : lhs.collectionName() > rhs.collectionName() ? false
-                                                         : lhs.name() < rhs.name();
+  // Natural comparison folds case and skips whitespace, so distinct names such as
+  // "base 1.wad" and "base1.wad" can compare equal. string_less_natural breaks such
+  // ties by exact name, which keeps equal collection names adjacent. Otherwise, the
+  // chunk_by below could split one collection into several.
+  materials = kdl::vec_sort(std::move(materials), [](const auto& lhs, const auto& rhs) {
+    return kdl::ci::string_less_natural{}(lhs.collectionName(), rhs.collectionName());
   });
 
   return materials | kdl::views::chunk_by([&](const auto& lhs, const auto& rhs) {

--- a/lib/TbMdlLib/src/TagMatcher.cpp
+++ b/lib/TbMdlLib/src/TagMatcher.cpp
@@ -42,6 +42,7 @@
 #include "kd/contracts.h"
 #include "kd/ranges/to.h"
 #include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
 #include "kd/struct_io.h"
 
 #include <algorithm>
@@ -132,7 +133,7 @@ void MaterialTagMatcher::enable(TagMatcherCallback& callback, Map& map) const
     });
 
   std::ranges::sort(matchingMaterials, [](const auto* lhs, const auto* rhs) {
-    return kdl::ci::str_compare(lhs->name(), rhs->name()) < 0;
+    return kdl::ci::string_less_natural{}(lhs->name(), rhs->name());
   });
 
   const gl::Material* material = nullptr;
@@ -452,7 +453,7 @@ void EntityClassNameTagMatcher::enable(TagMatcherCallback& callback, Map& map) c
                              | kdl::ranges::to<std::vector>();
 
   std::ranges::sort(matchingDefinitions, [](const auto* lhs, const auto* rhs) {
-    return kdl::ci::str_compare(lhs->name, rhs->name) < 0;
+    return kdl::ci::string_less_natural{}(lhs->name, rhs->name);
   });
 
   const EntityDefinition* definition = nullptr;

--- a/lib/TbUiLib/src/AboutDialog.cpp
+++ b/lib/TbUiLib/src/AboutDialog.cpp
@@ -76,6 +76,7 @@ FreeType (Font rendering library)<br />
 FreeImage (Image loading & manipulation library)<br />
 tinyxml2 (XML parsing library)<br />
 miniz (Archive library)<br />
+natsort (Natural order string comparison)<br />
 Assimp (Asset importer library)<br />
 Catch 2 (C++ testing framework)<br />
 StackWalker (C++ stack trace analyzer)<br />

--- a/lib/TbUiLib/src/MaterialBrowserView.cpp
+++ b/lib/TbUiLib/src/MaterialBrowserView.cpp
@@ -48,6 +48,7 @@
 #include "kd/contracts.h"
 #include "kd/ranges/to.h"
 #include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
 #include "kd/string_utils.h"
 #include "kd/vector_utils.h"
 
@@ -276,7 +277,7 @@ std::vector<const gl::Material*> MaterialBrowserView::sortMaterials(
   std::vector<const gl::Material*> materials) const
 {
   const auto compareNames = [](const auto& lhs, const auto& rhs) {
-    return kdl::ci::string_less{}(lhs->name(), rhs->name());
+    return kdl::ci::string_less_natural{}(lhs->name(), rhs->name());
   };
 
   switch (m_sortOrder)

--- a/lib/TbUiLib/src/ModEditor.cpp
+++ b/lib/TbUiLib/src/ModEditor.cpp
@@ -48,6 +48,7 @@
 #include "kd/ranges/to.h"
 #include "kd/result.h"
 #include "kd/string_compare.h"
+#include "kd/string_compare_natural.h"
 #include "kd/vector_utils.h"
 
 #include <ranges>
@@ -226,7 +227,8 @@ void ModEditor::updateAvailableMods()
 {
   auto& map = m_document.map();
   findAvailableMods(map.gameInfo()) | kdl::transform([&](auto availableMods) {
-    m_availableMods = kdl::col_sort(std::move(availableMods), kdl::ci::string_less{});
+    m_availableMods =
+      kdl::col_sort(std::move(availableMods), kdl::ci::string_less_natural{});
   }) | kdl::transform_error([&](auto e) {
     m_availableMods.clear();
     map.logger().error() << "Could not update available mods: " << e.msg;


### PR DESCRIPTION
### Overview

Hey! This PR introduces the natural string sorting we discussed in #2366. It introduces [natsort](https://github.com/sourcefrog/natsort) as a dependency. The main feature of this is sorting any numeric values how you would expect: 16, 32, 64, 128 vs. a naive string sorting: 128, 16, 32, 64. We added a light wrapper around `strnatcmp` (the new dependency) which is used now throughout the codebase. Here are the sections / features using the natural string sorting:

* Entity browser (definitions, groups, and the name sort order)
* Material browser
* Mod list
* Tags list

### Testing

1. To test, load up any game / FGD and check out the entity list. Make sure it is sorted alphabetically, but also numeric values are sorted naturally. Kingpin has some good entities for this - ensure that the `key` entity goes from 1 -> 2 -> 3 instead of 1 -> 10 -> 2. Also try sorting the list by Group and make sure it's still alphabetical
3. Add some materials. You can use the Quake FGD and add the [protoype WAD](https://www.slipseer.com/index.php?resources/prototype-wad.263/) which is good to test with as it follows the 16, 32, 64, 128 prefixing. Also try sorting the list by Group and make sure it's still alphabetical
4. To test mod sorting, just add directories in your game path for the FGD you have open. I created folders like 1mod, 16mod, 128mod, and they should be sorted like that respectively
5. For tags, select anything in the map and start adding properties in the entity key value list. Try 1, 16, and 128. They should naturally sort vertically just like the above steps
6. Sanity-check that search still works in the entity and material browsers and returns the expected results after the sort change