### PR TITLE
Invalidate cached entity rotation and transform when entity model is loaded

### DIFF
--- a/lib/TbGlLib/include/gl/Resource.h
+++ b/lib/TbGlLib/include/gl/Resource.h
@@ -268,6 +268,20 @@ public:
       m_state);
   }
 
+  bool isLoaded() const
+  {
+    return std::visit(
+      kdl::overload(
+        [](const ResourceUnloaded<T>&) { return false; },
+        [](const ResourceLoading<T>&) { return false; },
+        [](const ResourceLoaded<T>&) { return true; },
+        [](const ResourceReady<T>&) { return true; },
+        [](const ResourceDropping<T>&) { return false; },
+        [](const ResourceDropped&) { return false; },
+        [](const ResourceFailed&) { return false; }),
+      m_state);
+  }
+
   bool isDropped() const { return std::holds_alternative<ResourceDropped>(m_state); }
 
   bool needsProcessing() const

--- a/lib/TbGlLib/test/src/tst_Resource.cpp
+++ b/lib/TbGlLib/test/src/tst_Resource.cpp
@@ -746,6 +746,72 @@ TEST_CASE("Resource")
       CHECK(resource.needsProcessing());
     }
   }
+
+  SECTION("isLoaded")
+  {
+    SECTION("ResourceFailed state")
+    {
+      auto resource =
+        ResourceT{[&]() { return Result<MockResource>{Error{"MockResource failed"}}; }};
+
+      setResourceState<ResourceLoading<MockResource>>(
+        resource, mockTaskRunner, processContext);
+      mockTaskRunner.resolveNextPromise();
+
+      resource.process(taskRunner, processContext);
+      REQUIRE(
+        resource.state()
+        == ResourceState<MockResource>{ResourceFailed{"MockResource failed"}});
+      CHECK(!resource.isLoaded());
+    }
+
+    SECTION("ResourceUnloaded state")
+    {
+      auto resource = ResourceT{[&]() { return Result<MockResource>{MockResource{}}; }};
+      setResourceState<ResourceUnloaded<MockResource>>(
+        resource, mockTaskRunner, processContext);
+      CHECK(!resource.isLoaded());
+    }
+
+    SECTION("ResourceLoading state")
+    {
+      auto resource = ResourceT{[&]() { return Result<MockResource>{MockResource{}}; }};
+      setResourceState<ResourceLoading<MockResource>>(
+        resource, mockTaskRunner, processContext);
+      CHECK(!resource.isLoaded());
+    }
+
+    SECTION("ResourceLoaded state")
+    {
+      auto resource = ResourceT{[&]() { return Result<MockResource>{MockResource{}}; }};
+      setResourceState<ResourceLoaded<MockResource>>(
+        resource, mockTaskRunner, processContext);
+      CHECK(resource.isLoaded());
+    }
+
+    SECTION("ResourceReady state")
+    {
+      auto resource = ResourceT{[&]() { return Result<MockResource>{MockResource{}}; }};
+      setResourceState<ResourceReady<MockResource>>(
+        resource, mockTaskRunner, processContext);
+      CHECK(resource.isLoaded());
+    }
+
+    SECTION("ResourceDropping state")
+    {
+      auto resource = ResourceT{[&]() { return Result<MockResource>{MockResource{}}; }};
+      setResourceState<ResourceDropping<MockResource>>(
+        resource, mockTaskRunner, processContext);
+      CHECK(!resource.isLoaded());
+    }
+
+    SECTION("ResourceDropped state")
+    {
+      auto resource = ResourceT{[&]() { return Result<MockResource>{MockResource{}}; }};
+      setResourceState<ResourceDropped>(resource, mockTaskRunner, processContext);
+      CHECK(!resource.isLoaded());
+    }
+  }
 }
 
 } // namespace tb::gl

--- a/lib/TbMdlLib/include/mdl/Entity.h
+++ b/lib/TbMdlLib/include/mdl/Entity.h
@@ -105,8 +105,15 @@ private:
    */
   mutable std::optional<std::string> m_cachedClassname;
   mutable std::optional<vm::vec3d> m_cachedOrigin;
-  mutable std::optional<vm::mat4x4d> m_cachedRotation;
-  mutable std::optional<vm::mat4x4d> m_cachedModelTransformation;
+
+  struct ModelDependentTransformation
+  {
+    vm::mat4x4d transform;
+    bool modelIsLoaded;
+  };
+
+  mutable std::optional<ModelDependentTransformation> m_cachedRotation;
+  mutable std::optional<ModelDependentTransformation> m_cachedModelTransformation;
 
 public:
   Entity();

