### PR TITLE
Fix GoldSrc Studio model pitch orientation

### DIFF
--- a/lib/TbMdlLib/src/LoadAssimpModel.cpp
+++ b/lib/TbMdlLib/src/LoadAssimpModel.cpp
@@ -951,8 +951,10 @@ Result<EntityModelData> loadAssimpModel(
         "Assimp couldn't import model from '{}': {}", path, importer.GetErrorString())};
     }
 
-    // Create model data.
-    auto data = EntityModelData{PitchType::Normal, Orientation::Oriented};
+    // GoldSrc applies the Quake pitch inversion when rendering studio models.
+    const auto pitchType =
+      useQuakeCoordinateSystem(*scene) ? PitchType::MdlInverted : PitchType::Normal;
+    auto data = EntityModelData{pitchType, Orientation::Oriented};
 
     // create a frame for each animation in the scene
     // if we have no animations, always load 1 frame for the reference model

--- a/lib/TbMdlLib/test/src/tst_LoadAssimpModel.cpp
+++ b/lib/TbMdlLib/test/src/tst_LoadAssimpModel.cpp
@@ -60,6 +60,7 @@ TEST_CASE("loadAssimpModel")
       auto modelData = loadAssimpModel("cube.mdl", fs, logger);
       REQUIRE(modelData);
 
+      CHECK(modelData.value().pitchType() == PitchType::MdlInverted);
       CHECK(modelData.value().surfaceCount() == 4);
       CHECK(modelData.value().surface(0).skinCount() == 1);
       CHECK(modelData.value().surface(1).skinCount() == 3);
@@ -87,6 +88,7 @@ TEST_CASE("loadAssimpModel")
     auto modelData = loadAssimpModel(modelPath, fs, logger);
     REQUIRE(modelData);
 
+    CHECK(modelData.value().pitchType() == PitchType::Normal);
     REQUIRE(modelData.value().frameCount() == 1);
     REQUIRE(modelData.value().surfaceCount() == 1);
     REQUIRE(modelData.value().surface(0).skinCount() == 1);

--- a/lib/TbMdlLib/test/src/tst_LoadAssimpModel.cpp
+++ b/lib/TbMdlLib/test/src/tst_LoadAssimpModel.cpp
@@ -60,7 +60,6 @@ TEST_CASE("loadAssimpModel")
       auto modelData = loadAssimpModel("cube.mdl", fs, logger);
       REQUIRE(modelData);
 
-      CHECK(modelData.value().pitchType() == PitchType::MdlInverted);
       CHECK(modelData.value().surfaceCount() == 4);
       CHECK(modelData.value().surface(0).skinCount() == 1);
       CHECK(modelData.value().surface(1).skinCount() == 3);
@@ -68,6 +67,29 @@ TEST_CASE("loadAssimpModel")
       CHECK(modelData.value().surface(3).skinCount() == 1);
       CHECK(modelData.value().frameCount() == 3);
     }
+  }
+
+  SECTION("pitch type")
+  {
+    const auto [modelPath, expectedPitchType] =
+      GENERATE(table<std::filesystem::path, PitchType>({
+        {"cube/cube.mdl", PitchType::MdlInverted},
+        {"alignment/ase/cuboid.ase", PitchType::Normal},
+        {"alignment/obj/cuboid.obj", PitchType::Normal},
+        {"alignment/fbx/cuboid.fbx", PitchType::Normal},
+        {"alignment/gltf/cuboid.gltf", PitchType::Normal},
+        {"alignment/glb/cuboid.glb", PitchType::Normal},
+      }));
+
+    CAPTURE(modelPath);
+
+    const auto basePath = getFixtureRoot() / "test/mdl/LoadAssimpModel";
+    auto fs = fs::DiskFileSystem{basePath};
+
+    auto modelData = loadAssimpModel(modelPath, fs, logger);
+    REQUIRE(modelData);
+
+    CHECK(modelData.value().pitchType() == expectedPitchType);
   }
 
   SECTION("alignment")
@@ -88,7 +110,6 @@ TEST_CASE("loadAssimpModel")
     auto modelData = loadAssimpModel(modelPath, fs, logger);
     REQUIRE(modelData);
 
-    CHECK(modelData.value().pitchType() == PitchType::Normal);
     REQUIRE(modelData.value().frameCount() == 1);
     REQUIRE(modelData.value().surfaceCount() == 1);
     REQUIRE(modelData.value().surface(0).skinCount() == 1);


### PR DESCRIPTION
Fixes #5464

Assimp identifies GoldSrc Studio models with `HL1`. These models need
`PitchType::MdlInverted` for their editor rotation to match the compiled map.

The cache invalidation change is now in #5466.

Tested with `TbMdlLibTest` (132/132).