### PR TITLE
Introduce kdl::unpack

### DIFF
--- a/lib/KdLib/include/kd/unpack.h
+++ b/lib/KdLib/include/kd/unpack.h
@@ -1,0 +1,50 @@
+/*
+ Copyright 2026 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the "Software"), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify, merge,
+ publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+namespace kdl
+{
+
+/**
+ * Wraps the given function so that it can be called with a single tuple-like argument
+ * instead of a list of individual arguments. The elements of the tuple are unpacked and
+ * forwarded to the wrapped function as individual arguments, preserving the value
+ * category of the tuple argument. The wrapped function's return value, including
+ * references, is forwarded unchanged.
+ *
+ * @tparam F the type of the function to wrap
+ * @param f_ the function to wrap
+ *
+ * @return a function that accepts a single tuple-like argument and calls f with its
+ * unpacked elements
+ */
+template <typename F>
+constexpr auto unpack(F&& f_)
+{
+  return [f = std::forward<F>(f_)]<typename T>(T&& x) -> decltype(auto) {
+    return std::apply(f, std::forward<T>(x));
+  };
+}
+
+} // namespace kdl

--- a/lib/KdLib/test/CMakeLists.txt
+++ b/lib/KdLib/test/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(KdLibTest PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_struct_io.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_task_manager.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_tuple_utils.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_unpack.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_vector_set.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/tst_vector_utils.cpp"
 )

--- a/lib/KdLib/test/src/tst_unpack.cpp
+++ b/lib/KdLib/test/src/tst_unpack.cpp
@@ -1,0 +1,161 @@
+/*
+ Copyright 2026 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ software and associated documentation files (the "Software"), to deal in the Software
+ without restriction, including without limitation the rights to use, copy, modify, merge,
+ publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or
+ substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+*/
+
+#include "kd/unpack.h"
+
+#include <array>
+#include <ranges>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+namespace kdl
+{
+namespace
+{
+
+struct move_only
+{
+  move_only() = default;
+  move_only(const move_only&) = delete;
+  move_only(move_only&&) = default;
+};
+
+} // namespace
+
+TEST_CASE("unpack")
+{
+  using Catch::Matchers::RangeEquals;
+
+  SECTION("calls the wrapped function with the tuple's elements")
+  {
+    const auto add = unpack([](int a, int b) { return a + b; });
+
+    CHECK(add(std::tuple{1, 2}) == 3);
+    CHECK(add(std::pair{1, 2}) == 3);
+    CHECK(add(std::array{1, 2}) == 3);
+  }
+
+  SECTION("supports tuples with more than two elements")
+  {
+    const auto sum3 =
+      unpack([](const auto& a, const auto& b, const auto& c) { return a + b + c; });
+
+    CHECK(sum3(std::tuple{1, 2, 3}) == 6);
+  }
+
+  SECTION("is constexpr")
+  {
+    constexpr auto add = unpack([](int a, int b) { return a + b; });
+    static_assert(add(std::tuple{1, 2}) == 3);
+  }
+
+  SECTION("can be called repeatedly")
+  {
+    const auto add = unpack([](int a, int b) { return a + b; });
+
+    CHECK(add(std::tuple{1, 2}) == 3);
+    CHECK(add(std::tuple{3, 4}) == 7);
+  }
+
+  SECTION("forwards the wrapped function's return value, including references")
+  {
+    auto value = 1;
+    const auto identity = unpack([](int& x) -> int& { return x; });
+
+    CHECK(&identity(std::tie(value)) == &value);
+  }
+
+  SECTION("forwards the value category and constness of each tuple element")
+  {
+    const auto classify = unpack([](auto&& x) {
+      using X = decltype(x);
+      if constexpr (std::is_lvalue_reference_v<X>)
+      {
+        return std::is_const_v<std::remove_reference_t<X>> ? std::string{"const lvalue"}
+                                                           : std::string{"lvalue"};
+      }
+      else
+      {
+        return std::is_const_v<std::remove_reference_t<X>> ? std::string{"const rvalue"}
+                                                           : std::string{"rvalue"};
+      }
+    });
+
+    auto mutableTuple = std::tuple<int>{1};
+    const auto constTuple = std::tuple<int>{2};
+
+    CHECK(classify(mutableTuple) == "lvalue");
+    CHECK(classify(constTuple) == "const lvalue");
+    CHECK(classify(std::tuple<int>{3}) == "rvalue");
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    CHECK(classify(std::move(mutableTuple)) == "rvalue");
+
+    // moving a const object still binds to a const rvalue reference, which is exactly
+    // the category this asserts, so std::move here is intentional, not a mistake
+    // NOLINTNEXTLINE(bugprone-use-after-move,performance-move-const-arg)
+    CHECK(classify(std::move(constTuple)) == "const rvalue");
+  }
+
+  SECTION("moves elements out of an rvalue tuple")
+  {
+    const auto release = unpack([](move_only&& m) { return std::move(m); });
+
+    auto t = std::tuple<move_only>{};
+    auto result = release(std::move(t));
+
+    static_assert(std::is_same_v<decltype(result), move_only>);
+  }
+
+  SECTION("does not move elements out of an lvalue tuple")
+  {
+    const auto observe = unpack([](const move_only&) {});
+
+    auto t = std::tuple<move_only>{};
+    observe(t);
+
+    // t must still be valid since it was passed to the wrapped function by reference,
+    // not moved from
+    std::apply([](const move_only&) {}, t);
+  }
+
+  SECTION("works as a projection for std::views::transform")
+  {
+    const auto pairs = std::vector<std::pair<std::string, int>>{
+      {"a", 1},
+      {"b", 2},
+      {"c", 3},
+    };
+
+    const auto values = pairs
+                        | std::views::transform(
+                          unpack([](const auto&, const auto& value) { return value; }));
+
+    CHECK_THAT(values, RangeEquals(std::vector<int>{1, 2, 3}));
+  }
+}
+
+} // namespace kdl