--- a/lib/TbMdlLib/src/Entity.cpp
+++ b/lib/TbMdlLib/src/Entity.cpp
@@ -42,6 +42,26 @@
 
 namespace tb::mdl
 {
+namespace
+{
+
+vm::mat4x4d entityModelTransformation(
+  const Entity& entity,
+  const std::optional<el::ExpressionNode>& defaultModelScaleExpression)
+{
+  if (const auto* pointDefinition = getPointEntityDefinition(entity.definition()))
+  {
+    const auto variableStore = EntityPropertiesVariableStore{entity};
+    const auto scale = safeGetModelScale(
+      pointDefinition->modelDefinition, variableStore, defaultModelScaleExpression);
+    return vm::translation_matrix(entity.origin()) * entity.rotation()
+           * vm::scaling_matrix(scale);
+  }
+
+  return vm::mat4x4d::identity();
+}
+
+} // namespace
 
 void setDefaultProperties(
   const EntityDefinition& entityDefinition,
@@ -197,18 +217,8 @@ const vm::mat4x4d& Entity::modelTransformation(
 {
   if (!m_cachedModelTransformation)
   {
-    if (const auto* pointDefinition = getPointEntityDefinition(definition()))
-    {
-      const auto variableStore = EntityPropertiesVariableStore{*this};
-      const auto scale = safeGetModelScale(
-        pointDefinition->modelDefinition, variableStore, defaultModelScaleExpression);
-      m_cachedModelTransformation =
-        vm::translation_matrix(origin()) * rotation() * vm::scaling_matrix(scale);
-    }
-    else
-    {
-      m_cachedModelTransformation = vm::mat4x4d::identity();
-    }
+    m_cachedModelTransformation =
+      entityModelTransformation(*this, defaultModelScaleExpression);
   }
   return *m_cachedModelTransformation;
 }

--- a/lib/TbMdlLib/src/Entity.cpp
+++ b/lib/TbMdlLib/src/Entity.cpp
@@ -61,6 +61,11 @@ vm::mat4x4d entityModelTransformation(
   return vm::mat4x4d::identity();
 }
 
+bool isModelLoaded(const EntityModel* model)
+{
+  return model && model->dataResource().isLoaded();
+}
+
 } // namespace
 
 void setDefaultProperties(
@@ -215,12 +220,17 @@ Result<ModelSpecification> Entity::modelSpecification() const
 const vm::mat4x4d& Entity::modelTransformation(
   const std::optional<el::ExpressionNode>& defaultModelScaleExpression) const
 {
-  if (!m_cachedModelTransformation)
+  const auto modelIsLoaded = isModelLoaded(m_model);
+  if (
+    !m_cachedModelTransformation
+    || m_cachedModelTransformation->modelIsLoaded != modelIsLoaded)
   {
-    m_cachedModelTransformation =
-      entityModelTransformation(*this, defaultModelScaleExpression);
+    m_cachedModelTransformation = {
+      entityModelTransformation(*this, defaultModelScaleExpression),
+      modelIsLoaded,
+    };
   }
-  return *m_cachedModelTransformation;
+  return m_cachedModelTransformation->transform;
 }
 
 Result<DecalSpecification> Entity::decalSpecification() const
@@ -425,11 +435,15 @@ void Entity::setOrigin(const vm::vec3d& origin)
 
 const vm::mat4x4d& Entity::rotation() const
 {
-  if (!m_cachedRotation)
+  const auto modelIsLoaded = isModelLoaded(m_model);
+  if (!m_cachedRotation || m_cachedRotation->modelIsLoaded != modelIsLoaded)
   {
-    m_cachedRotation = entityRotation(*this);
+    m_cachedRotation = {
+      entityRotation(*this),
+      modelIsLoaded,
+    };
   }
-  return *m_cachedRotation;
+  return m_cachedRotation->transform;
 }
 
 std::vector<EntityProperty> Entity::propertiesWithKey(const std::string& key) const

--- a/lib/TbMdlLib/test/src/tst_Entity.cpp
+++ b/lib/TbMdlLib/test/src/tst_Entity.cpp
@@ -17,11 +17,14 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "base/Result.h"
 #include "el/Expression.h"
 #include "el/ParseExpression.h"
 #include "mdl/CatchConfig.h"
 #include "mdl/Entity.h"
 #include "mdl/EntityDefinition.h"
+#include "mdl/EntityModel.h"
+#include "mdl/EntityModelDataResource.h"
 #include "mdl/EntityProperties.h"
 #include "mdl/PropertyDefinition.h"
 
@@ -772,6 +775,42 @@ TEST_CASE("EntityTest")
       CHECK(
         entity.modelTransformation(defaultModelScaleExpression)
         == vm::translation_matrix(vm::vec3d{8, 7, 6})
+             * vm::scaling_matrix(vm::vec3d{2, 2, 2}));
+    }
+
+    SECTION(
+      "Rotation and model transformation caches are invalidated when the model "
+      "finishes loading")
+    {
+      entity.setClassname("light");
+      entity.setDefinition(&otherDefinition);
+      entity.addOrUpdateProperty(EntityPropertyKeys::Angles, "30 0 0");
+
+      // the model's data resource starts out unloaded, so entity.model()->data() is
+      // null and the pitch type is assumed to be PitchType::Normal
+      auto dataResource = std::make_shared<EntityModelDataResource>([] {
+        return Result<EntityModelData>{
+          EntityModelData{PitchType::MdlInverted, Orientation::Oriented}};
+      });
+      auto model = EntityModel{"some_model", dataResource};
+      entity.setModel(&model);
+
+      const auto defaultModelScaleExpression =
+        el::ExpressionNode{el::LiteralExpression{el::Value{2.0}}};
+      const auto pitch = vm::to_radians(30.0);
+
+      REQUIRE(entity.rotation() == vm::rotation_matrix(0.0, pitch, 0.0));
+      REQUIRE(
+        entity.modelTransformation(defaultModelScaleExpression)
+        == vm::rotation_matrix(0.0, pitch, 0.0) * vm::scaling_matrix(vm::vec3d{2, 2, 2}));
+
+      // loading the model reveals its real pitch type (MdlInverted), which flips the
+      // sign of the pitch, i.e. EntityRotationType::Euler
+      dataResource->loadSync();
+      CHECK(entity.rotation() == vm::rotation_matrix(0.0, -pitch, 0.0));
+      CHECK(
+        entity.modelTransformation(defaultModelScaleExpression)
+        == vm::rotation_matrix(0.0, -pitch, 0.0)
              * vm::scaling_matrix(vm::vec3d{2, 2, 2}));
     }
 


### PR DESCRIPTION
If we don't do this, then the model's transformation will be wrong if any assumptions about its rotational properties turned out wrong. One such example is the model's pitch type, which can change once the model was loaded.