### PR TITLE
Always group brushes created by the shape tool

### DIFF
--- a/lib/TbAppLib/include/ui/CreateBrushesToolBase.h
+++ b/lib/TbAppLib/include/ui/CreateBrushesToolBase.h
@@ -23,6 +23,8 @@
 #include "ui/Tool.h"
 
 #include <memory>
+#include <optional>
+#include <string>
 
 namespace tb
 {
@@ -59,7 +61,7 @@ public:
 public:
   const mdl::Grid& grid() const;
 
-  void createBrushes();
+  void createBrushes(std::optional<std::string> groupName);
   void clearBrushes();
   void cancel();
 

--- a/lib/TbAppLib/include/ui/DrawShapeTool.h
+++ b/lib/TbAppLib/include/ui/DrawShapeTool.h
@@ -23,6 +23,9 @@
 #include "ui/CreateBrushesToolBase.h"
 #include "ui/DrawShapeToolExtensionManager.h"
 
+#include <optional>
+#include <string>
+
 namespace tb::ui
 {
 class MapDocument;
@@ -40,6 +43,8 @@ public:
 
   DrawShapeToolExtensionManager& extensionManager();
   void applyExtensionParameters();
+
+  std::optional<std::string> groupNameForCreatedBrushes() const;
 
 private:
   DrawShapeToolExtensionManager m_extensionManager;

--- a/lib/TbAppLib/src/CreateBrushesToolBase.cpp
+++ b/lib/TbAppLib/src/CreateBrushesToolBase.cpp
@@ -22,6 +22,7 @@
 #include "base/PreferenceManager.h"
 #include "mdl/BrushNode.h"
 #include "mdl/Map.h"
+#include "mdl/Map_Groups.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/Transaction.h"
@@ -53,7 +54,7 @@ const mdl::Grid& CreateBrushesToolBase::grid() const
   return m_document.map().grid();
 }
 
-void CreateBrushesToolBase::createBrushes()
+void CreateBrushesToolBase::createBrushes(std::optional<std::string> groupName)
 {
   if (!m_brushNodes.empty())
   {
@@ -68,6 +69,10 @@ void CreateBrushesToolBase::createBrushes()
     auto addedNodes =
       addNodes(m_document.map(), {{&parentForNodes(m_document.map()), nodesToAdd}});
     selectNodes(m_document.map(), addedNodes);
+    if (groupName && addedNodes.size() > 1)
+    {
+      groupSelectedNodes(m_document.map(), *groupName);
+    }
     transaction.commit();
 
     doBrushesWereCreated();

--- a/lib/TbAppLib/src/DrawShapeTool.cpp
+++ b/lib/TbAppLib/src/DrawShapeTool.cpp
@@ -20,12 +20,14 @@
 #include "ui/DrawShapeTool.h"
 
 #include "base/Logger.h"
+#include "base/PreferenceManager.h"
 #include "mdl/Brush.h" // IWYU pragma: keep
 #include "mdl/BrushNode.h"
 #include "mdl/Map.h"
 #include "mdl/Map_Nodes.h"
 #include "mdl/Map_Selection.h"
 #include "mdl/Transaction.h"
+#include "prefs/Preferences.h"
 #include "ui/DrawShapeToolExtensionManager.h"
 #include "ui/MapDocument.h"
 
@@ -48,7 +50,7 @@ DrawShapeTool::DrawShapeTool(MapDocument& document)
       auto transaction = mdl::Transaction{map, "Apply shape parameters"};
       update(*bounds);
       mdl::removeSelectedNodes(map);
-      createBrushes();
+      createBrushes(groupNameForCreatedBrushes());
       transaction.commit();
     }
   });
@@ -82,6 +84,13 @@ bool DrawShapeTool::cancel()
 DrawShapeToolExtensionManager& DrawShapeTool::extensionManager()
 {
   return m_extensionManager;
+}
+
+std::optional<std::string> DrawShapeTool::groupNameForCreatedBrushes() const
+{
+  return pref(Preferences::GroupBrushesCreatedByShapeTool)
+           ? std::optional{m_extensionManager.currentExtension().name()}
+           : std::nullopt;
 }
 
 void DrawShapeTool::applyExtensionParameters()

--- a/lib/TbAppLib/src/DrawShapeToolController2D.cpp
+++ b/lib/TbAppLib/src/DrawShapeToolController2D.cpp
@@ -87,7 +87,10 @@ public:
     return DragStatus::Deny;
   }
 
-  void end(const InputState&, const DragState&) override { m_tool.createBrushes(); }
+  void end(const InputState&, const DragState&) override
+  {
+    m_tool.createBrushes(m_tool.groupNameForCreatedBrushes());
+  }
 
   void cancel(const DragState&) override { m_tool.cancel(); }
 

--- a/lib/TbAppLib/src/DrawShapeToolController3D.cpp
+++ b/lib/TbAppLib/src/DrawShapeToolController3D.cpp
@@ -119,7 +119,10 @@ public:
     return DragStatus::Deny;
   }
 