--- a/lib/TbAppLib/src/SweepTool.cpp
+++ b/lib/TbAppLib/src/SweepTool.cpp
@@ -41,6 +41,7 @@
 
 #include "kd/ranges/concat_view.h"
 #include "kd/ranges/to.h"
+#include "kd/unpack.h"
 #include "kd/vector_utils.h"
 
 #include "vm/bbox.h"
@@ -326,16 +327,16 @@ void SweepTool::commitSweep()
 {
   if (!m_previewBrushes.empty())
   {
-    auto nodesToAdd = m_previewBrushes | std::views::transform([](auto& entry) {
-                        auto& [parent, childrenPtrs] = entry;
-                        auto childrenRaw =
-                          childrenPtrs | std::views::transform([](auto& childPtr) {
-                            return static_cast<mdl::Node*>(childPtr.release());
-                          })
-                          | kdl::ranges::to<std::vector>();
-                        return std::pair{parent, std::move(childrenRaw)};
-                      })
-                      | kdl::ranges::to<std::map>();
+    auto nodesToAdd =
+      m_previewBrushes
+      | std::views::transform(kdl::unpack([](auto& parent, auto& childrenPtrs) {
+          auto childrenRaw = childrenPtrs | std::views::transform([](auto& childPtr) {
+                               return static_cast<mdl::Node*>(childPtr.release());
+                             })
+                             | kdl::ranges::to<std::vector>();
+          return std::pair{parent, std::move(childrenRaw)};
+        }))
+      | kdl::ranges::to<std::map>();
 
     m_previewBrushes.clear();
     m_brushRenderer->clear();

--- a/lib/TbElLib/src/Expression.cpp
+++ b/lib/TbElLib/src/Expression.cpp
@@ -27,6 +27,7 @@
 #include "kd/overload.h"
 #include "kd/ranges/concat_view.h"
 #include "kd/ranges/to.h"
+#include "kd/unpack.h"
 
 #include <fmt/format.h>
 
@@ -1189,9 +1190,11 @@ Expression optimize(
   EvaluationContext& context, const MapExpression& expression, const ExpressionNode&)
 {
   auto optimizedExpressions =
-    expression.elements | std::views::transform([&](const auto& entry) {
-      return std::pair{entry.first, entry.second.optimize(context)};
-    });
+    expression.elements
+    | std::views::transform(
+      kdl::unpack([&](const auto& key, const auto& valueExpression) {
+        return std::pair{key, valueExpression.optimize(context)};
+      }));
 
   const auto isLiteral = std::ranges::all_of(
     optimizedExpressions, [](const auto& entry) { return entry.second.isLiteral(); });
@@ -1199,9 +1202,11 @@ Expression optimize(
   if (isLiteral)
   {
     return LiteralExpression{Value{
-      optimizedExpressions | std::views::transform([&](const auto& entry) {
-        return std::pair{entry.first, entry.second.evaluate(context)};
-      })
+      optimizedExpressions
+      | std::views::transform(
+        kdl::unpack([&](const auto& key, const auto& valueExpression) {
+          return std::pair{key, valueExpression.evaluate(context)};
+        }))
       | kdl::ranges::to<MapType>()}};
   }
 

--- a/lib/TbElLib/src/Interpolate.cpp
+++ b/lib/TbElLib/src/Interpolate.cpp
@@ -27,6 +27,7 @@
 #include "kd/ranges/to.h"
 #include "kd/result_fold.h"
 #include "kd/string_utils.h"
+#include "kd/unpack.h"
 
 #include <fmt/format.h>
 
@@ -63,11 +64,11 @@ auto parseExpressions(
   const std::string_view str,
   const std::vector<std::tuple<std::size_t, std::size_t>>& expressionPositions)
 {
-  return expressionPositions | std::views::transform([&](const auto& expressionPosition) {
-           const auto [start, length] = expressionPosition;
-           const auto expressionStr = str.substr(start + 2, length - 3);
-           return parseExpression(ParseMode::Strict, expressionStr);
-         })
+  return expressionPositions
+         | std::views::transform(kdl::unpack([&](const auto& start, const auto& length) {
+             const auto expressionStr = str.substr(start + 2, length - 3);
+             return parseExpression(ParseMode::Strict, expressionStr);
+           }))
          | kdl::fold;
 }
 

--- a/lib/TbMdlLib/src/LoadAssimpModel.cpp
+++ b/lib/TbMdlLib/src/LoadAssimpModel.cpp
@@ -38,6 +38,7 @@
 #include "kd/ranges/as_rvalue_view.h"
 #include "kd/ranges/to.h"
 #include "kd/result_fold.h"
+#include "kd/unpack.h"
 
 #include <assimp/IOStream.hpp>
 #include <assimp/IOSystem.hpp>
@@ -860,13 +861,10 @@ Result<void> loadSceneFrame(
   return meshes | std::views::transform([&](const auto& mesh) {
            return std::tuple{mesh, getMeshIndex(scene, *mesh.m_mesh)};
          })
-         | std::views::filter([](const auto& meshAndIndex) {
-             return std::get<1>(meshAndIndex) != std::nullopt;
-           })
-         | std::views::transform([&](const auto& meshAndIndex) {
-             const auto& mesh = std::get<0>(meshAndIndex);
-             const auto& meshIndex = *std::get<1>(meshAndIndex);
-
+         | std::views::filter(kdl::unpack(
+           [](const auto&, const auto& meshIndex) { return meshIndex != std::nullopt; }))
+         | std::views::transform(
+           kdl::unpack([&](const auto& mesh, const auto& meshIndex) {
              return computeMeshVertices(
                       *mesh.m_mesh,
                       mesh.m_transform,
@@ -878,9 +876,9 @@ Result<void> loadSceneFrame(
                           bounds.add(v.attr);
                         }
 
-                        return computeMeshData(mesh, meshIndex, vertices);
+                        return computeMeshData(mesh, *meshIndex, vertices);
                       });
-           })
+           }))
          | kdl::fold | kdl::and_then([&](const auto& meshData) -> Result<void> {
              if (!bounds.initialized())
              {

--- a/lib/TbMdlLib/src/SetLinkIdsCommand.cpp
+++ b/lib/TbMdlLib/src/SetLinkIdsCommand.cpp
@@ -30,6 +30,7 @@
 
 #include "kd/contracts.h"
 #include "kd/ranges/to.h"
+#include "kd/unpack.h"
 
 #include <ranges>
 
@@ -40,9 +41,7 @@ namespace
 
 auto setLinkIds(const std::vector<std::tuple<Node*, std::string>>& linkIds)
 {
-  return linkIds | std::views::transform([](const auto& nodeAndLinkId) {
-           auto* node = std::get<Node*>(nodeAndLinkId);
-           const auto& linkId = std::get<std::string>(nodeAndLinkId);
+  return linkIds | std::views::transform(kdl::unpack([](auto* node, const auto& linkId) {
            return node->accept(kdl::overload(
              [&](const WorldNode&) -> std::tuple<Node*, std::string> {
                contract_assert(false);
@@ -55,7 +54,7 @@ auto setLinkIds(const std::vector<std::tuple<Node*, std::string>>& linkIds)
                object.setLinkId(std::move(linkId));
                return {node, std::move(oldLinkId)};
              }));
-         })
+         }))
          | kdl::ranges::to<std::vector>();
 }
 

--- a/lib/TbMdlLib/src/SwapNodeContentsCommand.cpp
+++ b/lib/TbMdlLib/src/SwapNodeContentsCommand.cpp
@@ -73,9 +73,7 @@ auto notifySpecialWorldProperties(
 void doSwapNodeContents(
   std::vector<std::pair<Node*, NodeContents>>& nodesToSwap, Map& map)
 {
-  const auto nodes = nodesToSwap
-                     | std::views::transform([](const auto& pair) { return pair.first; })
-                     | kdl::ranges::to<std::vector>();
+  const auto nodes = nodesToSwap | std::views::keys | kdl::ranges::to<std::vector>();
 
   auto notifyNodes =
     NotifyBeforeAndAfter{map.nodesWillChangeNotifier, map.nodesDidChangeNotifier, nodes};
@@ -148,12 +146,8 @@ bool SwapNodeContentsCommand::doCollateWith(UndoableCommand& command)
 {
   if (auto* other = dynamic_cast<SwapNodeContentsCommand*>(&command))
   {
-    auto myNodes = m_nodes
-                   | std::views::transform([](const auto& pair) { return pair.first; })
-                   | kdl::ranges::to<std::vector>();
-    auto theirNodes = other->m_nodes
-                      | std::views::transform([](const auto& pair) { return pair.first; })
-                      | kdl::ranges::to<std::vector>();
+    auto myNodes = m_nodes | std::views::keys | kdl::ranges::to<std::vector>();
+    auto theirNodes = other->m_nodes | std::views::keys | kdl::ranges::to<std::vector>();
 
     std::ranges::sort(myNodes);
     std::ranges::sort(theirNodes);

--- a/lib/TbRenderLib/src/EntityLinkRenderer.cpp
+++ b/lib/TbRenderLib/src/EntityLinkRenderer.cpp
@@ -50,12 +50,7 @@ namespace
 
 auto getLinkEnds(const auto& entityLinks)
 {
-  return entityLinks
-         | std::views::transform(
-           [](const auto& nameAndTargetNodes) -> const mdl::EntityLinkManager::LinkEnds& {
-             return nameAndTargetNodes.second;
-           })
-         | std::views::join;
+  return entityLinks | std::views::values | std::views::join;
 }
 
 void addLink(

--- a/lib/TbUiLib/src/AppController.cpp
+++ b/lib/TbUiLib/src/AppController.cpp
@@ -64,6 +64,7 @@
 #include "kd/ranges/join_with_view.h"
 #include "kd/ranges/to.h"
 #include "kd/task_manager.h"
+#include "kd/unpack.h"
 #include "kd/vector_utils.h"
 
 #include <fmt/format.h>
@@ -99,10 +100,11 @@ auto createGameManager()
              if (!warnings.empty())
              {
                const auto body =
-                 warnings | std::views::transform([](const auto& pair) {
-                   const auto& [path, warning] = pair;
-                   return fmt::format("<b>{}</b><br>{}", path.string(), warning);
-                 })
+                 warnings
+                 | std::views::transform(
+                   kdl::unpack([](const auto& path, const auto& warning) {
+                     return fmt::format("<b>{}</b><br>{}", path.string(), warning);
+                   }))
                  | kdl::views::join_with("<br><br>"s) | kdl::ranges::to<std::string>();
 
                auto messageBox = QMessageBox{};
@@ -138,10 +140,9 @@ std::optional<std::tuple<std::string, mdl::MapFormat>> detectOrQueryGameAndForma
   AppController& appController, const std::filesystem::path& path)
 {
   return fs::Disk::withInputStream(path, mdl::readMapHeader)
-         | kdl::transform(
-           [&](auto detectedGameNameAndMapFormat)
+         | kdl::transform(kdl::unpack(
+           [&](auto gameName, auto mapFormat)
              -> std::optional<std::tuple<std::string, mdl::MapFormat>> {
-             auto [gameName, mapFormat] = detectedGameNameAndMapFormat;
              const auto& gameManager = appController.gameManager();
              const auto gameList = gameManager.gameInfos()
                                    | std::views::transform([](const auto& gameInfo) {
@@ -163,8 +164,8 @@ std::optional<std::tuple<std::string, mdl::MapFormat>> detectOrQueryGameAndForma
                std::tie(gameName, mapFormat) = *queriedGameNameAndMapFormat;
              }
 
-             return std::optional{std::tuple{std::move(*gameName), mapFormat}};
-           })
+             return std::tuple{std::move(*gameName), mapFormat};
+           }))
          | kdl::transform_error([](const auto&) { return std::nullopt; }) | kdl::value();
 }
 


### PR DESCRIPTION
`kdl::unpack` is a small helper function that makes it easier to transform tuple-likes. Instead of unpacking the tuple-like in the transform function manually, `kdl::unpack` unpacks the tuple and forwards its elements perfectly to the transform function:

```
someRange | std::views::transform([](const auto& t) {
   const auto& [key, value] = t;
  ...
})
```

then becomes

```
someRange | std::views::transform(kdl::unpack([](const auto& key, const auto& value) {
  ...
}))
```