-  void end(const InputState&, const DragState&) override { m_tool.createBrushes(); }
+  void end(const InputState&, const DragState&) override
+  {
+    m_tool.createBrushes(m_tool.groupNameForCreatedBrushes());
+  }
 
   void cancel(const DragState&) override { m_tool.cancel(); }
 

--- a/lib/TbAppLib/test/CMakeLists.txt
+++ b/lib/TbAppLib/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(TbAppLibTest
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ClipTool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ClipToolController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ControlPointTool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_DrawShapeTool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_DrawShapeToolExtensions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ExtrudeTool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tst_ExtrudeToolController.cpp

--- a/lib/TbAppLib/test/src/tst_DrawShapeTool.cpp
+++ b/lib/TbAppLib/test/src/tst_DrawShapeTool.cpp
@@ -1,0 +1,121 @@
+/*
+ Copyright (C) 2026 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "base/PreferenceManager.h"
+#include "mdl/BrushNode.h"
+#include "mdl/GroupNode.h"
+#include "mdl/Map.h"
+#include "mdl/Map_Selection.h"
+#include "prefs/Preferences.h"
+#include "ui/DrawShapeTool.h"
+#include "ui/DrawShapeToolExtensionManager.h"
+#include "ui/MapDocument.h"
+#include "ui/MapDocumentFixture.h"
+
+#include "kd/range_utils.h"
+
+#include "vm/bbox.h"
+
+#include <algorithm>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace tb::ui
+{
+
+namespace
+{
+
+size_t indexOfExtensionNamed(
+  DrawShapeToolExtensionManager& extensionManager, const std::string& name)
+{
+  return *kdl::index_of(extensionManager.extensions(), [&](const auto* extension) {
+    return extension->name() == name;
+  });
+}
+
+} // namespace
+
+TEST_CASE("DrawShapeTool")
+{
+  auto fixture = MapDocumentFixture{};
+  auto& document = fixture.create();
+  auto& map = document.map();
+
+  auto tool = DrawShapeTool{document};
+
+  constexpr auto bounds = vm::bbox3d{{0, 0, 0}, {64, 64, 64}};
+
+  SECTION("createBrushes groups multiple brushes and names the group after the shape")
+  {
+    REQUIRE(pref(Preferences::GroupBrushesCreatedByShapeTool));
+
+    const auto stairsIndex = indexOfExtensionNamed(tool.extensionManager(), "Stairs");
+    REQUIRE(tool.extensionManager().setCurrentExtensionIndex(stairsIndex));
+
+    tool.update(bounds);
+    tool.createBrushes(tool.groupNameForCreatedBrushes());
+
+    const auto& selectedNodes = map.selection().nodes;
+    REQUIRE(selectedNodes.size() == 1);
+
+    auto* groupNode = dynamic_cast<mdl::GroupNode*>(selectedNodes.front());
+    REQUIRE(groupNode != nullptr);
+    CHECK(groupNode->group().name() == "Stairs");
+    CHECK(groupNode->childCount() > 1);
+  }
+
+  SECTION(
+    "createBrushes does not group multiple brushes when "
+    "GroupBrushesCreatedByShapeTool is disabled")
+  {
+    setPref(Preferences::GroupBrushesCreatedByShapeTool, false);
+
+    const auto stairsIndex = indexOfExtensionNamed(tool.extensionManager(), "Stairs");
+    REQUIRE(tool.extensionManager().setCurrentExtensionIndex(stairsIndex));
+
+    tool.update(bounds);
+    tool.createBrushes(tool.groupNameForCreatedBrushes());
+
+    const auto& selectedNodes = map.selection().nodes;
+    CHECK(selectedNodes.size() > 1);
+    for (auto* node : selectedNodes)
+    {
+      CHECK(dynamic_cast<mdl::BrushNode*>(node) != nullptr);
+    }
+
+    PreferenceManager::instance().resetToDefault(
+      Preferences::GroupBrushesCreatedByShapeTool);
+  }
+
+  SECTION("createBrushes does not create a group for a single brush")
+  {
+    // Cuboid is the default extension and always creates a single brush.
+    REQUIRE(tool.extensionManager().currentExtension().name() == "Cuboid");
+
+    tool.update(bounds);
+    tool.createBrushes(tool.groupNameForCreatedBrushes());
+
+    const auto& selectedNodes = map.selection().nodes;
+    REQUIRE(selectedNodes.size() == 1);
+    CHECK(dynamic_cast<mdl::BrushNode*>(selectedNodes.front()) != nullptr);
+  }
+}
+
+} // namespace tb::ui

--- a/lib/TbPreferencesLib/include/prefs/Preferences.h
+++ b/lib/TbPreferencesLib/include/prefs/Preferences.h
@@ -204,6 +204,8 @@ inline auto EnableMSAA = Preference<bool>{"render/Enable multisampling", true};
 
 inline auto AlignmentLock = Preference<bool>{"Editor/Texture lock", true};
 inline auto UvLock = Preference<bool>{"Editor/UV lock", false};
+inline auto GroupBrushesCreatedByShapeTool =
+  Preference<bool>{"Editor/Group brushes created by shape tool", true};
 
 inline auto RendererFontPath = Preference<std::filesystem::path>{
   "render/Font name", "fonts/SourceSansPro-Regular.otf"};

--- a/lib/TbUiLib/include/ui/DrawShapeToolPage.h
+++ b/lib/TbUiLib/include/ui/DrawShapeToolPage.h
@@ -24,6 +24,9 @@
 #include "base/Notifier.h"
 #include "base/NotifierConnection.h"
 
+#include <filesystem>
+
+class QCheckBox;
 class QStackedLayout;
 class QToolButton;
 
@@ -39,6 +42,7 @@ private:
 
   QToolButton* m_extensionButton = nullptr;
   QStackedLayout* m_extensionPages = nullptr;
+  QCheckBox* m_groupCheckBox = nullptr;
 
   NotifierConnection m_notifierConnection;
 
@@ -51,6 +55,7 @@ public:
 private:
   void createGui();
   void currentExtensionDidChange(size_t index);
+  void preferenceDidChange(const std::filesystem::path& path);
 };
 
 } // namespace tb::ui

--- a/lib/TbUiLib/src/DrawShapeToolPage.cpp
+++ b/lib/TbUiLib/src/DrawShapeToolPage.cpp
@@ -19,12 +19,15 @@
 
 #include "ui/DrawShapeToolPage.h"
 
+#include <QCheckBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
 #include <QStackedLayout>
 #include <QToolButton>
 
+#include "base/PreferenceManager.h"
+#include "prefs/Preferences.h"
 #include "ui/BitmapButton.h"
 #include "ui/DrawShapeToolExtensionManager.h"
 #include "ui/DrawShapeToolExtensionPages.h"
@@ -44,6 +47,9 @@ DrawShapeToolPage::DrawShapeToolPage(
   createGui();
   m_notifierConnection += m_extensionManager.currentExtensionDidChangeNotifier.connect(
     this, &DrawShapeToolPage::currentExtensionDidChange);
+  m_notifierConnection +=
+    PreferenceManager::instance().preferenceDidChangeNotifier.connect(
+      this, &DrawShapeToolPage::preferenceDidChange);
 }
 
 void DrawShapeToolPage::createGui()
@@ -77,12 +83,21 @@ void DrawShapeToolPage::createGui()
     m_extensionPages->addWidget(extensionPage);
   }
 
+  m_groupCheckBox = new QCheckBox{tr("Group")};
+  m_groupCheckBox->setToolTip(
+    tr("Group the created brushes if the shape consists of more than one brush"));
+  m_groupCheckBox->setChecked(pref(Preferences::GroupBrushesCreatedByShapeTool));
+  connect(m_groupCheckBox, &QCheckBox::toggled, this, [](const auto groupCreatedBrushes) {
+    setPref(Preferences::GroupBrushesCreatedByShapeTool, groupCreatedBrushes);
+  });
+
   auto* layout = new QHBoxLayout();
   layout->setContentsMargins(QMargins{});
   layout->setSpacing(LayoutConstants::MediumHMargin);
 
   layout->addWidget(label, 0, Qt::AlignVCenter);
   layout->addWidget(m_extensionButton, 0, Qt::AlignVCenter);
+  layout->addWidget(m_groupCheckBox, 0, Qt::AlignVCenter);
   layout->addLayout(m_extensionPages);
   layout->addStretch(2);
 
@@ -94,6 +109,14 @@ void DrawShapeToolPage::currentExtensionDidChange(const size_t index)
   auto icon = loadSVGIcon(m_extensionManager.currentExtension().iconPath());
   m_extensionButton->setIcon(icon);
   m_extensionPages->setCurrentIndex(int(index));
+}
+
+void DrawShapeToolPage::preferenceDidChange(const std::filesystem::path& path)
+{
+  if (path == Preferences::GroupBrushesCreatedByShapeTool.path)
+  {
+    m_groupCheckBox->setChecked(pref(Preferences::GroupBrushesCreatedByShapeTool));
+  }
 }
 
 } // namespace tb::ui

--- a/lib/TbUiLib/src/MapViewToolBox.cpp
+++ b/lib/TbUiLib/src/MapViewToolBox.cpp
@@ -48,6 +48,8 @@
 
 #include "kd/contracts.h"
 
+#include <optional>
+
 namespace tb::ui
 {
 
@@ -217,7 +219,8 @@ void MapViewToolBox::performAssembleBrush()
 {
   contract_pre(assembleBrushToolActive());
 
-  m_assembleBrushTool->createBrushes();
+  // AssembleBrushTool only ever creates a single brush, so it is never grouped.
+  m_assembleBrushTool->createBrushes(std::nullopt);
 }
 
 bool MapViewToolBox::canToggleClipTool() const


### PR DESCRIPTION
If the shape tool creates more than one brush, we immediately group them and name them after the used shape. Add a checkbox next to the shape selector to toggle grouping.

Closes #5471.